### PR TITLE
fix: Update .env.example with Google Tag Manager CSP source

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -228,6 +228,6 @@ APP_LOCAL_HOSTNAMES=localhost,127.0.0.1,finaegis.local,finaegis.test
 FORCE_HTTPS=false
 CSP_FONT_SOURCES=https://fonts.gstatic.com,https://fonts.bunny.net
 CSP_STYLE_SOURCES=https://fonts.googleapis.com,https://fonts.bunny.net
-CSP_SCRIPT_SOURCES=https://cdn.jsdelivr.net
+CSP_SCRIPT_SOURCES=https://cdn.jsdelivr.net,https://www.googletagmanager.com
 CSP_API_ENDPOINT=https://api.finaegis.org
 CSP_WS_ENDPOINT=wss://ws.finaegis.org

--- a/docs/CSP_DEPLOYMENT_NOTES.md
+++ b/docs/CSP_DEPLOYMENT_NOTES.md
@@ -1,0 +1,63 @@
+# CSP Configuration Deployment Notes
+
+## Important: After Deploying CSP Changes
+
+When updating Content Security Policy (CSP) settings, you must:
+
+1. **Update the .env file on production** to include Google Tag Manager:
+   ```
+   CSP_SCRIPT_SOURCES=https://cdn.jsdelivr.net,https://www.googletagmanager.com
+   ```
+
+2. **Clear the configuration cache**:
+   ```bash
+   php artisan config:clear
+   php artisan config:cache
+   ```
+
+3. **Clear any CDN/proxy caches** if you're using services like Cloudflare
+
+4. **Verify the headers** are being sent correctly:
+   ```bash
+   curl -I https://finaegis.org | grep -i content-security-policy
+   ```
+
+## Environment Variable Priority
+
+The CSP configuration uses this priority:
+1. Environment variables (if set) - **HIGHEST PRIORITY**
+2. Default values in `config/security.php`
+
+If `CSP_SCRIPT_SOURCES` is set in your .env file, it will override the default value in the config file.
+
+## Current Required CSP Sources
+
+### Script Sources
+- `https://cdn.jsdelivr.net` - For CDN scripts
+- `https://www.googletagmanager.com` - For Google Analytics
+
+### Connect Sources  
+- `self` - Same origin
+- API endpoint (configured)
+- WebSocket endpoint (configured)
+- `https://www.google-analytics.com` - Google Analytics data
+- `https://stats.g.doubleclick.net` - Google Analytics data
+
+## Troubleshooting
+
+If CSP errors persist after deployment:
+
+1. Check if the environment variable is set correctly:
+   ```bash
+   php artisan tinker
+   >>> env('CSP_SCRIPT_SOURCES')
+   ```
+
+2. Check the actual CSP header being sent:
+   ```bash
+   curl -s -I https://finaegis.org | grep -A5 -i content-security-policy
+   ```
+
+3. Ensure no web server (nginx/apache) is adding its own CSP headers
+
+4. Check for any caching layers (Cloudflare, Varnish, etc.) that might be caching old headers


### PR DESCRIPTION
## Summary

This PR fixes the persistent CSP issue by updating the .env.example file to include Google Tag Manager in the CSP_SCRIPT_SOURCES.

## Problem

Even after merging the previous CSP fix, the production site was still showing:
```
Refused to load the script 'https://www.googletagmanager.com/gtag/js?id=G-X65KH9NFMY' 
because it violates the following Content Security Policy directive: "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net"
```

## Root Cause

The CSP configuration in Laravel uses this priority:
1. **Environment variables (if set)** - HIGHEST PRIORITY
2. Default values in `config/security.php`

The production environment has `CSP_SCRIPT_SOURCES` set in the .env file, which was overriding our config file changes.

## Changes Made

### 1. Updated `.env.example`
- Changed `CSP_SCRIPT_SOURCES=https://cdn.jsdelivr.net`
- To: `CSP_SCRIPT_SOURCES=https://cdn.jsdelivr.net,https://www.googletagmanager.com`

### 2. Added `docs/CSP_DEPLOYMENT_NOTES.md`
- Documentation explaining CSP configuration priority
- Deployment instructions for clearing config cache
- Troubleshooting steps for CSP issues

## Deployment Instructions

After merging this PR, on the production server:

1. Update the .env file to include the new CSP_SCRIPT_SOURCES value
2. Run `php artisan config:clear` and `php artisan config:cache`
3. Clear any CDN/proxy caches
4. Verify the headers with: `curl -I https://finaegis.org | grep -i content-security-policy`

## Testing

- [x] Verified .env.example includes Google Tag Manager
- [x] Created comprehensive deployment documentation
- [x] Tested that environment variables override config defaults

## Related Issues

Completes the CSP fix for Google Analytics loading on production.