### PR TITLE
feat: Create missing basket workflow activities

### DIFF
--- a/app/Domain/Basket/Activities/ComposeBasketActivity.php
+++ b/app/Domain/Basket/Activities/ComposeBasketActivity.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Domain\Basket\Activities;
+
+use App\Domain\Account\DataObjects\AccountUuid;
+use App\Domain\Basket\Services\BasketAccountService;
+use App\Models\Account;
+use Workflow\Activity;
+
+class ComposeBasketActivity extends Activity
+{
+    public function __construct(
+        private BasketAccountService $basketAccountService
+    ) {}
+
+    /**
+     * Execute basket composition activity.
+     * 
+     * @param array $input Expected format: [
+     *   'account_uuid' => string,
+     *   'basket_code' => string,
+     *   'amount' => int
+     * ]
+     * @return array
+     */
+    public function execute(array $input): array
+    {
+        $accountUuid = $input['account_uuid'] ?? null;
+        $basketCode = $input['basket_code'] ?? null;
+        $amount = $input['amount'] ?? null;
+
+        if (!$accountUuid || !$basketCode || !$amount) {
+            throw new \InvalidArgumentException('Missing required parameters: account_uuid, basket_code, amount');
+        }
+
+        $account = Account::where('uuid', $accountUuid)->firstOrFail();
+
+        return $this->basketAccountService->composeBasket($account, $basketCode, $amount);
+    }
+}

--- a/app/Domain/Basket/Activities/DecomposeBasketActivity.php
+++ b/app/Domain/Basket/Activities/DecomposeBasketActivity.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Domain\Basket\Activities;
+
+use App\Domain\Account\DataObjects\AccountUuid;
+use App\Domain\Basket\Services\BasketAccountService;
+use App\Models\Account;
+use Workflow\Activity;
+
+class DecomposeBasketActivity extends Activity
+{
+    public function __construct(
+        private BasketAccountService $basketAccountService
+    ) {}
+
+    /**
+     * Execute basket decomposition activity.
+     * 
+     * @param array $input Expected format: [
+     *   'account_uuid' => string,
+     *   'basket_code' => string,
+     *   'amount' => int
+     * ]
+     * @return array
+     */
+    public function execute(array $input): array
+    {
+        $accountUuid = $input['account_uuid'] ?? null;
+        $basketCode = $input['basket_code'] ?? null;
+        $amount = $input['amount'] ?? null;
+
+        if (!$accountUuid || !$basketCode || !$amount) {
+            throw new \InvalidArgumentException('Missing required parameters: account_uuid, basket_code, amount');
+        }
+
+        $account = Account::where('uuid', $accountUuid)->firstOrFail();
+
+        return $this->basketAccountService->decomposeBasket($account, $basketCode, $amount);
+    }
+}

--- a/tests/Unit/Domain/Basket/Activities/ComposeBasketActivityTest.php
+++ b/tests/Unit/Domain/Basket/Activities/ComposeBasketActivityTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Basket\Activities;
+
+use App\Domain\Basket\Activities\ComposeBasketActivity;
+use App\Domain\Basket\Services\BasketAccountService;
+use App\Models\Account;
+use Tests\TestCase;
+use Mockery;
+
+class ComposeBasketActivityTest extends TestCase
+{
+    public function test_activity_extends_workflow_activity()
+    {
+        $basketService = Mockery::mock(BasketAccountService::class);
+        $activity = new ComposeBasketActivity($basketService);
+        
+        $this->assertInstanceOf(\Workflow\Activity::class, $activity);
+    }
+    
+    public function test_execute_method_validates_required_parameters()
+    {
+        $basketService = Mockery::mock(BasketAccountService::class);
+        $activity = new ComposeBasketActivity($basketService);
+        
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing required parameters: account_uuid, basket_code, amount');
+        
+        $activity->execute([]);
+    }
+    
+    public function test_execute_method_has_correct_signature()
+    {
+        $basketService = Mockery::mock(BasketAccountService::class);
+        $activity = new ComposeBasketActivity($basketService);
+        
+        $reflection = new \ReflectionClass($activity);
+        $executeMethod = $reflection->getMethod('execute');
+        
+        $this->assertTrue($executeMethod->isPublic());
+        $this->assertEquals('execute', $executeMethod->getName());
+        
+        $parameters = $executeMethod->getParameters();
+        $this->assertCount(1, $parameters);
+        $this->assertEquals('input', $parameters[0]->getName());
+        $this->assertEquals('array', $parameters[0]->getType()->getName());
+    }
+    
+    public function test_execute_method_validates_missing_account_uuid()
+    {
+        $basketService = Mockery::mock(BasketAccountService::class);
+        $activity = new ComposeBasketActivity($basketService);
+        
+        $this->expectException(\InvalidArgumentException::class);
+        
+        $activity->execute([
+            'basket_code' => 'GCU',
+            'amount' => 1000
+        ]);
+    }
+    
+    public function test_execute_method_validates_missing_basket_code()
+    {
+        $basketService = Mockery::mock(BasketAccountService::class);
+        $activity = new ComposeBasketActivity($basketService);
+        
+        $this->expectException(\InvalidArgumentException::class);
+        
+        $activity->execute([
+            'account_uuid' => 'test-uuid',
+            'amount' => 1000
+        ]);
+    }
+    
+    public function test_execute_method_validates_missing_amount()
+    {
+        $basketService = Mockery::mock(BasketAccountService::class);
+        $activity = new ComposeBasketActivity($basketService);
+        
+        $this->expectException(\InvalidArgumentException::class);
+        
+        $activity->execute([
+            'account_uuid' => 'test-uuid',
+            'basket_code' => 'GCU'
+        ]);
+    }
+}

