### PR TITLE
feat(agent-protocol): Add Protocol Negotiation API endpoints

### DIFF
--- a/app/Http/Controllers/Api/AgentProtocol/AgentProtocolNegotiationController.php
+++ b/app/Http/Controllers/Api/AgentProtocol/AgentProtocolNegotiationController.php
@@ -1,0 +1,459 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\AgentProtocol;
+
+use App\Domain\AgentProtocol\Messaging\A2AProtocolNegotiationService;
+use App\Domain\AgentProtocol\Services\DIDService;
+use App\Http\Controllers\Controller;
+use Exception;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Tag(
+ *     name="Agent Protocol - Negotiation",
+ *     description="Protocol version negotiation and agreement management endpoints"
+ * )
+ */
+class AgentProtocolNegotiationController extends Controller
+{
+    public function __construct(
+        private readonly A2AProtocolNegotiationService $negotiationService,
+        private readonly DIDService $didService
+    ) {
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/api/agent-protocol/protocol/versions",
+     *     operationId="getProtocolVersions",
+     *     tags={"Agent Protocol - Negotiation"},
+     *     summary="Get supported protocol versions",
+     *     @OA\Response(
+     *         response=200,
+     *         description="List of supported protocol versions",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="versions", type="array", @OA\Items(type="string"), example={"1.1", "1.0"}),
+     *                 @OA\Property(property="preferred", type="string", example="1.1")
+     *             )
+     *         )
+     *     )
+     * )
+     */
+    public function listVersions(): JsonResponse
+    {
+        $versions = $this->negotiationService->getSupportedVersions();
+
+        return response()->json([
+            'success' => true,
+            'data'    => [
+                'versions'  => $versions,
+                'preferred' => $versions[0] ?? null,
+            ],
+        ]);
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/api/agent-protocol/protocol/versions/{version}/capabilities",
+     *     operationId="getVersionCapabilities",
+     *     tags={"Agent Protocol - Negotiation"},
+     *     summary="Get capabilities for a specific protocol version",
+     *     @OA\Parameter(
+     *         name="version",
+     *         in="path",
+     *         required=true,
+     *         description="Protocol version",
+     *         @OA\Schema(type="string", example="1.1")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Version capabilities",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="version", type="string", example="1.1"),
+     *                 @OA\Property(property="capabilities", type="object")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=404, description="Version not supported")
+     * )
+     */
+    public function getVersionCapabilities(string $version): JsonResponse
+    {
+        $capabilities = $this->negotiationService->getVersionCapabilities($version);
+
+        if ($capabilities === null) {
+            return response()->json([
+                'success' => false,
+                'error'   => 'Protocol version not supported',
+                'data'    => [
+                    'requested' => $version,
+                    'supported' => $this->negotiationService->getSupportedVersions(),
+                ],
+            ], 404);
+        }
+
+        return response()->json([
+            'success' => true,
+            'data'    => [
+                'version'      => $version,
+                'capabilities' => $capabilities,
+            ],
+        ]);
+    }
+
+    /**
+     * @OA\Post(
+     *     path="/api/agent-protocol/agents/{did}/protocol/negotiate",
+     *     operationId="initiateProtocolNegotiation",
+     *     tags={"Agent Protocol - Negotiation"},
+     *     summary="Initiate protocol negotiation with another agent",
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="did",
+     *         in="path",
+     *         required=true,
+     *         description="Initiator agent DID",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"target_did"},
+     *             @OA\Property(property="target_did", type="string", description="Target agent DID"),
+     *             @OA\Property(property="preferred_capabilities", type="array", @OA\Items(type="string"),
+     *                 description="Preferred capabilities for the negotiation", example={"messaging", "payments"})
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Negotiation result",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="negotiation", type="object")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=400, description="Invalid request"),
+     *     @OA\Response(response=500, description="Negotiation failed")
+     * )
+     */
+    public function negotiate(Request $request, string $did): JsonResponse
+    {
+        $validated = $request->validate([
+            'target_did'               => 'required|string',
+            'preferred_capabilities'   => 'nullable|array',
+            'preferred_capabilities.*' => 'string',
+        ]);
+
+        // Validate initiator DID
+        if (! $this->didService->validateDID($did)) {
+            return response()->json([
+                'success' => false,
+                'error'   => 'Invalid initiator DID format',
+            ], 400);
+        }
+
+        // Validate target DID
+        if (! $this->didService->validateDID($validated['target_did'])) {
+            return response()->json([
+                'success' => false,
+                'error'   => 'Invalid target DID format',
+            ], 400);
+        }
+
+        try {
+            $result = $this->negotiationService->initiateNegotiation(
+                $did,
+                $validated['target_did'],
+                $validated['preferred_capabilities'] ?? null
+            );
+
+            return response()->json([
+                'success' => $result->isSuccess(),
+                'data'    => [
+                    'negotiation' => $result->toArray(),
+                ],
+            ]);
+        } catch (Exception $e) {
+            Log::error('Protocol negotiation failed', [
+                'initiator_did' => $did,
+                'target_did'    => $validated['target_did'],
+                'error'         => $e->getMessage(),
+            ]);
+
+            return response()->json([
+                'success' => false,
+                'error'   => 'Negotiation failed: ' . $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/api/agent-protocol/agents/{did}/protocol/agreements/{otherDid}",
+     *     operationId="getProtocolAgreement",
+     *     tags={"Agent Protocol - Negotiation"},
+     *     summary="Get protocol agreement between two agents",
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="did",
+     *         in="path",
+     *         required=true,
+     *         description="Agent DID",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="otherDid",
+     *         in="path",
+     *         required=true,
+     *         description="Other agent DID",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Protocol agreement details",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="agreement", type="object"),
+     *                 @OA\Property(property="has_agreement", type="boolean"),
+     *                 @OA\Property(property="is_valid", type="boolean")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=400, description="Invalid DID format")
+     * )
+     */
+    public function getAgreement(Request $request, string $did, string $otherDid): JsonResponse
+    {
+        // Validate DIDs
+        if (! $this->didService->validateDID($did)) {
+            return response()->json([
+                'success' => false,
+                'error'   => 'Invalid agent DID format',
+            ], 400);
+        }
+
+        if (! $this->didService->validateDID($otherDid)) {
+            return response()->json([
+                'success' => false,
+                'error'   => 'Invalid other agent DID format',
+            ], 400);
+        }
+
+        $agreement = $this->negotiationService->getAgreedProtocol($did, $otherDid);
+        $hasValidAgreement = $this->negotiationService->hasValidAgreement($did, $otherDid);
+
+        return response()->json([
+            'success' => true,
+            'data'    => [
+                'agreement'     => $agreement?->toArray(),
+                'has_agreement' => $agreement !== null,
+                'is_valid'      => $hasValidAgreement,
+            ],
+        ]);
+    }
+
+    /**
+     * @OA\Delete(
+     *     path="/api/agent-protocol/agents/{did}/protocol/agreements/{otherDid}",
+     *     operationId="revokeProtocolAgreement",
+     *     tags={"Agent Protocol - Negotiation"},
+     *     summary="Revoke protocol agreement between two agents",
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="did",
+     *         in="path",
+     *         required=true,
+     *         description="Agent DID",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="otherDid",
+     *         in="path",
+     *         required=true,
+     *         description="Other agent DID",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Agreement revoked successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Protocol agreement revoked")
+     *         )
+     *     ),
+     *     @OA\Response(response=400, description="Invalid DID format")
+     * )
+     */
+    public function revokeAgreement(Request $request, string $did, string $otherDid): JsonResponse
+    {
+        // Validate DIDs
+        if (! $this->didService->validateDID($did)) {
+            return response()->json([
+                'success' => false,
+                'error'   => 'Invalid agent DID format',
+            ], 400);
+        }
+
+        if (! $this->didService->validateDID($otherDid)) {
+            return response()->json([
+                'success' => false,
+                'error'   => 'Invalid other agent DID format',
+            ], 400);
+        }
+
+        $this->negotiationService->revokeAgreement($did, $otherDid);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Protocol agreement revoked',
+        ]);
+    }
+
+    /**
+     * @OA\Post(
+     *     path="/api/agent-protocol/agents/{did}/protocol/agreements/{otherDid}/refresh",
+     *     operationId="refreshProtocolAgreement",
+     *     tags={"Agent Protocol - Negotiation"},
+     *     summary="Refresh/extend protocol agreement between two agents",
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="did",
+     *         in="path",
+     *         required=true,
+     *         description="Agent DID",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="otherDid",
+     *         in="path",
+     *         required=true,
+     *         description="Other agent DID",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Agreement refresh result",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="negotiation", type="object")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=400, description="Invalid DID format"),
+     *     @OA\Response(response=500, description="Refresh failed")
+     * )
+     */
+    public function refreshAgreement(Request $request, string $did, string $otherDid): JsonResponse
+    {
+        // Validate DIDs
+        if (! $this->didService->validateDID($did)) {
+            return response()->json([
+                'success' => false,
+                'error'   => 'Invalid agent DID format',
+            ], 400);
+        }
+
+        if (! $this->didService->validateDID($otherDid)) {
+            return response()->json([
+                'success' => false,
+                'error'   => 'Invalid other agent DID format',
+            ], 400);
+        }
+
+        try {
+            $result = $this->negotiationService->refreshAgreement($did, $otherDid);
+
+            return response()->json([
+                'success' => $result->isSuccess(),
+                'data'    => [
+                    'negotiation' => $result->toArray(),
+                ],
+            ]);
+        } catch (Exception $e) {
+            Log::error('Protocol agreement refresh failed', [
+                'agent_did' => $did,
+                'other_did' => $otherDid,
+                'error'     => $e->getMessage(),
+            ]);
+
+            return response()->json([
+                'success' => false,
+                'error'   => 'Agreement refresh failed: ' . $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/api/agent-protocol/agents/{did}/protocol/agreements/{otherDid}/check",
+     *     operationId="checkProtocolAgreement",
+     *     tags={"Agent Protocol - Negotiation"},
+     *     summary="Check if a valid protocol agreement exists",
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="did",
+     *         in="path",
+     *         required=true,
+     *         description="Agent DID",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="otherDid",
+     *         in="path",
+     *         required=true,
+     *         description="Other agent DID",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Agreement check result",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="has_valid_agreement", type="boolean")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=400, description="Invalid DID format")
+     * )
+     */
+    public function checkAgreement(Request $request, string $did, string $otherDid): JsonResponse
+    {
+        // Validate DIDs
+        if (! $this->didService->validateDID($did)) {
+            return response()->json([
+                'success' => false,
+                'error'   => 'Invalid agent DID format',
+            ], 400);
+        }
+
+        if (! $this->didService->validateDID($otherDid)) {
+            return response()->json([
+                'success' => false,
+                'error'   => 'Invalid other agent DID format',
+            ], 400);
+        }
+
+        $hasValidAgreement = $this->negotiationService->hasValidAgreement($did, $otherDid);
+
+        return response()->json([
+            'success' => true,
+            'data'    => [
+                'has_valid_agreement' => $hasValidAgreement,
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/AgentProtocol/AgentProtocolNegotiationApiTest.php
+++ b/tests/Feature/AgentProtocol/AgentProtocolNegotiationApiTest.php
@@ -1,0 +1,646 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AgentProtocol;
+
+use App\Domain\AgentProtocol\Messaging\A2AProtocolNegotiationService;
+use App\Domain\AgentProtocol\Messaging\NegotiationResult;
+use App\Domain\AgentProtocol\Messaging\ProtocolAgreement;
+use App\Models\Agent;
+use App\Models\AgentApiKey;
+use App\Models\User;
+use DateTimeImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+use Mockery;
+use Tests\TestCase;
+
+class AgentProtocolNegotiationApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Agent $agent1;
+
+    private Agent $agent2;
+
+    protected User $user;
+
+    private string $apiKey1;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+
+        $this->user = User::factory()->create(['kyc_status' => 'approved']);
+
+        // Create agents with 32 hex chars for DID
+        // Note: capability must be 'messages' to match middleware requirement
+        $this->agent1 = Agent::factory()->create([
+            'did'          => 'did:finaegis:agent:' . bin2hex(random_bytes(16)),
+            'status'       => 'active',
+            'capabilities' => ['payments', 'messages', 'escrow'],
+        ]);
+
+        $this->agent2 = Agent::factory()->create([
+            'did'          => 'did:finaegis:agent:' . bin2hex(random_bytes(16)),
+            'status'       => 'active',
+            'capabilities' => ['payments', 'messages'],
+        ]);
+
+        // Create API key for agent1 for authenticated tests
+        $this->apiKey1 = 'ak_' . Str::random(40);
+        AgentApiKey::create([
+            'key_id'     => Str::uuid()->toString(),
+            'agent_id'   => $this->agent1->agent_id,
+            'name'       => 'Test API Key',
+            'key_hash'   => hash('sha256', $this->apiKey1),
+            'key_prefix' => substr($this->apiKey1, 0, 8),
+            'scopes'     => ['*'], // Universal scope for testing
+            'is_active'  => true,
+        ]);
+    }
+
+    /**
+     * Helper to make authenticated requests as an agent.
+     */
+    private function withAgentAuth(string $apiKey): self
+    {
+        return $this->withHeaders([
+            'Authorization' => 'AgentKey ' . $apiKey,
+        ]);
+    }
+
+    // =============================================================================
+    // Public endpoint tests - Protocol versions
+    // =============================================================================
+
+    public function test_list_versions_returns_supported_versions(): void
+    {
+        $response = $this->getJson('/api/agent-protocol/protocol/versions');
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'success' => true,
+            ])
+            ->assertJsonStructure([
+                'success',
+                'data' => [
+                    'versions',
+                    'preferred',
+                ],
+            ]);
+
+        $data = $response->json('data');
+        $this->assertIsArray($data['versions']);
+        $this->assertNotEmpty($data['versions']);
+        $this->assertContains('1.0', $data['versions']);
+        $this->assertContains('1.1', $data['versions']);
+    }
+
+    public function test_get_version_capabilities_returns_capabilities_for_valid_version(): void
+    {
+        $response = $this->getJson('/api/agent-protocol/protocol/versions/1.1/capabilities');
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'success' => true,
+                'data'    => [
+                    'version' => '1.1',
+                ],
+            ])
+            ->assertJsonStructure([
+                'success',
+                'data' => [
+                    'version',
+                    'capabilities',
+                ],
+            ]);
+
+        $capabilities = $response->json('data.capabilities');
+        $this->assertIsArray($capabilities);
+        $this->assertArrayHasKey('messaging', $capabilities);
+        $this->assertArrayHasKey('payments', $capabilities);
+        $this->assertArrayHasKey('escrow', $capabilities);
+    }
+
+    public function test_get_version_capabilities_for_version_1_0(): void
+    {
+        $response = $this->getJson('/api/agent-protocol/protocol/versions/1.0/capabilities');
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'success' => true,
+                'data'    => [
+                    'version' => '1.0',
+                ],
+            ]);
+
+        $capabilities = $response->json('data.capabilities');
+        $this->assertTrue($capabilities['messaging']);
+        $this->assertTrue($capabilities['payments']);
+        $this->assertFalse($capabilities['streaming']);
+    }
+
+    public function test_get_version_capabilities_returns_404_for_unsupported_version(): void
+    {
+        $response = $this->getJson('/api/agent-protocol/protocol/versions/2.0/capabilities');
+
+        $response->assertStatus(404)
+            ->assertJson([
+                'success' => false,
+                'error'   => 'Protocol version not supported',
+            ])
+            ->assertJsonStructure([
+                'success',
+                'error',
+                'data' => [
+                    'requested',
+                    'supported',
+                ],
+            ]);
+    }
+
+    // =============================================================================
+    // Authenticated endpoint tests - Protocol negotiation
+    // =============================================================================
+
+    public function test_negotiate_requires_authentication(): void
+    {
+        $response = $this->postJson(
+            "/api/agent-protocol/agents/{$this->agent1->did}/protocol/negotiate",
+            ['target_did' => $this->agent2->did]
+        );
+
+        $response->assertStatus(401);
+    }
+
+    public function test_negotiate_validates_initiator_did_format(): void
+    {
+        $response = $this->withAgentAuth($this->apiKey1)->postJson(
+            '/api/agent-protocol/agents/invalid-did/protocol/negotiate',
+            ['target_did' => $this->agent2->did]
+        );
+
+        $response->assertStatus(400)
+            ->assertJson([
+                'success' => false,
+                'error'   => 'Invalid initiator DID format',
+            ]);
+    }
+
+    public function test_negotiate_validates_target_did_format(): void
+    {
+        $response = $this->withAgentAuth($this->apiKey1)->postJson(
+            "/api/agent-protocol/agents/{$this->agent1->did}/protocol/negotiate",
+            ['target_did' => 'invalid-did']
+        );
+
+        $response->assertStatus(400)
+            ->assertJson([
+                'success' => false,
+                'error'   => 'Invalid target DID format',
+            ]);
+    }
+
+    public function test_negotiate_validates_required_target_did(): void
+    {
+        $response = $this->withAgentAuth($this->apiKey1)->postJson(
+            "/api/agent-protocol/agents/{$this->agent1->did}/protocol/negotiate",
+            []
+        );
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['target_did']);
+    }
+
+    public function test_negotiate_with_valid_data(): void
+    {
+        // Mock the negotiation service to return a successful result
+        $agreement = new ProtocolAgreement(
+            agreementId: bin2hex(random_bytes(16)),
+            version: '1.1',
+            initiatorDid: $this->agent1->did,
+            responderDid: $this->agent2->did,
+            encryptionMethod: 'aes-256-gcm',
+            signatureMethod: 'ed25519',
+            capabilities: ['messaging', 'payments', 'escrow'],
+            agreedAt: new DateTimeImmutable(),
+            expiresAt: new DateTimeImmutable('+24 hours')
+        );
+
+        $mockResult = NegotiationResult::success($agreement);
+
+        $mockService = Mockery::mock(A2AProtocolNegotiationService::class);
+        $mockService->shouldReceive('initiateNegotiation')
+            ->once()
+            ->with($this->agent1->did, $this->agent2->did, null)
+            ->andReturn($mockResult);
+
+        $this->app->instance(A2AProtocolNegotiationService::class, $mockService);
+
+        $response = $this->withAgentAuth($this->apiKey1)->postJson(
+            "/api/agent-protocol/agents/{$this->agent1->did}/protocol/negotiate",
+            ['target_did' => $this->agent2->did]
+        );
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'success' => true,
+            ])
+            ->assertJsonStructure([
+                'success',
+                'data' => [
+                    'negotiation',
+                ],
+            ]);
+    }
+
+    public function test_negotiate_with_preferred_capabilities(): void
+    {
+        $preferredCapabilities = ['messaging', 'payments'];
+
+        $agreement = new ProtocolAgreement(
+            agreementId: bin2hex(random_bytes(16)),
+            version: '1.1',
+            initiatorDid: $this->agent1->did,
+            responderDid: $this->agent2->did,
+            encryptionMethod: 'aes-256-gcm',
+            signatureMethod: 'ed25519',
+            capabilities: $preferredCapabilities,
+            agreedAt: new DateTimeImmutable(),
+            expiresAt: new DateTimeImmutable('+24 hours')
+        );
+
+        $mockResult = NegotiationResult::success($agreement);
+
+        $mockService = Mockery::mock(A2AProtocolNegotiationService::class);
+        $mockService->shouldReceive('initiateNegotiation')
+            ->once()
+            ->with($this->agent1->did, $this->agent2->did, $preferredCapabilities)
+            ->andReturn($mockResult);
+
+        $this->app->instance(A2AProtocolNegotiationService::class, $mockService);
+
+        $response = $this->withAgentAuth($this->apiKey1)->postJson(
+            "/api/agent-protocol/agents/{$this->agent1->did}/protocol/negotiate",
+            [
+                'target_did'             => $this->agent2->did,
+                'preferred_capabilities' => $preferredCapabilities,
+            ]
+        );
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'success' => true,
+            ]);
+    }
+
+    // =============================================================================
+    // Authenticated endpoint tests - Get agreement
+    // =============================================================================
+
+    public function test_get_agreement_requires_authentication(): void
+    {
+        $response = $this->getJson(
+            "/api/agent-protocol/agents/{$this->agent1->did}/protocol/agreements/{$this->agent2->did}"
+        );
+
+        $response->assertStatus(401);
+    }
+
+    public function test_get_agreement_validates_agent_did_format(): void
+    {
+        $response = $this->withAgentAuth($this->apiKey1)->getJson(
+            "/api/agent-protocol/agents/invalid-did/protocol/agreements/{$this->agent2->did}"
+        );
+
+        $response->assertStatus(400)
+            ->assertJson([
+                'success' => false,
+                'error'   => 'Invalid agent DID format',
+            ]);
+    }
+
+    public function test_get_agreement_validates_other_did_format(): void
+    {
+        $response = $this->withAgentAuth($this->apiKey1)->getJson(
+            "/api/agent-protocol/agents/{$this->agent1->did}/protocol/agreements/invalid-did"
+        );
+
+        $response->assertStatus(400)
+            ->assertJson([
+                'success' => false,
+                'error'   => 'Invalid other agent DID format',
+            ]);
+    }
+
+    public function test_get_agreement_returns_no_agreement_when_none_exists(): void
+    {
+        $mockService = Mockery::mock(A2AProtocolNegotiationService::class);
+        $mockService->shouldReceive('getAgreedProtocol')
+            ->once()
+            ->andReturn(null);
+        $mockService->shouldReceive('hasValidAgreement')
+            ->once()
+            ->andReturn(false);
+
+        $this->app->instance(A2AProtocolNegotiationService::class, $mockService);
+
+        $response = $this->withAgentAuth($this->apiKey1)->getJson(
+            "/api/agent-protocol/agents/{$this->agent1->did}/protocol/agreements/{$this->agent2->did}"
+        );
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'success' => true,
+                'data'    => [
+                    'has_agreement' => false,
+                    'is_valid'      => false,
+                    'agreement'     => null,
+                ],
+            ]);
+    }
+
+    public function test_get_agreement_returns_existing_agreement(): void
+    {
+        $agreement = new ProtocolAgreement(
+            agreementId: bin2hex(random_bytes(16)),
+            version: '1.1',
+            initiatorDid: $this->agent1->did,
+            responderDid: $this->agent2->did,
+            encryptionMethod: 'aes-256-gcm',
+            signatureMethod: 'ed25519',
+            capabilities: ['messaging', 'payments'],
+            agreedAt: new DateTimeImmutable(),
+            expiresAt: new DateTimeImmutable('+24 hours')
+        );
+
+        $mockService = Mockery::mock(A2AProtocolNegotiationService::class);
+        $mockService->shouldReceive('getAgreedProtocol')
+            ->once()
+            ->andReturn($agreement);
+        $mockService->shouldReceive('hasValidAgreement')
+            ->once()
+            ->andReturn(true);
+
+        $this->app->instance(A2AProtocolNegotiationService::class, $mockService);
+
+        $response = $this->withAgentAuth($this->apiKey1)->getJson(
+            "/api/agent-protocol/agents/{$this->agent1->did}/protocol/agreements/{$this->agent2->did}"
+        );
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'success' => true,
+                'data'    => [
+                    'has_agreement' => true,
+                    'is_valid'      => true,
+                ],
+            ])
+            ->assertJsonStructure([
+                'success',
+                'data' => [
+                    'agreement' => [
+                        'agreementId',
+                        'version',
+                        'initiatorDid',
+                        'responderDid',
+                        'encryptionMethod',
+                        'signatureMethod',
+                        'capabilities',
+                        'agreedAt',
+                        'expiresAt',
+                    ],
+                    'has_agreement',
+                    'is_valid',
+                ],
+            ]);
+    }
+
+    // =============================================================================
+    // Authenticated endpoint tests - Revoke agreement
+    // =============================================================================
+
+    public function test_revoke_agreement_requires_authentication(): void
+    {
+        $response = $this->deleteJson(
+            "/api/agent-protocol/agents/{$this->agent1->did}/protocol/agreements/{$this->agent2->did}"
+        );
+
+        $response->assertStatus(401);
+    }
+
+    public function test_revoke_agreement_validates_agent_did_format(): void
+    {
+        $response = $this->withAgentAuth($this->apiKey1)->deleteJson(
+            "/api/agent-protocol/agents/invalid-did/protocol/agreements/{$this->agent2->did}"
+        );
+
+        $response->assertStatus(400)
+            ->assertJson([
+                'success' => false,
+                'error'   => 'Invalid agent DID format',
+            ]);
+    }
+
+    public function test_revoke_agreement_validates_other_did_format(): void
+    {
+        $response = $this->withAgentAuth($this->apiKey1)->deleteJson(
+            "/api/agent-protocol/agents/{$this->agent1->did}/protocol/agreements/invalid-did"
+        );
+
+        $response->assertStatus(400)
+            ->assertJson([
+                'success' => false,
+                'error'   => 'Invalid other agent DID format',
+            ]);
+    }
+
+    public function test_revoke_agreement_succeeds(): void
+    {
+        $mockService = Mockery::mock(A2AProtocolNegotiationService::class);
+        $mockService->shouldReceive('revokeAgreement')
+            ->once()
+            ->with($this->agent1->did, $this->agent2->did)
+            ->andReturn(true);
+
+        $this->app->instance(A2AProtocolNegotiationService::class, $mockService);
+
+        $response = $this->withAgentAuth($this->apiKey1)->deleteJson(
+            "/api/agent-protocol/agents/{$this->agent1->did}/protocol/agreements/{$this->agent2->did}"
+        );
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'success' => true,
+                'message' => 'Protocol agreement revoked',
+            ]);
+    }
+
+    // =============================================================================
+    // Authenticated endpoint tests - Refresh agreement
+    // =============================================================================
+
+    public function test_refresh_agreement_requires_authentication(): void
+    {
+        $response = $this->postJson(
+            "/api/agent-protocol/agents/{$this->agent1->did}/protocol/agreements/{$this->agent2->did}/refresh"
+        );
+
+        $response->assertStatus(401);
+    }
+
+    public function test_refresh_agreement_validates_agent_did_format(): void
+    {
+        $response = $this->withAgentAuth($this->apiKey1)->postJson(
+            "/api/agent-protocol/agents/invalid-did/protocol/agreements/{$this->agent2->did}/refresh"
+        );
+
+        $response->assertStatus(400)
+            ->assertJson([
+                'success' => false,
+                'error'   => 'Invalid agent DID format',
+            ]);
+    }
+
+    public function test_refresh_agreement_validates_other_did_format(): void
+    {
+        $response = $this->withAgentAuth($this->apiKey1)->postJson(
+            "/api/agent-protocol/agents/{$this->agent1->did}/protocol/agreements/invalid-did/refresh"
+        );
+
+        $response->assertStatus(400)
+            ->assertJson([
+                'success' => false,
+                'error'   => 'Invalid other agent DID format',
+            ]);
+    }
+
+    public function test_refresh_agreement_succeeds(): void
+    {
+        $agreement = new ProtocolAgreement(
+            agreementId: bin2hex(random_bytes(16)),
+            version: '1.1',
+            initiatorDid: $this->agent1->did,
+            responderDid: $this->agent2->did,
+            encryptionMethod: 'aes-256-gcm',
+            signatureMethod: 'ed25519',
+            capabilities: ['messaging', 'payments'],
+            agreedAt: new DateTimeImmutable(),
+            expiresAt: new DateTimeImmutable('+24 hours')
+        );
+
+        $mockResult = NegotiationResult::success($agreement);
+
+        $mockService = Mockery::mock(A2AProtocolNegotiationService::class);
+        $mockService->shouldReceive('refreshAgreement')
+            ->once()
+            ->with($this->agent1->did, $this->agent2->did)
+            ->andReturn($mockResult);
+
+        $this->app->instance(A2AProtocolNegotiationService::class, $mockService);
+
+        $response = $this->withAgentAuth($this->apiKey1)->postJson(
+            "/api/agent-protocol/agents/{$this->agent1->did}/protocol/agreements/{$this->agent2->did}/refresh"
+        );
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'success' => true,
+            ])
+            ->assertJsonStructure([
+                'success',
+                'data' => [
+                    'negotiation',
+                ],
+            ]);
+    }
+
+    // =============================================================================
+    // Authenticated endpoint tests - Check agreement
+    // =============================================================================
+
+    public function test_check_agreement_requires_authentication(): void
+    {
+        $response = $this->getJson(
+            "/api/agent-protocol/agents/{$this->agent1->did}/protocol/agreements/{$this->agent2->did}/check"
+        );
+
+        $response->assertStatus(401);
+    }
+
+    public function test_check_agreement_validates_agent_did_format(): void
+    {
+        $response = $this->withAgentAuth($this->apiKey1)->getJson(
+            "/api/agent-protocol/agents/invalid-did/protocol/agreements/{$this->agent2->did}/check"
+        );
+
+        $response->assertStatus(400)
+            ->assertJson([
+                'success' => false,
+                'error'   => 'Invalid agent DID format',
+            ]);
+    }
+
+    public function test_check_agreement_validates_other_did_format(): void
+    {
+        $response = $this->withAgentAuth($this->apiKey1)->getJson(
+            "/api/agent-protocol/agents/{$this->agent1->did}/protocol/agreements/invalid-did/check"
+        );
+
+        $response->assertStatus(400)
+            ->assertJson([
+                'success' => false,
+                'error'   => 'Invalid other agent DID format',
+            ]);
+    }
+
+    public function test_check_agreement_returns_false_when_no_agreement(): void
+    {
+        $mockService = Mockery::mock(A2AProtocolNegotiationService::class);
+        $mockService->shouldReceive('hasValidAgreement')
+            ->once()
+            ->with($this->agent1->did, $this->agent2->did)
+            ->andReturn(false);
+
+        $this->app->instance(A2AProtocolNegotiationService::class, $mockService);
+
+        $response = $this->withAgentAuth($this->apiKey1)->getJson(
+            "/api/agent-protocol/agents/{$this->agent1->did}/protocol/agreements/{$this->agent2->did}/check"
+        );
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'success' => true,
+                'data'    => [
+                    'has_valid_agreement' => false,
+                ],
+            ]);
+    }
+
+    public function test_check_agreement_returns_true_when_valid_agreement_exists(): void
+    {
+        $mockService = Mockery::mock(A2AProtocolNegotiationService::class);
+        $mockService->shouldReceive('hasValidAgreement')
+            ->once()
+            ->with($this->agent1->did, $this->agent2->did)
+            ->andReturn(true);
+
+        $this->app->instance(A2AProtocolNegotiationService::class, $mockService);
+
+        $response = $this->withAgentAuth($this->apiKey1)->getJson(
+            "/api/agent-protocol/agents/{$this->agent1->did}/protocol/agreements/{$this->agent2->did}/check"
+        );
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'success' => true,
+                'data'    => [
+                    'has_valid_agreement' => true,
+                ],
+            ]);
+    }
+}


