### PR TITLE
fix: Add explicit nullable type declarations for PHP 8.4 compatibility

### DIFF
--- a/app/Domain/Compliance/Models/TransactionMonitoringRule.php
+++ b/app/Domain/Compliance/Models/TransactionMonitoringRule.php
@@ -159,7 +159,7 @@ class TransactionMonitoringRule extends Model
         return $this->auto_escalate;
     }
 
-    public function appliesTo(string $customerType, string $riskLevel, string $country = null, string $currency = null): bool
+    public function appliesTo(string $customerType, string $riskLevel, ?string $country = null, ?string $currency = null): bool
     {
         // Check customer type
         if ($this->applies_to_customer_types && ! in_array($customerType, $this->applies_to_customer_types)) {
@@ -184,7 +184,7 @@ class TransactionMonitoringRule extends Model
         return true;
     }
 
-    public function recordTrigger(bool $isTruePositive = null): void
+    public function recordTrigger(?bool $isTruePositive = null): void
     {
         $this->increment('triggers_count');
         $this->update(['last_triggered_at' => now()]);

--- a/app/Domain/Custodian/Models/CustodianWebhook.php
+++ b/app/Domain/Custodian/Models/CustodianWebhook.php
@@ -184,7 +184,7 @@ class CustodianWebhook extends Model
     /**
      * Mark the webhook as ignored.
      */
-    public function markAsIgnored(string $reason = null): void
+    public function markAsIgnored(?string $reason = null): void
     {
         $this->update(
             [

--- a/app/Domain/Regulatory/Models/RegulatoryThreshold.php
+++ b/app/Domain/Regulatory/Models/RegulatoryThreshold.php
@@ -270,7 +270,7 @@ class RegulatoryThreshold extends Model
         };
     }
 
-    public function getEffectiveAmountThreshold(string $currency = null): float
+    public function getEffectiveAmountThreshold(?string $currency = null): float
     {
         if (! $currency || $currency === $this->currency) {
             return $this->amount_threshold;

--- a/app/Domain/Regulatory/Services/ReportGeneratorService.php
+++ b/app/Domain/Regulatory/Services/ReportGeneratorService.php
@@ -13,7 +13,7 @@ class ReportGeneratorService
     /**
      * Generate report in specified format.
      */
-    public function generateReport(RegulatoryReport $report, string $format = null): string
+    public function generateReport(RegulatoryReport $report, ?string $format = null): string
     {
         $format = $format ?? $report->file_format;
 


### PR DESCRIPTION
## Summary
- Fixed PHP 8.4 deprecation warnings by adding explicit nullable type declarations
- Affected files are in Regulatory, Compliance, and Custodian domains
- All code quality checks pass (PHPStan, PHP CS Fixer, PHPCS)

## Changes
- Add `?string` type to `RegulatoryThreshold::getEffectiveAmountThreshold()`
- Add `?string` type to `ReportGeneratorService::generateReport()`
- Add `?string` type to `CustodianWebhook::markAsIgnored()`
- Add `?string` types to `TransactionMonitoringRule::appliesTo()`
- Add `?bool` type to `TransactionMonitoringRule::recordTrigger()`

## Context
PHP 8.4 now requires explicit nullable type declarations for parameters that accept null values. Previously, parameters with default null values were implicitly nullable, but this is now deprecated.

## Test Plan
- [x] Run performance tests: `./vendor/bin/pest tests/Performance --parallel`
- [x] PHPStan analysis passes
- [x] PHP CS Fixer compliance
- [x] PHPCS compliance
- [x] All tests pass without deprecation warnings

🤖 Generated with [Claude Code](https://claude.ai/code)