### PR TITLE
feat: Add Google Analytics tracking to all layout templates

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -18,6 +18,16 @@
 
         <!-- Styles -->
         @livewireStyles
+
+        <!-- Google tag (gtag.js) -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-X65KH9NFMY"></script>
+        <script>
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+
+          gtag('config', 'G-X65KH9NFMY');
+        </script>
     </head>
     <body class="font-sans antialiased">
         <x-platform-banners />

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -18,6 +18,16 @@
 
         <!-- Styles -->
         @livewireStyles
+
+        <!-- Google tag (gtag.js) -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-X65KH9NFMY"></script>
+        <script>
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+
+          gtag('config', 'G-X65KH9NFMY');
+        </script>
     </head>
     <body class="font-sans text-gray-900 antialiased">
         <x-platform-banners />

--- a/resources/views/layouts/public.blade.php
+++ b/resources/views/layouts/public.blade.php
@@ -28,6 +28,16 @@
     
     <!-- Custom Styles -->
     @stack('styles')
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-X65KH9NFMY"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-X65KH9NFMY');
+    </script>
 </head>
 <body class="font-sans antialiased">
     <x-platform-banners />


### PR DESCRIPTION
## Summary
- Added Google Analytics tracking code (G-X65KH9NFMY) to all main layout templates
- Ensures comprehensive analytics coverage across the entire application

## Changes
- Modified `resources/views/layouts/app.blade.php` - Added gtag.js script for authenticated user pages
- Modified `resources/views/layouts/guest.blade.php` - Added gtag.js script for guest/auth pages  
- Modified `resources/views/layouts/public.blade.php` - Added gtag.js script for public-facing pages

## Implementation Details
- Google Analytics script placed in the `<head>` section of each layout for optimal tracking performance
- Uses the async loading pattern recommended by Google
- Tracking ID: G-X65KH9NFMY

## Test Plan
1. Verify the Google Analytics script loads correctly on all page types:
   - [x] Authenticated user pages (using app.blade.php)
   - [x] Guest/authentication pages (using guest.blade.php)
   - [x] Public pages (using public.blade.php)
2. Check Google Analytics Real-Time reports to confirm tracking is working
3. Verify no console errors related to the gtag implementation

🤖 Generated with [Claude Code](https://claude.ai/code)