### PR TITLE
fix(openapi): Fix duplicate operationId and add Treasury schemas

### DIFF
--- a/app/Http/Controllers/Api/AgentsDiscoveryController.php
+++ b/app/Http/Controllers/Api/AgentsDiscoveryController.php
@@ -22,7 +22,7 @@ class AgentsDiscoveryController extends Controller
      *
      * @OA\Get(
      *     path="/api/agents/discovery",
-     *     operationId="discoverAgents",
+     *     operationId="discoverAgentsDocumentation",
      *     tags={"AI Agents"},
      *     summary="Discover all AGENTS.md files",
      *     description="Returns a list of all AGENTS.md files in the project with their locations and metadata",

--- a/app/Http/Controllers/Api/Treasury/TreasuryApiSchemas.php
+++ b/app/Http/Controllers/Api/Treasury/TreasuryApiSchemas.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Treasury;
+
+/**
+ * Treasury API Documentation Schemas.
+ *
+ * @OA\Tag(
+ *     name="Treasury Portfolio",
+ *     description="Treasury portfolio management operations"
+ * )
+ *
+ * @OA\Tag(
+ *     name="Treasury Operations",
+ *     description="Treasury operational endpoints"
+ * )
+ *
+ * @OA\Schema(
+ *     schema="TreasuryPortfolio",
+ *     type="object",
+ *     description="A treasury portfolio containing asset allocations",
+ *     @OA\Property(property="portfolio_id", type="string", format="uuid", example="550e8400-e29b-41d4-a716-446655440000"),
+ *     @OA\Property(property="treasury_id", type="string", format="uuid", example="550e8400-e29b-41d4-a716-446655440001"),
+ *     @OA\Property(property="name", type="string", example="Main Treasury Portfolio"),
+ *     @OA\Property(
+ *         property="status",
+ *         type="string",
+ *         enum={"active", "inactive", "rebalancing", "liquidating"},
+ *         example="active"
+ *     ),
+ *     @OA\Property(property="total_value", type="number", format="float", example=1000000.00),
+ *     @OA\Property(property="asset_count", type="integer", example=5),
+ *     @OA\Property(property="is_rebalancing", type="boolean", example=false),
+ *     @OA\Property(property="last_rebalance_date", type="string", format="date-time", nullable=true),
+ *     @OA\Property(property="created_at", type="string", format="date-time"),
+ *     @OA\Property(property="updated_at", type="string", format="date-time")
+ * )
+ *
+ * @OA\Schema(
+ *     schema="TreasuryPortfolioDetailed",
+ *     type="object",
+ *     description="Detailed treasury portfolio with summary and rebalancing status",
+ *     allOf={
+ *         @OA\Schema(ref="#/components/schemas/TreasuryPortfolio"),
+ *         @OA\Schema(
+ *             @OA\Property(property="strategy", type="object",
+ *                 @OA\Property(property="type", type="string", example="balanced"),
+ *                 @OA\Property(property="risk_tolerance", type="string", example="moderate"),
+ *                 @OA\Property(property="target_allocations", type="object")
+ *             ),
+ *             @OA\Property(property="asset_allocations", type="array", @OA\Items(ref="#/components/schemas/AssetAllocation")),
+ *             @OA\Property(property="latest_metrics", type="object"),
+ *             @OA\Property(property="summary", type="object"),
+ *             @OA\Property(property="needs_rebalancing", type="boolean", example=false)
+ *         )
+ *     }
+ * )
+ *
+ * @OA\Schema(
+ *     schema="CreateTreasuryPortfolioRequest",
+ *     type="object",
+ *     required={"treasury_id", "name", "strategy"},
+ *     @OA\Property(property="treasury_id", type="string", format="uuid", description="ID of the treasury account"),
+ *     @OA\Property(property="name", type="string", example="Growth Portfolio", description="Portfolio name"),
+ *     @OA\Property(property="strategy", type="object", required={"type"},
+ *         @OA\Property(property="type", type="string", enum={"conservative", "balanced", "aggressive", "custom"}, example="balanced"),
+ *         @OA\Property(property="risk_tolerance", type="string", enum={"low", "moderate", "high"}, example="moderate"),
+ *         @OA\Property(property="target_allocations", type="object",
+ *             @OA\Property(property="USD", type="number", format="float", example=40.0),
+ *             @OA\Property(property="EUR", type="number", format="float", example=30.0),
+ *             @OA\Property(property="GCU", type="number", format="float", example=30.0)
+ *         ),
+ *         @OA\Property(property="rebalancing_threshold", type="number", format="float", example=5.0, description="Percentage deviation threshold for rebalancing")
+ *     )
+ * )
+ *
+ * @OA\Schema(
+ *     schema="UpdateTreasuryPortfolioRequest",
+ *     type="object",
+ *     required={"strategy"},
+ *     @OA\Property(property="strategy", type="object",
+ *         @OA\Property(property="type", type="string", enum={"conservative", "balanced", "aggressive", "custom"}, example="balanced"),
+ *         @OA\Property(property="risk_tolerance", type="string", enum={"low", "moderate", "high"}, example="moderate"),
+ *         @OA\Property(property="target_allocations", type="object"),
+ *         @OA\Property(property="rebalancing_threshold", type="number", format="float", example=5.0)
+ *     )
+ * )
+ *
+ * @OA\Schema(
+ *     schema="AllocateAssetsRequest",
+ *     type="object",
+ *     required={"allocations"},
+ *     @OA\Property(property="allocations", type="array",
+ *         @OA\Items(type="object",
+ *             @OA\Property(property="asset_symbol", type="string", example="USD"),
+ *             @OA\Property(property="target_percentage", type="number", format="float", example=40.0),
+ *             @OA\Property(property="quantity", type="number", format="float", example=400000.00)
+ *         )
+ *     )
+ * )
+ *
+ * @OA\Schema(
+ *     schema="AssetAllocation",
+ *     type="object",
+ *     description="An asset allocation within a treasury portfolio",
+ *     @OA\Property(property="asset_id", type="string", format="uuid"),
+ *     @OA\Property(property="asset_symbol", type="string", example="USD"),
+ *     @OA\Property(property="asset_type", type="string", enum={"fiat", "crypto", "stablecoin", "commodity"}, example="fiat"),
+ *     @OA\Property(property="quantity", type="number", format="float", example=500000.00),
+ *     @OA\Property(property="current_value", type="number", format="float", example=500000.00),
+ *     @OA\Property(property="target_percentage", type="number", format="float", example=50.0),
+ *     @OA\Property(property="current_percentage", type="number", format="float", example=48.5),
+ *     @OA\Property(property="deviation", type="number", format="float", example=-1.5)
+ * )
+ *
+ * @OA\Schema(
+ *     schema="TriggerRebalancingRequest",
+ *     type="object",
+ *     @OA\Property(property="reason", type="string", example="manual_trigger", description="Reason for triggering rebalancing")
+ * )
+ *
+ * @OA\Schema(
+ *     schema="RebalancingPlan",
+ *     type="object",
+ *     description="Treasury portfolio rebalancing plan",
+ *     @OA\Property(property="plan_id", type="string", format="uuid"),
+ *     @OA\Property(property="portfolio_id", type="string", format="uuid"),
+ *     @OA\Property(
+ *         property="status",
+ *         type="string",
+ *         enum={"pending", "approved", "executing", "completed", "cancelled"},
+ *         example="pending"
+ *     ),
+ *     @OA\Property(property="trades", type="array", @OA\Items(
+ *         type="object",
+ *         @OA\Property(property="asset_symbol", type="string"),
+ *         @OA\Property(property="action", type="string", enum={"buy", "sell"}),
+ *         @OA\Property(property="quantity", type="number", format="float"),
+ *         @OA\Property(property="estimated_value", type="number", format="float")
+ *     )),
+ *     @OA\Property(property="estimated_cost", type="number", format="float", example=50.00),
+ *     @OA\Property(property="current_allocations", type="array", @OA\Items(ref="#/components/schemas/AssetAllocation")),
+ *     @OA\Property(property="target_allocations", type="object"),
+ *     @OA\Property(property="created_at", type="string", format="date-time"),
+ *     @OA\Property(property="approved_at", type="string", format="date-time", nullable=true)
+ * )
+ *
+ * @OA\Schema(
+ *     schema="ApproveRebalancingRequest",
+ *     type="object",
+ *     required={"plan"},
+ *     @OA\Property(property="plan", type="object",
+ *         @OA\Property(property="trades", type="array", @OA\Items(
+ *             type="object",
+ *             @OA\Property(property="asset_symbol", type="string"),
+ *             @OA\Property(property="action", type="string", enum={"buy", "sell"}),
+ *             @OA\Property(property="quantity", type="number", format="float")
+ *         ))
+ *     )
+ * )
+ *
+ * @OA\Schema(
+ *     schema="PortfolioPerformance",
+ *     type="object",
+ *     description="Portfolio performance metrics",
+ *     @OA\Property(property="portfolio_id", type="string", format="uuid"),
+ *     @OA\Property(property="period", type="string", example="30d"),
+ *     @OA\Property(property="performance", type="object",
+ *         @OA\Property(property="starting_value", type="number", format="float", example=1000000.00),
+ *         @OA\Property(property="ending_value", type="number", format="float", example=1050000.00),
+ *         @OA\Property(property="absolute_return", type="number", format="float", example=50000.00),
+ *         @OA\Property(property="percentage_return", type="number", format="float", example=5.0),
+ *         @OA\Property(property="volatility", type="number", format="float", example=2.5),
+ *         @OA\Property(property="sharpe_ratio", type="number", format="float", example=1.5)
+ *     ),
+ *     @OA\Property(property="rebalancing_metrics", type="object",
+ *         @OA\Property(property="total_rebalances", type="integer", example=3),
+ *         @OA\Property(property="last_rebalance", type="string", format="date-time"),
+ *         @OA\Property(property="deviation_score", type="number", format="float", example=2.1)
+ *     ),
+ *     @OA\Property(property="generated_at", type="string", format="date-time")
+ * )
+ *
+ * @OA\Schema(
+ *     schema="PortfolioValuation",
+ *     type="object",
+ *     description="Portfolio valuation details",
+ *     @OA\Property(property="portfolio_id", type="string", format="uuid"),
+ *     @OA\Property(property="valuation", type="object",
+ *         @OA\Property(property="total_value", type="number", format="float", example=1000000.00),
+ *         @OA\Property(property="currency", type="string", example="USD"),
+ *         @OA\Property(property="assets", type="array", @OA\Items(
+ *             type="object",
+ *             @OA\Property(property="symbol", type="string"),
+ *             @OA\Property(property="quantity", type="number", format="float"),
+ *             @OA\Property(property="unit_price", type="number", format="float"),
+ *             @OA\Property(property="total_value", type="number", format="float")
+ *         ))
+ *     ),
+ *     @OA\Property(property="timestamp", type="string", format="date-time")
+ * )
+ *
+ * @OA\Schema(
+ *     schema="PortfolioHistory",
+ *     type="object",
+ *     description="Portfolio historical data",
+ *     @OA\Property(property="portfolio_id", type="string", format="uuid"),
+ *     @OA\Property(property="type", type="string", enum={"rebalancing", "performance", "all"}, example="all"),
+ *     @OA\Property(property="history", type="object",
+ *         @OA\Property(property="rebalancing", type="array", @OA\Items(
+ *             type="object",
+ *             @OA\Property(property="date", type="string", format="date-time"),
+ *             @OA\Property(property="reason", type="string"),
+ *             @OA\Property(property="trades_executed", type="integer")
+ *         )),
+ *         @OA\Property(property="performance", type="array", @OA\Items(
+ *             type="object",
+ *             @OA\Property(property="date", type="string", format="date"),
+ *             @OA\Property(property="value", type="number", format="float"),
+ *             @OA\Property(property="daily_return", type="number", format="float")
+ *         ))
+ *     )
+ * )
+ *
+ * @OA\Schema(
+ *     schema="CreateReportRequest",
+ *     type="object",
+ *     required={"type", "period"},
+ *     @OA\Property(property="type", type="string", enum={"summary", "detailed", "compliance", "performance"}, example="summary"),
+ *     @OA\Property(property="period", type="string", example="30d", description="Report period (e.g., 7d, 30d, 90d, 1y)")
+ * )
+ *
+ * @OA\Schema(
+ *     schema="PortfolioReport",
+ *     type="object",
+ *     description="Generated portfolio report",
+ *     @OA\Property(property="report_id", type="string", format="uuid"),
+ *     @OA\Property(property="portfolio_id", type="string", format="uuid"),
+ *     @OA\Property(property="type", type="string", example="summary"),
+ *     @OA\Property(property="period", type="string", example="30d"),
+ *     @OA\Property(property="status", type="string", enum={"pending", "generating", "completed", "failed"}, example="completed"),
+ *     @OA\Property(property="generated_at", type="string", format="date-time"),
+ *     @OA\Property(property="download_url", type="string", format="uri", nullable=true)
+ * )
+ */
+class TreasuryApiSchemas
+{
+    // This class exists only for OpenAPI documentation schemas
+}

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -15,11 +15,11 @@
     },
     "servers": [
         {
-            "url": "http://finaegis.local/api/v2",
+            "url": "http://localhost/api/v2",
             "description": "API Server"
         },
         {
-            "url": "http://finaegis.local/api/v2",
+            "url": "http://localhost/api/v2",
             "description": "API Server"
         }
     ],
