### PR TITLE
fix: Add null-safe operators for Reflection methods in tests

### DIFF
--- a/phpstan-baseline-level8.neon
+++ b/phpstan-baseline-level8.neon
@@ -2899,66 +2899,6 @@ parameters:
 			path: tests/Domain/Account/Repositories/TransferRepositoryTest.php
 
 		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 6
-			path: tests/Domain/Account/Workflows/AccountValidationActivityTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: tests/Domain/Account/Workflows/BalanceInquiryActivityTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 6
-			path: tests/Domain/Account/Workflows/BatchProcessingActivityTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 5
-			path: tests/Domain/Account/Workflows/DepositAccountActivityTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 3
-			path: tests/Domain/Account/Workflows/DepositAccountWorkflowTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: tests/Domain/Account/Workflows/DestroyAccountWorkflowTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 8
-			path: tests/Domain/Account/Workflows/TransactionReversalActivityTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 3
-			path: tests/Domain/Account/Workflows/UnfreezeAccountWorkflowTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 5
-			path: tests/Domain/Account/Workflows/WithdrawAccountActivityTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 3
-			path: tests/Domain/Account/Workflows/WithdrawAccountWorkflowTest.php
-
-		-
 			message: '#^Cannot access property \$from_asset_code on App\\Domain\\Asset\\Models\\ExchangeRate\|null\.$#'
 			identifier: property.nonObject
 			count: 1
@@ -3001,24 +2941,6 @@ parameters:
 			path: tests/Domain/Asset/Services/ExchangeRateServiceTest.php
 
 		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 4
-			path: tests/Domain/Asset/Workflows/AssetDepositWorkflowTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: tests/Domain/Asset/Workflows/AssetTransferWorkflowTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 4
-			path: tests/Domain/Asset/Workflows/AssetWithdrawWorkflowTest.php
-
-		-
 			message: '#^Cannot access property \$code on App\\Domain\\Basket\\Models\\BasketAsset\|null\.$#'
 			identifier: property.nonObject
 			count: 1
@@ -3049,64 +2971,16 @@ parameters:
 			path: tests/Domain/Basket/Models/BasketAssetTest.php
 
 		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 4
-			path: tests/Domain/Basket/Workflows/DecomposeBasketWorkflowTest.php
-
-		-
 			message: '#^Offset ''error'' might not exist on array\|null\.$#'
 			identifier: offsetAccess.notFound
 			count: 1
 			path: tests/Domain/Custodian/Connectors/MockBankConnectorTest.php
 
 		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 7
-			path: tests/Domain/Custodian/Workflows/CustodianTransferWorkflowTest.php
-
-		-
 			message: '#^Offset ''source'' might not exist on array\|null\.$#'
 			identifier: offsetAccess.notFound
 			count: 1
 			path: tests/Domain/Exchange/Providers/MockExchangeRateProviderTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 4
-			path: tests/Domain/Payment/Activities/CreditAccountActivityTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 4
-			path: tests/Domain/Payment/Activities/DebitAccountActivityTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 3
-			path: tests/Domain/Payment/Activities/InitiateBankTransferActivityTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 3
-			path: tests/Domain/Payment/Activities/PublishDepositCompletedActivityTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 4
-			path: tests/Domain/Payment/Activities/PublishWithdrawalRequestedActivityTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: tests/Domain/Payment/Activities/ValidateWithdrawalActivityTest.php
 
 		-
 			message: '#^Cannot access property \$account_uuid on App\\Domain\\Payment\\Models\\PaymentTransaction\|null\.$#'
@@ -3685,18 +3559,6 @@ parameters:
 			path: tests/Feature/Domain/AI/MCPServerTest.php
 
 		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 3
-			path: tests/Feature/Domain/Basket/Activities/ComposeBasketActivityTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 3
-			path: tests/Feature/Domain/Basket/Activities/DecomposeBasketActivityTest.php
-
-		-
 			message: '#^Cannot access property \$activeComponents on App\\Domain\\Basket\\Models\\BasketAsset\|null\.$#'
 			identifier: property.nonObject
 			count: 3
@@ -3761,18 +3623,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: tests/Feature/Domain/Basket/Services/BasketValueCalculationServiceTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: tests/Feature/Domain/Compliance/Activities/KycSubmissionActivityTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: tests/Feature/Domain/Compliance/Activities/KycVerificationActivityTest.php
 
 		-
 			message: '#^Offset 0 might not exist on array\|null\.$#'
@@ -4681,12 +4531,6 @@ parameters:
 			path: tests/Unit/Domain/Product/ProductCatalogTest.php
 
 		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 5
-			path: tests/Unit/Domain/Stablecoin/Events/CollateralLockedTest.php
-
-		-
 			message: '#^Offset ''high'' might not exist on array\|null\.$#'
 			identifier: offsetAccess.notFound
 			count: 1
@@ -4777,12 +4621,6 @@ parameters:
 			path: tests/Unit/Domain/Stablecoin/Oracles/InternalAMMOracleTest.php
 
 		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 8
-			path: tests/Unit/Domain/Stablecoin/Projectors/StablecoinProjectorTest.php
-
-		-
 			message: '#^Cannot call method getDocComment\(\) on ReflectionMethod\|null\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -4790,12 +4628,6 @@ parameters:
 
 		-
 			message: '#^Cannot call method getEndLine\(\) on ReflectionMethod\|null\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: tests/Unit/Domain/Stablecoin/Repositories/StablecoinEventRepositoryTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
 			identifier: method.nonObject
 			count: 2
 			path: tests/Unit/Domain/Stablecoin/Repositories/StablecoinEventRepositoryTest.php
@@ -4819,22 +4651,10 @@ parameters:
 			path: tests/Unit/Domain/Stablecoin/Repositories/StablecoinSnapshotRepositoryTest.php
 
 		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: tests/Unit/Domain/Stablecoin/Repositories/StablecoinSnapshotRepositoryTest.php
-
-		-
 			message: '#^Cannot call method getStartLine\(\) on ReflectionMethod\|null\.$#'
 			identifier: method.nonObject
 			count: 2
 			path: tests/Unit/Domain/Stablecoin/Repositories/StablecoinSnapshotRepositoryTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 21
-			path: tests/Unit/Domain/Stablecoin/Services/CollateralServiceTest.php
 
 		-
 			message: '#^Cannot access property \$debt_amount on App\\Domain\\Stablecoin\\Models\\StablecoinCollateralPosition\|null\.$#'
@@ -4855,21 +4675,9 @@ parameters:
 			path: tests/Unit/Domain/Stablecoin/Services/DemoStablecoinServiceTest.php
 
 		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 6
-			path: tests/Unit/Domain/Stablecoin/Services/LiquidationServiceTest.php
-
-		-
 			message: '#^Cannot call method getEndLine\(\) on ReflectionMethod\|null\.$#'
 			identifier: method.nonObject
 			count: 1
-			path: tests/Unit/Domain/Stablecoin/Services/OracleAggregatorTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 8
 			path: tests/Unit/Domain/Stablecoin/Services/OracleAggregatorTest.php
 
 		-
@@ -4877,18 +4685,6 @@ parameters:
 			identifier: method.nonObject
 			count: 1
 			path: tests/Unit/Domain/Stablecoin/Services/OracleAggregatorTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 4
-			path: tests/Unit/Domain/Stablecoin/Services/StabilityMechanismServiceTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 9
-			path: tests/Unit/Domain/Stablecoin/Services/StablecoinIssuanceServiceTest.php
 
 		-
 			message: '#^Offset ''quality_scores'' might not exist on array\|null\.$#'
@@ -4913,72 +4709,6 @@ parameters:
 			identifier: offsetAccess.notFound
 			count: 1
 			path: tests/Unit/Domain/Stablecoin/ValueObjects/PriceDataTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 5
-			path: tests/Unit/Domain/Stablecoin/Workflows/Activities/BurnStablecoinActivityTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 3
-			path: tests/Unit/Domain/Stablecoin/Workflows/Activities/ClosePositionActivityTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 6
-			path: tests/Unit/Domain/Stablecoin/Workflows/Activities/CreatePositionActivityTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 5
-			path: tests/Unit/Domain/Stablecoin/Workflows/Activities/LockCollateralActivityTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 5
-			path: tests/Unit/Domain/Stablecoin/Workflows/Activities/MintStablecoinActivityTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 4
-			path: tests/Unit/Domain/Stablecoin/Workflows/Activities/ReleaseCollateralActivityTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: tests/Unit/Domain/Stablecoin/Workflows/Activities/UpdatePositionActivityTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 5
-			path: tests/Unit/Domain/Stablecoin/Workflows/AddCollateralWorkflowTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 7
-			path: tests/Unit/Domain/Stablecoin/Workflows/BurnStablecoinWorkflowTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 6
-			path: tests/Unit/Domain/Stablecoin/Workflows/MintStablecoinWorkflowTest.php
-
-		-
-			message: '#^Cannot call method getName\(\) on ReflectionType\|null\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: tests/Unit/Domain/Stablecoin/Workflows/ReserveManagementWorkflowTest.php
 
 		-
 			message: '#^Offset ''currency'' might not exist on array\|null\.$#'

