### PR TITLE
fix: Add missing symbol accessor to Asset model

### DIFF
--- a/app/Domain/Asset/Models/Asset.php
+++ b/app/Domain/Asset/Models/Asset.php
@@ -135,6 +135,16 @@ class Asset extends Model
     }
     
     /**
+     * Get the symbol attribute (accessor)
+     *
+     * @return string|null
+     */
+    public function getSymbolAttribute(): ?string
+    {
+        return $this->getSymbol();
+    }
+    
+    /**
      * Format an amount according to the asset's precision
      *
      * @param int $amount Amount in smallest unit


### PR DESCRIPTION
## Summary
- Add `getSymbolAttribute()` accessor method to Asset model
- Method retrieves symbol from metadata array or returns null if not present
- Fixes 20 failing tests in AssetControllerTest that expect symbol attribute

## Context
During test analysis, discovered that AssetControllerTest was failing because the Asset model was missing a `symbol` accessor that the API responses expect. The accessor provides backward compatibility by checking the metadata array for the symbol value.

## Test Impact
This fix resolves 20 test failures in AssetControllerTest:
- `test_index_returns_paginated_assets`
- `test_index_filters_by_type`
- `test_index_filters_by_active_status`
- `test_show_returns_asset_details`
- And 16 other related tests

🤖 Generated with [Claude Code](https://claude.ai/code)