### PR TITLE
refactor(agent-protocol): Config-driven fee calculation and interface tests

### DIFF
--- a/tests/Domain/AgentProtocol/Contracts/InterfaceContractTest.php
+++ b/tests/Domain/AgentProtocol/Contracts/InterfaceContractTest.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Domain\AgentProtocol\Contracts;
+
+use App\Domain\AgentProtocol\Contracts\RiskScoringInterface;
+use App\Domain\AgentProtocol\Contracts\TransactionVerifierInterface;
+use App\Domain\AgentProtocol\Contracts\WalletOperationInterface;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionNamedType;
+use ReflectionParameter;
+use Tests\TestCase;
+
+/**
+ * Tests for Agent Protocol interface contracts.
+ *
+ * These tests verify that the interfaces have the expected
+ * method signatures and follow the contract specifications.
+ */
+class InterfaceContractTest extends TestCase
+{
+    /**
+     * Get the type name from a ReflectionParameter or ReflectionMethod return type.
+     */
+    private function getTypeName(ReflectionParameter|ReflectionMethod $reflection): ?string
+    {
+        $type = $reflection instanceof ReflectionParameter
+            ? $reflection->getType()
+            : $reflection->getReturnType();
+
+        if ($type instanceof ReflectionNamedType) {
+            return $type->getName();
+        }
+
+        return $type !== null ? (string) $type : null;
+    }
+
+    public function test_transaction_verifier_interface_has_required_methods(): void
+    {
+        $reflection = new ReflectionClass(TransactionVerifierInterface::class);
+
+        $this->assertTrue($reflection->hasMethod('verify'));
+        $this->assertTrue($reflection->hasMethod('getVerificationLevel'));
+        $this->assertTrue($reflection->hasMethod('calculateRiskScore'));
+        $this->assertTrue($reflection->hasMethod('checkVelocityLimits'));
+    }
+
+    public function test_transaction_verifier_verify_method_signature(): void
+    {
+        $method = new ReflectionMethod(TransactionVerifierInterface::class, 'verify');
+
+        $parameters = $method->getParameters();
+        $this->assertCount(2, $parameters);
+        $this->assertEquals('transactionId', $parameters[0]->getName());
+        $this->assertEquals('string', $this->getTypeName($parameters[0]));
+        $this->assertEquals('transactionData', $parameters[1]->getName());
+        $this->assertEquals('array', $this->getTypeName($parameters[1]));
+
+        $this->assertEquals('array', $this->getTypeName($method));
+    }
+
+    public function test_transaction_verifier_get_verification_level_signature(): void
+    {
+        $method = new ReflectionMethod(TransactionVerifierInterface::class, 'getVerificationLevel');
+
+        $parameters = $method->getParameters();
+        $this->assertCount(1, $parameters);
+        $this->assertEquals('riskScore', $parameters[0]->getName());
+        $this->assertEquals('int', $this->getTypeName($parameters[0]));
+
+        $this->assertEquals('string', $this->getTypeName($method));
+    }
+
+    public function test_transaction_verifier_calculate_risk_score_signature(): void
+    {
+        $method = new ReflectionMethod(TransactionVerifierInterface::class, 'calculateRiskScore');
+
+        $parameters = $method->getParameters();
+        $this->assertCount(1, $parameters);
+        $this->assertEquals('transactionData', $parameters[0]->getName());
+        $this->assertEquals('array', $this->getTypeName($parameters[0]));
+
+        $this->assertEquals('int', $this->getTypeName($method));
+    }
+
+    public function test_transaction_verifier_check_velocity_limits_signature(): void
+    {
+        $method = new ReflectionMethod(TransactionVerifierInterface::class, 'checkVelocityLimits');
+
+        $parameters = $method->getParameters();
+        $this->assertCount(2, $parameters);
+        $this->assertEquals('agentId', $parameters[0]->getName());
+        $this->assertEquals('string', $this->getTypeName($parameters[0]));
+        $this->assertEquals('amount', $parameters[1]->getName());
+        $this->assertEquals('float', $this->getTypeName($parameters[1]));
+
+        $this->assertEquals('array', $this->getTypeName($method));
+    }
+
+    public function test_wallet_operation_interface_has_required_methods(): void
+    {
+        $reflection = new ReflectionClass(WalletOperationInterface::class);
+
+        $this->assertTrue($reflection->hasMethod('getBalance'));
+        $this->assertTrue($reflection->hasMethod('transfer'));
+        $this->assertTrue($reflection->hasMethod('holdFunds'));
+        $this->assertTrue($reflection->hasMethod('releaseFunds'));
+        $this->assertTrue($reflection->hasMethod('hasSufficientBalance'));
+    }
+
+    public function test_wallet_operation_get_balance_signature(): void
+    {
+        $method = new ReflectionMethod(WalletOperationInterface::class, 'getBalance');
+
+        $parameters = $method->getParameters();
+        $this->assertCount(2, $parameters);
+        $this->assertEquals('walletId', $parameters[0]->getName());
+        $this->assertEquals('string', $this->getTypeName($parameters[0]));
+        $this->assertEquals('currency', $parameters[1]->getName());
+        $this->assertTrue($parameters[1]->allowsNull());
+
+        $this->assertEquals('array', $this->getTypeName($method));
+    }
+
+    public function test_wallet_operation_transfer_signature(): void
+    {
+        $method = new ReflectionMethod(WalletOperationInterface::class, 'transfer');
+
+        $parameters = $method->getParameters();
+        $this->assertCount(5, $parameters);
+        $this->assertEquals('fromWalletId', $parameters[0]->getName());
+        $this->assertEquals('toWalletId', $parameters[1]->getName());
+        $this->assertEquals('amount', $parameters[2]->getName());
+        $this->assertEquals('float', $this->getTypeName($parameters[2]));
+        $this->assertEquals('currency', $parameters[3]->getName());
+        $this->assertEquals('metadata', $parameters[4]->getName());
+
+        $this->assertEquals('array', $this->getTypeName($method));
+    }
+
+    public function test_wallet_operation_hold_funds_signature(): void
+    {
+        $method = new ReflectionMethod(WalletOperationInterface::class, 'holdFunds');
+
+        $parameters = $method->getParameters();
+        $this->assertCount(5, $parameters);
+        $this->assertEquals('walletId', $parameters[0]->getName());
+        $this->assertEquals('amount', $parameters[1]->getName());
+        $this->assertEquals('float', $this->getTypeName($parameters[1]));
+        $this->assertEquals('currency', $parameters[2]->getName());
+        $this->assertEquals('reason', $parameters[3]->getName());
+        $this->assertEquals('expiresInSeconds', $parameters[4]->getName());
+        $this->assertTrue($parameters[4]->allowsNull());
+
+        $this->assertEquals('array', $this->getTypeName($method));
+    }
+
+    public function test_wallet_operation_release_funds_signature(): void
+    {
+        $method = new ReflectionMethod(WalletOperationInterface::class, 'releaseFunds');
+
+        $parameters = $method->getParameters();
+        $this->assertCount(2, $parameters);
+        $this->assertEquals('holdId', $parameters[0]->getName());
+        $this->assertEquals('releaseToWalletId', $parameters[1]->getName());
+        $this->assertTrue($parameters[1]->allowsNull());
+
+        $this->assertEquals('array', $this->getTypeName($method));
+    }
+
+    public function test_wallet_operation_has_sufficient_balance_signature(): void
+    {
+        $method = new ReflectionMethod(WalletOperationInterface::class, 'hasSufficientBalance');
+
+        $parameters = $method->getParameters();
+        $this->assertCount(4, $parameters);
+        $this->assertEquals('walletId', $parameters[0]->getName());
+        $this->assertEquals('amount', $parameters[1]->getName());
+        $this->assertEquals('float', $this->getTypeName($parameters[1]));
+        $this->assertEquals('currency', $parameters[2]->getName());
+        $this->assertEquals('includeHeld', $parameters[3]->getName());
+        $this->assertEquals('bool', $this->getTypeName($parameters[3]));
+
+        $this->assertEquals('bool', $this->getTypeName($method));
+    }
+
+    public function test_risk_scoring_interface_has_required_methods(): void
+    {
+        $reflection = new ReflectionClass(RiskScoringInterface::class);
+
+        $this->assertTrue($reflection->hasMethod('calculateRisk'));
+        $this->assertTrue($reflection->hasMethod('getRiskLevel'));
+        $this->assertTrue($reflection->hasMethod('isAcceptableRisk'));
+        $this->assertTrue($reflection->hasMethod('getRiskWeights'));
+    }
+
+    public function test_risk_scoring_calculate_risk_signature(): void
+    {
+        $method = new ReflectionMethod(RiskScoringInterface::class, 'calculateRisk');
+
+        $parameters = $method->getParameters();
+        $this->assertCount(3, $parameters);
+        $this->assertEquals('agentId', $parameters[0]->getName());
+        $this->assertEquals('string', $this->getTypeName($parameters[0]));
+        $this->assertEquals('amount', $parameters[1]->getName());
+        $this->assertEquals('float', $this->getTypeName($parameters[1]));
+        $this->assertEquals('context', $parameters[2]->getName());
+        $this->assertEquals('array', $this->getTypeName($parameters[2]));
+
+        $this->assertEquals('array', $this->getTypeName($method));
+    }
+
+    public function test_risk_scoring_get_risk_level_signature(): void
+    {
+        $method = new ReflectionMethod(RiskScoringInterface::class, 'getRiskLevel');
+
+        $parameters = $method->getParameters();
+        $this->assertCount(1, $parameters);
+        $this->assertEquals('score', $parameters[0]->getName());
+        $this->assertEquals('int', $this->getTypeName($parameters[0]));
+
+        $this->assertEquals('string', $this->getTypeName($method));
+    }
+
+    public function test_risk_scoring_is_acceptable_risk_signature(): void
+    {
+        $method = new ReflectionMethod(RiskScoringInterface::class, 'isAcceptableRisk');
+
+        $parameters = $method->getParameters();
+        $this->assertCount(2, $parameters);
+        $this->assertEquals('score', $parameters[0]->getName());
+        $this->assertEquals('int', $this->getTypeName($parameters[0]));
+        $this->assertEquals('operationType', $parameters[1]->getName());
+        $this->assertEquals('string', $this->getTypeName($parameters[1]));
+
+        $this->assertEquals('bool', $this->getTypeName($method));
+    }
+
+    public function test_risk_scoring_get_risk_weights_signature(): void
+    {
+        $method = new ReflectionMethod(RiskScoringInterface::class, 'getRiskWeights');
+
+        $parameters = $method->getParameters();
+        $this->assertCount(0, $parameters);
+
+        $this->assertEquals('array', $this->getTypeName($method));
+    }
+
+    public function test_all_interfaces_are_interfaces(): void
+    {
+        $interfaces = [
+            TransactionVerifierInterface::class,
+            WalletOperationInterface::class,
+            RiskScoringInterface::class,
+        ];
+
+        foreach ($interfaces as $interface) {
+            $reflection = new ReflectionClass($interface);
+            $this->assertTrue(
+                $reflection->isInterface(),
+                "{$interface} should be an interface"
+            );
+        }
+    }
+
+    public function test_all_interface_methods_are_public(): void
+    {
+        $interfaces = [
+            TransactionVerifierInterface::class,
+            WalletOperationInterface::class,
+            RiskScoringInterface::class,
+        ];
+
+        foreach ($interfaces as $interface) {
+            $reflection = new ReflectionClass($interface);
+            foreach ($reflection->getMethods() as $method) {
+                $this->assertTrue(
+                    $method->isPublic(),
+                    "{$interface}::{$method->getName()} should be public"
+                );
+            }
+        }
+    }
+}