--- a/tests/Domain/Account/Workflows/AccountValidationActivityTest.php
+++ b/tests/Domain/Account/Workflows/AccountValidationActivityTest.php
@@ -32,7 +32,7 @@ it('execute method returns array', function () {
     $reflection = new ReflectionClass(AccountValidationActivity::class);
     $method = $reflection->getMethod('execute');
 
-    expect($method->getReturnType()->getName())->toBe('array');
+    expect($method->getReturnType()?->getName())->toBe('array');
 });
 
 it('has proper type hints for parameters', function () {
@@ -40,9 +40,9 @@ it('has proper type hints for parameters', function () {
     $method = $reflection->getMethod('execute');
     $parameters = $method->getParameters();
 
-    expect($parameters[0]->getType()->getName())->toBe('App\Domain\Account\DataObjects\AccountUuid');
-    expect($parameters[1]->getType()->getName())->toBe('array');
-    expect($parameters[2]->getType()->getName())->toBe('string');
+    expect($parameters[0]->getType()?->getName())->toBe('App\Domain\Account\DataObjects\AccountUuid');
+    expect($parameters[1]->getType()?->getName())->toBe('array');
+    expect($parameters[2]->getType()?->getName())->toBe('string');
     expect($parameters[2]->allowsNull())->toBeTrue();
 });
 
@@ -92,7 +92,7 @@ it('validation methods return arrays', function () {
 
     foreach ($methods as $methodName) {
         $method = $reflection->getMethod($methodName);
-        expect($method->getReturnType()->getName())->toBe('array');
+        expect($method->getReturnType()?->getName())->toBe('array');
     }
 });
 
@@ -103,7 +103,7 @@ it('can access execute method through reflection', function () {
 
     expect($method->isPublic())->toBeTrue();
     expect($method->getNumberOfParameters())->toBe(3);
-    expect($method->getReturnType()->getName())->toBe('array');
+    expect($method->getReturnType()?->getName())->toBe('array');
 });
 
 it('validates all required validation methods exist', function () {

--- a/tests/Domain/Account/Workflows/BalanceInquiryActivityTest.php
+++ b/tests/Domain/Account/Workflows/BalanceInquiryActivityTest.php
@@ -42,7 +42,7 @@ it('can access execute method through reflection', function () {
 
     expect($method->isPublic())->toBeTrue();
     expect($method->getNumberOfParameters())->toBe(3);
-    expect($method->getReturnType()->getName())->toBe('array');
+    expect($method->getReturnType()?->getName())->toBe('array');
 });
 
 it('validates balance inquiry has private logInquiry method', function () {

--- a/tests/Domain/Account/Workflows/BatchProcessingActivityTest.php
+++ b/tests/Domain/Account/Workflows/BatchProcessingActivityTest.php
@@ -30,7 +30,7 @@ it('execute method returns array', function () {
     $reflection = new ReflectionClass(BatchProcessingActivity::class);
     $method = $reflection->getMethod('execute');
 
-    expect($method->getReturnType()->getName())->toBe('array');
+    expect($method->getReturnType()?->getName())->toBe('array');
 });
 
 it('has proper type hints for parameters', function () {
@@ -38,8 +38,8 @@ it('has proper type hints for parameters', function () {
     $method = $reflection->getMethod('execute');
     $parameters = $method->getParameters();
 
-    expect($parameters[0]->getType()->getName())->toBe('array');
-    expect($parameters[1]->getType()->getName())->toBe('string');
+    expect($parameters[0]->getType()?->getName())->toBe('array');
+    expect($parameters[1]->getType()?->getName())->toBe('string');
 });
 
 it('has batch operation methods', function () {
@@ -91,7 +91,7 @@ it('batch operation methods return arrays', function () {
 
     foreach ($methods as $methodName) {
         $method = $reflection->getMethod($methodName);
-        expect($method->getReturnType()->getName())->toBe('array');
+        expect($method->getReturnType()?->getName())->toBe('array');
     }
 });
 
@@ -101,7 +101,7 @@ it('supports all expected batch operations', function () {
 
     // This test verifies the method exists and can handle the switch cases
     expect($performOperationMethod->isPrivate())->toBeTrue();
-    expect($performOperationMethod->getReturnType()->getName())->toBe('array');
+    expect($performOperationMethod->getReturnType()?->getName())->toBe('array');
 });
 
 // Coverage tests - test method accessibility and parameter validation
@@ -111,7 +111,7 @@ it('can access execute method through reflection', function () {
 
     expect($method->isPublic())->toBeTrue();
     expect($method->getNumberOfParameters())->toBe(2);
-    expect($method->getReturnType()->getName())->toBe('array');
+    expect($method->getReturnType()?->getName())->toBe('array');
 });
 
 it('validates all batch processing methods exist', function () {

--- a/tests/Domain/Account/Workflows/DepositAccountActivityTest.php
+++ b/tests/Domain/Account/Workflows/DepositAccountActivityTest.php
@@ -34,7 +34,7 @@ it('execute method returns boolean', function () {
     $reflection = new ReflectionClass(DepositAccountActivity::class);
     $method = $reflection->getMethod('execute');
 
-    expect($method->getReturnType()->getName())->toBe('bool');
+    expect($method->getReturnType()?->getName())->toBe('bool');
 });
 
 it('has proper type hints for parameters', function () {
@@ -42,9 +42,9 @@ it('has proper type hints for parameters', function () {
     $method = $reflection->getMethod('execute');
     $parameters = $method->getParameters();
 
-    expect($parameters[0]->getType()->getName())->toBe('App\Domain\Account\DataObjects\AccountUuid');
-    expect($parameters[1]->getType()->getName())->toBe('App\Domain\Account\DataObjects\Money');
-    expect($parameters[2]->getType()->getName())->toBe('App\Domain\Account\Aggregates\TransactionAggregate');
+    expect($parameters[0]->getType()?->getName())->toBe('App\Domain\Account\DataObjects\AccountUuid');
+    expect($parameters[1]->getType()?->getName())->toBe('App\Domain\Account\DataObjects\Money');
+    expect($parameters[2]->getType()?->getName())->toBe('App\Domain\Account\Aggregates\TransactionAggregate');
 });
 
 // Coverage tests - test method accessibility and parameter validation
@@ -54,7 +54,7 @@ it('can access execute method through reflection', function () {
 
     expect($method->isPublic())->toBeTrue();
     expect($method->getNumberOfParameters())->toBe(3);
-    expect($method->getReturnType()->getName())->toBe('bool');
+    expect($method->getReturnType()?->getName())->toBe('bool');
 });
 
 it('validates all required data objects exist', function () {

--- a/tests/Domain/Account/Workflows/DepositAccountWorkflowTest.php
+++ b/tests/Domain/Account/Workflows/DepositAccountWorkflowTest.php
@@ -18,7 +18,7 @@ it('has execute method with correct signature', function () {
 
     expect($method->isPublic())->toBeTrue();
     expect($method->getNumberOfParameters())->toBe(2);
-    expect($method->getReturnType()->getName())->toBe('Generator');
+    expect($method->getReturnType()?->getName())->toBe('Generator');
 });
 
 it('extends workflow base class', function () {
@@ -35,6 +35,6 @@ it('has correct parameter types', function () {
     expect($parameters[1]->getName())->toBe('money');
 
     // Check parameter types
-    expect($parameters[0]->getType()->getName())->toBe('App\Domain\Account\DataObjects\AccountUuid');
-    expect($parameters[1]->getType()->getName())->toBe('App\Domain\Account\DataObjects\Money');
+    expect($parameters[0]->getType()?->getName())->toBe('App\Domain\Account\DataObjects\AccountUuid');
+    expect($parameters[1]->getType()?->getName())->toBe('App\Domain\Account\DataObjects\Money');
 });

--- a/tests/Domain/Account/Workflows/DestroyAccountWorkflowTest.php
+++ b/tests/Domain/Account/Workflows/DestroyAccountWorkflowTest.php
@@ -18,7 +18,7 @@ it('has execute method with correct signature', function () {
 
     expect($method->isPublic())->toBeTrue();
     expect($method->getNumberOfParameters())->toBe(1);
-    expect($method->getReturnType()->getName())->toBe('Generator');
+    expect($method->getReturnType()?->getName())->toBe('Generator');
 });
 
 it('extends workflow base class', function () {
@@ -34,5 +34,5 @@ it('has correct parameter types', function () {
     expect($parameters[0]->getName())->toBe('uuid');
 
     // Check parameter type
-    expect($parameters[0]->getType()->getName())->toBe('App\Domain\Account\DataObjects\AccountUuid');
+    expect($parameters[0]->getType()?->getName())->toBe('App\Domain\Account\DataObjects\AccountUuid');
 });

--- a/tests/Domain/Account/Workflows/TransactionReversalActivityTest.php
+++ b/tests/Domain/Account/Workflows/TransactionReversalActivityTest.php
@@ -36,7 +36,7 @@ it('execute method returns array', function () {
     $reflection = new ReflectionClass(TransactionReversalActivity::class);
     $method = $reflection->getMethod('execute');
 
-    expect($method->getReturnType()->getName())->toBe('array');
+    expect($method->getReturnType()?->getName())->toBe('array');
 });
 
 it('has proper type hints for parameters', function () {
@@ -44,13 +44,13 @@ it('has proper type hints for parameters', function () {
     $method = $reflection->getMethod('execute');
     $parameters = $method->getParameters();
 
-    expect($parameters[0]->getType()->getName())->toBe('App\Domain\Account\DataObjects\AccountUuid');
-    expect($parameters[1]->getType()->getName())->toBe('App\Domain\Account\DataObjects\Money');
-    expect($parameters[2]->getType()->getName())->toBe('string');
-    expect($parameters[3]->getType()->getName())->toBe('string');
-    expect($parameters[4]->getType()->getName())->toBe('string');
+    expect($parameters[0]->getType()?->getName())->toBe('App\Domain\Account\DataObjects\AccountUuid');
+    expect($parameters[1]->getType()?->getName())->toBe('App\Domain\Account\DataObjects\Money');
+    expect($parameters[2]->getType()?->getName())->toBe('string');
+    expect($parameters[3]->getType()?->getName())->toBe('string');
+    expect($parameters[4]->getType()?->getName())->toBe('string');
     expect($parameters[4]->allowsNull())->toBeTrue();
-    expect($parameters[5]->getType()->getName())->toBe('App\Domain\Account\Aggregates\TransactionAggregate');
+    expect($parameters[5]->getType()?->getName())->toBe('App\Domain\Account\Aggregates\TransactionAggregate');
 });
 
 it('has logReversal method', function () {
@@ -67,7 +67,7 @@ it('can access execute method through reflection', function () {
 
     expect($method->isPublic())->toBeTrue();
     expect($method->getNumberOfParameters())->toBe(6);
-    expect($method->getReturnType()->getName())->toBe('array');
+    expect($method->getReturnType()?->getName())->toBe('array');
 });
 
 it('validates transaction reversal has private logReversal method', function () {

--- a/tests/Domain/Account/Workflows/UnfreezeAccountWorkflowTest.php
+++ b/tests/Domain/Account/Workflows/UnfreezeAccountWorkflowTest.php
@@ -18,7 +18,7 @@ it('has execute method with correct signature', function () {
 
     expect($method->isPublic())->toBeTrue();
     expect($method->getNumberOfParameters())->toBe(3);
-    expect($method->getReturnType()->getName())->toBe('Generator');
+    expect($method->getReturnType()?->getName())->toBe('Generator');
 });
 
 it('extends workflow base class', function () {
@@ -36,8 +36,8 @@ it('has correct parameter types', function () {
     expect($parameters[2]->getName())->toBe('authorizedBy');
 
     // Check parameter types
-    expect($parameters[0]->getType()->getName())->toBe('App\Domain\Account\DataObjects\AccountUuid');
-    expect($parameters[1]->getType()->getName())->toBe('string');
+    expect($parameters[0]->getType()?->getName())->toBe('App\Domain\Account\DataObjects\AccountUuid');
+    expect($parameters[1]->getType()?->getName())->toBe('string');
     expect($parameters[2]->getType()?->getName())->toBe('string');
     expect($parameters[2]->allowsNull())->toBeTrue();
 });

--- a/tests/Domain/Account/Workflows/WithdrawAccountActivityTest.php
+++ b/tests/Domain/Account/Workflows/WithdrawAccountActivityTest.php
@@ -33,7 +33,7 @@ it('execute method returns boolean', function () {
     $reflection = new ReflectionClass(WithdrawAccountActivity::class);
     $method = $reflection->getMethod('execute');
 
-    expect($method->getReturnType()->getName())->toBe('bool');
+    expect($method->getReturnType()?->getName())->toBe('bool');
 });
 
 it('has proper type hints for parameters', function () {
@@ -41,9 +41,9 @@ it('has proper type hints for parameters', function () {
     $method = $reflection->getMethod('execute');
     $parameters = $method->getParameters();
 
-    expect($parameters[0]->getType()->getName())->toBe('App\Domain\Account\DataObjects\AccountUuid');
-    expect($parameters[1]->getType()->getName())->toBe('App\Domain\Account\DataObjects\Money');
-    expect($parameters[2]->getType()->getName())->toBe('App\Domain\Account\Aggregates\TransactionAggregate');
+    expect($parameters[0]->getType()?->getName())->toBe('App\Domain\Account\DataObjects\AccountUuid');
+    expect($parameters[1]->getType()?->getName())->toBe('App\Domain\Account\DataObjects\Money');
+    expect($parameters[2]->getType()?->getName())->toBe('App\Domain\Account\Aggregates\TransactionAggregate');
 });
 
 // Coverage tests - test method accessibility and parameter validation
@@ -53,7 +53,7 @@ it('can access execute method through reflection', function () {
 
     expect($method->isPublic())->toBeTrue();
     expect($method->getNumberOfParameters())->toBe(3);
-    expect($method->getReturnType()->getName())->toBe('bool');
+    expect($method->getReturnType()?->getName())->toBe('bool');
 });
 
 it('validates withdraw activity uses debit operation', function () {

--- a/tests/Domain/Account/Workflows/WithdrawAccountWorkflowTest.php
+++ b/tests/Domain/Account/Workflows/WithdrawAccountWorkflowTest.php
@@ -18,7 +18,7 @@ it('has execute method with correct signature', function () {
 
     expect($method->isPublic())->toBeTrue();
     expect($method->getNumberOfParameters())->toBe(2);
-    expect($method->getReturnType()->getName())->toBe('Generator');
+    expect($method->getReturnType()?->getName())->toBe('Generator');
 });
 
 it('extends workflow base class', function () {
@@ -35,6 +35,6 @@ it('has correct parameter types', function () {
     expect($parameters[1]->getName())->toBe('money');
 
     // Check parameter types
-    expect($parameters[0]->getType()->getName())->toBe('App\Domain\Account\DataObjects\AccountUuid');
-    expect($parameters[1]->getType()->getName())->toBe('App\Domain\Account\DataObjects\Money');
+    expect($parameters[0]->getType()?->getName())->toBe('App\Domain\Account\DataObjects\AccountUuid');
+    expect($parameters[1]->getType()?->getName())->toBe('App\Domain\Account\DataObjects\Money');
 });

--- a/tests/Domain/Asset/Workflows/AssetDepositWorkflowTest.php
+++ b/tests/Domain/Asset/Workflows/AssetDepositWorkflowTest.php
@@ -18,7 +18,7 @@ it('has execute method with correct signature', function () {
 
     expect($method->isPublic())->toBeTrue();
     expect($method->getNumberOfParameters())->toBe(4);
-    expect($method->getReturnType()->getName())->toBe('Generator');
+    expect($method->getReturnType()?->getName())->toBe('Generator');
 });
 
 it('extends workflow base class', function () {
@@ -37,9 +37,9 @@ it('has correct parameter types', function () {
     expect($parameters[3]->getName())->toBe('description');
 
     // Check parameter types
-    expect($parameters[0]->getType()->getName())->toBe('App\Domain\Account\DataObjects\AccountUuid');
-    expect($parameters[1]->getType()->getName())->toBe('string');
-    expect($parameters[2]->getType()->getName())->toBe('int');
+    expect($parameters[0]->getType()?->getName())->toBe('App\Domain\Account\DataObjects\AccountUuid');
+    expect($parameters[1]->getType()?->getName())->toBe('string');
+    expect($parameters[2]->getType()?->getName())->toBe('int');
     expect($parameters[3]->getType()?->getName())->toBe('string');
     expect($parameters[3]->allowsNull())->toBeTrue();
 });

--- a/tests/Domain/Asset/Workflows/AssetTransferWorkflowTest.php
+++ b/tests/Domain/Asset/Workflows/AssetTransferWorkflowTest.php
@@ -24,7 +24,7 @@ it('has execute method with correct signature', function () {
 
     expect($method->isPublic())->toBeTrue();
     expect($method->getNumberOfParameters())->toBe(5); // 4 required + 1 optional
-    expect($method->getReturnType()->getName())->toBe('Generator');
+    expect($method->getReturnType()?->getName())->toBe('Generator');
 });
 
 it('validates workflow activities exist', function () {

--- a/tests/Domain/Asset/Workflows/AssetWithdrawWorkflowTest.php
+++ b/tests/Domain/Asset/Workflows/AssetWithdrawWorkflowTest.php
@@ -18,7 +18,7 @@ it('has execute method with correct signature', function () {
 
     expect($method->isPublic())->toBeTrue();
     expect($method->getNumberOfParameters())->toBe(4);
-    expect($method->getReturnType()->getName())->toBe('Generator');
+    expect($method->getReturnType()?->getName())->toBe('Generator');
 });
 
 it('extends workflow base class', function () {
@@ -37,9 +37,9 @@ it('has correct parameter types', function () {
     expect($parameters[3]->getName())->toBe('description');
 
     // Check parameter types
-    expect($parameters[0]->getType()->getName())->toBe('App\Domain\Account\DataObjects\AccountUuid');
-    expect($parameters[1]->getType()->getName())->toBe('string');
-    expect($parameters[2]->getType()->getName())->toBe('int');
+    expect($parameters[0]->getType()?->getName())->toBe('App\Domain\Account\DataObjects\AccountUuid');
+    expect($parameters[1]->getType()?->getName())->toBe('string');
+    expect($parameters[2]->getType()?->getName())->toBe('int');
     expect($parameters[3]->getType()?->getName())->toBe('string');
     expect($parameters[3]->allowsNull())->toBeTrue();
 });

--- a/tests/Domain/Basket/Workflows/DecomposeBasketWorkflowTest.php
+++ b/tests/Domain/Basket/Workflows/DecomposeBasketWorkflowTest.php
@@ -18,7 +18,7 @@ it('has execute method with correct signature', function () {
 
     expect($method->isPublic())->toBeTrue();
     expect($method->getNumberOfParameters())->toBe(3);
-    expect($method->getReturnType()->getName())->toBe('Generator');
+    expect($method->getReturnType()?->getName())->toBe('Generator');
 });
 
 it('extends workflow base class', function () {
@@ -36,7 +36,7 @@ it('has correct parameter types', function () {
     expect($parameters[2]->getName())->toBe('amount');
 
     // Check parameter types
-    expect($parameters[0]->getType()->getName())->toBe('App\\Domain\\Account\\ValueObjects\\AccountUuid');
-    expect($parameters[1]->getType()->getName())->toBe('string');
-    expect($parameters[2]->getType()->getName())->toBe('int');
+    expect($parameters[0]->getType()?->getName())->toBe('App\\Domain\\Account\\ValueObjects\\AccountUuid');
+    expect($parameters[1]->getType()?->getName())->toBe('string');
+    expect($parameters[2]->getType()?->getName())->toBe('int');
 });

--- a/tests/Domain/Custodian/Workflows/CustodianTransferWorkflowTest.php
+++ b/tests/Domain/Custodian/Workflows/CustodianTransferWorkflowTest.php
@@ -18,7 +18,7 @@ it('has execute method with correct signature', function () {
 
     expect($method->isPublic())->toBeTrue();
     expect($method->getNumberOfParameters())->toBe(7);
-    expect($method->getReturnType()->getName())->toBe('Generator');
+    expect($method->getReturnType()?->getName())->toBe('Generator');
 });
 
 it('extends workflow base class', function () {
@@ -40,12 +40,12 @@ it('has correct parameter types', function () {
     expect($parameters[6]->getName())->toBe('reference');
 
     // Check parameter types
-    expect($parameters[0]->getType()->getName())->toBe('App\Domain\Account\DataObjects\AccountUuid');
-    expect($parameters[1]->getType()->getName())->toBe('string');
-    expect($parameters[2]->getType()->getName())->toBe('string');
-    expect($parameters[3]->getType()->getName())->toBe('App\Domain\Account\DataObjects\Money');
-    expect($parameters[4]->getType()->getName())->toBe('string');
-    expect($parameters[5]->getType()->getName())->toBe('string');
+    expect($parameters[0]->getType()?->getName())->toBe('App\Domain\Account\DataObjects\AccountUuid');
+    expect($parameters[1]->getType()?->getName())->toBe('string');
+    expect($parameters[2]->getType()?->getName())->toBe('string');
+    expect($parameters[3]->getType()?->getName())->toBe('App\Domain\Account\DataObjects\Money');
+    expect($parameters[4]->getType()?->getName())->toBe('string');
+    expect($parameters[5]->getType()?->getName())->toBe('string');
     expect($parameters[6]->getType()?->getName())->toBe('string');
     expect($parameters[6]->allowsNull())->toBeTrue();
 });

--- a/tests/Domain/Payment/Activities/CreditAccountActivityTest.php
+++ b/tests/Domain/Payment/Activities/CreditAccountActivityTest.php
@@ -23,18 +23,18 @@ it('execute method has correct signature', function () {
 
     $parameters = $method->getParameters();
     expect($parameters[0]->getName())->toBe('accountUuid');
-    expect($parameters[0]->getType()->getName())->toBe('string');
+    expect($parameters[0]->getType()?->getName())->toBe('string');
 
     expect($parameters[1]->getName())->toBe('amount');
-    expect($parameters[1]->getType()->getName())->toBe('int');
+    expect($parameters[1]->getType()?->getName())->toBe('int');
 
     expect($parameters[2]->getName())->toBe('currency');
-    expect($parameters[2]->getType()->getName())->toBe('string');
+    expect($parameters[2]->getType()?->getName())->toBe('string');
 });
 
 it('execute method returns void', function () {
     $reflection = new ReflectionClass(CreditAccountActivity::class);
     $method = $reflection->getMethod('execute');
 
-    expect($method->getReturnType()->getName())->toBe('void');
+    expect($method->getReturnType()?->getName())->toBe('void');
 });

--- a/tests/Domain/Payment/Activities/DebitAccountActivityTest.php
+++ b/tests/Domain/Payment/Activities/DebitAccountActivityTest.php
@@ -23,18 +23,18 @@ it('execute method has correct signature', function () {
 
     $parameters = $method->getParameters();
     expect($parameters[0]->getName())->toBe('accountUuid');
-    expect($parameters[0]->getType()->getName())->toBe('string');
+    expect($parameters[0]->getType()?->getName())->toBe('string');
 
     expect($parameters[1]->getName())->toBe('amount');
-    expect($parameters[1]->getType()->getName())->toBe('int');
+    expect($parameters[1]->getType()?->getName())->toBe('int');
 
     expect($parameters[2]->getName())->toBe('currency');
-    expect($parameters[2]->getType()->getName())->toBe('string');
+    expect($parameters[2]->getType()?->getName())->toBe('string');
 });
 
 it('execute method returns void', function () {
     $reflection = new ReflectionClass(DebitAccountActivity::class);
     $method = $reflection->getMethod('execute');
 
-    expect($method->getReturnType()->getName())->toBe('void');
+    expect($method->getReturnType()?->getName())->toBe('void');
 });

--- a/tests/Domain/Payment/Activities/InitiateBankTransferActivityTest.php
+++ b/tests/Domain/Payment/Activities/InitiateBankTransferActivityTest.php
@@ -24,15 +24,15 @@ it('execute method has correct signature', function () {
 
     $parameters = $method->getParameters();
     expect($parameters[0]->getName())->toBe('transactionId');
-    expect($parameters[0]->getType()->getName())->toBe('string');
+    expect($parameters[0]->getType()?->getName())->toBe('string');
 
     expect($parameters[1]->getName())->toBe('withdrawal');
-    expect($parameters[1]->getType()->getName())->toBe(BankWithdrawal::class);
+    expect($parameters[1]->getType()?->getName())->toBe(BankWithdrawal::class);
 });
 
 it('execute method returns string', function () {
     $reflection = new ReflectionClass(InitiateBankTransferActivity::class);
     $method = $reflection->getMethod('execute');
 
-    expect($method->getReturnType()->getName())->toBe('string');
+    expect($method->getReturnType()?->getName())->toBe('string');
 });

--- a/tests/Domain/Payment/Activities/PublishDepositCompletedActivityTest.php
+++ b/tests/Domain/Payment/Activities/PublishDepositCompletedActivityTest.php
@@ -24,15 +24,15 @@ it('execute method has correct signature', function () {
 
     $parameters = $method->getParameters();
     expect($parameters[0]->getName())->toBe('transactionId');
-    expect($parameters[0]->getType()->getName())->toBe('string');
+    expect($parameters[0]->getType()?->getName())->toBe('string');
 
     expect($parameters[1]->getName())->toBe('deposit');
-    expect($parameters[1]->getType()->getName())->toBe(StripeDeposit::class);
+    expect($parameters[1]->getType()?->getName())->toBe(StripeDeposit::class);
 });
 
 it('execute method returns void', function () {
     $reflection = new ReflectionClass(PublishDepositCompletedActivity::class);
     $method = $reflection->getMethod('execute');
 
-    expect($method->getReturnType()->getName())->toBe('void');
+    expect($method->getReturnType()?->getName())->toBe('void');
 });

--- a/tests/Domain/Payment/Activities/PublishWithdrawalRequestedActivityTest.php
+++ b/tests/Domain/Payment/Activities/PublishWithdrawalRequestedActivityTest.php
@@ -24,18 +24,18 @@ it('execute method has correct signature', function () {
 
     $parameters = $method->getParameters();
     expect($parameters[0]->getName())->toBe('transactionId');
-    expect($parameters[0]->getType()->getName())->toBe('string');
+    expect($parameters[0]->getType()?->getName())->toBe('string');
 
     expect($parameters[1]->getName())->toBe('transferId');
-    expect($parameters[1]->getType()->getName())->toBe('string');
+    expect($parameters[1]->getType()?->getName())->toBe('string');
 
     expect($parameters[2]->getName())->toBe('withdrawal');
-    expect($parameters[2]->getType()->getName())->toBe(BankWithdrawal::class);
+    expect($parameters[2]->getType()?->getName())->toBe(BankWithdrawal::class);
 });
 
 it('execute method returns void', function () {
     $reflection = new ReflectionClass(PublishWithdrawalRequestedActivity::class);
     $method = $reflection->getMethod('execute');
 
-    expect($method->getReturnType()->getName())->toBe('void');
+    expect($method->getReturnType()?->getName())->toBe('void');
 });

--- a/tests/Domain/Payment/Activities/ValidateWithdrawalActivityTest.php
+++ b/tests/Domain/Payment/Activities/ValidateWithdrawalActivityTest.php
@@ -24,12 +24,12 @@ it('execute method has correct signature', function () {
 
     $parameters = $method->getParameters();
     expect($parameters[0]->getName())->toBe('withdrawal');
-    expect($parameters[0]->getType()->getName())->toBe(BankWithdrawal::class);
+    expect($parameters[0]->getType()?->getName())->toBe(BankWithdrawal::class);
 });
 
 it('execute method returns array', function () {
     $reflection = new ReflectionClass(ValidateWithdrawalActivity::class);
     $method = $reflection->getMethod('execute');
 
-    expect($method->getReturnType()->getName())->toBe('array');
+    expect($method->getReturnType()?->getName())->toBe('array');
 });

--- a/tests/Feature/Domain/Basket/Activities/ComposeBasketActivityTest.php
+++ b/tests/Feature/Domain/Basket/Activities/ComposeBasketActivityTest.php
@@ -61,13 +61,13 @@ class ComposeBasketActivityTest extends TestCase
         $this->assertCount(3, $parameters);
 
         $this->assertEquals('accountUuid', $parameters[0]->getName());
-        $this->assertEquals('App\Domain\Account\DataObjects\AccountUuid', $parameters[0]->getType()->getName());
+        $this->assertEquals('App\Domain\Account\DataObjects\AccountUuid', $parameters[0]->getType()?->getName());
 
         $this->assertEquals('basketCode', $parameters[1]->getName());
-        $this->assertEquals('string', $parameters[1]->getType()->getName());
+        $this->assertEquals('string', $parameters[1]->getType()?->getName());
 
         $this->assertEquals('amount', $parameters[2]->getName());
-        $this->assertEquals('int', $parameters[2]->getType()->getName());
+        $this->assertEquals('int', $parameters[2]->getType()?->getName());
     }
 
     #[Test]

--- a/tests/Feature/Domain/Basket/Activities/DecomposeBasketActivityTest.php
+++ b/tests/Feature/Domain/Basket/Activities/DecomposeBasketActivityTest.php
@@ -61,13 +61,13 @@ class DecomposeBasketActivityTest extends TestCase
         $this->assertCount(3, $parameters);
 
         $this->assertEquals('accountUuid', $parameters[0]->getName());
-        $this->assertEquals('App\Domain\Account\DataObjects\AccountUuid', $parameters[0]->getType()->getName());
+        $this->assertEquals('App\Domain\Account\DataObjects\AccountUuid', $parameters[0]->getType()?->getName());
 
         $this->assertEquals('basketCode', $parameters[1]->getName());
-        $this->assertEquals('string', $parameters[1]->getType()->getName());
+        $this->assertEquals('string', $parameters[1]->getType()?->getName());
 
         $this->assertEquals('amount', $parameters[2]->getName());
-        $this->assertEquals('int', $parameters[2]->getType()->getName());
+        $this->assertEquals('int', $parameters[2]->getType()?->getName());
     }
 
     #[Test]

--- a/tests/Feature/Domain/Compliance/Activities/KycSubmissionActivityTest.php
+++ b/tests/Feature/Domain/Compliance/Activities/KycSubmissionActivityTest.php
@@ -78,6 +78,6 @@ class KycSubmissionActivityTest extends TestCase
         $parameters = $executeMethod->getParameters();
         $this->assertCount(1, $parameters);
         $this->assertEquals('input', $parameters[0]->getName());
-        $this->assertEquals('array', $parameters[0]->getType()->getName());
+        $this->assertEquals('array', $parameters[0]->getType()?->getName());
     }
 }

--- a/tests/Feature/Domain/Compliance/Activities/KycVerificationActivityTest.php
+++ b/tests/Feature/Domain/Compliance/Activities/KycVerificationActivityTest.php
@@ -87,6 +87,6 @@ class KycVerificationActivityTest extends TestCase
         $parameters = $executeMethod->getParameters();
         $this->assertCount(1, $parameters);
         $this->assertEquals('input', $parameters[0]->getName());
-        $this->assertEquals('array', $parameters[0]->getType()->getName());
+        $this->assertEquals('array', $parameters[0]->getType()?->getName());
     }
 }

--- a/tests/Unit/Domain/Stablecoin/Events/CollateralLockedTest.php
+++ b/tests/Unit/Domain/Stablecoin/Events/CollateralLockedTest.php
@@ -36,19 +36,19 @@ class CollateralLockedTest extends DomainTestCase
         $parameters = $constructor->getParameters();
 
         $this->assertEquals('position_uuid', $parameters[0]->getName());
-        $this->assertEquals('string', $parameters[0]->getType()->getName());
+        $this->assertEquals('string', $parameters[0]->getType()?->getName());
 
         $this->assertEquals('account_uuid', $parameters[1]->getName());
-        $this->assertEquals('string', $parameters[1]->getType()->getName());
+        $this->assertEquals('string', $parameters[1]->getType()?->getName());
 
         $this->assertEquals('collateral_asset_code', $parameters[2]->getName());
-        $this->assertEquals('string', $parameters[2]->getType()->getName());
+        $this->assertEquals('string', $parameters[2]->getType()?->getName());
 
         $this->assertEquals('amount', $parameters[3]->getName());
-        $this->assertEquals('float', $parameters[3]->getType()->getName());
+        $this->assertEquals('float', $parameters[3]->getType()?->getName());
 
         $this->assertEquals('metadata', $parameters[4]->getName());
-        $this->assertEquals('array', $parameters[4]->getType()->getName());
+        $this->assertEquals('array', $parameters[4]->getType()?->getName());
         $this->assertTrue($parameters[4]->isDefaultValueAvailable());
         $this->assertEquals([], $parameters[4]->getDefaultValue());
     }

--- a/tests/Unit/Domain/Stablecoin/Projectors/StablecoinProjectorTest.php
+++ b/tests/Unit/Domain/Stablecoin/Projectors/StablecoinProjectorTest.php
@@ -67,7 +67,7 @@ class StablecoinProjectorTest extends TestCase
 
         $parameter = $method->getParameters()[0];
         $this->assertEquals('event', $parameter->getName());
-        $this->assertEquals(CollateralPositionCreated::class, $parameter->getType()->getName());
+        $this->assertEquals(CollateralPositionCreated::class, $parameter->getType()?->getName());
     }
 
     #[Test]
@@ -80,7 +80,7 @@ class StablecoinProjectorTest extends TestCase
 
         $parameter = $method->getParameters()[0];
         $this->assertEquals('event', $parameter->getName());
-        $this->assertEquals(CollateralLocked::class, $parameter->getType()->getName());
+        $this->assertEquals(CollateralLocked::class, $parameter->getType()?->getName());
     }
 
     #[Test]
@@ -93,7 +93,7 @@ class StablecoinProjectorTest extends TestCase
 
         $parameter = $method->getParameters()[0];
         $this->assertEquals('event', $parameter->getName());
-        $this->assertEquals(StablecoinMinted::class, $parameter->getType()->getName());
+        $this->assertEquals(StablecoinMinted::class, $parameter->getType()?->getName());
     }
 
     #[Test]
@@ -106,7 +106,7 @@ class StablecoinProjectorTest extends TestCase
 
         $parameter = $method->getParameters()[0];
         $this->assertEquals('event', $parameter->getName());
-        $this->assertEquals(StablecoinBurned::class, $parameter->getType()->getName());
+        $this->assertEquals(StablecoinBurned::class, $parameter->getType()?->getName());
     }
 
     #[Test]
@@ -119,7 +119,7 @@ class StablecoinProjectorTest extends TestCase
 
         $parameter = $method->getParameters()[0];
         $this->assertEquals('event', $parameter->getName());
-        $this->assertEquals(CollateralReleased::class, $parameter->getType()->getName());
+        $this->assertEquals(CollateralReleased::class, $parameter->getType()?->getName());
     }
 
     #[Test]
@@ -132,7 +132,7 @@ class StablecoinProjectorTest extends TestCase
 
         $parameter = $method->getParameters()[0];
         $this->assertEquals('event', $parameter->getName());
-        $this->assertEquals(CollateralPositionUpdated::class, $parameter->getType()->getName());
+        $this->assertEquals(CollateralPositionUpdated::class, $parameter->getType()?->getName());
     }
 
     #[Test]
@@ -145,7 +145,7 @@ class StablecoinProjectorTest extends TestCase
 
         $parameter = $method->getParameters()[0];
         $this->assertEquals('event', $parameter->getName());
-        $this->assertEquals(CollateralPositionClosed::class, $parameter->getType()->getName());
+        $this->assertEquals(CollateralPositionClosed::class, $parameter->getType()?->getName());
     }
 
     #[Test]
@@ -158,7 +158,7 @@ class StablecoinProjectorTest extends TestCase
 
         $parameter = $method->getParameters()[0];
         $this->assertEquals('event', $parameter->getName());
-        $this->assertEquals(CollateralPositionLiquidated::class, $parameter->getType()->getName());
+        $this->assertEquals(CollateralPositionLiquidated::class, $parameter->getType()?->getName());
     }
 
     #[Test]

--- a/tests/Unit/Domain/Stablecoin/Repositories/StablecoinEventRepositoryTest.php
+++ b/tests/Unit/Domain/Stablecoin/Repositories/StablecoinEventRepositoryTest.php
@@ -42,7 +42,7 @@ class StablecoinEventRepositoryTest extends DomainTestCase
 
         $parameter = $constructor->getParameters()[0];
         $this->assertEquals('storedEventModel', $parameter->getName());
-        $this->assertEquals('string', $parameter->getType()->getName());
+        $this->assertEquals('string', $parameter->getType()?->getName());
         $this->assertTrue($parameter->isDefaultValueAvailable());
         $this->assertEquals(StablecoinEvent::class, $parameter->getDefaultValue());
     }
@@ -54,7 +54,7 @@ class StablecoinEventRepositoryTest extends DomainTestCase
         $property = $reflection->getProperty('storedEventModel');
 
         $this->assertTrue($property->isProtected());
-        $this->assertEquals('string', $property->getType()->getName());
+        $this->assertEquals('string', $property->getType()?->getName());
     }
 
     #[Test]

--- a/tests/Unit/Domain/Stablecoin/Repositories/StablecoinSnapshotRepositoryTest.php
+++ b/tests/Unit/Domain/Stablecoin/Repositories/StablecoinSnapshotRepositoryTest.php
@@ -42,7 +42,7 @@ class StablecoinSnapshotRepositoryTest extends DomainTestCase
 
         $parameter = $constructor->getParameters()[0];
         $this->assertEquals('snapshotModel', $parameter->getName());
-        $this->assertEquals('string', $parameter->getType()->getName());
+        $this->assertEquals('string', $parameter->getType()?->getName());
         $this->assertTrue($parameter->isDefaultValueAvailable());
         $this->assertEquals(StablecoinSnapshot::class, $parameter->getDefaultValue());
     }
@@ -54,7 +54,7 @@ class StablecoinSnapshotRepositoryTest extends DomainTestCase
         $property = $reflection->getProperty('snapshotModel');
 
         $this->assertTrue($property->isProtected());
-        $this->assertEquals('string', $property->getType()->getName());
+        $this->assertEquals('string', $property->getType()?->getName());
     }
 
     #[Test]

--- a/tests/Unit/Domain/Stablecoin/Services/CollateralServiceTest.php
+++ b/tests/Unit/Domain/Stablecoin/Services/CollateralServiceTest.php
@@ -48,7 +48,7 @@ class CollateralServiceTest extends ServiceTestCase
 
         $parameter = $constructor->getParameters()[0];
         $this->assertEquals('exchangeRateService', $parameter->getName());
-        $this->assertEquals(ExchangeRateService::class, $parameter->getType()->getName());
+        $this->assertEquals(ExchangeRateService::class, $parameter->getType()?->getName());
     }
 
     #[Test]
@@ -82,15 +82,15 @@ class CollateralServiceTest extends ServiceTestCase
 
         $parameters = $reflection->getParameters();
         $this->assertEquals('fromAsset', $parameters[0]->getName());
-        $this->assertEquals('string', $parameters[0]->getType()->getName());
+        $this->assertEquals('string', $parameters[0]->getType()?->getName());
 
         $this->assertEquals('amount', $parameters[1]->getName());
-        $this->assertEquals('float', $parameters[1]->getType()->getName());
+        $this->assertEquals('float', $parameters[1]->getType()?->getName());
 
         $this->assertEquals('pegAsset', $parameters[2]->getName());
-        $this->assertEquals('string', $parameters[2]->getType()->getName());
+        $this->assertEquals('string', $parameters[2]->getType()?->getName());
 
-        $this->assertEquals('float', $reflection->getReturnType()->getName());
+        $this->assertEquals('float', $reflection->getReturnType()?->getName());
     }
 
     #[Test]
@@ -103,9 +103,9 @@ class CollateralServiceTest extends ServiceTestCase
 
         $parameter = $reflection->getParameters()[0];
         $this->assertEquals('stablecoinCode', $parameter->getName());
-        $this->assertEquals('string', $parameter->getType()->getName());
+        $this->assertEquals('string', $parameter->getType()?->getName());
 
-        $this->assertEquals('float', $reflection->getReturnType()->getName());
+        $this->assertEquals('float', $reflection->getReturnType()?->getName());
     }
 
     #[Test]
@@ -118,11 +118,11 @@ class CollateralServiceTest extends ServiceTestCase
 
         $parameter = $reflection->getParameters()[0];
         $this->assertEquals('bufferRatio', $parameter->getName());
-        $this->assertEquals('float', $parameter->getType()->getName());
+        $this->assertEquals('float', $parameter->getType()?->getName());
         $this->assertTrue($parameter->isDefaultValueAvailable());
         $this->assertEquals(0.05, $parameter->getDefaultValue());
 
-        $this->assertEquals(Collection::class, $reflection->getReturnType()->getName());
+        $this->assertEquals(Collection::class, $reflection->getReturnType()?->getName());
     }
 
     #[Test]
@@ -132,7 +132,7 @@ class CollateralServiceTest extends ServiceTestCase
 
         $this->assertEquals(0, $reflection->getNumberOfParameters());
         $this->assertTrue($reflection->isPublic());
-        $this->assertEquals(Collection::class, $reflection->getReturnType()->getName());
+        $this->assertEquals(Collection::class, $reflection->getReturnType()?->getName());
     }
 
     #[Test]
@@ -145,9 +145,9 @@ class CollateralServiceTest extends ServiceTestCase
 
         $parameter = $reflection->getParameters()[0];
         $this->assertEquals('position', $parameter->getName());
-        $this->assertEquals(StablecoinCollateralPosition::class, $parameter->getType()->getName());
+        $this->assertEquals(StablecoinCollateralPosition::class, $parameter->getType()?->getName());
 
-        $this->assertEquals('void', $reflection->getReturnType()->getName());
+        $this->assertEquals('void', $reflection->getReturnType()?->getName());
     }
 
     #[Test]
@@ -160,9 +160,9 @@ class CollateralServiceTest extends ServiceTestCase
 
         $parameter = $reflection->getParameters()[0];
         $this->assertEquals('position', $parameter->getName());
-        $this->assertEquals(StablecoinCollateralPosition::class, $parameter->getType()->getName());
+        $this->assertEquals(StablecoinCollateralPosition::class, $parameter->getType()?->getName());
 
-        $this->assertEquals('float', $reflection->getReturnType()->getName());
+        $this->assertEquals('float', $reflection->getReturnType()?->getName());
     }
 
     #[Test]
@@ -175,9 +175,9 @@ class CollateralServiceTest extends ServiceTestCase
 
         $parameter = $reflection->getParameters()[0];
         $this->assertEquals('stablecoinCode', $parameter->getName());
-        $this->assertEquals('string', $parameter->getType()->getName());
+        $this->assertEquals('string', $parameter->getType()?->getName());
 
-        $this->assertEquals('array', $reflection->getReturnType()->getName());
+        $this->assertEquals('array', $reflection->getReturnType()?->getName());
     }
 
     #[Test]
@@ -187,7 +187,7 @@ class CollateralServiceTest extends ServiceTestCase
 
         $this->assertEquals(0, $reflection->getNumberOfParameters());
         $this->assertTrue($reflection->isPublic());
-        $this->assertEquals('array', $reflection->getReturnType()->getName());
+        $this->assertEquals('array', $reflection->getReturnType()?->getName());
     }
 
     #[Test]
@@ -200,9 +200,9 @@ class CollateralServiceTest extends ServiceTestCase
 
         $parameter = $reflection->getParameters()[0];
         $this->assertEquals('position', $parameter->getName());
-        $this->assertEquals(StablecoinCollateralPosition::class, $parameter->getType()->getName());
+        $this->assertEquals(StablecoinCollateralPosition::class, $parameter->getType()?->getName());
 
-        $this->assertEquals('float', $reflection->getReturnType()->getName());
+        $this->assertEquals('float', $reflection->getReturnType()?->getName());
     }
 
     #[Test]
@@ -215,9 +215,9 @@ class CollateralServiceTest extends ServiceTestCase
 
         $parameter = $reflection->getParameters()[0];
         $this->assertEquals('position', $parameter->getName());
-        $this->assertEquals(StablecoinCollateralPosition::class, $parameter->getType()->getName());
+        $this->assertEquals(StablecoinCollateralPosition::class, $parameter->getType()?->getName());
 
-        $this->assertEquals('array', $reflection->getReturnType()->getName());
+        $this->assertEquals('array', $reflection->getReturnType()?->getName());
     }
 
     #[Test]

--- a/tests/Unit/Domain/Stablecoin/Services/LiquidationServiceTest.php
+++ b/tests/Unit/Domain/Stablecoin/Services/LiquidationServiceTest.php
@@ -72,13 +72,13 @@ class LiquidationServiceTest extends ServiceTestCase
         $parameters = $constructor->getParameters();
 
         $this->assertEquals('exchangeRateService', $parameters[0]->getName());
-        $this->assertEquals(ExchangeRateService::class, $parameters[0]->getType()->getName());
+        $this->assertEquals(ExchangeRateService::class, $parameters[0]->getType()?->getName());
 
         $this->assertEquals('collateralService', $parameters[1]->getName());
-        $this->assertEquals(CollateralService::class, $parameters[1]->getType()->getName());
+        $this->assertEquals(CollateralService::class, $parameters[1]->getType()?->getName());
 
         $this->assertEquals('walletService', $parameters[2]->getName());
-        $this->assertEquals(WalletService::class, $parameters[2]->getType()->getName());
+        $this->assertEquals(WalletService::class, $parameters[2]->getType()?->getName());
     }
 
     #[Test]
@@ -98,16 +98,16 @@ class LiquidationServiceTest extends ServiceTestCase
         $parameters = $reflection->getParameters();
 
         $this->assertEquals('position', $parameters[0]->getName());
-        $this->assertEquals(StablecoinCollateralPosition::class, $parameters[0]->getType()->getName());
+        $this->assertEquals(StablecoinCollateralPosition::class, $parameters[0]->getType()?->getName());
         $this->assertFalse($parameters[0]->allowsNull());
 
         $this->assertEquals('liquidator', $parameters[1]->getName());
-        $this->assertEquals(Account::class, $parameters[1]->getType()->getName());
+        $this->assertEquals(Account::class, $parameters[1]->getType()?->getName());
         $this->assertTrue($parameters[1]->allowsNull());
         $this->assertTrue($parameters[1]->isDefaultValueAvailable());
         $this->assertNull($parameters[1]->getDefaultValue());
 
-        $this->assertEquals('array', $reflection->getReturnType()->getName());
+        $this->assertEquals('array', $reflection->getReturnType()?->getName());
     }
 
     #[Test]

--- a/tests/Unit/Domain/Stablecoin/Services/OracleAggregatorTest.php
+++ b/tests/Unit/Domain/Stablecoin/Services/OracleAggregatorTest.php
@@ -48,15 +48,15 @@ class OracleAggregatorTest extends TestCase
 
         $oraclesProperty = $reflection->getProperty('oracles');
         $this->assertTrue($oraclesProperty->isPrivate());
-        $this->assertEquals(Collection::class, $oraclesProperty->getType()->getName());
+        $this->assertEquals(Collection::class, $oraclesProperty->getType()?->getName());
 
         $minOraclesProperty = $reflection->getProperty('minOracles');
         $this->assertTrue($minOraclesProperty->isPrivate());
-        $this->assertEquals('int', $minOraclesProperty->getType()->getName());
+        $this->assertEquals('int', $minOraclesProperty->getType()?->getName());
 
         $maxDeviationProperty = $reflection->getProperty('maxDeviation');
         $this->assertTrue($maxDeviationProperty->isPrivate());
-        $this->assertEquals('float', $maxDeviationProperty->getType()->getName());
+        $this->assertEquals('float', $maxDeviationProperty->getType()?->getName());
     }
 
     #[Test]
@@ -89,9 +89,9 @@ class OracleAggregatorTest extends TestCase
 
         $parameter = $reflection->getParameters()[0];
         $this->assertEquals('oracle', $parameter->getName());
-        $this->assertEquals(OracleConnector::class, $parameter->getType()->getName());
+        $this->assertEquals(OracleConnector::class, $parameter->getType()?->getName());
 
-        $this->assertEquals('self', $reflection->getReturnType()->getName());
+        $this->assertEquals('self', $reflection->getReturnType()?->getName());
     }
 
     #[Test]
@@ -111,12 +111,12 @@ class OracleAggregatorTest extends TestCase
         $parameters = $reflection->getParameters();
 
         $this->assertEquals('base', $parameters[0]->getName());
-        $this->assertEquals('string', $parameters[0]->getType()->getName());
+        $this->assertEquals('string', $parameters[0]->getType()?->getName());
 
         $this->assertEquals('quote', $parameters[1]->getName());
-        $this->assertEquals('string', $parameters[1]->getType()->getName());
+        $this->assertEquals('string', $parameters[1]->getType()?->getName());
 
-        $this->assertEquals(AggregatedPrice::class, $reflection->getReturnType()->getName());
+        $this->assertEquals(AggregatedPrice::class, $reflection->getReturnType()?->getName());
     }
 
     #[Test]

--- a/tests/Unit/Domain/Stablecoin/Services/StabilityMechanismServiceTest.php
+++ b/tests/Unit/Domain/Stablecoin/Services/StabilityMechanismServiceTest.php
@@ -60,15 +60,15 @@ class StabilityMechanismServiceTest extends ServiceTestCase
         $parameters = $constructor->getParameters();
 
         $this->assertEquals('exchangeRateService', $parameters[0]->getName());
-        $this->assertEquals(ExchangeRateService::class, $parameters[0]->getType()->getName());
+        $this->assertEquals(ExchangeRateService::class, $parameters[0]->getType()?->getName());
         $this->assertFalse($parameters[0]->allowsNull());
 
         $this->assertEquals('collateralService', $parameters[1]->getName());
-        $this->assertEquals(CollateralService::class, $parameters[1]->getType()->getName());
+        $this->assertEquals(CollateralService::class, $parameters[1]->getType()?->getName());
         $this->assertFalse($parameters[1]->allowsNull());
 
         $this->assertEquals('liquidationService', $parameters[2]->getName());
-        $this->assertEquals(LiquidationService::class, $parameters[2]->getType()->getName());
+        $this->assertEquals(LiquidationService::class, $parameters[2]->getType()?->getName());
         $this->assertTrue($parameters[2]->allowsNull());
         $this->assertTrue($parameters[2]->isDefaultValueAvailable());
         $this->assertNull($parameters[2]->getDefaultValue());
@@ -87,7 +87,7 @@ class StabilityMechanismServiceTest extends ServiceTestCase
 
         $this->assertEquals(0, $reflection->getNumberOfParameters());
         $this->assertTrue($reflection->isPublic());
-        $this->assertEquals('array', $reflection->getReturnType()->getName());
+        $this->assertEquals('array', $reflection->getReturnType()?->getName());
     }
 
     #[Test]

--- a/tests/Unit/Domain/Stablecoin/Services/StablecoinIssuanceServiceTest.php
+++ b/tests/Unit/Domain/Stablecoin/Services/StablecoinIssuanceServiceTest.php
@@ -62,13 +62,13 @@ class StablecoinIssuanceServiceTest extends ServiceTestCase
         $parameters = $constructor->getParameters();
 
         $this->assertEquals('exchangeRateService', $parameters[0]->getName());
-        $this->assertEquals(ExchangeRateService::class, $parameters[0]->getType()->getName());
+        $this->assertEquals(ExchangeRateService::class, $parameters[0]->getType()?->getName());
 
         $this->assertEquals('collateralService', $parameters[1]->getName());
-        $this->assertEquals(CollateralService::class, $parameters[1]->getType()->getName());
+        $this->assertEquals(CollateralService::class, $parameters[1]->getType()?->getName());
 
         $this->assertEquals('walletService', $parameters[2]->getName());
-        $this->assertEquals(WalletService::class, $parameters[2]->getType()->getName());
+        $this->assertEquals(WalletService::class, $parameters[2]->getType()?->getName());
     }
 
     #[Test]
@@ -88,21 +88,21 @@ class StablecoinIssuanceServiceTest extends ServiceTestCase
         $parameters = $reflection->getParameters();
 
         $this->assertEquals('account', $parameters[0]->getName());
-        $this->assertEquals(Account::class, $parameters[0]->getType()->getName());
+        $this->assertEquals(Account::class, $parameters[0]->getType()?->getName());
 
         $this->assertEquals('stablecoinCode', $parameters[1]->getName());
-        $this->assertEquals('string', $parameters[1]->getType()->getName());
+        $this->assertEquals('string', $parameters[1]->getType()?->getName());
 
         $this->assertEquals('collateralAssetCode', $parameters[2]->getName());
-        $this->assertEquals('string', $parameters[2]->getType()->getName());
+        $this->assertEquals('string', $parameters[2]->getType()?->getName());
 
         $this->assertEquals('collateralAmount', $parameters[3]->getName());
-        $this->assertEquals('int', $parameters[3]->getType()->getName());
+        $this->assertEquals('int', $parameters[3]->getType()?->getName());
 
         $this->assertEquals('mintAmount', $parameters[4]->getName());
-        $this->assertEquals('int', $parameters[4]->getType()->getName());
+        $this->assertEquals('int', $parameters[4]->getType()?->getName());
 
-        $this->assertEquals(StablecoinCollateralPosition::class, $reflection->getReturnType()->getName());
+        $this->assertEquals(StablecoinCollateralPosition::class, $reflection->getReturnType()?->getName());
     }
 
     #[Test]

--- a/tests/Unit/Domain/Stablecoin/Workflows/Activities/BurnStablecoinActivityTest.php
+++ b/tests/Unit/Domain/Stablecoin/Workflows/Activities/BurnStablecoinActivityTest.php
@@ -44,16 +44,16 @@ class BurnStablecoinActivityTest extends DomainTestCase
         $parameters = $method->getParameters();
 
         $this->assertEquals('accountUuid', $parameters[0]->getName());
-        $this->assertEquals(AccountUuid::class, $parameters[0]->getType()->getName());
+        $this->assertEquals(AccountUuid::class, $parameters[0]->getType()?->getName());
 
         $this->assertEquals('positionUuid', $parameters[1]->getName());
-        $this->assertEquals('string', $parameters[1]->getType()->getName());
+        $this->assertEquals('string', $parameters[1]->getType()?->getName());
 
         $this->assertEquals('stablecoinCode', $parameters[2]->getName());
-        $this->assertEquals('string', $parameters[2]->getType()->getName());
+        $this->assertEquals('string', $parameters[2]->getType()?->getName());
 
         $this->assertEquals('amount', $parameters[3]->getName());
-        $this->assertEquals('int', $parameters[3]->getType()->getName());
+        $this->assertEquals('int', $parameters[3]->getType()?->getName());
     }
 
     #[Test]
@@ -62,7 +62,7 @@ class BurnStablecoinActivityTest extends DomainTestCase
         $reflection = new ReflectionClass(BurnStablecoinActivity::class);
         $method = $reflection->getMethod('execute');
 
-        $this->assertEquals('bool', $method->getReturnType()->getName());
+        $this->assertEquals('bool', $method->getReturnType()?->getName());
     }
 
     #[Test]

--- a/tests/Unit/Domain/Stablecoin/Workflows/Activities/ClosePositionActivityTest.php
+++ b/tests/Unit/Domain/Stablecoin/Workflows/Activities/ClosePositionActivityTest.php
@@ -39,10 +39,10 @@ class ClosePositionActivityTest extends DomainTestCase
         $parameters = $method->getParameters();
 
         $this->assertEquals('positionUuid', $parameters[0]->getName());
-        $this->assertEquals('string', $parameters[0]->getType()->getName());
+        $this->assertEquals('string', $parameters[0]->getType()?->getName());
 
         $this->assertEquals('reason', $parameters[1]->getName());
-        $this->assertEquals('string', $parameters[1]->getType()->getName());
+        $this->assertEquals('string', $parameters[1]->getType()?->getName());
         $this->assertTrue($parameters[1]->isDefaultValueAvailable());
         $this->assertEquals('user_closed', $parameters[1]->getDefaultValue());
     }
@@ -53,7 +53,7 @@ class ClosePositionActivityTest extends DomainTestCase
         $reflection = new ReflectionClass(ClosePositionActivity::class);
         $method = $reflection->getMethod('execute');
 
-        $this->assertEquals('bool', $method->getReturnType()->getName());
+        $this->assertEquals('bool', $method->getReturnType()?->getName());
     }
 
     #[Test]

--- a/tests/Unit/Domain/Stablecoin/Workflows/Activities/CreatePositionActivityTest.php
+++ b/tests/Unit/Domain/Stablecoin/Workflows/Activities/CreatePositionActivityTest.php
@@ -40,19 +40,19 @@ class CreatePositionActivityTest extends DomainTestCase
         $parameters = $method->getParameters();
 
         $this->assertEquals('accountUuid', $parameters[0]->getName());
-        $this->assertEquals(AccountUuid::class, $parameters[0]->getType()->getName());
+        $this->assertEquals(AccountUuid::class, $parameters[0]->getType()?->getName());
 
         $this->assertEquals('stablecoinCode', $parameters[1]->getName());
-        $this->assertEquals('string', $parameters[1]->getType()->getName());
+        $this->assertEquals('string', $parameters[1]->getType()?->getName());
 
         $this->assertEquals('collateralAssetCode', $parameters[2]->getName());
-        $this->assertEquals('string', $parameters[2]->getType()->getName());
+        $this->assertEquals('string', $parameters[2]->getType()?->getName());
 
         $this->assertEquals('collateralAmount', $parameters[3]->getName());
-        $this->assertEquals('int', $parameters[3]->getType()->getName());
+        $this->assertEquals('int', $parameters[3]->getType()?->getName());
 
         $this->assertEquals('mintAmount', $parameters[4]->getName());
-        $this->assertEquals('int', $parameters[4]->getType()->getName());
+        $this->assertEquals('int', $parameters[4]->getType()?->getName());
 
         $this->assertEquals('positionUuid', $parameters[5]->getName());
         $this->assertTrue($parameters[5]->isOptional());
@@ -65,7 +65,7 @@ class CreatePositionActivityTest extends DomainTestCase
         $reflection = new ReflectionClass(CreatePositionActivity::class);
         $method = $reflection->getMethod('execute');
 
-        $this->assertEquals('array', $method->getReturnType()->getName());
+        $this->assertEquals('array', $method->getReturnType()?->getName());
     }
 
     #[Test]

--- a/tests/Unit/Domain/Stablecoin/Workflows/Activities/LockCollateralActivityTest.php
+++ b/tests/Unit/Domain/Stablecoin/Workflows/Activities/LockCollateralActivityTest.php
@@ -40,16 +40,16 @@ class LockCollateralActivityTest extends DomainTestCase
         $parameters = $method->getParameters();
 
         $this->assertEquals('accountUuid', $parameters[0]->getName());
-        $this->assertEquals(AccountUuid::class, $parameters[0]->getType()->getName());
+        $this->assertEquals(AccountUuid::class, $parameters[0]->getType()?->getName());
 
         $this->assertEquals('positionUuid', $parameters[1]->getName());
-        $this->assertEquals('string', $parameters[1]->getType()->getName());
+        $this->assertEquals('string', $parameters[1]->getType()?->getName());
 
         $this->assertEquals('collateralAssetCode', $parameters[2]->getName());
-        $this->assertEquals('string', $parameters[2]->getType()->getName());
+        $this->assertEquals('string', $parameters[2]->getType()?->getName());
 
         $this->assertEquals('amount', $parameters[3]->getName());
-        $this->assertEquals('int', $parameters[3]->getType()->getName());
+        $this->assertEquals('int', $parameters[3]->getType()?->getName());
     }
 
     #[Test]