### PR DESCRIPTION
## Summary
- Add REST API endpoints for A2A protocol version negotiation and agreement management
- Add `AgentProtocolNegotiationController` with full OpenAPI documentation  
- Add comprehensive API tests (28 tests) covering all endpoints

## New Endpoints

### Public endpoints:
- `GET /api/agent-protocol/protocol/versions` - List supported protocol versions (1.0, 1.1)
- `GET /api/agent-protocol/protocol/versions/{version}/capabilities` - Get capabilities for a version

### Agent-authenticated endpoints (require messages capability):
- `POST /agents/{did}/protocol/negotiate` - Initiate protocol negotiation with another agent
- `GET /agents/{did}/protocol/agreements/{otherDid}` - Get protocol agreement details
- `DELETE /agents/{did}/protocol/agreements/{otherDid}` - Revoke protocol agreement  
- `POST /agents/{did}/protocol/agreements/{otherDid}/refresh` - Refresh/extend agreement
- `GET /agents/{did}/protocol/agreements/{otherDid}/check` - Quick validity check

## Test plan
- [x] Run protocol negotiation API tests: `./vendor/bin/pest tests/Feature/AgentProtocol/AgentProtocolNegotiationApiTest.php` (28 tests pass)
- [x] Run PHPStan on new files (no errors)
- [x] Run PHP-CS-Fixer for code style

🤖 Generated with [Claude Code](https://claude.com/claude-code)