--- a/tests/Domain/AgentProtocol/Services/AgentPaymentIntegrationServiceTest.php
+++ b/tests/Domain/AgentProtocol/Services/AgentPaymentIntegrationServiceTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Domain\AgentProtocol\Services;
+
+use App\Domain\AgentProtocol\Services\AgentPaymentIntegrationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use ReflectionClass;
+use Tests\TestCase;
+
+class AgentPaymentIntegrationServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private AgentPaymentIntegrationService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new AgentPaymentIntegrationService();
+    }
+
+    public function test_get_default_currency_returns_config_value(): void
+    {
+        config(['agent_protocol.wallet.default_currency' => 'EUR']);
+
+        $currency = $this->service->getDefaultCurrency();
+
+        $this->assertEquals('EUR', $currency);
+    }
+
+    public function test_get_default_currency_returns_usd_when_not_configured(): void
+    {
+        // Remove the config key entirely to test fallback
+        config(['agent_protocol.wallet' => []]);
+
+        // Create a new service instance to get fresh config
+        $service = new AgentPaymentIntegrationService();
+        $currency = $service->getDefaultCurrency();
+
+        $this->assertEquals('USD', $currency);
+    }
+
+    public function test_calculate_integration_fee_returns_exempt_for_small_amounts(): void
+    {
+        config([
+            'agent_protocol.fees.exemption_threshold' => 1.0,
+            'agent_protocol.fees.integration_rate'    => 0.025,
+        ]);
+
+        $service = new AgentPaymentIntegrationService();
+
+        // Use reflection to test private method
+        $reflection = new ReflectionClass($service);
+        $method = $reflection->getMethod('calculateIntegrationFee');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($service, 0.50, 'funding');
+
+        $this->assertEquals(0.0, $result['amount']);
+        $this->assertEquals('exempt', $result['type']);
+        $this->assertEquals(0.0, $result['rate']);
+    }
+
+    public function test_calculate_integration_fee_returns_none_when_rate_is_zero(): void
+    {
+        config([
+            'agent_protocol.fees.exemption_threshold' => 1.0,
+            'agent_protocol.fees.integration_rate'    => 0.0,
+        ]);
+
+        $service = new AgentPaymentIntegrationService();
+
+        $reflection = new ReflectionClass($service);
+        $method = $reflection->getMethod('calculateIntegrationFee');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($service, 100.00, 'withdrawal');
+
+        $this->assertEquals(0.0, $result['amount']);
+        $this->assertEquals('none', $result['type']);
+        $this->assertEquals(0.0, $result['rate']);
+    }
+
+    public function test_calculate_integration_fee_applies_minimum_fee(): void
+    {
+        config([
+            'agent_protocol.fees.exemption_threshold' => 1.0,
+            'agent_protocol.fees.integration_rate'    => 0.01,
+            'agent_protocol.fees.minimum_fee'         => 1.00,
+            'agent_protocol.fees.maximum_fee'         => 100.00,
+        ]);
+
+        $service = new AgentPaymentIntegrationService();
+
+        $reflection = new ReflectionClass($service);
+        $method = $reflection->getMethod('calculateIntegrationFee');
+        $method->setAccessible(true);
+
+        // 10 * 0.01 = 0.10, but minimum is 1.00
+        $result = $method->invoke($service, 10.00, 'funding');
+
+        $this->assertEquals(1.00, $result['amount']);
+        $this->assertEquals('percentage', $result['type']);
+        $this->assertEquals(0.01, $result['rate']);
+    }
+
+    public function test_calculate_integration_fee_applies_maximum_fee(): void
+    {
+        config([
+            'agent_protocol.fees.exemption_threshold' => 1.0,
+            'agent_protocol.fees.integration_rate'    => 0.10, // 10%
+            'agent_protocol.fees.minimum_fee'         => 1.00,
+            'agent_protocol.fees.maximum_fee'         => 50.00,
+        ]);
+
+        $service = new AgentPaymentIntegrationService();
+
+        $reflection = new ReflectionClass($service);
+        $method = $reflection->getMethod('calculateIntegrationFee');
+        $method->setAccessible(true);
+
+        // 10000 * 0.10 = 1000, but maximum is 50.00
+        $result = $method->invoke($service, 10000.00, 'withdrawal');
+
+        $this->assertEquals(50.00, $result['amount']);
+        $this->assertEquals('percentage', $result['type']);
+        $this->assertEquals(0.10, $result['rate']);
+    }
+
+    public function test_calculate_integration_fee_calculates_percentage_correctly(): void
+    {
+        config([
+            'agent_protocol.fees.exemption_threshold' => 1.0,
+            'agent_protocol.fees.integration_rate'    => 0.025, // 2.5%
+            'agent_protocol.fees.minimum_fee'         => 0.50,
+            'agent_protocol.fees.maximum_fee'         => 100.00,
+        ]);
+
+        $service = new AgentPaymentIntegrationService();
+
+        $reflection = new ReflectionClass($service);
+        $method = $reflection->getMethod('calculateIntegrationFee');
+        $method->setAccessible(true);
+
+        // 200 * 0.025 = 5.00
+        $result = $method->invoke($service, 200.00, 'funding');
+
+        $this->assertEquals(5.00, $result['amount']);
+        $this->assertEquals('percentage', $result['type']);
+        $this->assertEquals(0.025, $result['rate']);
+    }
+
+    public function test_service_can_be_instantiated_without_exchange_service(): void
+    {
+        $service = new AgentPaymentIntegrationService();
+
+        $this->assertInstanceOf(AgentPaymentIntegrationService::class, $service);
+    }
+
+    public function test_get_linked_main_account_returns_null_for_nonexistent_agent(): void
+    {
+        $result = $this->service->getLinkedMainAccount('did:nonexistent:agent');
+
+        $this->assertNull($result);
+    }
+
+    public function test_get_integration_transaction_history_returns_empty_for_nonexistent_agent(): void
+    {
+        $result = $this->service->getIntegrationTransactionHistory('did:nonexistent:agent');
+
+        $this->assertIsArray($result);
+        $this->assertEmpty($result);
+    }
+
+    public function test_link_main_account_returns_false_for_nonexistent_wallet(): void
+    {
+        $result = $this->service->linkMainAccount('nonexistent-wallet', 'nonexistent-account');
+
+        $this->assertFalse($result);
+    }
+}