@@ -58,7 +58,7 @@ class LockCollateralActivityTest extends DomainTestCase
         $reflection = new ReflectionClass(LockCollateralActivity::class);
         $method = $reflection->getMethod('execute');
 
-        $this->assertEquals('bool', $method->getReturnType()->getName());
+        $this->assertEquals('bool', $method->getReturnType()?->getName());
     }
 
     #[Test]

--- a/tests/Unit/Domain/Stablecoin/Workflows/Activities/MintStablecoinActivityTest.php
+++ b/tests/Unit/Domain/Stablecoin/Workflows/Activities/MintStablecoinActivityTest.php
@@ -44,16 +44,16 @@ class MintStablecoinActivityTest extends DomainTestCase
         $parameters = $method->getParameters();
 
         $this->assertEquals('accountUuid', $parameters[0]->getName());
-        $this->assertEquals(AccountUuid::class, $parameters[0]->getType()->getName());
+        $this->assertEquals(AccountUuid::class, $parameters[0]->getType()?->getName());
 
         $this->assertEquals('positionUuid', $parameters[1]->getName());
-        $this->assertEquals('string', $parameters[1]->getType()->getName());
+        $this->assertEquals('string', $parameters[1]->getType()?->getName());
 
         $this->assertEquals('stablecoinCode', $parameters[2]->getName());
