### PR TITLE
Fix dashboard transaction count error

### DIFF
--- a/app/Domain/Account/Projectors/TransactionProjector.php
+++ b/app/Domain/Account/Projectors/TransactionProjector.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Account\Projectors;
+
+use App\Domain\Asset\Events\AssetTransactionCreated;
+use App\Domain\Asset\Events\AssetTransferCompleted;
+use App\Domain\Payment\Events\PaymentDepositCreated;
+use App\Domain\Payment\Events\PaymentWithdrawalCreated;
+use App\Models\TransactionProjection;
+use Spatie\EventSourcing\EventHandlers\Projectors\Projector;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+class TransactionProjector extends Projector
+{
+    /**
+     * Handle asset transaction created event
+     */
+    public function onAssetTransactionCreated(AssetTransactionCreated $event): void
+    {
+        try {
+            TransactionProjection::create([
+                'uuid' => Str::uuid(),
+                'account_uuid' => (string) $event->accountUuid,
+                'type' => $event->isCredit() ? 'deposit' : 'withdrawal',
+                'asset_code' => $event->assetCode,
+                'amount' => $event->getAmount(),
+                'description' => $event->description ?? ($event->isCredit() ? 'Deposit' : 'Withdrawal'),
+                'reference' => $event->transactionId ?? null,
+                'status' => 'completed',
+                'metadata' => [
+                    'event_type' => 'AssetTransactionCreated',
+                    'event_uuid' => $event->aggregateRootUuid(),
+                ],
+            ]);
+            
+            Log::info('Transaction projection created for AssetTransactionCreated', [
+                'account_uuid' => (string) $event->accountUuid,
+                'asset_code' => $event->assetCode,
+                'amount' => $event->getAmount(),
+            ]);
+        } catch (\Exception $e) {
+            Log::error('Error creating transaction projection', [
+                'event' => 'AssetTransactionCreated',
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+    
+    /**
+     * Handle asset transfer completed event
+     */
+    public function onAssetTransferCompleted(AssetTransferCompleted $event): void
+    {
+        try {
+            // Create debit transaction for sender
+            TransactionProjection::create([
+                'uuid' => Str::uuid(),
+                'account_uuid' => (string) $event->fromAccountUuid,
+                'type' => 'transfer_out',
+                'asset_code' => $event->assetCode,
+                'amount' => $event->amount,
+                'description' => $event->description ?? 'Transfer to ' . substr((string) $event->toAccountUuid, 0, 8),
+                'reference' => $event->transferId ?? null,
+                'status' => 'completed',
+                'metadata' => [
+                    'event_type' => 'AssetTransferCompleted',
+                    'event_uuid' => $event->aggregateRootUuid(),
+                    'to_account' => (string) $event->toAccountUuid,
+                ],
+            ]);
+            
+            // Create credit transaction for receiver
+            TransactionProjection::create([
+                'uuid' => Str::uuid(),
+                'account_uuid' => (string) $event->toAccountUuid,
+                'type' => 'transfer_in',
+                'asset_code' => $event->assetCode,
+                'amount' => $event->amount,
+                'description' => $event->description ?? 'Transfer from ' . substr((string) $event->fromAccountUuid, 0, 8),
+                'reference' => $event->transferId ?? null,
+                'status' => 'completed',
+                'metadata' => [
+                    'event_type' => 'AssetTransferCompleted',
+                    'event_uuid' => $event->aggregateRootUuid(),
+                    'from_account' => (string) $event->fromAccountUuid,
+                ],
+            ]);
+            
+            Log::info('Transaction projections created for AssetTransferCompleted', [
+                'from_account' => (string) $event->fromAccountUuid,
+                'to_account' => (string) $event->toAccountUuid,
+                'asset_code' => $event->assetCode,
+                'amount' => $event->amount,
+            ]);
+        } catch (\Exception $e) {
+            Log::error('Error creating transaction projections for transfer', [
+                'event' => 'AssetTransferCompleted',
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+    
+    /**
+     * Handle payment deposit created event
+     */
+    public function onPaymentDepositCreated(PaymentDepositCreated $event): void
+    {
+        try {
+            TransactionProjection::create([
+                'uuid' => Str::uuid(),
+                'account_uuid' => (string) $event->accountUuid,
+                'type' => 'deposit',
+                'asset_code' => $event->assetCode,
+                'amount' => $event->amount,
+                'description' => $event->description ?? 'Payment deposit',
+                'reference' => $event->paymentReference ?? null,
+                'status' => 'completed',
+                'metadata' => [
+                    'event_type' => 'PaymentDepositCreated',
+                    'event_uuid' => $event->aggregateRootUuid(),
+                    'payment_method' => $event->paymentMethod ?? null,
+                ],
+            ]);
+            
+            Log::info('Transaction projection created for PaymentDepositCreated', [
+                'account_uuid' => (string) $event->accountUuid,
+                'asset_code' => $event->assetCode,
+                'amount' => $event->amount,
+            ]);
+        } catch (\Exception $e) {
+            Log::error('Error creating transaction projection for deposit', [
+                'event' => 'PaymentDepositCreated',
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+    
+    /**
+     * Handle payment withdrawal created event
+     */
+    public function onPaymentWithdrawalCreated(PaymentWithdrawalCreated $event): void
+    {
+        try {
+            TransactionProjection::create([
+                'uuid' => Str::uuid(),
+                'account_uuid' => (string) $event->accountUuid,
+                'type' => 'withdrawal',
+                'asset_code' => $event->assetCode,
+                'amount' => $event->amount,
+                'description' => $event->description ?? 'Payment withdrawal',
+                'reference' => $event->paymentReference ?? null,
+                'status' => 'completed',
+                'metadata' => [
+                    'event_type' => 'PaymentWithdrawalCreated',
+                    'event_uuid' => $event->aggregateRootUuid(),
+                    'payment_method' => $event->paymentMethod ?? null,
+                ],
+            ]);
+            
+            Log::info('Transaction projection created for PaymentWithdrawalCreated', [
+                'account_uuid' => (string) $event->accountUuid,
+                'asset_code' => $event->assetCode,
+                'amount' => $event->amount,
+            ]);
+        } catch (\Exception $e) {
+            Log::error('Error creating transaction projection for withdrawal', [
+                'event' => 'PaymentWithdrawalCreated',
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -142,14 +142,11 @@ class Account extends Model
     // Legacy balance manipulation methods removed - use event sourcing via WalletService instead
     
     /**
-     * Get transactions from event sourcing ledger
-     * This is a temporary method until we have a proper transaction projection
+     * Get transactions from the transaction projection table
      */
     public function transactions()
     {
-        // For now, return an empty relationship to prevent errors
-        // In a proper implementation, this would query the event store or a transaction projection
-        return $this->hasMany(Transaction::class, 'account_uuid', 'uuid');
+        return $this->hasMany(TransactionProjection::class, 'account_uuid', 'uuid');
     }
     
     /**

--- a/app/Models/TransactionProjection.php
+++ b/app/Models/TransactionProjection.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TransactionProjection extends Model
+{
+    use HasFactory, HasUuids;
+    
+    protected $table = 'transaction_projections';
+    
+    protected $guarded = [];
+    
+    protected $casts = [
+        'amount' => 'integer',
+        'metadata' => 'array',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+    
+    /**
+     * Get the columns that should receive a unique identifier.
+     */
+    public function uniqueIds(): array
+    {
+        return ['uuid'];
+    }
+    
+    /**
+     * Get the account that owns the transaction.
+     */
+    public function account(): BelongsTo
+    {
+        return $this->belongsTo(Account::class, 'account_uuid', 'uuid');
+    }
+    
+    /**
+     * Get formatted amount (in dollars/cents format)
+     */
+    public function getFormattedAmountAttribute(): string
+    {
+        return number_format($this->amount / 100, 2);
+    }
+    
+    /**
+     * Scope to get transactions for a specific type
+     */
+    public function scopeOfType($query, string $type)
+    {
+        return $query->where('type', $type);
+    }
+    
+    /**
+     * Scope to get completed transactions
+     */
+    public function scopeCompleted($query)
+    {
+        return $query->where('status', 'completed');
+    }
+}

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -177,7 +177,10 @@
                             <div>
                                 <p class="text-sm font-medium text-gray-600 dark:text-gray-400">Transactions</p>
                                 <p class="text-2xl font-bold text-gray-900 dark:text-white">
-                                    {{ Auth::user()->accounts->count() > 0 ? Auth::user()->accounts->sum(function($account) { return $account->transactions()->count(); }) : 0 }}
+                                    {{ Auth::user()->accounts->count() > 0 ? Auth::user()->accounts->sum(function($account) { 
+                                        // Transaction count from projections
+                                        return \App\Models\TransactionProjection::where('account_uuid', $account->uuid)->count();
+                                    }) : 0 }}
                                 </p>
                             </div>
                             <div class="p-3 bg-yellow-100 rounded-full">


### PR DESCRIPTION
## Summary
- Fix 'Column not found: transactions.account_uuid' error on dashboard
- Add proper transaction projection layer for event sourced transactions
- Update dashboard to use projections instead of querying event store directly

## Problem
The dashboard was trying to count transactions using a relationship that expected a regular table structure, but transactions are stored as events in the event sourcing system.

## Solution
- Created TransactionProjection model to store transaction data for display
- Created TransactionProjector that listens to transaction events and creates projections
- Updated Account model's transactions() relationship to use projections
- Modified dashboard to query transaction projections instead of event store

## Test plan
- [ ] Visit dashboard - should load without errors
- [ ] Transaction count should display (will be 0 initially)
- [ ] Make a deposit/transfer - transaction count should update
- [ ] Verify TransactionProjector creates projections for new events

🤖 Generated with [Claude Code](https://claude.ai/code)