### PR TITLE
fix(agent-protocol): Fix Activity return types for workflow compatibility

### DIFF
--- a/app/Domain/AgentProtocol/Workflows/PaymentOrchestrationWorkflow.php
+++ b/app/Domain/AgentProtocol/Workflows/PaymentOrchestrationWorkflow.php
@@ -39,7 +39,7 @@ class PaymentOrchestrationWorkflow extends Workflow
      * Execute the payment orchestration workflow.
      *
      * @param AgentPaymentRequest $request The payment request details
-     * @return Generator The payment result generator
+     * @return Generator<int, mixed, mixed, PaymentResult> The payment result
      * @throws Throwable If payment processing fails
      */
     public function execute(AgentPaymentRequest $request): Generator
@@ -184,7 +184,7 @@ class PaymentOrchestrationWorkflow extends Workflow
      * Handle split payments for multiple recipients.
      *
      * @param AgentPaymentRequest $request The payment request with splits
-     * @return Generator The aggregated payment result generator
+     * @return Generator<int, mixed, mixed, PaymentResult> The aggregated payment result
      */
     public function executeSplitPayment(AgentPaymentRequest $request): Generator
     {
@@ -253,7 +253,7 @@ class PaymentOrchestrationWorkflow extends Workflow
      *
      * @param AgentPaymentRequest $request The payment request
      * @param int $maxRetries Maximum retry attempts
-     * @return Generator The payment result generator
+     * @return Generator<int, mixed, mixed, PaymentResult> The payment result
      */
     public function executeWithRetry(
         AgentPaymentRequest $request,


### PR DESCRIPTION
## Summary
- Fix `CheckTransactionLimitActivity` to return `stdClass` instead of `array` for consistency with other activities
- The workflow code accesses activity results using object property syntax (`$result->allowed`) which requires stdClass
- Add proper PHPDoc annotations with generic types for Generator returns in PaymentOrchestrationWorkflow

## Changes
- `CheckTransactionLimitActivity.php` - Returns stdClass instead of array
- `PaymentOrchestrationWorkflow.php` - Updated docblocks with proper Generator<int, mixed, mixed, PaymentResult> annotations

## Test plan
- [x] PHPStan analysis passes
- [ ] Run Agent Protocol tests
- [ ] Verify workflow execution in development

## Note
The PaymentOrchestrationWorkflow tests currently fail because WorkflowStub doesn't automatically execute through Generator returns. This is a test infrastructure issue that requires further investigation into how Laravel Workflow's testing utilities handle generator-based workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)