@@ -1019,6 +1019,2684 @@
                 ]
             }
         },
+        "/api/agent-protocol/auth/challenge": {
+            "post": {
+                "tags": [
+                    "Agent Protocol - Authentication"
+                ],
+                "summary": "Get authentication challenge for DID signature verification",
+                "operationId": "getAuthChallenge",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "did"
+                                ],
+                                "properties": {
+                                    "did": {
+                                        "type": "string",
+                                        "example": "did:finaegis:agent:abc123def456"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Challenge generated successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "challenge": {
+                                                    "type": "string"
+                                                },
+                                                "nonce": {
+                                                    "type": "string"
+                                                },
+                                                "expires_at": {
+                                                    "type": "string",
+                                                    "format": "date-time"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid DID format"
+                    },
+                    "500": {
+                        "description": "Server error"
+                    }
+                }
+            }
+        },
+        "/api/agent-protocol/auth/did": {
+            "post": {
+                "tags": [
+                    "Agent Protocol - Authentication"
+                ],
+                "summary": "Authenticate agent using DID signature",
+                "operationId": "authenticateWithDID",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "did",
+                                    "signature",
+                                    "challenge"
+                                ],
+                                "properties": {
+                                    "did": {
+                                        "type": "string",
+                                        "example": "did:finaegis:agent:abc123def456"
+                                    },
+                                    "signature": {
+                                        "type": "string",
+                                        "example": "base64_encoded_signature"
+                                    },
+                                    "challenge": {
+                                        "type": "string",
+                                        "example": "base64_encoded_challenge"
+                                    },
+                                    "nonce": {
+                                        "type": "string",
+                                        "example": "random_nonce_string"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Authentication successful",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "session_token": {
+                                                    "type": "string"
+                                                },
+                                                "expires_at": {
+                                                    "type": "string",
+                                                    "format": "date-time"
+                                                },
+                                                "agent": {
+                                                    "type": "object"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Authentication failed"
+                    },
+                    "500": {
+                        "description": "Server error"
+                    }
+                }
+            }
+        },
+        "/api/agent-protocol/auth/api-key": {
+            "post": {
+                "tags": [
+                    "Agent Protocol - Authentication"
+                ],
+                "summary": "Authenticate agent using API key",
+                "operationId": "authenticateWithApiKey",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "api_key"
+                                ],
+                                "properties": {
+                                    "api_key": {
+                                        "type": "string",
+                                        "example": "your_64_char_api_key"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Authentication successful",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "session_token": {
+                                                    "type": "string"
+                                                },
+                                                "expires_at": {
+                                                    "type": "string",
+                                                    "format": "date-time"
+                                                },
+                                                "agent": {
+                                                    "type": "object"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid API key"
+                    },
+                    "500": {
+                        "description": "Server error"
+                    }
+                }
+            }
+        },
+        "/api/agent-protocol/auth/session/validate": {
+            "post": {
+                "tags": [
+                    "Agent Protocol - Authentication"
+                ],
+                "summary": "Validate an existing session token",
+                "operationId": "validateSession",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "session_token"
+                                ],
+                                "properties": {
+                                    "session_token": {
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Session validation result",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean"
+                                        },
+                                        "valid": {
+                                            "type": "boolean"
+                                        },
+                                        "data": {
+                                            "type": "object",
+                                            "nullable": true
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/agent-protocol/auth/session/revoke": {
+            "post": {
+                "tags": [
+                    "Agent Protocol - Authentication"
+                ],
+                "summary": "Revoke a session token",
+                "operationId": "revokeSession",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "session_token"
+                                ],
+                                "properties": {
+                                    "session_token": {
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Session revoked successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Session revoked"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "agentAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/agent-protocol/agents/{did}/api-keys": {
+            "get": {
+                "tags": [
+                    "Agent Protocol - Authentication"
+                ],
+                "summary": "List all API keys for an agent",
+                "operationId": "listApiKeys",
+                "parameters": [
+                    {
+                        "name": "did",
+                        "in": "path",
+                        "description": "Agent DID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of API keys",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "properties": {
+                                                    "key_id": {
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    },
+                                                    "key_prefix": {
+                                                        "type": "string"
+                                                    },
+                                                    "scopes": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "is_active": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "last_used_at": {
+                                                        "type": "string",
+                                                        "format": "date-time",
+                                                        "nullable": true
+                                                    },
+                                                    "expires_at": {
+                                                        "type": "string",
+                                                        "format": "date-time",
+                                                        "nullable": true
+                                                    }
+                                                },
+                                                "type": "object"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Agent not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": [],
+                        "agentAuth": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Agent Protocol - Authentication"
+                ],
+                "summary": "Generate a new API key for an agent",
+                "operationId": "generateApiKey",
+                "parameters": [
+                    {
+                        "name": "did",
+                        "in": "path",
+                        "description": "Agent DID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "name"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "example": "Production API Key"
+                                    },
+                                    "scopes": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "example": [
+                                            "payments:read",
+                                            "wallet:read"
+                                        ]
+                                    },
+                                    "expires_at": {
+                                        "type": "string",
+                                        "format": "date-time",
+                                        "nullable": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "API key generated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "api_key": {
+                                                    "description": "Only shown once",
+                                                    "type": "string"
+                                                },
+                                                "key_id": {
+                                                    "type": "string"
+                                                },
+                                                "created_at": {
+                                                    "type": "string",
+                                                    "format": "date-time"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "warning": {
+                                            "type": "string",
+                                            "example": "Store this API key securely. It will not be shown again."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Agent not found"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": [],
+                        "agentAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/agent-protocol/agents/{did}/api-keys/{keyId}": {
+            "delete": {
+                "tags": [
+                    "Agent Protocol - Authentication"
+                ],
+                "summary": "Revoke an API key",
+                "operationId": "revokeApiKey",
+                "parameters": [
+                    {
+                        "name": "did",
+                        "in": "path",
+                        "description": "Agent DID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "keyId",
+                        "in": "path",
+                        "description": "API key ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "API key revoked",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "API key revoked"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Agent or API key not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": [],
+                        "agentAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/agent-protocol/agents/{did}/sessions": {
+            "get": {
+                "tags": [
+                    "Agent Protocol - Authentication"
+                ],
+                "summary": "List active sessions for an agent",
+                "operationId": "listAgentSessions",
+                "parameters": [
+                    {
+                        "name": "did",
+                        "in": "path",
+                        "description": "Agent DID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of active sessions",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Agent not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": [],
+                        "agentAuth": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Agent Protocol - Authentication"
+                ],
+                "summary": "Revoke all sessions for an agent",
+                "operationId": "revokeAllAgentSessions",
+                "parameters": [
+                    {
+                        "name": "did",
+                        "in": "path",
+                        "description": "Agent DID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "All sessions revoked",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "revoked_count": {
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Agent not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": [],
+                        "agentAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/agent-protocol/auth/scopes": {
+            "get": {
+                "tags": [
+                    "Agent Protocol - Authentication"
+                ],
+                "summary": "List all available OAuth2-style scopes",
+                "operationId": "listAvailableScopes",
+                "responses": {
+                    "200": {
+                        "description": "List of available scopes",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "scopes": {
+                                                    "type": "object"
+                                                },
+                                                "default_scopes": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/agent-protocol/escrow": {
+            "post": {
+                "tags": [
+                    "Agent Protocol - Escrow"
+                ],
+                "summary": "Create a new escrow",
+                "operationId": "createEscrow",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "buyer_did",
+                                    "seller_did",
+                                    "amount",
+                                    "currency"
+                                ],
+                                "properties": {
+                                    "buyer_did": {
+                                        "type": "string",
+                                        "example": "did:finaegis:agent:buyer123"
+                                    },
+                                    "seller_did": {
+                                        "type": "string",
+                                        "example": "did:finaegis:agent:seller456"
+                                    },
+                                    "amount": {
+                                        "type": "number",
+                                        "format": "float",
+                                        "example": 1000
+                                    },
+                                    "currency": {
+                                        "type": "string",
+                                        "example": "USD"
+                                    },
+                                    "conditions": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "example": [
+                                            "delivery_confirmed",
+                                            "quality_verified"
+                                        ]
+                                    },
+                                    "release_conditions": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "example": [
+                                            "delivery_confirmed"
+                                        ]
+                                    },
+                                    "timeout_seconds": {
+                                        "type": "integer",
+                                        "example": 86400
+                                    },
+                                    "dispute_resolution_did": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "metadata": {
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Escrow created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "escrow_id": {
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "type": "string"
+                                                },
+                                                "amount": {
+                                                    "type": "number"
+                                                },
+                                                "expires_at": {
+                                                    "type": "string",
+                                                    "format": "date-time"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request"
+                    },
+                    "404": {
+                        "description": "Agent not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/agent-protocol/escrow/{escrowId}": {
+            "get": {
+                "tags": [
+                    "Agent Protocol - Escrow"
+                ],
+                "summary": "Get escrow details",
+                "operationId": "getEscrow",
+                "parameters": [
+                    {
+                        "name": "escrowId",
+                        "in": "path",
+                        "description": "Escrow ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Escrow details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Escrow not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/agent-protocol/escrow/{escrowId}/fund": {
+            "post": {
+                "tags": [
+                    "Agent Protocol - Escrow"
+                ],
+                "summary": "Fund an escrow (deposit funds)",
+                "operationId": "fundEscrow",
+                "parameters": [
+                    {
+                        "name": "escrowId",
+                        "in": "path",
+                        "description": "Escrow ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "funder_did"
+                                ],
+                                "properties": {
+                                    "funder_did": {
+                                        "type": "string",
+                                        "example": "did:finaegis:agent:buyer123"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Escrow funded"
+                    },
+                    "400": {
+                        "description": "Cannot fund escrow"
+                    },
+                    "404": {
+                        "description": "Escrow not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/agent-protocol/escrow/{escrowId}/release": {
+            "post": {
+                "tags": [
+                    "Agent Protocol - Escrow"
+                ],
+                "summary": "Release escrow funds to seller",
+                "operationId": "releaseEscrow",
+                "parameters": [
+                    {
+                        "name": "escrowId",
+                        "in": "path",
+                        "description": "Escrow ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "releaser_did": {
+                                        "type": "string",
+                                        "example": "did:finaegis:agent:buyer123"
+                                    },
+                                    "conditions_met": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Escrow released"
+                    },
+                    "400": {
+                        "description": "Cannot release escrow"
+                    },
+                    "404": {
+                        "description": "Escrow not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/agent-protocol/escrow/{escrowId}/dispute": {
+            "post": {
+                "tags": [
+                    "Agent Protocol - Escrow"
+                ],
+                "summary": "Raise a dispute on an escrow",
+                "operationId": "raiseEscrowDispute",
+                "parameters": [
+                    {
+                        "name": "escrowId",
+                        "in": "path",
+                        "description": "Escrow ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "disputer_did",
+                                    "reason"
+                                ],
+                                "properties": {
+                                    "disputer_did": {
+                                        "type": "string",
+                                        "example": "did:finaegis:agent:buyer123"
+                                    },
+                                    "reason": {
+                                        "type": "string",
+                                        "example": "Service not delivered as agreed"
+                                    },
+                                    "evidence": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Dispute raised"
+                    },
+                    "400": {
+                        "description": "Cannot dispute escrow"
+                    },
+                    "404": {
+                        "description": "Escrow not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/agent-protocol/escrow/{escrowId}/resolve": {
+            "post": {
+                "tags": [
+                    "Agent Protocol - Escrow"
+                ],
+                "summary": "Resolve an escrow dispute",
+                "operationId": "resolveEscrowDispute",
+                "parameters": [
+                    {
+                        "name": "escrowId",
+                        "in": "path",
+                        "description": "Escrow ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "resolver_did",
+                                    "resolution_type"
+                                ],
+                                "properties": {
+                                    "resolver_did": {
+                                        "type": "string",
+                                        "example": "did:finaegis:agent:arbiter789"
+                                    },
+                                    "resolution_type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "release_to_receiver",
+                                            "return_to_sender",
+                                            "split"
+                                        ],
+                                        "example": "release_to_receiver"
+                                    },
+                                    "split_percentage": {
+                                        "description": "Required if resolution_type is split",
+                                        "type": "number",
+                                        "example": 50
+                                    },
+                                    "reason": {
+                                        "type": "string",
+                                        "example": "Evidence supports seller's claim"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Dispute resolved"
+                    },
+                    "400": {
+                        "description": "Cannot resolve dispute"
+                    },
+                    "404": {
+                        "description": "Escrow not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/agent-protocol/agents/register": {
+            "post": {
+                "tags": [
+                    "Agent Protocol - Identity"
+                ],
+                "summary": "Register a new agent in the system",
+                "operationId": "registerAgent",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "name",
+                                    "type"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "example": "Trading Agent Alpha"
+                                    },
+                                    "type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "service",
+                                            "user",
+                                            "system"
+                                        ],
+                                        "example": "service"
+                                    },
+                                    "description": {
+                                        "type": "string",
+                                        "example": "Automated trading agent"
+                                    },
+                                    "capabilities": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "example": [
+                                            "payment",
+                                            "trading"
+                                        ]
+                                    },
+                                    "metadata": {
+                                        "type": "object",
+                                        "example": {
+                                            "version": "1.0",
+                                            "provider": "FinAegis"
+                                        }
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Agent registered successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "agent_id": {
+                                                    "type": "string"
+                                                },
+                                                "did": {
+                                                    "type": "string"
+                                                },
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "type": {
+                                                    "type": "string"
+                                                },
+                                                "registered_at": {
+                                                    "type": "string",
+                                                    "format": "date-time"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    },
+                    "500": {
+                        "description": "Server error"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/agent-protocol/agents/discover": {
+            "get": {
+                "tags": [
+                    "Agent Protocol - Identity"
+                ],
+                "summary": "Discover agents by capabilities or type",
+                "operationId": "discoverAgents",
+                "parameters": [
+                    {
+                        "name": "capability",
+                        "in": "query",
+                        "description": "Filter by capability",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "description": "Filter by agent type",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "service",
+                                "user",
+                                "system"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "description": "Filter by status",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "active",
+                                "inactive",
+                                "suspended"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Number of results",
+                        "schema": {
+                            "type": "integer",
+                            "default": 20
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of discovered agents",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/agent-protocol/agents/{did}": {
+            "get": {
+                "tags": [
+                    "Agent Protocol - Identity"
+                ],
+                "summary": "Get agent details by DID",
+                "operationId": "getAgentByDID",
+                "parameters": [
+                    {
+                        "name": "did",
+                        "in": "path",
+                        "description": "Agent DID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Agent details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Agent not found"
+                    }
+                }
+            }
+        },
+        "/api/agent-protocol/agents/{did}/capabilities": {
+            "put": {
+                "tags": [
+                    "Agent Protocol - Identity"
+                ],
+                "summary": "Update agent capabilities",
+                "operationId": "updateAgentCapabilities",
+                "parameters": [
+                    {
+                        "name": "did",
+                        "in": "path",
+                        "description": "Agent DID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "capabilities"
+                                ],
+                                "properties": {
+                                    "capabilities": {
+                                        "type": "array",
+                                        "items": {
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "version": {
+                                                    "type": "string"
+                                                },
+                                                "metadata": {
+                                                    "type": "object"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Capabilities updated"
+                    },
+                    "404": {
+                        "description": "Agent not found"
+                    },
+                    "403": {
+                        "description": "Not authorized"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/.well-known/ap2-configuration": {
+            "get": {
+                "tags": [
+                    "Agent Protocol - Identity"
+                ],
+                "summary": "AP2 well-known configuration endpoint",
+                "operationId": "ap2Configuration",
+                "responses": {
+                    "200": {
+                        "description": "AP2 configuration",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "issuer": {
+                                            "type": "string"
+                                        },
+                                        "agent_registration_endpoint": {
+                                            "type": "string"
+                                        },
+                                        "agent_discovery_endpoint": {
+                                            "type": "string"
+                                        },
+                                        "payment_endpoint": {
+                                            "type": "string"
+                                        },
+                                        "escrow_endpoint": {
+                                            "type": "string"
+                                        },
+                                        "supported_capabilities": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/agent-protocol/agents/{did}/messages": {
+            "get": {
+                "tags": [
+                    "Agent Protocol - Messaging"
+                ],
+                "summary": "Get messages for an agent",
+                "operationId": "getAgentMessages",
+                "parameters": [
+                    {
+                        "name": "did",
+                        "in": "path",
+                        "description": "Agent DID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "description": "Filter by inbox/outbox",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "inbox",
+                                "outbox",
+                                "all"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "description": "Filter by status",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "unacknowledged_only",
+                        "in": "query",
+                        "description": "Only show unacknowledged messages",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Number of results",
+                        "schema": {
+                            "type": "integer",
+                            "default": 20
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of messages",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Agent Protocol - Messaging"
+                ],
+                "summary": "Send a message to another agent",
+                "operationId": "sendAgentMessage",
+                "parameters": [
+                    {
+                        "name": "did",
+                        "in": "path",
+                        "description": "Sender agent DID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "to_agent_did",
+                                    "message_type",
+                                    "payload"
+                                ],
+                                "properties": {
+                                    "to_agent_did": {
+                                        "type": "string",
+                                        "example": "did:finaegis:agent:receiver456"
+                                    },
+                                    "message_type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "direct",
+                                            "broadcast",
+                                            "protocol",
+                                            "transaction",
+                                            "notification"
+                                        ],
+                                        "example": "direct"
+                                    },
+                                    "payload": {
+                                        "type": "object",
+                                        "example": {
+                                            "action": "quote_request",
+                                            "data": []
+                                        }
+                                    },
+                                    "priority": {
+                                        "type": "string",
+                                        "enum": [
+                                            "low",
+                                            "normal",
+                                            "high",
+                                            "critical"
+                                        ],
+                                        "example": "normal"
+                                    },
+                                    "requires_acknowledgment": {
+                                        "type": "boolean",
+                                        "example": true
+                                    },
+                                    "correlation_id": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "reply_to": {
+                                        "type": "string",
+                                        "nullable": true
+                                    },
+                                    "headers": {
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Message sent",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "message_id": {
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "type": "string"
+                                                },
+                                                "sent_at": {
+                                                    "type": "string",
+                                                    "format": "date-time"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request"
+                    },
+                    "404": {
+                        "description": "Agent not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/agent-protocol/agents/{did}/messages/{messageId}/ack": {
+            "post": {
+                "tags": [
+                    "Agent Protocol - Messaging"
+                ],
+                "summary": "Acknowledge receipt of a message",
+                "operationId": "acknowledgeAgentMessage",
+                "parameters": [
+                    {
+                        "name": "did",
+                        "in": "path",
+                        "description": "Receiver agent DID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "messageId",
+                        "in": "path",
+                        "description": "Message ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Message acknowledged",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "message_id": {
+                                                    "type": "string"
+                                                },
+                                                "acknowledged_at": {
+                                                    "type": "string",
+                                                    "format": "date-time"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Cannot acknowledge message"
+                    },
+                    "404": {
+                        "description": "Message not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/agent-protocol/agents/{did}/messages/{messageId}": {
+            "get": {
+                "tags": [
+                    "Agent Protocol - Messaging"
+                ],
+                "summary": "Get message details",
+                "operationId": "getAgentMessage",
+                "parameters": [
+                    {
+                        "name": "did",
+                        "in": "path",
+                        "description": "Agent DID (must be sender or receiver)",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "messageId",
+                        "in": "path",
+                        "description": "Message ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Message details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Message not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/agent-protocol/agents/{did}/payments": {
+            "get": {
+                "tags": [
+                    "Agent Protocol - Payments"
+                ],
+                "summary": "List payments for an agent",
+                "operationId": "listAgentPayments",
+                "parameters": [
+                    {
+                        "name": "did",
+                        "in": "path",
+                        "description": "Agent DID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "description": "Filter by status",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "description": "Filter by type (sent/received)",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "sent",
+                                "received",
+                                "all"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Number of results",
+                        "schema": {
+                            "type": "integer",
+                            "default": 20
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of payments",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Agent Protocol - Payments"
+                ],
+                "summary": "Initiate a payment from an agent",
+                "operationId": "initiateAgentPayment",
+                "parameters": [
+                    {
+                        "name": "did",
+                        "in": "path",
+                        "description": "Sender agent DID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "to_agent_did",
+                                    "amount",
+                                    "currency"
+                                ],
+                                "properties": {
+                                    "to_agent_did": {
+                                        "type": "string",
+                                        "example": "did:finaegis:agent:abc123"
+                                    },
+                                    "amount": {
+                                        "type": "number",
+                                        "format": "float",
+                                        "example": 100.5
+                                    },
+                                    "currency": {
+                                        "type": "string",
+                                        "example": "USD"
+                                    },
+                                    "description": {
+                                        "type": "string",
+                                        "example": "Payment for service"
+                                    },
+                                    "escrow_required": {
+                                        "type": "boolean",
+                                        "example": false
+                                    },
+                                    "metadata": {
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Payment initiated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "transaction_id": {
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "type": "string"
+                                                },
+                                                "amount": {
+                                                    "type": "number"
+                                                },
+                                                "currency": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request"
+                    },
+                    "404": {
+                        "description": "Agent not found"
+                    },
+                    "422": {
+                        "description": "Insufficient balance"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/agent-protocol/agents/{did}/payments/{transactionId}": {
+            "get": {
+                "tags": [
+                    "Agent Protocol - Payments"
+                ],
+                "summary": "Get payment status",
+                "operationId": "getAgentPaymentStatus",
+                "parameters": [
+                    {
+                        "name": "did",
+                        "in": "path",
+                        "description": "Agent DID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "transactionId",
+                        "in": "path",
+                        "description": "Transaction ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Payment status",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Payment not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/agent-protocol/agents/{did}/payments/{transactionId}/confirm": {
+            "post": {
+                "tags": [
+                    "Agent Protocol - Payments"
+                ],
+                "summary": "Confirm a pending payment",
+                "operationId": "confirmAgentPayment",
+                "parameters": [
+                    {
+                        "name": "did",
+                        "in": "path",
+                        "description": "Agent DID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "transactionId",
+                        "in": "path",
+                        "description": "Transaction ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Payment confirmed"
+                    },
+                    "400": {
+                        "description": "Cannot confirm payment"
+                    },
+                    "404": {
+                        "description": "Payment not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/agent-protocol/agents/{did}/payments/{transactionId}/cancel": {
+            "post": {
+                "tags": [
+                    "Agent Protocol - Payments"
+                ],
+                "summary": "Cancel a pending payment",
+                "operationId": "cancelAgentPayment",
+                "parameters": [
+                    {
+                        "name": "did",
+                        "in": "path",
+                        "description": "Agent DID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "transactionId",
+                        "in": "path",
+                        "description": "Transaction ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "reason": {
+                                        "type": "string",
+                                        "example": "User requested cancellation"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Payment cancelled"
+                    },
+                    "400": {
+                        "description": "Cannot cancel payment"
+                    },
+                    "404": {
+                        "description": "Payment not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/agent-protocol/agents/{did}/reputation": {
+            "get": {
+                "tags": [
+                    "Agent Protocol - Reputation"
+                ],
+                "summary": "Get agent reputation score and details",
+                "operationId": "getAgentReputation",
+                "parameters": [
+                    {
+                        "name": "did",
+                        "in": "path",
+                        "description": "Agent DID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Reputation details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "agent_did": {
+                                                    "type": "string"
+                                                },
+                                                "score": {
+                                                    "type": "number",
+                                                    "example": 85.5
+                                                },
+                                                "trust_level": {
+                                                    "type": "string",
+                                                    "example": "trusted"
+                                                },
+                                                "total_transactions": {
+                                                    "type": "integer",
+                                                    "example": 150
+                                                },
+                                                "success_rate": {
+                                                    "type": "number",
+                                                    "example": 98.5
+                                                },
+                                                "dispute_count": {
+                                                    "type": "integer",
+                                                    "example": 2
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Agent not found"
+                    }
+                }
+            }
+        },
+        "/api/agent-protocol/agents/{did}/reputation/feedback": {
+            "post": {
+                "tags": [
+                    "Agent Protocol - Reputation"
+                ],
+                "summary": "Submit feedback about an agent transaction",
+                "operationId": "submitAgentFeedback",
+                "parameters": [
+                    {
+                        "name": "did",
+                        "in": "path",
+                        "description": "Agent DID to review",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "reviewer_did",
+                                    "transaction_id",
+                                    "outcome"
+                                ],
+                                "properties": {
+                                    "reviewer_did": {
+                                        "type": "string",
+                                        "example": "did:finaegis:agent:reviewer123"
+                                    },
+                                    "transaction_id": {
+                                        "type": "string",
+                                        "example": "txn-uuid-here"
+                                    },
+                                    "outcome": {
+                                        "type": "string",
+                                        "enum": [
+                                            "success",
+                                            "failed",
+                                            "cancelled",
+                                            "timeout"
+                                        ],
+                                        "example": "success"
+                                    },
+                                    "rating": {
+                                        "type": "integer",
+                                        "maximum": 5,
+                                        "minimum": 1,
+                                        "example": 5
+                                    },
+                                    "comment": {
+                                        "type": "string",
+                                        "example": "Fast and reliable service"
+                                    },
+                                    "transaction_value": {
+                                        "type": "number",
+                                        "example": 1000
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Feedback submitted",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "new_score": {
+                                                    "type": "number"
+                                                },
+                                                "score_change": {
+                                                    "type": "number"
+                                                },
+                                                "new_trust_level": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request"
+                    },
+                    "404": {
+                        "description": "Agent not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/agent-protocol/agents/{did}/reputation/history": {
+            "get": {
+                "tags": [
+                    "Agent Protocol - Reputation"
+                ],
+                "summary": "Get agent reputation history",
+                "operationId": "getAgentReputationHistory",
+                "parameters": [
+                    {
+                        "name": "did",
+                        "in": "path",
+                        "description": "Agent DID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Number of history entries",
+                        "schema": {
+                            "type": "integer",
+                            "default": 20
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Reputation history",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/agent-protocol/reputation/leaderboard": {
+            "get": {
+                "tags": [
+                    "Agent Protocol - Reputation"
+                ],
+                "summary": "Get top-rated agents",
+                "operationId": "getReputationLeaderboard",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Number of agents",
+                        "schema": {
+                            "type": "integer",
+                            "default": 10
+                        }
+                    },
+                    {
+                        "name": "capability",
+                        "in": "query",
+                        "description": "Filter by capability",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Top agents by reputation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/agent-protocol/agents/{agentA}/trust/{agentB}": {
+            "get": {
+                "tags": [
+                    "Agent Protocol - Reputation"
+                ],
+                "summary": "Evaluate trust relationship between two agents",
+                "operationId": "evaluateTrustRelationship",
+                "parameters": [
+                    {
+                        "name": "agentA",
+                        "in": "path",
+                        "description": "First agent DID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "agentB",
+                        "in": "path",
+                        "description": "Second agent DID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Trust evaluation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "trust_score": {
+                                                    "type": "number"
+                                                },
+                                                "recommended_escrow": {
+                                                    "type": "boolean"
+                                                },
+                                                "max_transaction_value": {
+                                                    "type": "number"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/agents/discovery": {
+            "get": {
+                "tags": [
+                    "AI Agents"
+                ],
+                "summary": "Discover all AGENTS.md files",
+                "description": "Returns a list of all AGENTS.md files in the project with their locations and metadata",
+                "operationId": "discoverAgentsDocumentation",
+                "responses": {
+                    "200": {
+                        "description": "Successful discovery",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "count": {
+                                            "type": "integer",
+                                            "example": 15
+                                        },
+                                        "agents": {
+                                            "type": "array",
+                                            "items": {
+                                                "properties": {
+                                                    "path": {
+                                                        "type": "string",
+                                                        "example": "app/Domain/Exchange/AGENTS.md"
+                                                    },
+                                                    "domain": {
+                                                        "type": "string",
+                                                        "example": "Exchange"
+                                                    },
+                                                    "type": {
+                                                        "type": "string",
+                                                        "example": "domain"
+                                                    },
+                                                    "size": {
+                                                        "type": "integer",
+                                                        "example": 4567
+                                                    },
+                                                    "last_modified": {
+                                                        "type": "string",
+                                                        "format": "date-time"
+                                                    },
+                                                    "url": {
+                                                        "type": "string",
+                                                        "example": "/api/agents/content/app/Domain/Exchange"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/agents/content/{path}": {
+            "get": {
+                "tags": [
+                    "AI Agents"
+                ],
+                "summary": "Get AGENTS.md content",
+                "description": "Returns the content of a specific AGENTS.md file",
+                "operationId": "getAgentContent",
+                "parameters": [
+                    {
+                        "name": "path",
+                        "in": "path",
+                        "description": "Base64 encoded path to the AGENTS.md file",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful retrieval",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "path": {
+                                            "type": "string"
+                                        },
+                                        "content": {
+                                            "type": "string"
+                                        },
+                                        "metadata": {
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "File not found"
+                    }
+                }
+            }
+        },
+        "/api/agents/summary": {
+            "get": {
+                "tags": [
+                    "AI Agents"
+                ],
+                "summary": "Get AGENTS.md summary",
+                "description": "Returns a summary of all domains with AGENTS.md coverage",
+                "operationId": "getAgentsSummary",
+                "responses": {
+                    "200": {
+                        "description": "Successful summary",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "total_files": {
+                                            "type": "integer"
+                                        },
+                                        "domains": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "coverage": {
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/assets": {
             "get": {
                 "tags": [
@@ -1361,7 +4039,7 @@
                                     "properties": {
                                         "message": {
                                             "type": "string",
-                                            "example": "The given data was invalid."
+                                            "example": "The provided credentials are incorrect."
                                         },
                                         "errors": {
                                             "properties": {
@@ -1390,18 +4068,18 @@
                     "Authentication"
                 ],
                 "summary": "Logout user",
-                "description": "Revoke the current access token",
+                "description": "Logout the authenticated user and revoke all their tokens",
                 "operationId": "logout",
                 "responses": {
                     "200": {
-                        "description": "Successfully logged out",
+                        "description": "Logout successful",
                         "content": {
                             "application/json": {
                                 "schema": {
                                     "properties": {
                                         "message": {
                                             "type": "string",
-                                            "example": "Successfully logged out"
+                                            "example": "Logged out successfully"
                                         }
                                     },
                                     "type": "object"
@@ -1410,87 +4088,20 @@
                         }
                     },
                     "401": {
-                        "description": "Unauthenticated"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ]
-            }
-        },
-        "/api/auth/logout-all": {
-            "post": {
-                "tags": [
-                    "Authentication"
-                ],
-                "summary": "Logout from all devices",
-                "description": "Revoke all access tokens for the user",
-                "operationId": "logoutAll",
-                "responses": {
-                    "200": {
-                        "description": "Successfully logged out from all devices",
+                        "description": "Unauthenticated",
                         "content": {
                             "application/json": {
                                 "schema": {
                                     "properties": {
                                         "message": {
                                             "type": "string",
-                                            "example": "Successfully logged out from all devices"
+                                            "example": "Unauthenticated"
                                         }
                                     },
                                     "type": "object"
                                 }
                             }
                         }
-                    },
-                    "401": {
-                        "description": "Unauthenticated"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ]
-            }
-        },
-        "/api/auth/refresh": {
-            "post": {
-                "tags": [
-                    "Authentication"
-                ],
-                "summary": "Refresh access token",
-                "description": "Get a new access token by revoking the current one",
-                "operationId": "refreshToken",
-                "responses": {
-                    "200": {
-                        "description": "Token refreshed successfully",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "properties": {
-                                        "access_token": {
-                                            "type": "string",
-                                            "example": "3|newTokenHere..."
-                                        },
-                                        "token_type": {
-                                            "type": "string",
-                                            "example": "Bearer"
-                                        },
-                                        "expires_in": {
-                                            "type": "integer",
-                                            "nullable": true
-                                        }
-                                    },
-                                    "type": "object"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthenticated"
                     }
                 },
                 "security": [
@@ -1553,7 +4164,20 @@
                         }
                     },
                     "401": {
-                        "description": "Unauthenticated"
+                        "description": "Unauthenticated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Unauthenticated"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -1682,7 +4306,7 @@
                                     "properties": {
                                         "message": {
                                             "type": "string",
-                                            "example": "We have emailed your password reset link."
+                                            "example": "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
                                         }
                                     },
                                     "type": "object"
@@ -1696,6 +4320,22 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        }
+                    },
+                    "429": {
+                        "description": "Too many requests",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Too many requests. Please try again later."
+                                        }
+                                    },
+                                    "type": "object"
                                 }
                             }
                         }
@@ -6964,6 +9604,1194 @@
                 ]
             }
         },
+        "/api/compliance/alerts": {
+            "get": {
+                "tags": [
+                    "Compliance Alerts"
+                ],
+                "summary": "Get compliance alerts",
+                "description": "Retrieve compliance alerts with filtering options",
+                "operationId": "getComplianceAlerts",
+                "parameters": [
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "description": "Filter by status",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "new",
+                                "assigned",
+                                "investigating",
+                                "escalated",
+                                "resolved",
+                                "closed"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "severity",
+                        "in": "query",
+                        "description": "Filter by severity",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "low",
+                                "medium",
+                                "high",
+                                "critical"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "description": "Filter by alert type",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "assigned_to",
+                        "in": "query",
+                        "description": "Filter by assigned user ID",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "Page number",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of compliance alerts",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Compliance Alerts"
+                ],
+                "summary": "Create alert",
+                "description": "Create a new compliance alert",
+                "operationId": "createComplianceAlert",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "type",
+                                    "severity",
+                                    "description"
+                                ],
+                                "properties": {
+                                    "type": {
+                                        "type": "string"
+                                    },
+                                    "severity": {
+                                        "type": "string",
+                                        "enum": [
+                                            "low",
+                                            "medium",
+                                            "high",
+                                            "critical"
+                                        ]
+                                    },
+                                    "description": {
+                                        "type": "string"
+                                    },
+                                    "entity_type": {
+                                        "type": "string"
+                                    },
+                                    "entity_id": {
+                                        "type": "string"
+                                    },
+                                    "details": {
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Alert created successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/compliance/alerts/{id}": {
+            "get": {
+                "tags": [
+                    "Compliance Alerts"
+                ],
+                "summary": "Get alert details",
+                "description": "Retrieve detailed information about a specific compliance alert",
+                "operationId": "getComplianceAlert",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Alert ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Alert details",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Alert not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/compliance/alerts/{id}/status": {
+            "put": {
+                "tags": [
+                    "Compliance Alerts"
+                ],
+                "summary": "Update alert status",
+                "description": "Update the status of a compliance alert",
+                "operationId": "updateAlertStatus",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Alert ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "status"
+                                ],
+                                "properties": {
+                                    "status": {
+                                        "type": "string",
+                                        "enum": [
+                                            "new",
+                                            "assigned",
+                                            "investigating",
+                                            "escalated",
+                                            "resolved",
+                                            "closed"
+                                        ]
+                                    },
+                                    "notes": {
+                                        "type": "string"
+                                    },
+                                    "resolution": {
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Status updated successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/compliance/alerts/{id}/assign": {
+            "put": {
+                "tags": [
+                    "Compliance Alerts"
+                ],
+                "summary": "Assign alert",
+                "description": "Assign a compliance alert to a user",
+                "operationId": "assignAlert",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Alert ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "user_id"
+                                ],
+                                "properties": {
+                                    "user_id": {
+                                        "type": "integer"
+                                    },
+                                    "notes": {
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Alert assigned successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/compliance/alerts/{id}/notes": {
+            "post": {
+                "tags": [
+                    "Compliance Alerts"
+                ],
+                "summary": "Add investigation note",
+                "description": "Add an investigation note to a compliance alert",
+                "operationId": "addAlertNote",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Alert ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "note"
+                                ],
+                                "properties": {
+                                    "note": {
+                                        "type": "string"
+                                    },
+                                    "findings": {
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Note added successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/compliance/alerts/link": {
+            "post": {
+                "tags": [
+                    "Compliance Alerts"
+                ],
+                "summary": "Link related alerts",
+                "description": "Link multiple related compliance alerts",
+                "operationId": "linkAlerts",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "alert_ids",
+                                    "relationship_type"
+                                ],
+                                "properties": {
+                                    "alert_ids": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "relationship_type": {
+                                        "type": "string"
+                                    },
+                                    "notes": {
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Alerts linked successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/compliance/alerts/create-case": {
+            "post": {
+                "tags": [
+                    "Compliance Alerts"
+                ],
+                "summary": "Create case from alerts",
+                "description": "Create a compliance case from multiple alerts",
+                "operationId": "createCaseFromAlerts",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "alert_ids",
+                                    "title"
+                                ],
+                                "properties": {
+                                    "alert_ids": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "title": {
+                                        "type": "string"
+                                    },
+                                    "description": {
+                                        "type": "string"
+                                    },
+                                    "priority": {
+                                        "type": "string",
+                                        "enum": [
+                                            "low",
+                                            "medium",
+                                            "high",
+                                            "critical"
+                                        ]
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Case created successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/compliance/alerts/statistics": {
+            "get": {
+                "tags": [
+                    "Compliance Alerts"
+                ],
+                "summary": "Get alert statistics",
+                "description": "Get statistics and metrics for compliance alerts",
+                "operationId": "getAlertStatistics",
+                "parameters": [
+                    {
+                        "name": "period",
+                        "in": "query",
+                        "description": "Time period for statistics",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "today",
+                                "week",
+                                "month",
+                                "quarter",
+                                "year"
+                            ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Alert statistics",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/compliance/alerts/trends": {
+            "get": {
+                "tags": [
+                    "Compliance Alerts"
+                ],
+                "summary": "Get alert trends",
+                "description": "Get trend analysis for compliance alerts",
+                "operationId": "getAlertTrends",
+                "parameters": [
+                    {
+                        "name": "days",
+                        "in": "query",
+                        "description": "Number of days for trend analysis",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 30
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Alert trends",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/compliance/alerts/search": {
+            "post": {
+                "tags": [
+                    "Compliance Alerts"
+                ],
+                "summary": "Search alerts",
+                "description": "Search compliance alerts with advanced filters",
+                "operationId": "searchAlerts",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "query": {
+                                        "type": "string"
+                                    },
+                                    "entity_type": {
+                                        "type": "string"
+                                    },
+                                    "date_from": {
+                                        "type": "string",
+                                        "format": "date"
+                                    },
+                                    "date_to": {
+                                        "type": "string",
+                                        "format": "date"
+                                    },
+                                    "min_severity": {
+                                        "type": "string"
+                                    },
+                                    "include_resolved": {
+                                        "type": "boolean"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Search results",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/compliance/cases": {
+            "get": {
+                "tags": [
+                    "Compliance Cases"
+                ],
+                "summary": "Get compliance cases",
+                "description": "Retrieve compliance cases with filtering options",
+                "operationId": "getComplianceCases",
+                "parameters": [
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "description": "Filter by status",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "open",
+                                "investigating",
+                                "pending_review",
+                                "resolved",
+                                "closed"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "priority",
+                        "in": "query",
+                        "description": "Filter by priority",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "low",
+                                "medium",
+                                "high",
+                                "critical"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "assigned_to",
+                        "in": "query",
+                        "description": "Filter by assigned user ID",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "Page number",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of compliance cases",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Compliance Cases"
+                ],
+                "summary": "Create case",
+                "description": "Create a new compliance case",
+                "operationId": "createComplianceCase",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "title",
+                                    "priority"
+                                ],
+                                "properties": {
+                                    "title": {
+                                        "type": "string"
+                                    },
+                                    "description": {
+                                        "type": "string"
+                                    },
+                                    "priority": {
+                                        "type": "string",
+                                        "enum": [
+                                            "low",
+                                            "medium",
+                                            "high",
+                                            "critical"
+                                        ]
+                                    },
+                                    "entities": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object"
+                                        }
+                                    },
+                                    "evidence": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object"
+                                        }
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Case created successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/compliance/cases/{id}": {
+            "get": {
+                "tags": [
+                    "Compliance Cases"
+                ],
+                "summary": "Get case details",
+                "description": "Retrieve detailed information about a specific compliance case",
+                "operationId": "getComplianceCase",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Case ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Case details",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Case not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "Compliance Cases"
+                ],
+                "summary": "Update case",
+                "description": "Update a compliance case",
+                "operationId": "updateComplianceCase",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Case ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "title": {
+                                        "type": "string"
+                                    },
+                                    "description": {
+                                        "type": "string"
+                                    },
+                                    "priority": {
+                                        "type": "string",
+                                        "enum": [
+                                            "low",
+                                            "medium",
+                                            "high",
+                                            "critical"
+                                        ]
+                                    },
+                                    "status": {
+                                        "type": "string",
+                                        "enum": [
+                                            "open",
+                                            "investigating",
+                                            "pending_review",
+                                            "resolved",
+                                            "closed"
+                                        ]
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Case updated successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Compliance Cases"
+                ],
+                "summary": "Delete case",
+                "description": "Delete a compliance case (soft delete)",
+                "operationId": "deleteComplianceCase",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Case ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Case deleted successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/compliance/cases/{id}/assign": {
+            "put": {
+                "tags": [
+                    "Compliance Cases"
+                ],
+                "summary": "Assign case",
+                "description": "Assign a compliance case to a user",
+                "operationId": "assignCase",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Case ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "user_id"
+                                ],
+                                "properties": {
+                                    "user_id": {
+                                        "type": "integer"
+                                    },
+                                    "notes": {
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Case assigned successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/compliance/cases/{id}/evidence": {
+            "post": {
+                "tags": [
+                    "Compliance Cases"
+                ],
+                "summary": "Add evidence",
+                "description": "Add evidence to a compliance case",
+                "operationId": "addCaseEvidence",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Case ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "type",
+                                    "description"
+                                ],
+                                "properties": {
+                                    "type": {
+                                        "type": "string"
+                                    },
+                                    "description": {
+                                        "type": "string"
+                                    },
+                                    "data": {
+                                        "type": "object"
+                                    },
+                                    "source": {
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Evidence added successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/compliance/cases/{id}/notes": {
+            "post": {
+                "tags": [
+                    "Compliance Cases"
+                ],
+                "summary": "Add case note",
+                "description": "Add a note to a compliance case",
+                "operationId": "addCaseNote",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Case ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "note"
+                                ],
+                                "properties": {
+                                    "note": {
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "general",
+                                            "investigation",
+                                            "review",
+                                            "decision"
+                                        ]
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Note added successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/compliance/cases/{id}/escalate": {
+            "post": {
+                "tags": [
+                    "Compliance Cases"
+                ],
+                "summary": "Escalate case",
+                "description": "Escalate a compliance case",
+                "operationId": "escalateCase",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Case ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "reason"
+                                ],
+                                "properties": {
+                                    "reason": {
+                                        "type": "string"
+                                    },
+                                    "escalate_to": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Case escalated successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/compliance/cases/{id}/timeline": {
+            "get": {
+                "tags": [
+                    "Compliance Cases"
+                ],
+                "summary": "Get case timeline",
+                "description": "Get the timeline of events for a compliance case",
+                "operationId": "getCaseTimeline",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Case ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Case timeline",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
         "/api/custodians": {
             "get": {
                 "tags": [
@@ -11350,6 +15178,444 @@
                 ]
             }
         },
+        "/api/monitoring/health": {
+            "get": {
+                "tags": [
+                    "Monitoring"
+                ],
+                "summary": "Get application health status",
+                "description": "Returns comprehensive health check results",
+                "operationId": "getHealthStatus",
+                "responses": {
+                    "200": {
+                        "description": "Health status retrieved successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": [
+                                                "healthy",
+                                                "degraded",
+                                                "unhealthy"
+                                            ]
+                                        },
+                                        "healthy": {
+                                            "type": "boolean"
+                                        },
+                                        "timestamp": {
+                                            "type": "string",
+                                            "format": "date-time"
+                                        },
+                                        "checks": {
+                                            "type": "object"
+                                        },
+                                        "summary": {
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/monitoring/ready": {
+            "get": {
+                "tags": [
+                    "Monitoring"
+                ],
+                "summary": "Get application readiness status",
+                "description": "Returns whether the application is ready to serve traffic",
+                "operationId": "getReadyStatus",
+                "responses": {
+                    "200": {
+                        "description": "Application is ready",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "ready": {
+                                            "type": "boolean"
+                                        },
+                                        "timestamp": {
+                                            "type": "string",
+                                            "format": "date-time"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Application not ready"
+                    }
+                }
+            }
+        },
+        "/api/monitoring/alive": {
+            "get": {
+                "tags": [
+                    "Monitoring"
+                ],
+                "summary": "Get application liveness status",
+                "description": "Simple liveness check for Kubernetes",
+                "operationId": "getAliveStatus",
+                "responses": {
+                    "200": {
+                        "description": "Application is alive",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "alive": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "timestamp": {
+                                            "type": "string",
+                                            "format": "date-time"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/monitoring/metrics": {
+            "get": {
+                "tags": [
+                    "Monitoring"
+                ],
+                "summary": "Get application metrics",
+                "description": "Returns current application metrics in JSON format",
+                "operationId": "getMetrics",
+                "responses": {
+                    "200": {
+                        "description": "Metrics retrieved successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/monitoring/prometheus": {
+            "get": {
+                "tags": [
+                    "Monitoring"
+                ],
+                "summary": "Export metrics in Prometheus format",
+                "description": "Returns metrics formatted for Prometheus scraping",
+                "operationId": "getPrometheusMetrics",
+                "responses": {
+                    "200": {
+                        "description": "Prometheus metrics exported",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/monitoring/traces": {
+            "get": {
+                "tags": [
+                    "Monitoring"
+                ],
+                "summary": "Get distributed traces",
+                "description": "Returns list of distributed traces",
+                "operationId": "getTraces",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Number of traces to return",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 100
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Traces retrieved successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/monitoring/trace/{traceId}": {
+            "get": {
+                "tags": [
+                    "Monitoring"
+                ],
+                "summary": "Get specific trace details",
+                "description": "Returns detailed information about a specific trace",
+                "operationId": "getTrace",
+                "parameters": [
+                    {
+                        "name": "traceId",
+                        "in": "path",
+                        "description": "Trace ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Trace details retrieved",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Trace not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/monitoring/alerts": {
+            "get": {
+                "tags": [
+                    "Monitoring"
+                ],
+                "summary": "Get active alerts",
+                "description": "Returns list of active monitoring alerts",
+                "operationId": "getAlerts",
+                "parameters": [
+                    {
+                        "name": "severity",
+                        "in": "query",
+                        "description": "Filter by severity",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "critical",
+                                "error",
+                                "warning",
+                                "info"
+                            ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Alerts retrieved successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/monitoring/alerts/{alertId}/acknowledge": {
+            "put": {
+                "tags": [
+                    "Monitoring"
+                ],
+                "summary": "Acknowledge an alert",
+                "description": "Marks an alert as acknowledged",
+                "operationId": "acknowledgeAlert",
+                "parameters": [
+                    {
+                        "name": "alertId",
+                        "in": "path",
+                        "description": "Alert ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Alert acknowledged",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "alert_id": {
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Alert not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/monitoring/workflow/start": {
+            "post": {
+                "tags": [
+                    "Monitoring"
+                ],
+                "summary": "Start monitoring workflow",
+                "description": "Starts the automated monitoring workflow",
+                "operationId": "startMonitoringWorkflow",
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "interval": {
+                                        "type": "integer",
+                                        "default": 60
+                                    },
+                                    "max_iterations": {
+                                        "type": "integer",
+                                        "nullable": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Workflow started",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "workflow_id": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/monitoring/workflow/stop": {
+            "post": {
+                "tags": [
+                    "Monitoring"
+                ],
+                "summary": "Stop monitoring workflow",
+                "description": "Stops the automated monitoring workflow",
+                "operationId": "stopMonitoringWorkflow",
+                "responses": {
+                    "200": {
+                        "description": "Workflow stopped",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "No active workflow found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
         "/api/polls": {
             "get": {
                 "tags": [
@@ -14794,6 +19060,622 @@
                 ]
             }
         },
+        "/api/transaction-monitoring": {
+            "get": {
+                "tags": [
+                    "Transaction Monitoring"
+                ],
+                "summary": "Get monitored transactions",
+                "description": "Retrieve transactions that are being monitored for compliance",
+                "operationId": "getMonitoredTransactions",
+                "parameters": [
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "description": "Filter by status",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "pending",
+                                "reviewing",
+                                "cleared",
+                                "flagged"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "risk_level",
+                        "in": "query",
+                        "description": "Filter by risk level",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "low",
+                                "medium",
+                                "high",
+                                "critical"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "Page number",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of monitored transactions",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/transaction-monitoring/{id}": {
+            "get": {
+                "tags": [
+                    "Transaction Monitoring"
+                ],
+                "summary": "Get transaction monitoring details",
+                "description": "Retrieve detailed monitoring information for a specific transaction",
+                "operationId": "getTransactionDetails",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Transaction ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Transaction monitoring details",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Transaction not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/transaction-monitoring/{id}/flag": {
+            "post": {
+                "tags": [
+                    "Transaction Monitoring"
+                ],
+                "summary": "Flag a transaction",
+                "description": "Flag a transaction for compliance review",
+                "operationId": "flagTransaction",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Transaction ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "reason": {
+                                        "description": "Reason for flagging",
+                                        "type": "string"
+                                    },
+                                    "severity": {
+                                        "type": "string",
+                                        "enum": [
+                                            "low",
+                                            "medium",
+                                            "high",
+                                            "critical"
+                                        ]
+                                    },
+                                    "notes": {
+                                        "description": "Additional notes",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Transaction flagged successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/transaction-monitoring/{id}/clear": {
+            "post": {
+                "tags": [
+                    "Transaction Monitoring"
+                ],
+                "summary": "Clear a transaction",
+                "description": "Clear a transaction from compliance monitoring",
+                "operationId": "clearTransaction",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Transaction ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "reason": {
+                                        "description": "Reason for clearing",
+                                        "type": "string"
+                                    },
+                                    "reviewer": {
+                                        "description": "Reviewer ID",
+                                        "type": "string"
+                                    },
+                                    "notes": {
+                                        "description": "Additional notes",
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Transaction cleared successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/transaction-monitoring/rules": {
+            "get": {
+                "tags": [
+                    "Transaction Monitoring"
+                ],
+                "summary": "Get monitoring rules",
+                "description": "Retrieve all transaction monitoring rules",
+                "operationId": "getMonitoringRules",
+                "responses": {
+                    "200": {
+                        "description": "List of monitoring rules",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Transaction Monitoring"
+                ],
+                "summary": "Create monitoring rule",
+                "description": "Create a new transaction monitoring rule",
+                "operationId": "createMonitoringRule",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "name",
+                                    "type",
+                                    "conditions",
+                                    "severity"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "type": {
+                                        "type": "string"
+                                    },
+                                    "conditions": {
+                                        "type": "object"
+                                    },
+                                    "threshold": {
+                                        "type": "number"
+                                    },
+                                    "severity": {
+                                        "type": "string",
+                                        "enum": [
+                                            "low",
+                                            "medium",
+                                            "high",
+                                            "critical"
+                                        ]
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Rule created successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/transaction-monitoring/rules/{id}": {
+            "put": {
+                "tags": [
+                    "Transaction Monitoring"
+                ],
+                "summary": "Update monitoring rule",
+                "description": "Update an existing transaction monitoring rule",
+                "operationId": "updateMonitoringRule",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Rule ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {}
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Rule updated successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Transaction Monitoring"
+                ],
+                "summary": "Delete monitoring rule",
+                "description": "Delete a transaction monitoring rule",
+                "operationId": "deleteMonitoringRule",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Rule ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Rule deleted successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/transaction-monitoring/patterns": {
+            "get": {
+                "tags": [
+                    "Transaction Monitoring"
+                ],
+                "summary": "Get detected patterns",
+                "description": "Retrieve patterns detected in transaction monitoring",
+                "operationId": "getDetectedPatterns",
+                "parameters": [
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "description": "Pattern type filter",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of detected patterns",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/transaction-monitoring/thresholds": {
+            "get": {
+                "tags": [
+                    "Transaction Monitoring"
+                ],
+                "summary": "Get monitoring thresholds",
+                "description": "Retrieve current transaction monitoring thresholds",
+                "operationId": "getMonitoringThresholds",
+                "responses": {
+                    "200": {
+                        "description": "Current monitoring thresholds",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "Transaction Monitoring"
+                ],
+                "summary": "Update monitoring thresholds",
+                "description": "Update transaction monitoring thresholds",
+                "operationId": "updateMonitoringThresholds",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {}
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Thresholds updated successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/transaction-monitoring/analyze/realtime": {
+            "post": {
+                "tags": [
+                    "Transaction Monitoring"
+                ],
+                "summary": "Analyze transaction in real-time",
+                "description": "Perform real-time analysis of a transaction",
+                "operationId": "analyzeTransactionRealtime",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "transaction_id"
+                                ],
+                                "properties": {
+                                    "transaction_id": {
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Analysis completed",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/transaction-monitoring/analyze/batch": {
+            "post": {
+                "tags": [
+                    "Transaction Monitoring"
+                ],
+                "summary": "Analyze transactions in batch",
+                "description": "Perform batch analysis of multiple transactions",
+                "operationId": "analyzeTransactionBatch",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "transaction_ids"
+                                ],
+                                "properties": {
+                                    "transaction_ids": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Batch analysis started",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/transaction-monitoring/analysis/{analysisId}": {
+            "get": {
+                "tags": [
+                    "Transaction Monitoring"
+                ],
+                "summary": "Get analysis status",
+                "description": "Get the status of a batch analysis",
+                "operationId": "getAnalysisStatus",
+                "parameters": [
+                    {
+                        "name": "analysisId",
+                        "in": "path",
+                        "description": "Analysis ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Analysis status",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Analysis not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
         "/api/accounts/{uuid}/transactions/reverse": {
             "post": {
                 "tags": [
@@ -15233,6 +20115,954 @@
                 "security": [
                     {
                         "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/treasury/portfolios": {
+            "get": {
+                "tags": [
+                    "Treasury Portfolio"
+                ],
+                "summary": "List portfolios for treasury",
+                "description": "Retrieves a list of portfolios for the authenticated treasury account",
+                "operationId": "listTreasuryPortfolios",
+                "parameters": [
+                    {
+                        "name": "treasury_id",
+                        "in": "query",
+                        "description": "Treasury ID to filter portfolios",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of treasury portfolios",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/TreasuryPortfolio"
+                                            }
+                                        },
+                                        "meta": {
+                                            "properties": {
+                                                "total": {
+                                                    "type": "integer"
+                                                },
+                                                "count": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "403": {
+                        "description": "Forbidden - insufficient treasury permissions"
+                    },
+                    "429": {
+                        "description": "Too Many Requests"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": [
+                            "treasury"
+                        ]
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Treasury Portfolio"
+                ],
+                "summary": "Create a new treasury portfolio",
+                "description": "Creates a new portfolio for treasury management with investment strategy",
+                "operationId": "createTreasuryPortfolio",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateTreasuryPortfolioRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Portfolio created successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/TreasuryPortfolio"
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Portfolio created successfully"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request - validation errors"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "403": {
+                        "description": "Forbidden - insufficient treasury permissions"
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity - validation failed"
+                    },
+                    "429": {
+                        "description": "Too Many Requests"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": [
+                            "treasury"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/api/treasury/portfolios/{id}": {
+            "get": {
+                "tags": [
+                    "Treasury Portfolio"
+                ],
+                "summary": "Get portfolio details",
+                "description": "Retrieves detailed information about a specific treasury portfolio",
+                "operationId": "getTreasuryPortfolio",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Portfolio ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Portfolio details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/TreasuryPortfolioDetailed"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Portfolio not found"
+                    },
+                    "401": {
+                        "description": "Unauthorized"
+                    },
+                    "403": {
+                        "description": "Forbidden"
+                    },
+                    "429": {
+                        "description": "Too Many Requests"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": [
+                            "treasury"
+                        ]
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "Treasury Portfolio"
+                ],
+                "summary": "Update portfolio strategy",
+                "description": "Updates the investment strategy for a treasury portfolio",
+                "operationId": "updateTreasuryPortfolio",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Portfolio ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateTreasuryPortfolioRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Portfolio updated successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/TreasuryPortfolio"
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Portfolio strategy updated successfully"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Portfolio not found"
+                    },
+                    "422": {
+                        "description": "Validation failed"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": [
+                            "treasury"
+                        ]
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Treasury Portfolio"
+                ],
+                "summary": "Delete portfolio",
+                "description": "Soft deletes a treasury portfolio (sets status to inactive)",
+                "operationId": "deleteTreasuryPortfolio",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Portfolio ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Portfolio deleted successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Portfolio deleted successfully"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Portfolio not found"
+                    },
+                    "409": {
+                        "description": "Conflict - portfolio cannot be deleted"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": [
+                            "treasury"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/api/treasury/portfolios/{id}/allocate": {
+            "post": {
+                "tags": [
+                    "Treasury Portfolio"
+                ],
+                "summary": "Allocate assets to portfolio",
+                "description": "Allocates assets to a treasury portfolio with specified weights",
+                "operationId": "allocatePortfolioAssets",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Portfolio ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AllocateAssetsRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Assets allocated successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/TreasuryPortfolio"
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Assets allocated successfully"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": [
+                            "treasury"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/api/treasury/portfolios/{id}/allocations": {
+            "get": {
+                "tags": [
+                    "Treasury Portfolio"
+                ],
+                "summary": "Get current asset allocations",
+                "description": "Retrieves current asset allocation details for a portfolio",
+                "operationId": "getPortfolioAllocations",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Portfolio ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Current asset allocations",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "allocations": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "#/components/schemas/AssetAllocation"
+                                                    }
+                                                },
+                                                "total_value": {
+                                                    "type": "number",
+                                                    "format": "float"
+                                                },
+                                                "last_updated": {
+                                                    "type": "string",
+                                                    "format": "date-time"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": [
+                            "treasury"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/api/treasury/portfolios/{id}/rebalance": {
+            "post": {
+                "tags": [
+                    "Treasury Portfolio"
+                ],
+                "summary": "Trigger portfolio rebalancing",
+                "description": "Initiates rebalancing workflow for a treasury portfolio",
+                "operationId": "triggerPortfolioRebalancing",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Portfolio ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/TriggerRebalancingRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Rebalancing workflow started",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "workflow_id": {
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "type": "string",
+                                                    "example": "started"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Rebalancing workflow started"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": [
+                            "treasury"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/api/treasury/portfolios/{id}/rebalancing-plan": {
+            "get": {
+                "tags": [
+                    "Treasury Portfolio"
+                ],
+                "summary": "Get rebalancing plan",
+                "description": "Calculates and returns the rebalancing plan for a portfolio",
+                "operationId": "getRebalancingPlan",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Portfolio ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Rebalancing plan details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/RebalancingPlan"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": [
+                            "treasury"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/api/treasury/portfolios/{id}/approve-rebalancing": {
+            "post": {
+                "tags": [
+                    "Treasury Portfolio"
+                ],
+                "summary": "Approve rebalancing execution",
+                "description": "Approves and executes a portfolio rebalancing plan",
+                "operationId": "approvePortfolioRebalancing",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Portfolio ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApproveRebalancingRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Rebalancing approved and executed",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Rebalancing executed successfully"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": [
+                            "treasury"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/api/treasury/portfolios/{id}/performance": {
+            "get": {
+                "tags": [
+                    "Treasury Portfolio"
+                ],
+                "summary": "Get performance metrics",
+                "description": "Retrieves performance metrics and analytics for a portfolio",
+                "operationId": "getPortfolioPerformance",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Portfolio ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
+                        "name": "period",
+                        "in": "query",
+                        "description": "Performance period",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "30d",
+                            "enum": [
+                                "1d",
+                                "7d",
+                                "30d",
+                                "90d",
+                                "1y",
+                                "ytd",
+                                "all"
+                            ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Portfolio performance metrics",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/PortfolioPerformance"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": [
+                            "treasury"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/api/treasury/portfolios/{id}/valuation": {
+            "get": {
+                "tags": [
+                    "Treasury Portfolio"
+                ],
+                "summary": "Get current portfolio valuation",
+                "description": "Retrieves real-time valuation of portfolio assets",
+                "operationId": "getPortfolioValuation",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Portfolio ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Portfolio valuation details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/PortfolioValuation"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": [
+                            "treasury"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/api/treasury/portfolios/{id}/history": {
+            "get": {
+                "tags": [
+                    "Treasury Portfolio"
+                ],
+                "summary": "Get portfolio historical data",
+                "description": "Retrieves historical performance and rebalancing data",
+                "operationId": "getPortfolioHistory",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Portfolio ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "description": "Type of historical data",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "all",
+                            "enum": [
+                                "rebalancing",
+                                "performance",
+                                "all"
+                            ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Portfolio historical data",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "$ref": "#/components/schemas/PortfolioHistory"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": [
+                            "treasury"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/api/treasury/portfolios/{id}/reports": {
+            "get": {
+                "tags": [
+                    "Treasury Portfolio"
+                ],
+                "summary": "List portfolio reports",
+                "description": "Retrieves a list of generated reports for a portfolio",
+                "operationId": "listPortfolioReports",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Portfolio ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of portfolio reports",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/PortfolioReport"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": [
+                            "treasury"
+                        ]
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Treasury Portfolio"
+                ],
+                "summary": "Generate portfolio report",
+                "description": "Generates a comprehensive report for a treasury portfolio",
+                "operationId": "generatePortfolioReport",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "Portfolio ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateReportRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "202": {
+                        "description": "Report generation started",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "workflow_id": {
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "type": "string",
+                                                    "example": "started"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Report generation started"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": [
+                            "treasury"
+                        ]
                     }
                 ]
             }
@@ -19868,10 +25698,673 @@
                 },
                 "type": "object"
             },
+            "TreasuryPortfolio": {
+                "description": "A treasury portfolio containing asset allocations",
+                "properties": {
+                    "portfolio_id": {
+                        "description": "Treasury API Documentation Schemas.",
+                        "type": "string",
+                        "format": "uuid",
+                        "example": "550e8400-e29b-41d4-a716-446655440000"
+                    },
+                    "treasury_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "example": "550e8400-e29b-41d4-a716-446655440001"
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "Main Treasury Portfolio"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "active",
+                            "inactive",
+                            "rebalancing",
+                            "liquidating"
+                        ],
+                        "example": "active"
+                    },
+                    "total_value": {
+                        "type": "number",
+                        "format": "float",
+                        "example": 1000000
+                    },
+                    "asset_count": {
+                        "type": "integer",
+                        "example": 5
+                    },
+                    "is_rebalancing": {
+                        "type": "boolean",
+                        "example": false
+                    },
+                    "last_rebalance_date": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "type": "object"
+            },
+            "TreasuryPortfolioDetailed": {
+                "description": "Detailed treasury portfolio with summary and rebalancing status",
+                "type": "object",
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/TreasuryPortfolio"
+                    },
+                    {
+                        "properties": {
+                            "strategy": {
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "example": "balanced"
+                                    },
+                                    "risk_tolerance": {
+                                        "type": "string",
+                                        "example": "moderate"
+                                    },
+                                    "target_allocations": {
+                                        "type": "object"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "asset_allocations": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/AssetAllocation"
+                                }
+                            },
+                            "latest_metrics": {
+                                "type": "object"
+                            },
+                            "summary": {
+                                "type": "object"
+                            },
+                            "needs_rebalancing": {
+                                "type": "boolean",
+                                "example": false
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "CreateTreasuryPortfolioRequest": {
+                "required": [
+                    "treasury_id",
+                    "name",
+                    "strategy"
+                ],
+                "properties": {
+                    "treasury_id": {
+                        "description": "ID of the treasury account",
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "name": {
+                        "description": "Portfolio name",
+                        "type": "string",
+                        "example": "Growth Portfolio"
+                    },
+                    "strategy": {
+                        "required": [
+                            "type"
+                        ],
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": [
+                                    "conservative",
+                                    "balanced",
+                                    "aggressive",
+                                    "custom"
+                                ],
+                                "example": "balanced"
+                            },
+                            "risk_tolerance": {
+                                "type": "string",
+                                "enum": [
+                                    "low",
+                                    "moderate",
+                                    "high"
+                                ],
+                                "example": "moderate"
+                            },
+                            "target_allocations": {
+                                "properties": {
+                                    "USD": {
+                                        "type": "number",
+                                        "format": "float",
+                                        "example": 40
+                                    },
+                                    "EUR": {
+                                        "type": "number",
+                                        "format": "float",
+                                        "example": 30
+                                    },
+                                    "GCU": {
+                                        "type": "number",
+                                        "format": "float",
+                                        "example": 30
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "rebalancing_threshold": {
+                                "description": "Percentage deviation threshold for rebalancing",
+                                "type": "number",
+                                "format": "float",
+                                "example": 5
+                            }
+                        },
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "UpdateTreasuryPortfolioRequest": {
+                "required": [
+                    "strategy"
+                ],
+                "properties": {
+                    "strategy": {
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": [
+                                    "conservative",
+                                    "balanced",
+                                    "aggressive",
+                                    "custom"
+                                ],
+                                "example": "balanced"
+                            },
+                            "risk_tolerance": {
+                                "type": "string",
+                                "enum": [
+                                    "low",
+                                    "moderate",
+                                    "high"
+                                ],
+                                "example": "moderate"
+                            },
+                            "target_allocations": {
+                                "type": "object"
+                            },
+                            "rebalancing_threshold": {
+                                "type": "number",
+                                "format": "float",
+                                "example": 5
+                            }
+                        },
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "AllocateAssetsRequest": {
+                "required": [
+                    "allocations"
+                ],
+                "properties": {
+                    "allocations": {
+                        "type": "array",
+                        "items": {
+                            "properties": {
+                                "asset_symbol": {
+                                    "type": "string",
+                                    "example": "USD"
+                                },
+                                "target_percentage": {
+                                    "type": "number",
+                                    "format": "float",
+                                    "example": 40
+                                },
+                                "quantity": {
+                                    "type": "number",
+                                    "format": "float",
+                                    "example": 400000
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "AssetAllocation": {
+                "description": "An asset allocation within a treasury portfolio",
+                "properties": {
+                    "asset_id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "asset_symbol": {
+                        "type": "string",
+                        "example": "USD"
+                    },
+                    "asset_type": {
+                        "type": "string",
+                        "enum": [
+                            "fiat",
+                            "crypto",
+                            "stablecoin",
+                            "commodity"
+                        ],
+                        "example": "fiat"
+                    },
+                    "quantity": {
+                        "type": "number",
+                        "format": "float",
+                        "example": 500000
+                    },
+                    "current_value": {
+                        "type": "number",
+                        "format": "float",
+                        "example": 500000
+                    },
+                    "target_percentage": {
+                        "type": "number",
+                        "format": "float",
+                        "example": 50
+                    },
+                    "current_percentage": {
+                        "type": "number",
+                        "format": "float",
+                        "example": 48.5
+                    },
+                    "deviation": {
+                        "type": "number",
+                        "format": "float",
+                        "example": -1.5
+                    }
+                },
+                "type": "object"
+            },
+            "TriggerRebalancingRequest": {
+                "properties": {
+                    "reason": {
+                        "description": "Reason for triggering rebalancing",
+                        "type": "string",
+                        "example": "manual_trigger"
+                    }
+                },
+                "type": "object"
+            },
+            "RebalancingPlan": {
+                "description": "Treasury portfolio rebalancing plan",
+                "properties": {
+                    "plan_id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "portfolio_id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "pending",
+                            "approved",
+                            "executing",
+                            "completed",
+                            "cancelled"
+                        ],
+                        "example": "pending"
+                    },
+                    "trades": {
+                        "type": "array",
+                        "items": {
+                            "properties": {
+                                "asset_symbol": {
+                                    "type": "string"
+                                },
+                                "action": {
+                                    "type": "string",
+                                    "enum": [
+                                        "buy",
+                                        "sell"
+                                    ]
+                                },
+                                "quantity": {
+                                    "type": "number",
+                                    "format": "float"
+                                },
+                                "estimated_value": {
+                                    "type": "number",
+                                    "format": "float"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "estimated_cost": {
+                        "type": "number",
+                        "format": "float",
+                        "example": 50
+                    },
+                    "current_allocations": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AssetAllocation"
+                        }
+                    },
+                    "target_allocations": {
+                        "type": "object"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "approved_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
+            "ApproveRebalancingRequest": {
+                "required": [
+                    "plan"
+                ],
+                "properties": {
+                    "plan": {
+                        "properties": {
+                            "trades": {
+                                "type": "array",
+                                "items": {
+                                    "properties": {
+                                        "asset_symbol": {
+                                            "type": "string"
+                                        },
+                                        "action": {
+                                            "type": "string",
+                                            "enum": [
+                                                "buy",
+                                                "sell"
+                                            ]
+                                        },
+                                        "quantity": {
+                                            "type": "number",
+                                            "format": "float"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "PortfolioPerformance": {
+                "description": "Portfolio performance metrics",
+                "properties": {
+                    "portfolio_id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "period": {
+                        "type": "string",
+                        "example": "30d"
+                    },
+                    "performance": {
+                        "properties": {
+                            "starting_value": {
+                                "type": "number",
+                                "format": "float",
+                                "example": 1000000
+                            },
+                            "ending_value": {
+                                "type": "number",
+                                "format": "float",
+                                "example": 1050000
+                            },
+                            "absolute_return": {
+                                "type": "number",
+                                "format": "float",
+                                "example": 50000
+                            },
+                            "percentage_return": {
+                                "type": "number",
+                                "format": "float",
+                                "example": 5
+                            },
+                            "volatility": {
+                                "type": "number",
+                                "format": "float",
+                                "example": 2.5
+                            },
+                            "sharpe_ratio": {
+                                "type": "number",
+                                "format": "float",
+                                "example": 1.5
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "rebalancing_metrics": {
+                        "properties": {
+                            "total_rebalances": {
+                                "type": "integer",
+                                "example": 3
+                            },
+                            "last_rebalance": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "deviation_score": {
+                                "type": "number",
+                                "format": "float",
+                                "example": 2.1
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "generated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "type": "object"
+            },
+            "PortfolioValuation": {
+                "description": "Portfolio valuation details",
+                "properties": {
+                    "portfolio_id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "valuation": {
+                        "properties": {
+                            "total_value": {
+                                "type": "number",
+                                "format": "float",
+                                "example": 1000000
+                            },
+                            "currency": {
+                                "type": "string",
+                                "example": "USD"
+                            },
+                            "assets": {
+                                "type": "array",
+                                "items": {
+                                    "properties": {
+                                        "symbol": {
+                                            "type": "string"
+                                        },
+                                        "quantity": {
+                                            "type": "number",
+                                            "format": "float"
+                                        },
+                                        "unit_price": {
+                                            "type": "number",
+                                            "format": "float"
+                                        },
+                                        "total_value": {
+                                            "type": "number",
+                                            "format": "float"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "type": "object"
+            },
+            "PortfolioHistory": {
+                "description": "Portfolio historical data",
+                "properties": {
+                    "portfolio_id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "rebalancing",
+                            "performance",
+                            "all"
+                        ],
+                        "example": "all"
+                    },
+                    "history": {
+                        "properties": {
+                            "rebalancing": {
+                                "type": "array",
+                                "items": {
+                                    "properties": {
+                                        "date": {
+                                            "type": "string",
+                                            "format": "date-time"
+                                        },
+                                        "reason": {
+                                            "type": "string"
+                                        },
+                                        "trades_executed": {
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            },
+                            "performance": {
+                                "type": "array",
+                                "items": {
+                                    "properties": {
+                                        "date": {
+                                            "type": "string",
+                                            "format": "date"
+                                        },
+                                        "value": {
+                                            "type": "number",
+                                            "format": "float"
+                                        },
+                                        "daily_return": {
+                                            "type": "number",
+                                            "format": "float"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        },
+                        "type": "object"
+                    }
+                },
+                "type": "object"
+            },
+            "CreateReportRequest": {
+                "required": [
+                    "type",
+                    "period"
+                ],
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "summary",
+                            "detailed",
+                            "compliance",
+                            "performance"
+                        ],
+                        "example": "summary"
+                    },
+                    "period": {
+                        "description": "Report period (e.g., 7d, 30d, 90d, 1y)",
+                        "type": "string",
+                        "example": "30d"
+                    }
+                },
+                "type": "object"
+            },
+            "PortfolioReport": {
+                "description": "Generated portfolio report",
+                "properties": {
+                    "report_id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "portfolio_id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "type": {
+                        "type": "string",
+                        "example": "summary"
+                    },
+                    "period": {
+                        "type": "string",
+                        "example": "30d"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "pending",
+                            "generating",
+                            "completed",
+                            "failed"
+                        ],
+                        "example": "completed"
+                    },
+                    "generated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "download_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true
+                    }
+                },
+                "type": "object"
+            },
             "V2Error": {
                 "properties": {
                     "message": {
-                        "description": "V2 API Documentation Schemas",
+                        "description": "V2 API Documentation Schemas.",
                         "type": "string",
                         "example": "An error occurred"
                     },
@@ -20078,6 +26571,30 @@
             "description": "APIs for managing multi-asset account balances"
         },
         {
+            "name": "Agent Protocol - Authentication",
+            "description": "Agent authentication, API key management, and session handling"
+        },
+        {
+            "name": "Agent Protocol - Escrow",
+            "description": "Escrow management for secure agent-to-agent transactions"
+        },
+        {
+            "name": "Agent Protocol - Identity",
+            "description": "Agent registration, discovery, and identity management endpoints"
+        },
+        {
+            "name": "Agent Protocol - Messaging",
+            "description": "Agent-to-Agent (A2A) messaging endpoints"
+        },
+        {
+            "name": "Agent Protocol - Payments",
+            "description": "Agent payment initiation and management endpoints"
+        },
+        {
+            "name": "Agent Protocol - Reputation",
+            "description": "Agent reputation and trust management endpoints"
+        },
+        {
             "name": "Assets",
             "description": "Asset and currency management"
         },
@@ -20186,6 +26703,10 @@
             "description": "Critical transaction reversal operations for error recovery"
         },
         {
+            "name": "Treasury Portfolio",
+            "description": "Treasury portfolio management operations"
+        },
+        {
             "name": "User Voting",
             "description": "User-friendly voting interface for GCU governance"
         },
@@ -20214,8 +26735,28 @@
             "description": "Monitor and manage workflow executions, compensations, and saga patterns"
         },
         {
+            "name": "AI Agents",
+            "description": "AI Agents"
+        },
+        {
+            "name": "Compliance Alerts",
+            "description": "Compliance Alerts"
+        },
+        {
+            "name": "Compliance Cases",
+            "description": "Compliance Cases"
+        },
+        {
             "name": "Exchange",
             "description": "Exchange"
+        },
+        {
+            "name": "Monitoring",
+            "description": "Monitoring"
+        },
+        {
+            "name": "Transaction Monitoring",
+            "description": "Transaction Monitoring"
         },
         {
             "name": "GCU Voting",


### PR DESCRIPTION
## Summary
- Fixed duplicate `operationId` error that was preventing Swagger documentation generation
- Added comprehensive OpenAPI schemas for Treasury Portfolio API endpoints

## Changes
1. **Fixed duplicate operationId "discoverAgents"**
   - Renamed AGENTS.md discovery endpoint operationId to `discoverAgentsDocumentation`
   - Agent Protocol discovery endpoint retains `discoverAgents` operationId

2. **Added TreasuryApiSchemas.php with 14 schema definitions:**
   - `TreasuryPortfolio` - Basic portfolio representation
   - `TreasuryPortfolioDetailed` - Extended portfolio with strategy and allocations
   - `CreateTreasuryPortfolioRequest` - Request schema for portfolio creation
   - `UpdateTreasuryPortfolioRequest` - Request schema for portfolio updates
   - `AllocateAssetsRequest` - Request schema for asset allocation
   - `AssetAllocation` - Individual asset allocation within portfolio
   - `TriggerRebalancingRequest` - Request to trigger rebalancing
   - `RebalancingPlan` - Rebalancing plan with trades
   - `ApproveRebalancingRequest` - Request to approve rebalancing
   - `PortfolioPerformance` - Performance metrics schema
   - `PortfolioValuation` - Real-time valuation schema
   - `PortfolioHistory` - Historical data schema
   - `CreateReportRequest` - Request for report generation
   - `PortfolioReport` - Generated report schema

3. **Regenerated api-docs.json** with all fixes applied

## Test plan
- [x] `php artisan l5-swagger:generate` completes without errors
- [x] Code style validation passes
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)