-        $this->assertEquals('string', $parameters[2]->getType()->getName());
+        $this->assertEquals('string', $parameters[2]->getType()?->getName());
 
         $this->assertEquals('amount', $parameters[3]->getName());
-        $this->assertEquals('int', $parameters[3]->getType()->getName());
+        $this->assertEquals('int', $parameters[3]->getType()?->getName());
     }
 
     #[Test]
@@ -62,7 +62,7 @@ class MintStablecoinActivityTest extends DomainTestCase
         $reflection = new ReflectionClass(MintStablecoinActivity::class);
         $method = $reflection->getMethod('execute');
 
-        $this->assertEquals('bool', $method->getReturnType()->getName());
+        $this->assertEquals('bool', $method->getReturnType()?->getName());
     }
 
     #[Test]

--- a/tests/Unit/Domain/Stablecoin/Workflows/Activities/ReleaseCollateralActivityTest.php
+++ b/tests/Unit/Domain/Stablecoin/Workflows/Activities/ReleaseCollateralActivityTest.php
@@ -40,17 +40,17 @@ class ReleaseCollateralActivityTest extends DomainTestCase
         $parameters = $method->getParameters();
 
         $this->assertEquals('accountUuid', $parameters[0]->getName());
-        $this->assertEquals(AccountUuid::class, $parameters[0]->getType()->getName());
+        $this->assertEquals(AccountUuid::class, $parameters[0]->getType()?->getName());
 
         $this->assertEquals('positionUuid', $parameters[1]->getName());
