### PR TITLE
Add platform banners to authenticated pages

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -18,6 +18,7 @@
         @livewireStyles
     </head>
     <body class="font-sans antialiased">
+        <x-platform-banners />
         <x-banner />
 
         <div class="min-h-screen bg-gray-100 dark:bg-gray-900">


### PR DESCRIPTION
## Summary
- Added alpha testing and CGO investment banners to all authenticated pages
- Ensures consistent messaging across the entire platform

## Changes
- Added `<x-platform-banners />` component to `layouts/app.blade.php`
- This affects all authenticated pages that use the app layout (dashboard, wallet, transactions, etc.)

## Test plan
- [x] Visit dashboard page - banners should appear at the top
- [x] Navigate to wallet pages - banners should persist
- [x] Check other authenticated pages - banners should be consistent

🤖 Generated with [Claude Code](https://claude.ai/code)