### PR TITLE
feat(agent-protocol): Add type-safe AgentScope enum for OAuth2-style authorization

### DIFF
--- a/app/Domain/AgentProtocol/Enums/AgentScope.php
+++ b/app/Domain/AgentProtocol/Enums/AgentScope.php
@@ -1,0 +1,328 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AgentProtocol\Enums;
+
+/**
+ * Agent OAuth2-style scopes for API authorization.
+ *
+ * Scopes control what operations an agent's API key or session can perform.
+ * Use wildcards (*) for category-wide or universal access.
+ */
+enum AgentScope: string
+{
+    // Payment scopes
+    case PAYMENTS_READ = 'payments:read';
+    case PAYMENTS_CREATE = 'payments:create';
+    case PAYMENTS_CANCEL = 'payments:cancel';
+    case PAYMENTS_ALL = 'payments:*';
+
+    // Wallet scopes
+    case WALLET_READ = 'wallet:read';
+    case WALLET_TRANSFER = 'wallet:transfer';
+    case WALLET_WITHDRAW = 'wallet:withdraw';
+    case WALLET_ALL = 'wallet:*';
+
+    // Escrow scopes
+    case ESCROW_READ = 'escrow:read';
+    case ESCROW_CREATE = 'escrow:create';
+    case ESCROW_RELEASE = 'escrow:release';
+    case ESCROW_DISPUTE = 'escrow:dispute';
+    case ESCROW_ALL = 'escrow:*';
+
+    // Messaging scopes
+    case MESSAGES_READ = 'messages:read';
+    case MESSAGES_SEND = 'messages:send';
+    case MESSAGES_WRITE = 'messages:write';
+    case MESSAGES_ALL = 'messages:*';
+
+    // Agent management scopes
+    case AGENT_READ = 'agent:read';
+    case AGENT_UPDATE = 'agent:update';
+    case AGENT_KEYS = 'agent:keys';
+    case AGENT_SESSIONS = 'agent:sessions';
+    case AGENT_ALL = 'agent:*';
+
+    // Reputation scopes
+    case REPUTATION_READ = 'reputation:read';
+    case REPUTATION_REVIEW = 'reputation:review';
+    case REPUTATION_WRITE = 'reputation:write';
+    case REPUTATION_ALL = 'reputation:*';
+
+    // Compliance scopes
+    case COMPLIANCE_READ = 'compliance:read';
+    case COMPLIANCE_VERIFY = 'compliance:verify';
+    case COMPLIANCE_ALL = 'compliance:*';
+
+    // Administrative scopes (restricted)
+    case ADMIN_READ = 'admin:read';
+    case ADMIN_MANAGE = 'admin:manage';
+    case ADMIN_ALL = 'admin:*';
+
+    // Universal scope
+    case UNIVERSAL = '*';
+
+    /**
+     * Get a human-readable description for the scope.
+     */
+    public function description(): string
+    {
+        return match ($this) {
+            self::PAYMENTS_READ   => 'View payment transactions and history',
+            self::PAYMENTS_CREATE => 'Create new payment transactions',
+            self::PAYMENTS_CANCEL => 'Cancel pending payment transactions',
+            self::PAYMENTS_ALL    => 'Full access to payment operations',
+
+            self::WALLET_READ     => 'View wallet balance and transactions',
+            self::WALLET_TRANSFER => 'Transfer funds between wallets',
+            self::WALLET_WITHDRAW => 'Withdraw funds from wallet',
+            self::WALLET_ALL      => 'Full access to wallet operations',
+
+            self::ESCROW_READ    => 'View escrow transactions',
+            self::ESCROW_CREATE  => 'Create new escrow transactions',
+            self::ESCROW_RELEASE => 'Release escrow funds',
+            self::ESCROW_DISPUTE => 'Dispute escrow transactions',
+            self::ESCROW_ALL     => 'Full access to escrow operations',
+
+            self::MESSAGES_READ  => 'View A2A messages and conversations',
+            self::MESSAGES_SEND  => 'Send A2A messages to other agents',
+            self::MESSAGES_WRITE => 'Create and manage A2A messages',
+            self::MESSAGES_ALL   => 'Full access to messaging operations',
+
+            self::AGENT_READ     => 'View agent profile and capabilities',
+            self::AGENT_UPDATE   => 'Update agent profile',
+            self::AGENT_KEYS     => 'Manage API keys',
+            self::AGENT_SESSIONS => 'Manage sessions',
+            self::AGENT_ALL      => 'Full access to agent management',
+
+            self::REPUTATION_READ   => 'View reputation scores',
+            self::REPUTATION_REVIEW => 'Submit reviews and ratings',
+            self::REPUTATION_WRITE  => 'Modify reputation data',
+            self::REPUTATION_ALL    => 'Full access to reputation system',
+
+            self::COMPLIANCE_READ   => 'View compliance status',
+            self::COMPLIANCE_VERIFY => 'Submit verification documents',
+            self::COMPLIANCE_ALL    => 'Full access to compliance operations',
+
+            self::ADMIN_READ   => 'View administrative data',
+            self::ADMIN_MANAGE => 'Manage agents and transactions',
+            self::ADMIN_ALL    => 'Full administrative access',
+
+            self::UNIVERSAL => 'Full access to all operations',
+        };
+    }
+
+    /**
+     * Get the category (prefix) for this scope.
+     */
+    public function category(): string
+    {
+        if ($this === self::UNIVERSAL) {
+            return '*';
+        }
+
+        $parts = explode(':', $this->value);
+
+        return $parts[0];
+    }
+
+    /**
+     * Check if this is a wildcard scope.
+     */
+    public function isWildcard(): bool
+    {
+        return $this === self::UNIVERSAL || str_ends_with($this->value, ':*');
+    }
+
+    /**
+     * Check if this scope covers another scope.
+     *
+     * @param AgentScope|string $other The scope to check coverage for
+     */
+    public function covers(AgentScope|string $other): bool
+    {
+        $otherValue = $other instanceof AgentScope ? $other->value : $other;
+
+        // Universal scope covers everything
+        if ($this === self::UNIVERSAL) {
+            return true;
+        }
+
+        // Exact match
+        if ($this->value === $otherValue) {
+            return true;
+        }
+
+        // Category wildcard (e.g., payments:* covers payments:read)
+        if ($this->isWildcard()) {
+            $thisCategory = $this->category();
+            $otherParts = explode(':', $otherValue);
+            $otherCategory = $otherParts[0];
+
+            return $thisCategory === $otherCategory;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get all scopes in a category.
+     *
+     * @return array<AgentScope>
+     */
+    public static function inCategory(string $category): array
+    {
+        $results = [];
+
+        foreach (self::cases() as $scope) {
+            if ($scope->category() === $category) {
+                $results[] = $scope;
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Get the default scopes for a new agent.
+     *
+     * @return array<AgentScope>
+     */
+    public static function defaults(): array
+    {
+        return [
+            self::PAYMENTS_READ,
+            self::WALLET_READ,
+            self::AGENT_READ,
+            self::REPUTATION_READ,
+            self::MESSAGES_READ,
+        ];
+    }
+
+    /**
+     * Get all read-only scopes.
+     *
+     * @return array<AgentScope>
+     */
+    public static function readOnly(): array
+    {
+        return [
+            self::PAYMENTS_READ,
+            self::WALLET_READ,
+            self::ESCROW_READ,
+            self::MESSAGES_READ,
+            self::AGENT_READ,
+            self::REPUTATION_READ,
+            self::COMPLIANCE_READ,
+            self::ADMIN_READ,
+        ];
+    }
+
+    /**
+     * Get all write/modify scopes.
+     *
+     * @return array<AgentScope>
+     */
+    public static function writeScopes(): array
+    {
+        return [
+            self::PAYMENTS_CREATE,
+            self::PAYMENTS_CANCEL,
+            self::WALLET_TRANSFER,
+            self::WALLET_WITHDRAW,
+            self::ESCROW_CREATE,
+            self::ESCROW_RELEASE,
+            self::ESCROW_DISPUTE,
+            self::MESSAGES_SEND,
+            self::MESSAGES_WRITE,
+            self::AGENT_UPDATE,
+            self::AGENT_KEYS,
+            self::AGENT_SESSIONS,
+            self::REPUTATION_REVIEW,
+            self::REPUTATION_WRITE,
+            self::COMPLIANCE_VERIFY,
+            self::ADMIN_MANAGE,
+        ];
+    }
+
+    /**
+     * Get all wildcard scopes.
+     *
+     * @return array<AgentScope>
+     */
+    public static function wildcards(): array
+    {
+        return [
+            self::PAYMENTS_ALL,
+            self::WALLET_ALL,
+            self::ESCROW_ALL,
+            self::MESSAGES_ALL,
+            self::AGENT_ALL,
+            self::REPUTATION_ALL,
+            self::COMPLIANCE_ALL,
+            self::ADMIN_ALL,
+            self::UNIVERSAL,
+        ];
+    }
+
+    /**
+     * Convert scope string values to enum instances.
+     *
+     * @param array<string> $scopeValues
+     * @return array<AgentScope>
+     */
+    public static function fromValues(array $scopeValues): array
+    {
+        $results = [];
+
+        foreach ($scopeValues as $value) {
+            $scope = self::tryFrom($value);
+            if ($scope !== null) {
+                $results[] = $scope;
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Check if a set of scopes includes the required scope.
+     *
+     * @param array<AgentScope|string> $available Available scopes
+     * @param AgentScope|string $required Required scope
+     */
+    public static function hasScope(array $available, AgentScope|string $required): bool
+    {
+        // Empty scopes means all allowed (backward compatibility)
+        if (empty($available)) {
+            return true;
+        }
+
+        $requiredValue = $required instanceof AgentScope ? $required->value : $required;
+
+        foreach ($available as $scope) {
+            $scopeValue = $scope instanceof AgentScope ? $scope->value : $scope;
+
+            // Universal access
+            if ($scopeValue === '*') {
+                return true;
+            }
+
+            // Exact match
+            if ($scopeValue === $requiredValue) {
+                return true;
+            }
+
+            // Category wildcard
+            if (str_ends_with($scopeValue, ':*')) {
+                $category = substr($scopeValue, 0, -2);
+                if (str_starts_with($requiredValue, $category . ':')) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/config/agent_protocol.php
+++ b/config/agent_protocol.php
@@ -45,6 +45,12 @@ return [
             'escrow:dispute' => 'Dispute escrow transactions',
             'escrow:*'       => 'Full access to escrow operations',
 
+            // Messaging scopes
+            'messages:read'  => 'View A2A messages and conversations',
+            'messages:send'  => 'Send A2A messages to other agents',
+            'messages:write' => 'Create and manage A2A messages',
+            'messages:*'     => 'Full access to messaging operations',
+
             // Agent management scopes
             'agent:read'     => 'View agent profile and capabilities',
             'agent:update'   => 'Update agent profile',
@@ -75,6 +81,7 @@ return [
             'wallet:read',
             'agent:read',
             'reputation:read',
+            'messages:read',
         ],
     ],
 

--- a/tests/Unit/AgentProtocol/Enums/AgentScopeTest.php
+++ b/tests/Unit/AgentProtocol/Enums/AgentScopeTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\AgentProtocol\Enums;
+
+use App\Domain\AgentProtocol\Enums\AgentScope;
+use PHPUnit\Framework\TestCase;
+
+class AgentScopeTest extends TestCase
+{
+    public function test_has_correct_string_values(): void
+    {
+        $this->assertEquals('payments:read', AgentScope::PAYMENTS_READ->value);
+        $this->assertEquals('payments:*', AgentScope::PAYMENTS_ALL->value);
+        $this->assertEquals('messages:send', AgentScope::MESSAGES_SEND->value);
+        $this->assertEquals('escrow:create', AgentScope::ESCROW_CREATE->value);
+        $this->assertEquals('*', AgentScope::UNIVERSAL->value);
+    }
+
+    public function test_returns_correct_descriptions(): void
+    {
+        $this->assertStringContainsString('View payment', AgentScope::PAYMENTS_READ->description());
+        $this->assertStringContainsString('Create new payment', AgentScope::PAYMENTS_CREATE->description());
+        $this->assertStringContainsString('A2A messages', AgentScope::MESSAGES_READ->description());
+        $this->assertStringContainsString('Full access', AgentScope::UNIVERSAL->description());
+    }
+
+    public function test_identifies_categories_correctly(): void
+    {
+        $this->assertEquals('payments', AgentScope::PAYMENTS_READ->category());
+        $this->assertEquals('payments', AgentScope::PAYMENTS_ALL->category());
+        $this->assertEquals('messages', AgentScope::MESSAGES_SEND->category());
+        $this->assertEquals('escrow', AgentScope::ESCROW_CREATE->category());
+        $this->assertEquals('*', AgentScope::UNIVERSAL->category());
+    }
+
+    public function test_identifies_wildcards(): void
+    {
+        $this->assertTrue(AgentScope::PAYMENTS_ALL->isWildcard());
+        $this->assertTrue(AgentScope::MESSAGES_ALL->isWildcard());
+        $this->assertTrue(AgentScope::UNIVERSAL->isWildcard());
+
+        $this->assertFalse(AgentScope::PAYMENTS_READ->isWildcard());
+        $this->assertFalse(AgentScope::MESSAGES_SEND->isWildcard());
+    }
+
+    public function test_universal_scope_covers_everything(): void
+    {
+        $this->assertTrue(AgentScope::UNIVERSAL->covers(AgentScope::PAYMENTS_READ));
+        $this->assertTrue(AgentScope::UNIVERSAL->covers(AgentScope::MESSAGES_ALL));
+        $this->assertTrue(AgentScope::UNIVERSAL->covers('any:scope'));
+    }
+
+    public function test_exact_match_covers_itself(): void
+    {
+        $this->assertTrue(AgentScope::PAYMENTS_READ->covers(AgentScope::PAYMENTS_READ));
+        $this->assertTrue(AgentScope::MESSAGES_SEND->covers('messages:send'));
+    }
+
+    public function test_category_wildcard_covers_category_scopes(): void
+    {
+        $this->assertTrue(AgentScope::PAYMENTS_ALL->covers(AgentScope::PAYMENTS_READ));
+        $this->assertTrue(AgentScope::PAYMENTS_ALL->covers(AgentScope::PAYMENTS_CREATE));
+        $this->assertTrue(AgentScope::PAYMENTS_ALL->covers('payments:cancel'));
+
+        $this->assertFalse(AgentScope::PAYMENTS_ALL->covers(AgentScope::ESCROW_READ));
+        $this->assertFalse(AgentScope::PAYMENTS_ALL->covers('escrow:create'));
+    }
+
+    public function test_specific_scope_does_not_cover_other_scopes(): void
+    {
+        $this->assertFalse(AgentScope::PAYMENTS_READ->covers(AgentScope::PAYMENTS_CREATE));
+        $this->assertFalse(AgentScope::MESSAGES_READ->covers(AgentScope::MESSAGES_SEND));
+    }
+
+    public function test_gets_scopes_in_category(): void
+    {
+        $paymentScopes = AgentScope::inCategory('payments');
+
+        $this->assertContains(AgentScope::PAYMENTS_READ, $paymentScopes);
+        $this->assertContains(AgentScope::PAYMENTS_CREATE, $paymentScopes);
+        $this->assertContains(AgentScope::PAYMENTS_ALL, $paymentScopes);
+        $this->assertNotContains(AgentScope::ESCROW_READ, $paymentScopes);
+    }
+
+    public function test_returns_default_scopes(): void
+    {
+        $defaults = AgentScope::defaults();
+
+        $this->assertContains(AgentScope::PAYMENTS_READ, $defaults);
+        $this->assertContains(AgentScope::WALLET_READ, $defaults);
+        $this->assertContains(AgentScope::AGENT_READ, $defaults);
+        $this->assertContains(AgentScope::REPUTATION_READ, $defaults);
+        $this->assertContains(AgentScope::MESSAGES_READ, $defaults);
+
+        // Should not contain write scopes
+        $this->assertNotContains(AgentScope::PAYMENTS_CREATE, $defaults);
+        $this->assertNotContains(AgentScope::MESSAGES_SEND, $defaults);
+    }
+
+    public function test_returns_read_only_scopes(): void
+    {
+        $readOnly = AgentScope::readOnly();
+
+        $this->assertContains(AgentScope::PAYMENTS_READ, $readOnly);
+        $this->assertContains(AgentScope::ESCROW_READ, $readOnly);
+        $this->assertContains(AgentScope::MESSAGES_READ, $readOnly);
+
+        // Should not contain write scopes
+        $this->assertNotContains(AgentScope::PAYMENTS_CREATE, $readOnly);
+        $this->assertNotContains(AgentScope::ESCROW_CREATE, $readOnly);
+    }
+
+    public function test_returns_write_scopes(): void
+    {
+        $writeScopes = AgentScope::writeScopes();
+
+        $this->assertContains(AgentScope::PAYMENTS_CREATE, $writeScopes);
+        $this->assertContains(AgentScope::ESCROW_CREATE, $writeScopes);
+        $this->assertContains(AgentScope::MESSAGES_SEND, $writeScopes);
+
+        // Should not contain read scopes
+        $this->assertNotContains(AgentScope::PAYMENTS_READ, $writeScopes);
+        $this->assertNotContains(AgentScope::ESCROW_READ, $writeScopes);
+    }
+
+    public function test_returns_wildcard_scopes(): void
+    {
+        $wildcards = AgentScope::wildcards();
+
+        $this->assertContains(AgentScope::PAYMENTS_ALL, $wildcards);
+        $this->assertContains(AgentScope::ESCROW_ALL, $wildcards);
+        $this->assertContains(AgentScope::MESSAGES_ALL, $wildcards);
+        $this->assertContains(AgentScope::UNIVERSAL, $wildcards);
+
+        // Should not contain specific scopes
+        $this->assertNotContains(AgentScope::PAYMENTS_READ, $wildcards);
+        $this->assertNotContains(AgentScope::MESSAGES_SEND, $wildcards);
+    }
+
+    public function test_converts_values_to_enums(): void
+    {
+        $values = ['payments:read', 'messages:send', 'invalid:scope'];
+        $enums = AgentScope::fromValues($values);
+
+        $this->assertCount(2, $enums);
+        $this->assertContains(AgentScope::PAYMENTS_READ, $enums);
+        $this->assertContains(AgentScope::MESSAGES_SEND, $enums);
+    }
+
+    public function test_checks_scope_membership_with_empty_array(): void
+    {
+        // Empty scopes means all allowed (backward compatibility)
+        $this->assertTrue(AgentScope::hasScope([], AgentScope::PAYMENTS_READ));
+        $this->assertTrue(AgentScope::hasScope([], 'any:scope'));
+    }
+
+    public function test_checks_scope_membership_with_universal(): void
+    {
+        $scopes = ['*'];
+        $this->assertTrue(AgentScope::hasScope($scopes, AgentScope::PAYMENTS_READ));
+        $this->assertTrue(AgentScope::hasScope($scopes, 'any:scope'));
+    }
+
+    public function test_checks_scope_membership_with_exact_match(): void
+    {
+        $scopes = ['payments:read', 'messages:send'];
+
+        $this->assertTrue(AgentScope::hasScope($scopes, 'payments:read'));
+        $this->assertTrue(AgentScope::hasScope($scopes, AgentScope::MESSAGES_SEND));
+        $this->assertFalse(AgentScope::hasScope($scopes, 'escrow:create'));
+    }
+
+    public function test_checks_scope_membership_with_category_wildcard(): void
+    {
+        $scopes = ['payments:*'];
+
+        $this->assertTrue(AgentScope::hasScope($scopes, 'payments:read'));
+        $this->assertTrue(AgentScope::hasScope($scopes, 'payments:create'));
+        $this->assertTrue(AgentScope::hasScope($scopes, AgentScope::PAYMENTS_CANCEL));
+        $this->assertFalse(AgentScope::hasScope($scopes, 'escrow:read'));
+    }
+
+    public function test_checks_scope_membership_with_enum_values(): void
+    {
+        $scopes = [AgentScope::PAYMENTS_READ, AgentScope::MESSAGES_ALL];
+
+        $this->assertTrue(AgentScope::hasScope($scopes, AgentScope::PAYMENTS_READ));
+        $this->assertTrue(AgentScope::hasScope($scopes, AgentScope::MESSAGES_SEND));
+        $this->assertFalse(AgentScope::hasScope($scopes, AgentScope::ESCROW_READ));
+    }
+}

--- a/tests/Unit/AgentProtocol/Middleware/CheckAgentScopeTest.php
+++ b/tests/Unit/AgentProtocol/Middleware/CheckAgentScopeTest.php
@@ -1,0 +1,309 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\AgentProtocol\Middleware;
+
+use App\Http\Middleware\CheckAgentScope;
+use App\Models\Agent;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class CheckAgentScopeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private CheckAgentScope $middleware;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->middleware = new CheckAgentScope();
+    }
+
+    public function test_allows_agent_with_required_scope(): void
+    {
+        // Arrange
+        $agent = Agent::factory()->create(['status' => 'active']);
+        $request = $this->createRequestWithAgent($agent, ['payments:read']);
+
+        // Act
+        $response = $this->middleware->handle($request, function ($req) {
+            return response()->json(['success' => true]);
+        }, 'payments:read');
+
+        // Assert
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function test_allows_agent_with_universal_scope(): void
+    {
+        // Arrange
+        $agent = Agent::factory()->create(['status' => 'active']);
+        $request = $this->createRequestWithAgent($agent, ['*']);
+
+        // Act
+        $response = $this->middleware->handle($request, function ($req) {
+            return response()->json(['success' => true]);
+        }, 'any:scope');
+
+        // Assert
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function test_allows_agent_with_category_wildcard_scope(): void
+    {
+        // Arrange
+        $agent = Agent::factory()->create(['status' => 'active']);
+        $request = $this->createRequestWithAgent($agent, ['payments:*']);
+
+        // Act
+        $response = $this->middleware->handle($request, function ($req) {
+            return response()->json(['success' => true]);
+        }, 'payments:create');
+
+        // Assert
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function test_rejects_agent_without_required_scope(): void
+    {
+        // Arrange
+        $agent = Agent::factory()->create(['status' => 'active']);
+        $request = $this->createRequestWithAgent($agent, ['payments:read']);
+
+        // Act
+        $response = $this->middleware->handle($request, function ($req) {
+            return response()->json(['success' => true]);
+        }, 'escrow:create');
+
+        // Assert
+        $this->assertEquals(403, $response->getStatusCode());
+        $data = json_decode((string) $response->getContent(), true);
+        $this->assertEquals('Forbidden', $data['error']);
+        $this->assertEquals('SCOPE_REQUIRED', $data['code']);
+        $this->assertStringContainsString('escrow:create', $data['message']);
+    }
+
+    public function test_rejects_request_without_authenticated_agent(): void
+    {
+        // Arrange
+        $request = Request::create('/api/test', 'GET');
+
+        // Act
+        $response = $this->middleware->handle($request, function ($req) {
+            return response()->json(['success' => true]);
+        }, 'payments:read');
+
+        // Assert
+        $this->assertEquals(401, $response->getStatusCode());
+        $data = json_decode((string) $response->getContent(), true);
+        $this->assertEquals('Unauthorized', $data['error']);
+        $this->assertEquals('AGENT_NOT_AUTHENTICATED', $data['code']);
+    }
+
+    public function test_checks_multiple_required_scopes(): void
+    {
+        // Arrange
+        $agent = Agent::factory()->create(['status' => 'active']);
+        $request = $this->createRequestWithAgent($agent, ['payments:read']);
+
+        // Act - require both payments:read and escrow:read
+        $response = $this->middleware->handle($request, function ($req) {
+            return response()->json(['success' => true]);
+        }, 'payments:read', 'escrow:read');
+
+        // Assert
+        $this->assertEquals(403, $response->getStatusCode());
+        $data = json_decode((string) $response->getContent(), true);
+        $this->assertStringContainsString('escrow:read', $data['message']);
+    }
+
+    public function test_allows_agent_with_all_required_scopes(): void
+    {
+        // Arrange
+        $agent = Agent::factory()->create(['status' => 'active']);
+        $request = $this->createRequestWithAgent($agent, ['payments:read', 'escrow:read', 'wallet:read']);
+
+        // Act
+        $response = $this->middleware->handle($request, function ($req) {
+            return response()->json(['success' => true]);
+        }, 'payments:read', 'escrow:read');
+
+        // Assert
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function test_handles_comma_separated_scopes(): void
+    {
+        // Arrange
+        $agent = Agent::factory()->create(['status' => 'active']);
+        $request = $this->createRequestWithAgent($agent, ['payments:read', 'escrow:read']);
+
+        // Act - scopes as comma-separated string
+        $response = $this->middleware->handle($request, function ($req) {
+            return response()->json(['success' => true]);
+        }, 'payments:read,escrow:read');
+
+        // Assert
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function test_allows_empty_scopes_for_backward_compatibility(): void
+    {
+        // Arrange
+        $agent = Agent::factory()->create(['status' => 'active']);
+        $request = $this->createRequestWithAgent($agent, []);
+
+        // Act
+        $response = $this->middleware->handle($request, function ($req) {
+            return response()->json(['success' => true]);
+        }, 'payments:read');
+
+        // Assert - Empty scopes means all allowed for backward compatibility
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function test_validates_payment_scopes(): void
+    {
+        // Arrange
+        $agent = Agent::factory()->create(['status' => 'active']);
+
+        // Test various payment scopes
+        $testCases = [
+            ['available' => ['payments:read'], 'required' => 'payments:read', 'allowed' => true],
+            ['available' => ['payments:create'], 'required' => 'payments:create', 'allowed' => true],
+            ['available' => ['payments:*'], 'required' => 'payments:cancel', 'allowed' => true],
+            ['available' => ['payments:read'], 'required' => 'payments:create', 'allowed' => false],
+        ];
+
+        foreach ($testCases as $case) {
+            $request = $this->createRequestWithAgent($agent, $case['available']);
+            $response = $this->middleware->handle($request, function ($req) {
+                return response()->json(['success' => true]);
+            }, $case['required']);
+
+            $expectedStatus = $case['allowed'] ? 200 : 403;
+            $this->assertEquals(
+                $expectedStatus,
+                $response->getStatusCode(),
+                sprintf(
+                    'Failed for available: %s, required: %s',
+                    implode(',', $case['available']),
+                    $case['required']
+                )
+            );
+        }
+    }
+
+    public function test_validates_messaging_scopes(): void
+    {
+        // Arrange
+        $agent = Agent::factory()->create(['status' => 'active']);
+
+        // Test messaging scopes
+        $testCases = [
+            ['available' => ['messages:read'], 'required' => 'messages:read', 'allowed' => true],
+            ['available' => ['messages:send'], 'required' => 'messages:send', 'allowed' => true],
+            ['available' => ['messages:*'], 'required' => 'messages:write', 'allowed' => true],
+            ['available' => ['messages:read'], 'required' => 'messages:send', 'allowed' => false],
+        ];
+
+        foreach ($testCases as $case) {
+            $request = $this->createRequestWithAgent($agent, $case['available']);
+            $response = $this->middleware->handle($request, function ($req) {
+                return response()->json(['success' => true]);
+            }, $case['required']);
+
+            $expectedStatus = $case['allowed'] ? 200 : 403;
+            $this->assertEquals(
+                $expectedStatus,
+                $response->getStatusCode(),
+                sprintf(
+                    'Failed for available: %s, required: %s',
+                    implode(',', $case['available']),
+                    $case['required']
+                )
+            );
+        }
+    }
+
+    public function test_validates_escrow_scopes(): void
+    {
+        // Arrange
+        $agent = Agent::factory()->create(['status' => 'active']);
+
+        // Test escrow scopes
+        $testCases = [
+            ['available' => ['escrow:read'], 'required' => 'escrow:read', 'allowed' => true],
+            ['available' => ['escrow:create'], 'required' => 'escrow:create', 'allowed' => true],
+            ['available' => ['escrow:*'], 'required' => 'escrow:dispute', 'allowed' => true],
+            ['available' => ['escrow:read'], 'required' => 'escrow:release', 'allowed' => false],
+        ];
+
+        foreach ($testCases as $case) {
+            $request = $this->createRequestWithAgent($agent, $case['available']);
+            $response = $this->middleware->handle($request, function ($req) {
+                return response()->json(['success' => true]);
+            }, $case['required']);
+
+            $expectedStatus = $case['allowed'] ? 200 : 403;
+            $this->assertEquals(
+                $expectedStatus,
+                $response->getStatusCode(),
+                sprintf(
+                    'Failed for available: %s, required: %s',
+                    implode(',', $case['available']),
+                    $case['required']
+                )
+            );
+        }
+    }
+
+    public function test_validates_reputation_scopes(): void
+    {
+        // Arrange
+        $agent = Agent::factory()->create(['status' => 'active']);
+
+        // Test reputation scopes
+        $testCases = [
+            ['available' => ['reputation:read'], 'required' => 'reputation:read', 'allowed' => true],
+            ['available' => ['reputation:review'], 'required' => 'reputation:review', 'allowed' => true],
+            ['available' => ['reputation:*'], 'required' => 'reputation:write', 'allowed' => true],
+            ['available' => ['reputation:read'], 'required' => 'reputation:review', 'allowed' => false],
+        ];
+
+        foreach ($testCases as $case) {
+            $request = $this->createRequestWithAgent($agent, $case['available']);
+            $response = $this->middleware->handle($request, function ($req) {
+                return response()->json(['success' => true]);
+            }, $case['required']);
+
+            $expectedStatus = $case['allowed'] ? 200 : 403;
+            $this->assertEquals(
+                $expectedStatus,
+                $response->getStatusCode(),
+                sprintf(
+                    'Failed for available: %s, required: %s',
+                    implode(',', $case['available']),
+                    $case['required']
+                )
+            );
+        }
+    }
+
+    /**
+     * Helper to create request with authenticated agent and scopes.
+     *
+     * @param array<string> $scopes
+     */
+    private function createRequestWithAgent(Agent $agent, array $scopes): Request
+    {
+        $request = Request::create('/api/test', 'GET');
+        $request->attributes->set('agent', $agent);
+        $request->attributes->set('authenticated_agent', ['scopes' => $scopes]);
+
+        return $request;
+    }
+}


### PR DESCRIPTION
## Summary

- Add `AgentScope` enum for type-safe OAuth2-style scope management
- Implement scope hierarchy with wildcard support (e.g., `payments:*` covers `payments:read`)
- Add missing messaging scopes to config (`messages:read`, `messages:send`, `messages:write`, `messages:*`)
- Include `messages:read` in default scopes for backward compatibility
- Add comprehensive test coverage for both enum and middleware

## Changes

### New Files
- `app/Domain/AgentProtocol/Enums/AgentScope.php` - Type-safe enum for all agent OAuth2-style scopes
- `tests/Unit/AgentProtocol/Enums/AgentScopeTest.php` - 19 tests with 75 assertions
- `tests/Unit/AgentProtocol/Middleware/CheckAgentScopeTest.php` - 13 tests for scope middleware

### Modified Files
- `config/agent_protocol.php` - Added messaging scopes and updated default scopes

## Features

The `AgentScope` enum provides:
- All scope categories: payments, wallet, escrow, messages, agent, reputation, compliance, admin
- Wildcard scopes (e.g., `payments:*`, `*` for universal)
- Utility methods: `covers()`, `isWildcard()`, `hasScope()`, `inCategory()`, `defaults()`, `readOnly()`, `writeScopes()`, `wildcards()`, `fromValues()`
- Human-readable descriptions for each scope
- Category detection and grouping

## Test plan

- [x] All 19 AgentScope enum tests pass
- [x] PHPStan passes
- [x] Code style checks pass
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)