-        $this->assertEquals('string', $parameters[1]->getType()->getName());
+        $this->assertEquals('string', $parameters[1]->getType()?->getName());
 
         $this->assertEquals('collateralAssetCode', $parameters[2]->getName());
         $this->assertTrue($parameters[2]->allowsNull());
         $this->assertTrue($parameters[2]->isOptional() || $parameters[2]->allowsNull());
 
         $this->assertEquals('amount', $parameters[3]->getName());
-        $this->assertEquals('int', $parameters[3]->getType()->getName());
+        $this->assertEquals('int', $parameters[3]->getType()?->getName());
     }
 
     #[Test]
@@ -59,7 +59,7 @@ class ReleaseCollateralActivityTest extends DomainTestCase
         $reflection = new ReflectionClass(ReleaseCollateralActivity::class);
         $method = $reflection->getMethod('execute');
 
-        $this->assertEquals('bool', $method->getReturnType()->getName());
+        $this->assertEquals('bool', $method->getReturnType()?->getName());
     }
 
     #[Test]

--- a/tests/Unit/Domain/Stablecoin/Workflows/Activities/UpdatePositionActivityTest.php
+++ b/tests/Unit/Domain/Stablecoin/Workflows/Activities/UpdatePositionActivityTest.php
@@ -39,7 +39,7 @@ class UpdatePositionActivityTest extends DomainTestCase
         $parameters = $method->getParameters();
 
         $this->assertEquals('positionUuid', $parameters[0]->getName());
