### PR TITLE
Fix deposit page errors

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -41,5 +41,6 @@
         @stack('modals')
 
         @livewireScripts
+        @stack('scripts')
     </body>
 </html>

--- a/resources/views/wallet/deposit-manual.blade.php
+++ b/resources/views/wallet/deposit-manual.blade.php
@@ -1,12 +1,10 @@
-@extends('layouts.app')
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Manual Bank Transfer') }}
+        </h2>
+    </x-slot>
 
-@section('header')
-    <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
-        {{ __('Manual Bank Transfer') }}
-    </h2>
-@endsection
-
-@section('content')
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
@@ -77,4 +75,4 @@
             </div>
         </div>
     </div>
-@endsection
+</x-app-layout>


### PR DESCRIPTION
## Summary
- Fixed "Undefined variable $slot" error on manual deposit page by converting from @extends to component syntax
- Fixed OpenBanking bank selection JavaScript not working by adding missing @stack('scripts') to app layout

## Test plan
- [x] Visit /wallet/deposit/manual - page should load without errors
- [x] Visit /wallet/deposit/openbanking - clicking on banks should show the deposit form

🤖 Generated with [Claude Code](https://claude.ai/code)