### PR TITLE
Reorganize navigation menu and move Invest to floating elements

### DIFF
--- a/resources/views/components/floating-invest-cta.blade.php
+++ b/resources/views/components/floating-invest-cta.blade.php
@@ -1,0 +1,41 @@
+@props(['show' => true])
+
+@if($show && !auth()->user()->cgoInvestments()->exists())
+<div x-data="{ 
+    show: false,
+    dismissed: false,
+    handleScroll() {
+        if (this.dismissed) return;
+        this.show = window.scrollY > 300;
+    }
+}" 
+    x-init="window.addEventListener('scroll', handleScroll)"
+    x-show="show"
+    x-transition:enter="transition ease-out duration-300"
+    x-transition:enter-start="transform translate-y-full"
+    x-transition:enter-end="transform translate-y-0"
+    x-transition:leave="transition ease-in duration-300"
+    x-transition:leave-start="transform translate-y-0"
+    x-transition:leave-end="transform translate-y-full"
+    class="fixed bottom-6 right-6 z-50">
+    
+    <div class="relative">
+        <a href="{{ route('cgo.invest') }}" 
+           class="flex items-center px-6 py-3 bg-gradient-to-r from-yellow-400 to-orange-500 text-white font-bold rounded-full shadow-lg hover:shadow-xl transform hover:scale-105 transition duration-200 ease-out">
+            <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+            </svg>
+            Invest in CGO
+        </a>
+        
+        <!-- Close button -->
+        <button @click="show = false; dismissed = true" 
+                class="absolute -top-2 -right-2 bg-white dark:bg-gray-800 rounded-full p-1 shadow-md hover:bg-gray-100 dark:hover:bg-gray-700 transition duration-150 ease-in-out"
+                aria-label="Dismiss">
+            <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+            </svg>
+        </button>
+    </div>
+</div>
+@endif

--- a/resources/views/components/invest-banner.blade.php
+++ b/resources/views/components/invest-banner.blade.php
@@ -1,0 +1,52 @@
+@props(['class' => ''])
+
+<div {{ $attributes->merge(['class' => 'relative bg-gradient-to-r from-purple-600 to-indigo-600 rounded-lg shadow-lg overflow-hidden ' . $class]) }}>
+    <div class="absolute inset-0 bg-black opacity-10"></div>
+    <div class="relative px-6 py-4 sm:px-8 sm:py-6">
+        <div class="flex flex-col sm:flex-row items-center justify-between">
+            <div class="mb-4 sm:mb-0">
+                <h3 class="text-lg sm:text-xl font-bold text-white mb-1">
+                    Join the CGO Investment Round
+                </h3>
+                <p class="text-sm sm:text-base text-purple-100">
+                    Be part of the future of decentralized finance. Limited spots available!
+                </p>
+            </div>
+            <div class="flex items-center space-x-4">
+                <a href="{{ route('cgo') }}" 
+                   class="inline-flex items-center px-4 py-2 bg-white text-purple-600 font-medium rounded-lg hover:bg-purple-50 transition duration-150 ease-in-out shadow-md">
+                    <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"></path>
+                    </svg>
+                    Learn More
+                </a>
+                @auth
+                    @if(auth()->user()->hasVerifiedEmail())
+                        <a href="{{ route('cgo.invest') }}" 
+                           class="inline-flex items-center px-4 py-2 bg-yellow-400 text-purple-900 font-bold rounded-lg hover:bg-yellow-300 transition duration-150 ease-in-out shadow-md">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                            </svg>
+                            Invest Now
+                        </a>
+                    @endif
+                @endauth
+            </div>
+        </div>
+        
+        <!-- Decorative elements -->
+        <div class="absolute -top-10 -right-10 w-40 h-40 bg-purple-500 rounded-full opacity-20"></div>
+        <div class="absolute -bottom-10 -left-10 w-32 h-32 bg-indigo-500 rounded-full opacity-20"></div>
+    </div>
+    
+    <!-- Close button -->
+    <button 
+        x-data
+        @click="$el.closest('.invest-banner-container').remove()"
+        class="absolute top-2 right-2 text-white hover:text-purple-200 transition duration-150 ease-in-out"
+        aria-label="Close banner">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+        </svg>
+    </button>
+</div>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -104,6 +104,13 @@
 
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <!-- Investment Banner -->
+            @if(!session('hide_invest_banner') && !auth()->user()->cgoInvestments()->exists())
+                <div class="invest-banner-container mb-8">
+                    <x-invest-banner />
+                </div>
+            @endif
+            
             <!-- Quick Stats -->
             <div class="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
                 <!-- Total Balance -->

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -38,6 +38,9 @@
                 {{ $slot }}
             </main>
         </div>