-        $this->assertEquals('string', $parameters[0]->getType()->getName());
+        $this->assertEquals('string', $parameters[0]->getType()?->getName());
     }
 
     #[Test]
@@ -48,7 +48,7 @@ class UpdatePositionActivityTest extends DomainTestCase
         $reflection = new ReflectionClass(UpdatePositionActivity::class);
         $method = $reflection->getMethod('execute');
 
-        $this->assertEquals('bool', $method->getReturnType()->getName());
+        $this->assertEquals('bool', $method->getReturnType()?->getName());
     }
 
     #[Test]

--- a/tests/Unit/Domain/Stablecoin/Workflows/AddCollateralWorkflowTest.php
+++ b/tests/Unit/Domain/Stablecoin/Workflows/AddCollateralWorkflowTest.php
@@ -39,16 +39,16 @@ class AddCollateralWorkflowTest extends DomainTestCase
         $parameters = $method->getParameters();
 
         $this->assertEquals('accountUuid', $parameters[0]->getName());
-        $this->assertEquals('App\Domain\Account\DataObjects\AccountUuid', $parameters[0]->getType()->getName());
+        $this->assertEquals('App\Domain\Account\DataObjects\AccountUuid', $parameters[0]->getType()?->getName());
 
         $this->assertEquals('positionUuid', $parameters[1]->getName());