### PR DESCRIPTION
## Summary

This PR continues the Agent Protocol Phase 2 improvements with a focus on config-driven fee calculation and comprehensive interface tests.

### Changes

**AgentPaymentIntegrationService Updates:**
- Added `getDefaultCurrency()` public method that reads from `config/agent_protocol.php`
- Added `calculateIntegrationFee()` method with config-driven fee calculation supporting:
  - Fee exemption threshold for small transactions
  - Minimum and maximum fee caps
  - Percentage-based fee calculation
- Updated `fundAgentWallet()` to use config-based fee calculation
- Updated `withdrawToMainAccount()` to use config-based fee calculation

**New Test Coverage:**
- `InterfaceContractTest` - 18 tests verifying contract signatures for:
  - `TransactionVerifierInterface` (4 method signatures)
  - `WalletOperationInterface` (5 method signatures)
  - `RiskScoringInterface` (4 method signatures)
- `AgentPaymentIntegrationServiceTest` - 11 tests covering:
  - Default currency configuration
  - Fee calculation with exemptions
  - Minimum/maximum fee application
  - Service instantiation
  - Edge cases for non-existent entities

## Test Plan

- [ ] All 129 Agent Protocol domain tests pass
- [ ] PHPStan Level 5 passes with no errors
- [ ] PHP CS Fixer reports no style issues
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)