--- a/tests/Unit/Domain/Basket/Activities/DecomposeBasketActivityTest.php
+++ b/tests/Unit/Domain/Basket/Activities/DecomposeBasketActivityTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Basket\Activities;
+
+use App\Domain\Basket\Activities\DecomposeBasketActivity;
+use App\Domain\Basket\Services\BasketAccountService;
+use App\Models\Account;
+use Tests\TestCase;
+use Mockery;
+
+class DecomposeBasketActivityTest extends TestCase
+{
+    public function test_activity_extends_workflow_activity()
+    {
+        $basketService = Mockery::mock(BasketAccountService::class);
+        $activity = new DecomposeBasketActivity($basketService);
+        
+        $this->assertInstanceOf(\Workflow\Activity::class, $activity);
+    }
+    
+    public function test_execute_method_validates_required_parameters()
+    {
+        $basketService = Mockery::mock(BasketAccountService::class);
+        $activity = new DecomposeBasketActivity($basketService);
+        
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing required parameters: account_uuid, basket_code, amount');
+        
+        $activity->execute([]);
+    }
+    
+    public function test_execute_method_has_correct_signature()
+    {
+        $basketService = Mockery::mock(BasketAccountService::class);
+        $activity = new DecomposeBasketActivity($basketService);
+        
+        $reflection = new \ReflectionClass($activity);
+        $executeMethod = $reflection->getMethod('execute');
+        
+        $this->assertTrue($executeMethod->isPublic());
+        $this->assertEquals('execute', $executeMethod->getName());
+        
+        $parameters = $executeMethod->getParameters();
+        $this->assertCount(1, $parameters);
+        $this->assertEquals('input', $parameters[0]->getName());
+        $this->assertEquals('array', $parameters[0]->getType()->getName());
+    }
+    
+    public function test_execute_method_validates_missing_account_uuid()
+    {
+        $basketService = Mockery::mock(BasketAccountService::class);
+        $activity = new DecomposeBasketActivity($basketService);
+        
+        $this->expectException(\InvalidArgumentException::class);
+        
+        $activity->execute([
+            'basket_code' => 'GCU',
+            'amount' => 1000
+        ]);
+    }
+    
+    public function test_execute_method_validates_missing_basket_code()
+    {
+        $basketService = Mockery::mock(BasketAccountService::class);
+        $activity = new DecomposeBasketActivity($basketService);
+        
+        $this->expectException(\InvalidArgumentException::class);
+        
+        $activity->execute([
+            'account_uuid' => 'test-uuid',
+            'amount' => 1000
+        ]);
+    }
+    
+    public function test_execute_method_validates_missing_amount()
+    {
+        $basketService = Mockery::mock(BasketAccountService::class);
+        $activity = new DecomposeBasketActivity($basketService);
+        
+        $this->expectException(\InvalidArgumentException::class);
+        
+        $activity->execute([
+            'account_uuid' => 'test-uuid',
+            'basket_code' => 'GCU'
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- Implement ComposeBasketActivity for basket composition operations
- Implement DecomposeBasketActivity for basket decomposition operations  
- Add comprehensive unit tests for both activities

## Changes
- Created `app/Domain/Basket/Activities/ComposeBasketActivity.php`
- Created `app/Domain/Basket/Activities/DecomposeBasketActivity.php`
- Added unit tests with parameter validation and signature verification
- Follow existing domain pattern with Service → Workflow → Activity → Aggregate
- Activities delegate to BasketAccountService for business logic

## Test Plan
- [x] All new unit tests pass (12 tests, 22 assertions)
- [x] Existing basket workflow tests continue to pass
- [x] Activities properly extend Workflow\Activity base class
- [x] Parameter validation works correctly
- [x] Activities integrate with existing workflows

🤖 Generated with [Claude Code](https://claude.ai/code)