### PR TITLE
fix: Fix N+1 query issues with eager loading

### DIFF
--- a/app/Http/Controllers/Api/AssetController.php
+++ b/app/Http/Controllers/Api/AssetController.php
@@ -200,9 +200,13 @@ class AssetController extends Controller
             );
         }
 
-        // Calculate statistics
-        $totalAccounts = $asset->accountBalances()->count();
-        $totalBalance = $asset->accountBalances()->sum('balance');
+        // Calculate statistics with a single query
+        $balanceStats = $asset->accountBalances()
+            ->selectRaw('COUNT(*) as total_accounts, COALESCE(SUM(balance), 0) as total_balance')
+            ->first();
+
+        $totalAccounts = $balanceStats->total_accounts ?? 0;
+        $totalBalance = $balanceStats->total_balance ?? 0;
         $activeRates = $asset->exchangeRatesFrom()->valid()->count();
 
         // Format balance according to asset precision

--- a/app/Http/Controllers/Api/BasketController.php
+++ b/app/Http/Controllers/Api/BasketController.php
@@ -65,7 +65,7 @@ class BasketController extends Controller
     {
         $query = BasketAsset::with([
             'components.asset',
-            'latestValue' // This is already defined as a hasOne relationship
+            'latestValue', // This is already defined as a hasOne relationship
         ]);
 
         if ($request->has('type')) {

--- a/app/Http/Controllers/Api/BasketController.php
+++ b/app/Http/Controllers/Api/BasketController.php
@@ -63,7 +63,10 @@ class BasketController extends Controller
      */
     public function index(Request $request): JsonResponse
     {
-        $query = BasketAsset::with(['components.asset']);
+        $query = BasketAsset::with([
+            'components.asset',
+            'latestValue' // This is already defined as a hasOne relationship
+        ]);
 
         if ($request->has('type')) {
             $query->where('type', $request->input('type'));
@@ -75,7 +78,7 @@ class BasketController extends Controller
 
         $baskets = $query->get()->map(
             function ($basket) {
-                $latestValue = $basket->values()->latest('calculated_at')->first();
+                $latestValue = $basket->latestValue;
 
                 return [
                     'code'                => $basket->code,

--- a/app/Http/Controllers/Api/UserVotingController.php
+++ b/app/Http/Controllers/Api/UserVotingController.php
@@ -43,8 +43,17 @@ class UserVotingController extends Controller
      */
     public function getActivePolls(): JsonResponse
     {
+        $user = Auth::user();
+
         $polls = Poll::where('status', PollStatus::ACTIVE)
             ->where('end_date', '>', now())
+            ->with(['votes' => function ($query) use ($user) {
+                if ($user) {
+                    $query->where('user_uuid', $user->uuid);
+                }
+            }])
+            ->withCount('votes')
+            ->withSum('votes', 'voting_power')
             ->orderBy('end_date', 'asc')
             ->get();
 

--- a/app/Http/Resources/UserVotingPollResource.php
+++ b/app/Http/Resources/UserVotingPollResource.php
@@ -25,8 +25,8 @@ class UserVotingPollResource extends JsonResource
             $strategy = app($this->voting_power_strategy ?? AssetWeightedVotingStrategy::class);
             $votingPower = $strategy->calculatePower($user, $this->resource);
 
-            // Check if user has voted
-            $userVote = $this->votes()->where('user_uuid', $user->uuid)->first();
+            // Check if user has voted (using eager-loaded relationship)
+            $userVote = $this->resource->votes->first();
             $hasVoted = $userVote !== null;
         }
 
@@ -69,7 +69,8 @@ class UserVotingPollResource extends JsonResource
      */
     private function calculateParticipation(): float
     {
-        $totalVotingPower = $this->votes()->sum('voting_power');
+        // Use the eager-loaded aggregate value
+        $totalVotingPower = $this->resource->votes_sum_voting_power ?? 0;
         $potentialVotingPower = $this->estimatePotentialVotingPower();
 
         if ($potentialVotingPower === 0) {

--- a/tests/Feature/Http/Controllers/Api/N1QueryOptimizationTest.php
+++ b/tests/Feature/Http/Controllers/Api/N1QueryOptimizationTest.php
@@ -59,12 +59,12 @@ class N1QueryOptimizationTest extends TestCase
         // Create baskets with components and values
         for ($i = 1; $i <= 10; $i++) {
             $basket = BasketAsset::create([
-                'code' => 'BSKT' . $i,
-                'name' => 'Test Basket ' . $i,
-                'type' => 'fixed',
+                'code'                => 'BSKT' . $i,
+                'name'                => 'Test Basket ' . $i,
+                'type'                => 'fixed',
                 'rebalance_frequency' => 'never',
-                'is_active' => true,
-                'created_by' => $user->uuid,
+                'is_active'           => true,
+                'created_by'          => $user->uuid,
             ]);
 
             // Create components
@@ -75,9 +75,9 @@ class N1QueryOptimizationTest extends TestCase
 
                 BasketComponent::create([
                     'basket_asset_id' => $basket->id,
-                    'asset_code' => $asset->code,
-                    'weight' => $weight,
-                    'is_active' => true,
+                    'asset_code'      => $asset->code,
+                    'weight'          => $weight,
+                    'is_active'       => true,
                 ]);
             }
 
@@ -85,8 +85,8 @@ class N1QueryOptimizationTest extends TestCase
             for ($j = 1; $j <= 5; $j++) {
                 BasketValue::create([
                     'basket_asset_code' => $basket->code,
-                    'value' => rand(1000, 5000) / 100,
-                    'calculated_at' => now()->subDays($j),
+                    'value'             => rand(1000, 5000) / 100,
+                    'calculated_at'     => now()->subDays($j),
                 ]);
             }
         }
@@ -131,8 +131,8 @@ class N1QueryOptimizationTest extends TestCase
         $asset = Asset::firstOrCreate(
             ['code' => 'BTC'],
             [
-                'name' => 'Bitcoin',
-                'type' => 'crypto',
+                'name'      => 'Bitcoin',
+                'type'      => 'crypto',
                 'precision' => 8,
                 'is_active' => true,
             ]
@@ -140,24 +140,24 @@ class N1QueryOptimizationTest extends TestCase
 
         // Create account and balances
         $account = Account::create([
-            'uuid' => Str::uuid()->toString(),
-            'name' => 'Test Account',
+            'uuid'      => Str::uuid()->toString(),
+            'name'      => 'Test Account',
             'user_uuid' => $user->uuid,
-            'balance' => 0,
+            'balance'   => 0,
         ]);
 
         // Create 10 different accounts with balances
         for ($i = 0; $i < 10; $i++) {
             $otherAccount = Account::create([
-                'uuid' => Str::uuid()->toString(),
-                'name' => 'Other Account ' . $i,
+                'uuid'      => Str::uuid()->toString(),
+                'name'      => 'Other Account ' . $i,
                 'user_uuid' => $user->uuid,
-                'balance' => 0,
+                'balance'   => 0,
             ]);
 
             AccountBalance::firstOrCreate([
                 'account_uuid' => $otherAccount->uuid,
-                'asset_code' => $asset->code,
+                'asset_code'   => $asset->code,
             ], [
                 'balance' => rand(1000, 10000),
             ]);
@@ -202,32 +202,32 @@ class N1QueryOptimizationTest extends TestCase
         // Create polls
         for ($i = 1; $i <= 10; $i++) {
             $poll = Poll::create([
-                'uuid' => Str::uuid()->toString(),
-                'title' => 'Test Poll ' . $i,
+                'uuid'        => Str::uuid()->toString(),
+                'title'       => 'Test Poll ' . $i,
                 'description' => 'Test poll description',
-                'type' => 'single_choice',
-                'status' => 'active',
-                'options' => [
+                'type'        => 'single_choice',
+                'status'      => 'active',
+                'options'     => [
                     ['value' => 'option1', 'label' => 'Option 1'],
                     ['value' => 'option2', 'label' => 'Option 2'],
                 ],
-                'start_date' => now()->subDay(),
-                'end_date' => now()->addDays(7),
-                'created_by' => $user->uuid,
+                'start_date'             => now()->subDay(),
+                'end_date'               => now()->addDays(7),
+                'created_by'             => $user->uuid,
                 'required_participation' => 0,
-                'allow_multiple_votes' => false,
-                'voting_power_strategy' => null,
-                'execution_strategy' => null,
-                'metadata' => [],
+                'allow_multiple_votes'   => false,
+                'voting_power_strategy'  => null,
+                'execution_strategy'     => null,
+                'metadata'               => [],
             ]);
 
             // Create votes for first 5 polls
             if ($i <= 5) {
                 Vote::create([
-                    'poll_uuid' => $poll->uuid,
-                    'user_uuid' => $user->uuid,
+                    'poll_uuid'        => $poll->uuid,
+                    'user_uuid'        => $user->uuid,
                     'selected_options' => ['option1'],
-                    'voting_power' => rand(100, 1000),
+                    'voting_power'     => rand(100, 1000),
                 ]);
             }
         }
@@ -272,9 +272,9 @@ class N1QueryOptimizationTest extends TestCase
 
         foreach ($queries as $index => $query) {
             dump([
-                'query' => $query['query'],
+                'query'    => $query['query'],
                 'bindings' => $query['bindings'],
-                'time' => $query['time'] ?? null,
+                'time'     => $query['time'] ?? null,
             ]);
         }
     }

--- a/tests/Feature/Http/Controllers/Api/N1QueryOptimizationTest.php
+++ b/tests/Feature/Http/Controllers/Api/N1QueryOptimizationTest.php
@@ -1,0 +1,283 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers\Api;
+
+use App\Domain\Account\Models\Account;
+use App\Domain\Account\Models\AccountBalance;
+use App\Domain\Asset\Models\Asset;
+use App\Domain\Basket\Models\BasketAsset;
+use App\Domain\Basket\Models\BasketComponent;
+use App\Domain\Basket\Models\BasketValue;
+use App\Domain\Governance\Enums\PollStatus;
+use App\Domain\Governance\Enums\PollType;
+use App\Domain\Governance\Models\Poll;
+use App\Domain\Governance\Models\Vote;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class N1QueryOptimizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Enable query logging
+        DB::enableQueryLog();
+    }
+
+    protected function tearDown(): void
+    {
+        // Clear query log
+        DB::disableQueryLog();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test that BasketController index doesn't have N+1 queries.
+     */
+    public function test_basket_controller_index_no_n1_queries(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        // Create test assets
+        $assets = [];
+        for ($i = 1; $i <= 5; $i++) {
+            $assets[] = Asset::create([
+                'code' => 'TST' . $i,
+                'name' => 'Test Asset ' . $i,
+                'type' => 'crypto',
+                'precision' => 8,
+                'is_active' => true,
+            ]);
+        }
+
+        // Create baskets with components and values
+        for ($i = 1; $i <= 10; $i++) {
+            $basket = BasketAsset::create([
+                'code' => 'BSKT' . $i,
+                'name' => 'Test Basket ' . $i,
+                'type' => 'fixed',
+                'rebalance_frequency' => 'never',
+                'is_active' => true,
+                'created_by' => $user->uuid,
+            ]);
+
+            // Create components
+            $totalWeight = 0;
+            foreach (array_slice($assets, 0, 3) as $index => $asset) {
+                $weight = $index === 2 ? (100 - $totalWeight) : rand(20, 40);
+                $totalWeight += $weight;
+
+                BasketComponent::create([
+                    'basket_asset_id' => $basket->id,
+                    'asset_code' => $asset->code,
+                    'weight' => $weight,
+                    'is_active' => true,
+                ]);
+            }
+
+            // Create values
+            for ($j = 1; $j <= 5; $j++) {
+                BasketValue::create([
+                    'basket_asset_code' => $basket->code,
+                    'value' => rand(1000, 5000) / 100,
+                    'calculated_at' => now()->subDays($j),
+                ]);
+            }
+        }
+
+        // Clear query log before making the request
+        DB::flushQueryLog();
+
+        // Make the request
+        $response = $this->getJson('/api/v2/baskets');
+
+        $response->assertSuccessful();
+
+        // Analyze queries
+        $queries = collect(DB::getQueryLog());
+
+        // Count SELECT queries
+        $selectQueries = $queries->filter(function ($query) {
+            return str_starts_with($query['query'], 'select');
+        });
+
+        // We should have:
+        // 1. Query to get baskets
+        // 2. Query to get components with assets (eager loaded)
+        // 3. Query to get latest values (eager loaded)
+        // Total: 3 queries regardless of basket count
+        $this->assertLessThanOrEqual(
+            4,
+            $selectQueries->count(),
+            'Too many queries detected. Possible N+1 query issue.'
+        );
+    }
+
+    /**
+     * Test that AssetController show doesn't have N+1 queries.
+     */
+    public function test_asset_controller_show_no_n1_queries(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        // Create test asset
+        $asset = Asset::firstOrCreate(
+            ['code' => 'BTC'],
+            [
+                'name' => 'Bitcoin',
+                'type' => 'crypto',
+                'precision' => 8,
+                'is_active' => true,
+            ]
+        );
+
+        // Create account and balances
+        $account = Account::create([
+            'uuid' => Str::uuid()->toString(),
+            'name' => 'Test Account',
+            'user_uuid' => $user->uuid,
+            'balance' => 0,
+        ]);
+
+        // Create 10 different accounts with balances
+        for ($i = 0; $i < 10; $i++) {
+            $otherAccount = Account::create([
+                'uuid' => Str::uuid()->toString(),
+                'name' => 'Other Account ' . $i,
+                'user_uuid' => $user->uuid,
+                'balance' => 0,
+            ]);
+
+            AccountBalance::firstOrCreate([
+                'account_uuid' => $otherAccount->uuid,
+                'asset_code' => $asset->code,
+            ], [
+                'balance' => rand(1000, 10000),
+            ]);
+        }
+
+        // Clear query log before making the request
+        DB::flushQueryLog();
+
+        // Make the request
+        $response = $this->getJson('/api/assets/BTC');
+
+        $response->assertSuccessful();
+
+        // Analyze queries
+        $queries = collect(DB::getQueryLog());
+
+        // Count SELECT queries
+        $selectQueries = $queries->filter(function ($query) {
+            return str_starts_with($query['query'], 'select');
+        });
+
+        // We should have:
+        // 1. Query to get the asset
+        // 2. Single query to get balance statistics (count and sum)
+        // 3. Query to count exchange rates
+        // Total: 3 queries
+        $this->assertLessThanOrEqual(
+            4,
+            $selectQueries->count(),
+            'Too many queries detected. Possible N+1 query issue.'
+        );
+    }
+
+    /**
+     * Test that UserVotingController getActivePolls doesn't have N+1 queries.
+     */
+    public function test_user_voting_controller_no_n1_queries(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        // Create polls
+        for ($i = 1; $i <= 10; $i++) {
+            $poll = Poll::create([
+                'uuid' => Str::uuid()->toString(),
+                'title' => 'Test Poll ' . $i,
+                'description' => 'Test poll description',
+                'type' => 'single_choice',
+                'status' => 'active',
+                'options' => [
+                    ['value' => 'option1', 'label' => 'Option 1'],
+                    ['value' => 'option2', 'label' => 'Option 2'],
+                ],
+                'start_date' => now()->subDay(),
+                'end_date' => now()->addDays(7),
+                'created_by' => $user->uuid,
+                'required_participation' => 0,
+                'allow_multiple_votes' => false,
+                'voting_power_strategy' => null,
+                'execution_strategy' => null,
+                'metadata' => [],
+            ]);
+
+            // Create votes for first 5 polls
+            if ($i <= 5) {
+                Vote::create([
+                    'poll_uuid' => $poll->uuid,
+                    'user_uuid' => $user->uuid,
+                    'selected_options' => ['option1'],
+                    'voting_power' => rand(100, 1000),
+                ]);
+            }
+        }
+
+        // Clear query log before making the request
+        DB::flushQueryLog();
+
+        // Make the request
+        $response = $this->getJson('/api/voting/polls');
+
+        $response->assertSuccessful();
+
+        // Analyze queries
+        $queries = collect(DB::getQueryLog());
+
+        // Count SELECT queries
+        $selectQueries = $queries->filter(function ($query) {
+            return str_starts_with($query['query'], 'select');
+        });
+
+        // We should have:
+        // 1. Query to get polls
+        // 2. Query to get user's votes (eager loaded)
+        // 3. Query to count votes (aggregate)
+        // 4. Query to sum voting power (aggregate)
+        // Total: 4 queries regardless of poll count
+        $this->assertLessThanOrEqual(
+            5,
+            $selectQueries->count(),
+            'Too many queries detected. Possible N+1 query issue.'
+        );
+    }
+
+    /**
+     * Helper to debug queries when tests fail.
+     */
+    private function debugQueries(): void
+    {
+        $queries = DB::getQueryLog();
+
+        dump('Total queries: ' . count($queries));
+
+        foreach ($queries as $index => $query) {
+            dump([
+                'query' => $query['query'],
+                'bindings' => $query['bindings'],
+                'time' => $query['time'] ?? null,
+            ]);
+        }
+    }
+}

--- a/tests/Feature/Http/Controllers/Api/N1QueryOptimizationTest.php
+++ b/tests/Feature/Http/Controllers/Api/N1QueryOptimizationTest.php
@@ -8,8 +8,6 @@ use App\Domain\Asset\Models\Asset;
 use App\Domain\Basket\Models\BasketAsset;
 use App\Domain\Basket\Models\BasketComponent;
 use App\Domain\Basket\Models\BasketValue;
-use App\Domain\Governance\Enums\PollStatus;
-use App\Domain\Governance\Enums\PollType;
 use App\Domain\Governance\Models\Poll;
 use App\Domain\Governance\Models\Vote;
 use App\Models\User;
@@ -50,9 +48,9 @@ class N1QueryOptimizationTest extends TestCase
         $assets = [];
         for ($i = 1; $i <= 5; $i++) {
             $assets[] = Asset::create([
-                'code' => 'TST' . $i,
-                'name' => 'Test Asset ' . $i,
-                'type' => 'crypto',
+                'code'      => 'TST' . $i,
+                'name'      => 'Test Asset ' . $i,
+                'type'      => 'crypto',
                 'precision' => 8,
                 'is_active' => true,
             ]);


### PR DESCRIPTION
## Summary
- Fixed N+1 query issues in multiple API controllers by implementing proper eager loading
- Added comprehensive tests to prevent regression of N+1 queries
- All changes pass PHPStan and PHPCS checks

## Changes Made

### 1. BasketController (`app/Http/Controllers/Api/BasketController.php`)
- **Issue**: In the `index` method, `$basket->values()->latest('calculated_at')->first()` was being called for each basket
- **Fix**: Added `'latestValue'` to the eager loading relationships

### 2. AssetController (`app/Http/Controllers/Api/AssetController.php`)
- **Issue**: In the `show` method, separate queries were made to count and sum account balances
- **Fix**: Combined both operations into a single query using `selectRaw` with COUNT and SUM aggregations

### 3. UserVotingController (`app/Http/Controllers/Api/UserVotingController.php`)
- **Issue**: The UserVotingPollResource was accessing `$this->votes()` for each poll
- **Fix**: 
  - Added eager loading with `with(['votes'])` filtered by user
  - Added `withCount('votes')` and `withSum('votes', 'voting_power')` for aggregations
  - Updated the resource to use the eager-loaded data

## Test plan
- [x] Created comprehensive N+1 query tests in `tests/Feature/Http/Controllers/Api/N1QueryOptimizationTest.php`
- [x] Tests monitor the number of database queries to ensure they don't increase with more records
- [x] All tests pass for the fixed controllers
- [x] PHPStan analysis passes with no errors
- [x] PHP CodeSniffer passes with no violations

## Performance Impact
These optimizations will significantly improve performance when dealing with collections of models that have relationships, especially as the data grows. For example:
- Loading 100 baskets will now use 3 queries instead of 101+ queries
- Loading asset statistics is now done with a single optimized query
- Loading polls with voting data uses predictable query count regardless of poll count

🤖 Generated with [Claude Code](https://claude.ai/code)