### PR TITLE
Quick Win #2: Pre-configure GCU basket with performance analytics

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -148,7 +148,7 @@
   - ✅ `GET /api/custodians/{id}/transactions` - Transaction history
 
 ### 🎯 Phase 4: GCU Foundation Enhancement (Q1 2025) - 6 weeks
-**Status: 🔄 IN PROGRESS**
+**Status: ✅ MOSTLY COMPLETED**
 **Goal**: Enhance existing FinAegis platform for GCU readiness
 
 #### 4.1 User Bank Selection (Week 1-2) ✅ COMPLETED
@@ -157,11 +157,11 @@
 - [x] **Distribution Algorithm**: Implemented intelligent fund splitting with rounding handling
 - [x] **Admin Interface**: Created Filament resource and dashboard widget for bank management
 
-#### 4.2 Enhanced Governance (Week 3-4)
-- [ ] **Currency Basket Voting**: Extend existing poll system for basket composition
-- [ ] **Monthly Rebalancing**: Automated basket updates based on votes
-- [ ] **Voting Power**: Asset-weighted voting (already partially implemented)
-- [ ] **User Dashboard**: Voting interface in existing frontend
+#### 4.2 Enhanced Governance (Week 3-4) ✅ COMPLETED
+- [x] **Currency Basket Voting**: Extend existing poll system for basket composition ✅
+- [x] **Monthly Rebalancing**: Automated basket updates based on votes ✅
+- [x] **Voting Power**: Asset-weighted voting (already partially implemented) ✅
+- [x] **User Dashboard**: Voting interface in existing frontend ✅
 
 #### 4.3 Compliance Framework (Week 5-6)
 - [ ] **Enhanced KYC**: Strengthen existing user verification
@@ -321,25 +321,25 @@
 
 ## 🎯 Quick Wins (Immediate Implementation)
 
-### 1. Rebrand to GCU Platform (1 day)
-- [ ] Update admin dashboard to show "GCU Platform"
-- [ ] Add GCU branding and currency basket widgets
-- [ ] Showcase multi-bank distribution visualization
+### 1. Rebrand to GCU Platform (1 day) ✅ COMPLETED
+- [x] Update admin dashboard to show "GCU Platform" ✅
+- [x] Add GCU branding and currency basket widgets ✅
+- [x] Showcase multi-bank distribution visualization ✅
 
-### 2. Pre-configure GCU Basket (3 days)
-- [ ] Create "GCU Basket" with USD/EUR/GBP/CHF/JPY/Gold
-- [ ] Set up monthly rebalancing schedule
-- [ ] Add basket performance analytics
+### 2. Pre-configure GCU Basket (3 days) ✅ COMPLETED
+- [x] Create "GCU Basket" with USD/EUR/GBP/CHF/JPY/Gold ✅
+- [x] Set up monthly rebalancing schedule ✅
+- [x] Add basket performance analytics ✅
 
-### 3. User Bank Preference Model (2 days)
-- [ ] Add `user_bank_preferences` table
-- [ ] Extend user model with bank allocation settings
-- [ ] Create admin interface for bank selection
+### 3. User Bank Preference Model (2 days) ✅ COMPLETED (Phase 4.1)
+- [x] Add `user_bank_preferences` table ✅
+- [x] Extend user model with bank allocation settings ✅
+- [x] Create admin interface for bank selection ✅
 
-### 4. Currency Voting Templates (2 days)
-- [ ] Create poll templates for monthly votes
-- [ ] Pre-populate currency options
-- [ ] Set up automated poll scheduling
+### 4. Currency Voting Templates (2 days) ✅ COMPLETED (Phase 4.2)
+- [x] Create poll templates for monthly votes ✅
+- [x] Pre-populate currency options ✅
+- [x] Set up automated poll scheduling ✅
 
 ### 5. Documentation Consolidation (5 days)
 - [ ] Create unified `GCU_VISION.md`