+        
+        <!-- Floating Investment CTA -->
+        <x-floating-invest-cta />
 
         @stack('modals')
 

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -74,30 +74,6 @@
                                         {{ __('Fund Flow') }}
                                     </div>
                                 </x-dropdown-link>
-                                <x-dropdown-link href="{{ route('exchange-rates.index') }}">
-                                    <div class="flex items-center">
-                                        <svg class="w-4 h-4 mr-2 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                                        </svg>
-                                        {{ __('Exchange Rates') }}
-                                    </div>
-                                </x-dropdown-link>
-                                <x-dropdown-link href="{{ route('batch-processing.index') }}">
-                                    <div class="flex items-center">
-                                        <svg class="w-4 h-4 mr-2 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"></path>
-                                        </svg>
-                                        {{ __('Batch Processing') }}
-                                    </div>
-                                </x-dropdown-link>
-                                <x-dropdown-link href="{{ route('asset-management.index') }}">
-                                    <div class="flex items-center">
-                                        <svg class="w-4 h-4 mr-2 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
-                                        </svg>
-                                        {{ __('Asset Management') }}
-                                    </div>
-                                </x-dropdown-link>
                                 <x-dropdown-link href="{{ route('wallet.bank-allocation') }}">
                                     <div class="flex items-center">
                                         <svg class="w-4 h-4 mr-2 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -117,16 +93,6 @@
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"></path>
                             </svg>
                             {{ __('Governance') }}
-                        </div>
-                    </x-nav-link>
-                    
-                    <!-- Invest -->
-                    <x-nav-link href="{{ route('cgo') }}" :active="request()->routeIs('cgo*')">
-                        <div class="flex items-center">
-                            <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                            </svg>
-                            {{ __('Invest') }}
                         </div>
                     </x-nav-link>
                     
@@ -239,66 +205,6 @@
                             </x-dropdown>
                         </div>
                     @endcanany
-                    
-                    <!-- Quick Actions Dropdown -->
-                    <div class="hidden sm:flex sm:items-center">
-                        <x-dropdown align="left" width="48">
-                            <x-slot name="trigger">
-                                <button class="flex items-center text-sm font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 focus:outline-none transition duration-150 ease-in-out">
-                                    <div>{{ __('Quick Actions') }}</div>
-                                    <div class="ms-1">
-                                        <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-                                            <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
-                                        </svg>
-                                    </div>
-                                </button>
-                            </x-slot>
-                            
-                            <x-slot name="content">
-                                <x-dropdown-link href="{{ route('wallet.deposit') }}">
-                                    <div class="flex items-center">
-                                        <svg class="w-4 h-4 mr-2 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
-                                        </svg>
-                                        {{ __('Deposit Funds') }}
-                                    </div>
-                                </x-dropdown-link>
-                                <x-dropdown-link href="{{ route('wallet.withdraw') }}">
-                                    <div class="flex items-center">
-                                        <svg class="w-4 h-4 mr-2 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4"></path>
-                                        </svg>
-                                        {{ __('Withdraw Funds') }}
-                                    </div>
-                                </x-dropdown-link>
-                                <x-dropdown-link href="{{ route('wallet.transfer') }}">
-                                    <div class="flex items-center">
-                                        <svg class="w-4 h-4 mr-2 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"></path>
-                                        </svg>
-                                        {{ __('Transfer Money') }}
-                                    </div>
-                                </x-dropdown-link>
-                                <x-dropdown-link href="{{ route('wallet.convert') }}">
-                                    <div class="flex items-center">
-                                        <svg class="w-4 h-4 mr-2 text-purple-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                                        </svg>
-                                        {{ __('Convert Currency') }}
-                                    </div>
-                                </x-dropdown-link>
-                                <div class="border-t border-gray-100 dark:border-gray-600"></div>
-                                <x-dropdown-link href="{{ route('gcu.trading') }}">
-                                    <div class="flex items-center">
-                                        <svg class="w-4 h-4 mr-2 text-yellow-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"></path>
-                                        </svg>
-                                        {{ __('Trade GCU') }}
-                                    </div>
-                                </x-dropdown-link>
-                            </x-slot>
-                        </x-dropdown>
-                    </div>
                 </div>
             </div>
 
@@ -433,20 +339,20 @@
                 {{ __('Dashboard') }}
             </x-responsive-nav-link>
             
-            <x-responsive-nav-link href="{{ route('wallet') }}" :active="request()->routeIs('wallet')">
+            <x-responsive-nav-link href="{{ route('wallet.index') }}" :active="request()->routeIs('wallet.index')">
                 {{ __('Wallet') }}
             </x-responsive-nav-link>
             
             <!-- Banking Section -->
             <div class="border-t border-gray-200 dark:border-gray-600"></div>
             <div class="block px-4 py-2 text-xs text-gray-400">{{ __('Banking') }}</div>
