### PR TITLE
fix: Correct blog route name from blog.index to blog

### DIFF
--- a/resources/views/blog/index.blade.php
+++ b/resources/views/blog/index.blade.php
@@ -173,7 +173,7 @@
             @if($recentPosts->count() == 6)
             <!-- Load More -->
             <div class="text-center mt-12">
-                <a href="{{ route('blog.index') }}?page=2" class="bg-blue-600 text-white px-8 py-3 rounded-lg font-semibold hover:bg-blue-700 transition duration-200 inline-block">
+                <a href="{{ route('blog') }}?page=2" class="bg-blue-600 text-white px-8 py-3 rounded-lg font-semibold hover:bg-blue-700 transition duration-200 inline-block">
                     View All Posts
                 </a>
             </div>


### PR DESCRIPTION
## Summary
Fixes route not found error on blog page

## Issue
The blog index view was using `route('blog.index')` but the actual route name is just `blog`, causing a "Route [blog.index] not defined" error.

## Fix
Updated the route reference in the blog index view from `blog.index` to `blog`

## Test plan
- Visit /blog
- Verify the page loads without errors
- Check that the "View All Posts" button works correctly