-        $this->assertEquals('string', $parameters[1]->getType()->getName());
+        $this->assertEquals('string', $parameters[1]->getType()?->getName());
 
         $this->assertEquals('collateralAssetCode', $parameters[2]->getName());
-        $this->assertEquals('string', $parameters[2]->getType()->getName());
+        $this->assertEquals('string', $parameters[2]->getType()?->getName());
 
         $this->assertEquals('collateralAmount', $parameters[3]->getName());
-        $this->assertEquals('int', $parameters[3]->getType()->getName());
+        $this->assertEquals('int', $parameters[3]->getType()?->getName());
     }
 
     #[Test]
@@ -57,7 +57,7 @@ class AddCollateralWorkflowTest extends DomainTestCase
         $reflection = new ReflectionClass(AddCollateralWorkflow::class);
         $method = $reflection->getMethod('execute');
 
-        $this->assertEquals('Generator', $method->getReturnType()->getName());
+        $this->assertEquals('Generator', $method->getReturnType()?->getName());
     }
 
     #[Test]

--- a/tests/Unit/Domain/Stablecoin/Workflows/BurnStablecoinWorkflowTest.php
+++ b/tests/Unit/Domain/Stablecoin/Workflows/BurnStablecoinWorkflowTest.php
@@ -39,22 +39,22 @@ class BurnStablecoinWorkflowTest extends DomainTestCase
         $parameters = $method->getParameters();
 
         $this->assertEquals('accountUuid', $parameters[0]->getName());