-            <x-responsive-nav-link href="{{ route('transactions.index') }}" :active="request()->routeIs('transactions.*')">
+            <x-responsive-nav-link href="{{ route('wallet.transactions') }}" :active="request()->routeIs('wallet.transactions')">
                 {{ __('Transactions') }}
             </x-responsive-nav-link>
-            <x-responsive-nav-link href="{{ route('transaction.status') }}" :active="request()->routeIs('transaction.status')">
+            <x-responsive-nav-link href="{{ route('transactions.status') }}" :active="request()->routeIs('transactions.status.*')">
                 {{ __('Track Status') }}
             </x-responsive-nav-link>
-            <x-responsive-nav-link href="{{ route('fund-flow') }}" :active="request()->routeIs('fund-flow')">
+            <x-responsive-nav-link href="{{ route('fund-flow.index') }}" :active="request()->routeIs('fund-flow.*')">
                 {{ __('Fund Flow') }}
             </x-responsive-nav-link>
             
@@ -454,30 +360,6 @@
             <div class="border-t border-gray-200 dark:border-gray-600"></div>
             <x-responsive-nav-link href="{{ route('wallet.voting') }}" :active="request()->routeIs('wallet.voting')">
                 {{ __('Governance') }}
-            </x-responsive-nav-link>
-            
-            <!-- Invest -->
-            <x-responsive-nav-link href="{{ route('cgo') }}" :active="request()->routeIs('cgo*')">
-                {{ __('Invest') }}
-            </x-responsive-nav-link>
-            
-            <!-- Quick Actions -->
-            <div class="border-t border-gray-200 dark:border-gray-600"></div>
-            <div class="block px-4 py-2 text-xs text-gray-400">{{ __('Quick Actions') }}</div>
-            <x-responsive-nav-link href="{{ route('wallet.deposit') }}">
-                {{ __('Deposit Funds') }}
-            </x-responsive-nav-link>
-            <x-responsive-nav-link href="{{ route('wallet.withdraw') }}">
-                {{ __('Withdraw Funds') }}
-            </x-responsive-nav-link>
-            <x-responsive-nav-link href="{{ route('wallet.transfer') }}">
-                {{ __('Transfer Money') }}
-            </x-responsive-nav-link>
-            <x-responsive-nav-link href="{{ route('wallet.convert') }}">
-                {{ __('Convert Currency') }}
-            </x-responsive-nav-link>
-            <x-responsive-nav-link href="{{ route('gcu.trading') }}">
-                {{ __('Trade GCU') }}
             </x-responsive-nav-link>
         </div>
 

--- a/resources/views/wallet/index.blade.php
+++ b/resources/views/wallet/index.blade.php
@@ -7,6 +7,13 @@
 
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <!-- Investment Banner -->
+            @if(!session('hide_invest_banner_wallet') && !auth()->user()->cgoInvestments()->exists())
+                <div class="invest-banner-container mb-8">
+                    <x-invest-banner class="mb-0" />
+                </div>
+            @endif
+            
             <!-- Account Status Alert -->
             @if(!auth()->user()->accounts->first())
                 <div class="mb-6 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-400 dark:border-yellow-600 text-yellow-800 dark:text-yellow-200 px-6 py-4 rounded-lg">


### PR DESCRIPTION
## Summary
- Reorganized authenticated navigation menu to reduce clutter
- Moved "Invest" option from top menu to floating banners and CTAs
- Simplified menu structure for better user experience

## Changes Made

### Navigation Menu Cleanup
- **Removed "Invest"** from main navigation - now uses floating elements
- **Removed "Quick Actions" dropdown** - these actions are already in the dashboard
- **Simplified "Banking" dropdown** - removed less-used items (exchange rates, batch processing, asset management)
- Fixed responsive menu routes to match desktop navigation

### New Investment UI Elements
1. **Investment Banner Component** (`invest-banner.blade.php`)
   - Attractive gradient banner with investment CTA
   - Appears on dashboard and wallet pages
   - Dismissible with close button
   - Only shows for users who haven't invested yet

2. **Floating Investment CTA** (`floating-invest-cta.blade.php`)
   - Appears when user scrolls down (after 300px)
   - Fixed position bottom-right
   - Dismissible and won't reappear after dismissal
   - Eye-catching design with gradient background

### User Experience Improvements
- Cleaner, less cluttered navigation menu
- Investment opportunities are more prominent with dedicated UI elements
- Quick actions remain easily accessible from dashboard
- Consistent navigation between desktop and mobile views

## Screenshots
The navigation is now cleaner with investment promoted through banners rather than menu items.

## Testing
- All navigation tests pass ✅
- Views compile without errors ✅
- Routes are correctly referenced ✅

🤖 Generated with [Claude Code](https://claude.ai/code)