--- a/app/Console/Commands/RebalanceBasketsCommand.php
+++ b/app/Console/Commands/RebalanceBasketsCommand.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Domain\Basket\Services\BasketRebalancingService;
+use App\Models\BasketAsset;
+use Illuminate\Console\Command;
+
+class RebalanceBasketsCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'baskets:rebalance 
+                            {--basket= : Specific basket code to rebalance}
+                            {--force : Force rebalancing even if not due}
+                            {--dry-run : Simulate rebalancing without executing}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Rebalance dynamic baskets based on their rebalancing frequency';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(BasketRebalancingService $rebalancingService): int
+    {
+        $basketCode = $this->option('basket');
+        $force = $this->option('force');
+        $dryRun = $this->option('dry-run');
+
+        if ($dryRun) {
+            $this->info('Running in dry-run mode - no changes will be made');
+        }
+
+        if ($basketCode) {
+            // Rebalance specific basket
+            $basket = BasketAsset::where('code', $basketCode)->first();
+            
+            if (!$basket) {
+                $this->error("Basket with code '{$basketCode}' not found.");
+                return Command::FAILURE;
+            }
+
+            if ($basket->type !== 'dynamic') {
+                $this->error("Basket '{$basketCode}' is not a dynamic basket.");
+                return Command::FAILURE;
+            }
+
+            $this->info("Processing basket: {$basket->name} ({$basket->code})");
+            
+            if ($dryRun) {
+                $result = $rebalancingService->simulateRebalancing($basket);
+                $this->displaySimulationResults($basket, $result);
+            } else {
+                if (!$force && !$rebalancingService->needsRebalancing($basket)) {
+                    $this->info("Basket does not need rebalancing yet. Use --force to override.");
+                    return Command::SUCCESS;
+                }
+
+                $result = $rebalancingService->rebalance($basket);
+                $this->displayRebalancingResults($basket, $result);
+            }
+        } else {
+            // Rebalance all baskets that need it
+            $this->info('Checking all dynamic baskets for rebalancing...');
+            
+            $baskets = BasketAsset::where('type', 'dynamic')
+                ->where('is_active', true)
+                ->get();
+
+            if ($baskets->isEmpty()) {
+                $this->info('No dynamic baskets found.');
+                return Command::SUCCESS;
+            }
+
+            $rebalancedCount = 0;
+            
+            foreach ($baskets as $basket) {
+                $this->info("\nProcessing basket: {$basket->name} ({$basket->code})");
+                
+                if ($dryRun) {
+                    $result = $rebalancingService->simulateRebalancing($basket);
+                    $this->displaySimulationResults($basket, $result);
+                    $rebalancedCount++;
+                } else {
+                    if ($force || $rebalancingService->needsRebalancing($basket)) {
+                        $result = $rebalancingService->rebalance($basket);
+                        $this->displayRebalancingResults($basket, $result);
+                        $rebalancedCount++;
+                    } else {
+                        $this->info("Basket does not need rebalancing yet.");
+                    }
+                }
+            }
+
+            $this->info("\nCompleted. {$rebalancedCount} basket(s) processed.");
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Display simulation results
+     */
+    private function displaySimulationResults(BasketAsset $basket, array $result): void
+    {
+        $this->info("Simulation results for {$basket->name}:");
+        
+        if (empty($result['adjustments'])) {
+            $this->info("No adjustments needed.");
+            return;
+        }
+
+        $this->table(
+            ['Asset', 'Current Weight', 'New Weight', 'Change'],
+            collect($result['adjustments'])->map(function ($adjustment) {
+                return [
+                    $adjustment['asset_code'],
+                    number_format($adjustment['old_weight'], 2) . '%',
+                    number_format($adjustment['new_weight'], 2) . '%',
+                    ($adjustment['adjustment'] > 0 ? '+' : '') . number_format($adjustment['adjustment'], 2) . '%',
+                ];
+            })->toArray()
+        );
+    }
+
+    /**
+     * Display rebalancing results
+     */
+    private function displayRebalancingResults(BasketAsset $basket, array $result): void
+    {
+        if ($result['status'] === 'completed') {
+            $this->info("✅ Basket rebalanced successfully!");
+            
+            if (!empty($result['adjustments'])) {
+                $this->table(
+                    ['Asset', 'Old Weight', 'New Weight', 'Change'],
+                    collect($result['adjustments'])->map(function ($adjustment) {
+                        return [
+                            $adjustment['asset_code'],
+                            number_format($adjustment['old_weight'], 2) . '%',
+                            number_format($adjustment['new_weight'], 2) . '%',
+                            ($adjustment['adjustment'] > 0 ? '+' : '') . number_format($adjustment['adjustment'], 2) . '%',
+                        ];
+                    })->toArray()
+                );
+            } else {
+                $this->info("No adjustments were made.");
+            }
+        } else {
+            $this->error("❌ Rebalancing failed: " . ($result['message'] ?? 'Unknown error'));
+        }
+    }
+}

--- a/app/Console/Commands/ShowBasketPerformanceCommand.php
+++ b/app/Console/Commands/ShowBasketPerformanceCommand.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Domain\Basket\Services\BasketValueCalculationService;
+use App\Models\BasketAsset;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+
+class ShowBasketPerformanceCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'baskets:performance 
+                            {basket? : Basket code (defaults to GCU)}
+                            {--period=30d : Performance period (1d, 7d, 30d, 90d, 1y)}
+                            {--detailed : Show component breakdown}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Display basket performance analytics and value history';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(BasketValueCalculationService $valueService): int
+    {
+        $basketCode = $this->argument('basket') ?? config('baskets.primary_code', 'GCU');
+        $period = $this->option('period');
+        $detailed = $this->option('detailed');
+        
+        // Find the basket
+        $basket = BasketAsset::where('code', $basketCode)->first();
+        
+        if (!$basket) {
+            $this->error("Basket '{$basketCode}' not found.");
+            return Command::FAILURE;
+        }
+        
+        $this->info("🧺 Basket Performance: {$basket->name} ({$basket->code})");
+        $this->newLine();
+        
+        // Calculate current value
+        $currentValue = $valueService->calculateValue($basket);
+        $this->displayCurrentValue($basket, $currentValue);
+        
+        // Calculate performance
+        $this->displayPerformance($basket, $valueService, $period);
+        
+        // Show component breakdown if requested
+        if ($detailed) {
+            $this->displayComponentBreakdown($basket, $currentValue);
+        }
+        
+        // Show recent value history
+        $this->displayRecentHistory($basket, $valueService);
+        
+        // Show rebalancing info
+        $this->displayRebalancingInfo($basket);
+        
+        return Command::SUCCESS;
+    }
+    
+    /**
+     * Display current basket value
+     */
+    private function displayCurrentValue(BasketAsset $basket, $value): void
+    {
+        $this->table(
+            ['Metric', 'Value'],
+            [
+                ['Current Value (USD)', '$' . number_format($value->value, 2)],
+                ['Last Calculated', $value->calculated_at->format('Y-m-d H:i:s')],
+                ['Components', $basket->components()->where('is_active', true)->count()],
+                ['Type', ucfirst($basket->type)],
+            ]
+        );
+    }
+    
+    /**
+     * Display performance metrics
+     */
+    private function displayPerformance(BasketAsset $basket, BasketValueCalculationService $valueService, string $period): void
+    {
+        $this->info("📊 Performance Metrics ({$period}):");
+        
+        // Parse period
+        $startDate = match($period) {
+            '1d' => now()->subDay(),
+            '7d' => now()->subDays(7),
+            '30d' => now()->subDays(30),
+            '90d' => now()->subDays(90),
+            '1y' => now()->subYear(),
+            default => now()->subDays(30),
+        };
+        
+        $performance = $valueService->calculatePerformance($basket, $startDate, now());
+        
+        if (!empty($performance)) {
+            $changeClass = $performance['percentage_change'] >= 0 ? 'info' : 'error';
+            $changeSymbol = $performance['percentage_change'] >= 0 ? '+' : '';
+            
+            $this->table(
+                ['Period', 'Start Value', 'End Value', 'Change ($)', 'Change (%)'],
+                [[
+                    $period,
+                    '$' . number_format($performance['start_value'], 2),
+                    '$' . number_format($performance['end_value'], 2),
+                    $changeSymbol . '$' . number_format($performance['absolute_change'], 2),
+                    $changeSymbol . number_format($performance['percentage_change'], 2) . '%',
+                ]]
+            );
+        } else {
+            $this->warn("No performance data available for the selected period.");
+        }
+        
+        $this->newLine();
+    }
+    
+    /**
+     * Display component breakdown
+     */
+    private function displayComponentBreakdown(BasketAsset $basket, $value): void
+    {
+        $this->info("🔍 Component Breakdown:");
+        
+        $components = $basket->components()
+            ->where('is_active', true)
+            ->with('asset')
+            ->get();
+        
+        $componentData = [];
+        $componentValues = $value->component_values ?? [];
+        
+        foreach ($components as $component) {
+            $componentValue = $componentValues[$component->asset_code] ?? null;
+            
+            $componentData[] = [
+                $component->asset_code,
+                number_format($component->weight, 2) . '%',
+                $componentValue ? '$' . number_format($componentValue['weighted_value'], 2) : 'N/A',
+                $componentValue ? '$' . number_format($componentValue['rate'], 4) : 'N/A',
+            ];
+        }
+        
+        $this->table(
+            ['Asset', 'Target Weight', 'Value Contribution', 'Exchange Rate'],
+            $componentData
+        );
+        
+        $this->newLine();
+    }
+    
+    /**
+     * Display recent value history
+     */
+    private function displayRecentHistory(BasketAsset $basket, BasketValueCalculationService $valueService): void
+    {
+        $this->info("📈 Recent Value History (Last 7 Days):");
+        
+        $history = $valueService->getHistoricalValues($basket, now()->subDays(7), now());
+        
+        if ($history->isEmpty()) {
+            $this->warn("No historical data available.");
+            return;
+        }
+        
+        $historyData = [];
+        $previousValue = null;
+        
+        foreach ($history as $value) {
+            $change = '';
+            if ($previousValue) {
+                $diff = $value->value - $previousValue;
+                $change = ($diff >= 0 ? '+' : '') . number_format($diff, 2);
+            }
+            
+            $historyData[] = [
+                $value->calculated_at->format('Y-m-d H:i'),
+                '$' . number_format($value->value, 2),
+                $change,
+            ];
+            
+            $previousValue = $value->value;
+        }
+        
+        $this->table(
+            ['Date', 'Value', 'Change'],
+            array_slice($historyData, -10) // Show last 10 entries
+        );
+        
+        $this->newLine();
+    }
+    
+    /**
+     * Display rebalancing information
+     */
+    private function displayRebalancingInfo(BasketAsset $basket): void
+    {
+        if ($basket->type !== 'dynamic') {
+            return;
+        }
+        
+        $this->info("⚖️ Rebalancing Information:");
+        
+        $nextRebalance = $basket->metadata['next_rebalance'] ?? null;
+        $lastRebalanced = $basket->last_rebalanced_at;
+        
+        $this->table(
+            ['Metric', 'Value'],
+            [
+                ['Rebalance Frequency', ucfirst($basket->rebalance_frequency)],
+                ['Last Rebalanced', $lastRebalanced ? $lastRebalanced->format('Y-m-d H:i:s') : 'Never'],
+                ['Next Rebalance', $nextRebalance ?? 'Not scheduled'],
+                ['Voting Enabled', ($basket->metadata['voting_enabled'] ?? false) ? 'Yes' : 'No'],
+            ]
+        );
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,5 +15,6 @@ class DatabaseSeeder extends Seeder
     {
         $this->call(RolesSeeder::class);
         $this->call(StablecoinSeeder::class);
+        $this->call(GCUBasketSeeder::class);
     }
 }

--- a/routes/console.php
+++ b/routes/console.php
@@ -14,3 +14,17 @@ Schedule::command('voting:setup')
     ->monthlyOn(20, '00:00')
     ->description('Create next month\'s GCU voting poll')
     ->appendOutputTo(storage_path('logs/gcu-voting-setup.log'));
+
+// Schedule monthly basket rebalancing
+// Runs on the 1st of each month at 00:05 (5 minutes after midnight)
+Schedule::command('baskets:rebalance')
+    ->monthlyOn(1, '00:05')
+    ->description('Rebalance dynamic baskets including GCU')
+    ->appendOutputTo(storage_path('logs/basket-rebalancing.log'));
+
+// Schedule hourly basket value calculations for performance tracking
+Schedule::call(function () {
+    $service = app(\App\Domain\Basket\Services\BasketValueCalculationService::class);
+    $service->calculateAllBasketValues();
+})->hourly()
+    ->description('Calculate and store basket values for performance tracking');

--- a/tests/Feature/Console/RebalanceBasketsCommandTest.php
+++ b/tests/Feature/Console/RebalanceBasketsCommandTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\BasketAsset;
+use App\Domain\Basket\Services\BasketRebalancingService;
+
+beforeEach(function () {
+    // Create a dynamic basket for testing using direct creation to avoid factory callbacks
+    $this->basket = BasketAsset::create([
+        'code' => 'TEST_BASKET_' . uniqid(),
+        'name' => 'Test Basket',
+        'type' => 'dynamic',
+        'rebalance_frequency' => 'monthly',
+        'is_active' => true,
+        'last_rebalanced_at' => now()->subMonth()->subDay(), // Make it need rebalancing
+    ]);
+    
+    // Add components manually
+    $this->basket->components()->createMany([
+        ['asset_code' => 'USD', 'weight' => 50.0, 'min_weight' => 40.0, 'max_weight' => 60.0, 'is_active' => true],
+        ['asset_code' => 'EUR', 'weight' => 30.0, 'min_weight' => 20.0, 'max_weight' => 40.0, 'is_active' => true],
+        ['asset_code' => 'GBP', 'weight' => 20.0, 'min_weight' => 10.0, 'max_weight' => 30.0, 'is_active' => true],
+    ]);
+});
+
+it('can run basket rebalancing command', function () {
+    $this->artisan('baskets:rebalance')
+        ->expectsOutput('Checking all dynamic baskets for rebalancing...')
+        ->expectsOutputToContain('Processing basket: Test Basket')
+        ->expectsOutputToContain('Completed.')
+        ->assertSuccessful();
+});
+
+it('can rebalance specific basket', function () {
+    $this->artisan('baskets:rebalance', ['--basket' => $this->basket->code])
+        ->expectsOutputToContain('Processing basket: Test Basket')
+        ->assertSuccessful();
+});
+
+it('handles non-existent basket', function () {
+    $this->artisan('baskets:rebalance', ['--basket' => 'NON_EXISTENT'])
+        ->expectsOutput("Basket with code 'NON_EXISTENT' not found.")
+        ->assertFailed();
+});
+
+it('handles fixed basket type', function () {
+    $fixedBasket = BasketAsset::factory()->create([
+        'code' => 'FIXED_BASKET',
+        'name' => 'Fixed Basket',
+        'type' => 'fixed',
+        'is_active' => true,
+    ]);
+    
+    $this->artisan('baskets:rebalance', ['--basket' => 'FIXED_BASKET'])
+        ->expectsOutput("Basket 'FIXED_BASKET' is not a dynamic basket.")
+        ->assertFailed();
+});
+
+it('can force rebalancing', function () {
+    // Update basket to not need rebalancing
+    $this->basket->update(['last_rebalanced_at' => now()]);
+    
+    $this->artisan('baskets:rebalance', ['--basket' => $this->basket->code, '--force' => true])
+        ->expectsOutputToContain('Processing basket: Test Basket')
+        ->assertSuccessful();
+});
+
+it('skips baskets that do not need rebalancing', function () {
+    // Update basket to not need rebalancing
+    $this->basket->update(['last_rebalanced_at' => now()]);
+    
+    $this->artisan('baskets:rebalance', ['--basket' => $this->basket->code])
+        ->expectsOutputToContain('Processing basket: Test Basket')
+        ->expectsOutput('Basket does not need rebalancing yet. Use --force to override.')
+        ->assertSuccessful();
+});
+
+it('can run in dry-run mode', function () {
+    $this->artisan('baskets:rebalance', ['--basket' => $this->basket->code, '--dry-run' => true])
+        ->expectsOutput('Running in dry-run mode - no changes will be made')
+        ->expectsOutputToContain('Processing basket: Test Basket')
+        ->expectsOutput('Simulation results for Test Basket:')
+        ->assertSuccessful();
+});
+
+it('handles no dynamic baskets scenario', function () {
+    // Delete all dynamic baskets
+    BasketAsset::where('type', 'dynamic')->delete();
+    
+    $this->artisan('baskets:rebalance')
+        ->expectsOutput('Checking all dynamic baskets for rebalancing...')
+        ->expectsOutput('No dynamic baskets found.')
+        ->assertSuccessful();
+});
+
+it('processes multiple baskets', function () {
+    // Create another dynamic basket
+    $anotherBasket = BasketAsset::create([
+        'code' => 'ANOTHER_BASKET_' . uniqid(),
+        'name' => 'Another Basket',
+        'type' => 'dynamic',
+        'rebalance_frequency' => 'monthly',
+        'is_active' => true,
+        'last_rebalanced_at' => now()->subMonth()->subDay(),
+    ]);
+    
+    $anotherBasket->components()->createMany([
+        ['asset_code' => 'USD', 'weight' => 60.0, 'is_active' => true],
+        ['asset_code' => 'EUR', 'weight' => 40.0, 'is_active' => true],
+    ]);
+    
+    $this->artisan('baskets:rebalance')
+        ->expectsOutput('Checking all dynamic baskets for rebalancing...')
+        ->expectsOutputToContain('Processing basket: Test Basket')
+        ->expectsOutputToContain('Processing basket: Another Basket')
+        ->expectsOutputToContain('Completed.')
+        ->assertSuccessful();
+});
+
+it('ignores inactive baskets', function () {
+    // Make basket inactive
+    $this->basket->update(['is_active' => false]);
+    
+    $this->artisan('baskets:rebalance')
+        ->expectsOutput('Checking all dynamic baskets for rebalancing...')
+        ->expectsOutput('No dynamic baskets found.')
+        ->assertSuccessful();
+});

--- a/tests/Feature/Console/RebalanceBasketsCommandTest.php
+++ b/tests/Feature/Console/RebalanceBasketsCommandTest.php
@@ -8,7 +8,7 @@ use App\Domain\Basket\Services\BasketRebalancingService;
 beforeEach(function () {
     // Create a dynamic basket for testing using direct creation to avoid factory callbacks
     $this->basket = BasketAsset::create([
-        'code' => 'TEST_BASKET_' . uniqid(),
+        'code' => 'TEST_' . substr(uniqid(), 0, 8),
         'name' => 'Test Basket',
         'type' => 'dynamic',
         'rebalance_frequency' => 'monthly',
@@ -97,7 +97,7 @@ it('handles no dynamic baskets scenario', function () {
 it('processes multiple baskets', function () {
     // Create another dynamic basket
     $anotherBasket = BasketAsset::create([
-        'code' => 'ANOTHER_BASKET_' . uniqid(),
+        'code' => 'OTHER_' . substr(uniqid(), 0, 8),
         'name' => 'Another Basket',
         'type' => 'dynamic',
         'rebalance_frequency' => 'monthly',


### PR DESCRIPTION
## Summary

This PR implements Quick Win #2 from the roadmap - pre-configuring the GCU (Global Currency Unit) basket with automated rebalancing and performance analytics.

## Changes Made

### 1. GCU Basket Configuration
- Added `GCUBasketSeeder` to `DatabaseSeeder` for automatic GCU basket creation
- GCU basket includes 6 components: USD (40%), EUR (30%), GBP (15%), CHF (10%), JPY (3%), XAU/Gold (2%)
- Configured as a dynamic basket with monthly rebalancing

### 2. Basket Rebalancing Command
- Created `baskets:rebalance` command for automated basket rebalancing
- Options: `--basket`, `--force`, `--dry-run`
- Scheduled to run monthly on the 1st at 00:05

### 3. Performance Analytics
- Created `baskets:performance` command to display basket analytics
- Shows current value, performance metrics, component breakdown, and history
- Options: `--period` (1d, 7d, 30d, 90d, 1y), `--detailed`
- Scheduled hourly basket value calculations for performance tracking

### 4. Comprehensive Testing
- Added complete test suite for basket rebalancing command
- Tests cover all command options and edge cases

### 5. Roadmap Updates
- Marked Quick Wins #1-4 as completed
- Updated Phase 4 status to "MOSTLY COMPLETED"

## Testing
```bash
# Run the new commands
php artisan baskets:rebalance --basket=GCU --dry-run
php artisan baskets:performance GCU --detailed

# Run tests
./vendor/bin/pest tests/Feature/Console/RebalanceBasketsCommandTest.php
```

## Notes
- The GCU basket configuration was already implemented in Phase 4.2
- User Bank Preferences (Quick Win #3) were implemented in Phase 4.1
- Currency Voting Templates (Quick Win #4) were implemented in Phase 4.2
- This PR adds the missing pieces: automatic seeding and performance commands

🤖 Generated with [Claude Code](https://claude.ai/code)