### PR TITLE
Fix dashboard SQL error and x-init attribute syntax

### DIFF
--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -149,7 +149,7 @@ class Account extends Model
     {
         // For now, return an empty relationship to prevent errors
         // In a proper implementation, this would query the event store or a transaction projection
-        return $this->hasMany(Transaction::class, 'account_uuid', 'uuid');
+        return $this->hasMany(Transaction::class, 'aggregate_uuid', 'uuid');
     }
     
     /**

--- a/resources/views/components/gcu-wallet.blade.php
+++ b/resources/views/components/gcu-wallet.blade.php
@@ -32,7 +32,7 @@
                     fetch('/api/accounts/{{ auth()->user()->accounts->first()->uuid }}/balances?asset=GCU', {
                         headers: {
                             'Accept': 'application/json',
-                            'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+                            'X-CSRF-TOKEN': document.querySelector('meta[name=csrf-token]').getAttribute('content')
                         },
                         credentials: 'same-origin'
                     })
@@ -69,7 +69,7 @@
                     fetch('/api/accounts/{{ auth()->user()->accounts->first()->uuid }}/balances', {
                         headers: {
                             'Accept': 'application/json',
-                            'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+                            'X-CSRF-TOKEN': document.querySelector('meta[name=csrf-token]').getAttribute('content')
                         },
                         credentials: 'same-origin'
                     })
@@ -106,7 +106,7 @@
                     fetch('/api/accounts/{{ auth()->user()->accounts->first()->uuid }}/balances?asset=GCU', {
                         headers: {
                             'Accept': 'application/json',
-                            'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+                            'X-CSRF-TOKEN': document.querySelector('meta[name=csrf-token]').getAttribute('content')
                         },
                         credentials: 'same-origin'
                     })
@@ -185,7 +185,7 @@
                         fetch('/api/accounts/{{ auth()->user()->accounts->first()->uuid }}/balances', {
                             headers: {
                                 'Accept': 'application/json',
-                                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+                                'X-CSRF-TOKEN': document.querySelector('meta[name=csrf-token]').getAttribute('content')
                             },
                             credentials: 'same-origin'
                         })


### PR DESCRIPTION
## Summary
- Fixed SQL error on dashboard caused by incorrect transactions relationship
- Fixed x-init attribute syntax error in GCU wallet component

## Changes Made
1. **Fixed Account->transactions() relationship**
   - Changed foreign key from `account_uuid` to `aggregate_uuid` 
   - The transactions table uses event sourcing pattern with aggregate_uuid column
   
2. **Fixed x-init attribute syntax**
   - Removed nested double quotes in document.querySelector calls
   - Changed `'meta[name="csrf-token"]'` to `'meta[name=csrf-token]'`

## Test plan
- [x] Dashboard loads without SQL errors
- [x] GCU wallet component renders correctly
- [ ] Account tests pass with updated relationship
- [ ] Browser console shows no JavaScript errors

🤖 Generated with [Claude Code](https://claude.ai/code)