-        $this->assertEquals('App\Domain\Account\DataObjects\AccountUuid', $parameters[0]->getType()->getName());
+        $this->assertEquals('App\Domain\Account\DataObjects\AccountUuid', $parameters[0]->getType()?->getName());
 
         $this->assertEquals('positionUuid', $parameters[1]->getName());
-        $this->assertEquals('string', $parameters[1]->getType()->getName());
+        $this->assertEquals('string', $parameters[1]->getType()?->getName());
 
         $this->assertEquals('stablecoinCode', $parameters[2]->getName());
-        $this->assertEquals('string', $parameters[2]->getType()->getName());
+        $this->assertEquals('string', $parameters[2]->getType()?->getName());
 
         $this->assertEquals('burnAmount', $parameters[3]->getName());
-        $this->assertEquals('int', $parameters[3]->getType()->getName());
+        $this->assertEquals('int', $parameters[3]->getType()?->getName());
 
         $this->assertEquals('collateralReleaseAmount', $parameters[4]->getName());
-        $this->assertEquals('int', $parameters[4]->getType()->getName());
+        $this->assertEquals('int', $parameters[4]->getType()?->getName());
 
         $this->assertEquals('closePosition', $parameters[5]->getName());
-        $this->assertEquals('bool', $parameters[5]->getType()->getName());
+        $this->assertEquals('bool', $parameters[5]->getType()?->getName());
         $this->assertTrue($parameters[5]->isDefaultValueAvailable());
         $this->assertFalse($parameters[5]->getDefaultValue());
     }
@@ -65,7 +65,7 @@ class BurnStablecoinWorkflowTest extends DomainTestCase
         $reflection = new ReflectionClass(BurnStablecoinWorkflow::class);
         $method = $reflection->getMethod('execute');
 
-        $this->assertEquals('Generator', $method->getReturnType()->getName());
+        $this->assertEquals('Generator', $method->getReturnType()?->getName());
     }
 
     #[Test]

--- a/tests/Unit/Domain/Stablecoin/Workflows/MintStablecoinWorkflowTest.php
+++ b/tests/Unit/Domain/Stablecoin/Workflows/MintStablecoinWorkflowTest.php
@@ -39,19 +39,19 @@ class MintStablecoinWorkflowTest extends DomainTestCase
         $parameters = $method->getParameters();
 
         $this->assertEquals('accountUuid', $parameters[0]->getName());
-        $this->assertEquals('App\Domain\Account\DataObjects\AccountUuid', $parameters[0]->getType()->getName());
+        $this->assertEquals('App\Domain\Account\DataObjects\AccountUuid', $parameters[0]->getType()?->getName());
 
         $this->assertEquals('stablecoinCode', $parameters[1]->getName());
-        $this->assertEquals('string', $parameters[1]->getType()->getName());
+        $this->assertEquals('string', $parameters[1]->getType()?->getName());
 
         $this->assertEquals('collateralAssetCode', $parameters[2]->getName());
-        $this->assertEquals('string', $parameters[2]->getType()->getName());
+        $this->assertEquals('string', $parameters[2]->getType()?->getName());
 
         $this->assertEquals('collateralAmount', $parameters[3]->getName());
-        $this->assertEquals('int', $parameters[3]->getType()->getName());
+        $this->assertEquals('int', $parameters[3]->getType()?->getName());
 
         $this->assertEquals('mintAmount', $parameters[4]->getName());
-        $this->assertEquals('int', $parameters[4]->getType()->getName());
+        $this->assertEquals('int', $parameters[4]->getType()?->getName());
 
         $this->assertEquals('positionUuid', $parameters[5]->getName());
         $this->assertTrue($parameters[5]->isOptional());
@@ -64,7 +64,7 @@ class MintStablecoinWorkflowTest extends DomainTestCase
         $reflection = new ReflectionClass(MintStablecoinWorkflow::class);
         $method = $reflection->getMethod('execute');
 
-        $this->assertEquals('Generator', $method->getReturnType()->getName());
+        $this->assertEquals('Generator', $method->getReturnType()?->getName());
     }
 
     #[Test]

--- a/tests/Unit/Domain/Stablecoin/Workflows/ReserveManagementWorkflowTest.php
+++ b/tests/Unit/Domain/Stablecoin/Workflows/ReserveManagementWorkflowTest.php
@@ -41,7 +41,7 @@ class ReserveManagementWorkflowTest extends DomainTestCase
         $parameters = $method->getParameters();
 
         $this->assertEquals('data', $parameters[0]->getName());
-        $this->assertEquals('App\Domain\Stablecoin\Workflows\Data\ReserveDepositData', $parameters[0]->getType()->getName());
+        $this->assertEquals('App\Domain\Stablecoin\Workflows\Data\ReserveDepositData', $parameters[0]->getType()?->getName());
     }
 
     #[Test]
@@ -52,7 +52,7 @@ class ReserveManagementWorkflowTest extends DomainTestCase
         $methods = ['depositReserve', 'withdrawReserve', 'rebalanceReserves'];
         foreach ($methods as $methodName) {
             $method = $reflection->getMethod($methodName);
-            $this->assertEquals('Generator', $method->getReturnType()->getName());
+            $this->assertEquals('Generator', $method->getReturnType()?->getName());
         }
     }
 


### PR DESCRIPTION
## Summary
- Fixed 205 PHPStan level 8 errors using null-safe operator (?->)
- Reduces level 8 baseline from **1,499 to 1,294 errors** 

## Changes
Applied null-safe operator to Reflection method calls in 46 test files:

```php
// Before - can error when method has no declared type
$method->getReturnType()->getName()
$parameter->getType()->getName()

// After - safely handles null return
$method->getReturnType()?->getName()
$parameter->getType()?->getName()
```

## Files Modified
- 46 test files in `tests/Domain/` and `tests/Unit/Domain/`
- Updated `phpstan-baseline-level8.neon` 

## Test plan
- [x] PHPStan level 8 passes with 0 errors
- [x] Code style passes (PHP-CS-Fixer)
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)