### PR TITLE
fix: Resolve database schema mismatches in test factories

### DIFF
--- a/database/factories/CustodianWebhookFactory.php
+++ b/database/factories/CustodianWebhookFactory.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\CustodianWebhook;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\CustodianWebhook>
+ */
+class CustodianWebhookFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'uuid' => fake()->uuid(),
+            'custodian_name' => fake()->randomElement(['coinbase', 'binance', 'kraken', 'gemini']),
+            'event_type' => fake()->randomElement(['transaction.completed', 'transaction.pending', 'deposit.confirmed', 'withdrawal.processed']),
+            'event_id' => fake()->uuid(),
+            'headers' => [
+                'X-Webhook-ID' => fake()->uuid(),
+                'X-Webhook-Timestamp' => now()->timestamp,
+                'Content-Type' => 'application/json',
+            ],
+            'payload' => [
+                'id' => fake()->uuid(),
+                'type' => 'transaction',
+                'amount' => fake()->randomFloat(2, 10, 10000),
+                'currency' => fake()->randomElement(['BTC', 'ETH', 'USD', 'EUR']),
+                'status' => 'completed',
+                'timestamp' => now()->toISOString(),
+            ],
+            'signature' => fake()->sha256(),
+            'status' => fake()->randomElement(['pending', 'processing', 'processed', 'failed']),
+            'attempts' => fake()->numberBetween(0, 3),
+            'processed_at' => null,
+            'error_message' => null,
+            'custodian_account_id' => null,
+            'transaction_id' => null,
+        ];
+    }
+
+    /**
+     * Indicate that the webhook is pending.
+     */
+    public function pending(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => 'pending',
+            'processed_at' => null,
+            'error_message' => null,
+        ]);
+    }
+
+    /**
+     * Indicate that the webhook has been processed.
+     */
+    public function processed(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => 'processed',
+            'processed_at' => now(),
+            'error_message' => null,
+        ]);
+    }
+
+    /**
+     * Indicate that the webhook processing failed.
+     */
+    public function failed(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => 'failed',
+            'processed_at' => null,
+            'error_message' => fake()->sentence(),
+        ]);
+    }
+}

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -53,8 +53,8 @@ it('has correct casts', function () {
 });
 
 it('can check if user can access panel', function () {
-    $adminUser = User::factory()->create(['role' => 'admin']);
-    $regularUser = User::factory()->create(['role' => 'user']);
+    $adminUser = User::factory()->withAdminRole()->create();
+    $regularUser = User::factory()->create(); // Uses default private role
     
     $panel = app(\Filament\Panel::class);
     


### PR DESCRIPTION
## Summary
- Fix database schema mismatches in test factories that were causing CI failures
- Resolve missing factory class that was breaking job tests

## Changes
### User Test Fix
- Fixed `tests/Unit/Models/UserTest.php` to use proper role assignment methods
- Replaced `User::factory()->create(['role' => 'admin'])` with `User::factory()->withAdminRole()->create()`
- Uses proper Spatie Laravel Permission package methods instead of non-existent 'role' column

### Missing Factory Fix  
- Created `database/factories/CustodianWebhookFactory.php` that was missing
- Added comprehensive factory with all required model attributes
- Included state methods: `pending()`, `processed()`, `failed()`
- Fixes "Class CustodianWebhookFactory not found" errors in ProcessCustodianWebhookTest

## Technical Details
The `users` table correctly uses:
- `roles` table with `model_has_roles` pivot table (Spatie Laravel Permission)
- KYC fields: `kyc_status`, `kyc_level`, etc. (not `kyc_verified`)

## Test Plan
- [x] UserTest.php no longer tries to set non-existent 'role' column
- [x] ProcessCustodianWebhookTest no longer fails with "CustodianWebhookFactory not found"
- [x] All factories reference existing database columns
- [x] Role assignment uses proper Laravel Permission methods

🤖 Generated with [Claude Code](https://claude.ai/code)