### PR TITLE
fix: Add User type annotations for PHPStan level 8

### DIFF
--- a/app/Http/Controllers/Api/V2/ComplianceController.php
+++ b/app/Http/Controllers/Api/V2/ComplianceController.php
@@ -38,6 +38,7 @@ class ComplianceController extends Controller
      */
     public function getKycStatus(Request $request): JsonResponse
     {
+        /** @var User $user */
         $user = $request->user();
 
         $verifications = KycVerification::where('user_id', $user->id)
@@ -84,6 +85,7 @@ class ComplianceController extends Controller
             ]
         );
 
+        /** @var User $user */
         $user = $request->user();
 
         try {
@@ -137,6 +139,7 @@ class ComplianceController extends Controller
             ]
         );
 
+        /** @var User $user */
         $user = $request->user();
         $verification = KycVerification::where('id', $verificationId)
             ->where('user_id', $user->id)
@@ -208,6 +211,7 @@ class ComplianceController extends Controller
             ]
         );
 
+        /** @var User $user */
         $user = $request->user();
         $verification = KycVerification::where('id', $verificationId)
             ->where('user_id', $user->id)
@@ -263,6 +267,7 @@ class ComplianceController extends Controller
      */
     public function getScreeningStatus(Request $request): JsonResponse
     {
+        /** @var User $user */
         $user = $request->user();
 
         $screenings = AmlScreening::where('entity_id', $user->uuid)
@@ -307,6 +312,7 @@ class ComplianceController extends Controller
             ]
         );
 
+        /** @var User $user */
         $user = $request->user();
 
         try {
@@ -352,6 +358,7 @@ class ComplianceController extends Controller
      */
     public function getRiskProfile(Request $request): JsonResponse
     {
+        /** @var User $user */
         $user = $request->user();
         $profile = CustomerRiskProfile::where('user_id', $user->id)->first();
 
@@ -397,6 +404,7 @@ class ComplianceController extends Controller
             ]
         );
 
+        /** @var User $user */
         $user = $request->user();
         $result = $this->riskService->canPerformTransaction(
             $user,

--- a/phpstan-baseline-level8.neon
+++ b/phpstan-baseline-level8.neon
@@ -2281,62 +2281,8 @@ parameters:
 			path: app/Http/Controllers/Api/V2/BankIntegrationController.php
 
 		-
-			message: '#^Cannot access property \$id on App\\Models\\User\|null\.$#'
-			identifier: property.nonObject
-			count: 8
-			path: app/Http/Controllers/Api/V2/ComplianceController.php
-
-		-
-			message: '#^Cannot access property \$kyc_level on App\\Models\\User\|null\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: app/Http/Controllers/Api/V2/ComplianceController.php
-
-		-
-			message: '#^Cannot access property \$kyc_status on App\\Models\\User\|null\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: app/Http/Controllers/Api/V2/ComplianceController.php
-
-		-
 			message: '#^Cannot access property \$status on App\\Domain\\Compliance\\Models\\KycVerification\|null\.$#'
 			identifier: property.nonObject
-			count: 1
-			path: app/Http/Controllers/Api/V2/ComplianceController.php
-
-		-
-			message: '#^Cannot access property \$uuid on App\\Models\\User\|null\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: app/Http/Controllers/Api/V2/ComplianceController.php
-
-		-
-			message: '#^Parameter \#1 \$user of method App\\Domain\\Compliance\\Services\\CustomerRiskService\:\:canPerformTransaction\(\) expects App\\Models\\User, App\\Models\\User\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/Http/Controllers/Api/V2/ComplianceController.php
-
-		-
-			message: '#^Parameter \#1 \$user of method App\\Domain\\Compliance\\Services\\CustomerRiskService\:\:createOrUpdateProfile\(\) expects App\\Models\\User, App\\Models\\User\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/Http/Controllers/Api/V2/ComplianceController.php
-
-		-
-			message: '#^Parameter \#1 \$user of method App\\Domain\\Compliance\\Services\\EnhancedKycService\:\:startVerification\(\) expects App\\Models\\User, App\\Models\\User\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/Http/Controllers/Api/V2/ComplianceController.php
-
-		-
-			message: '#^Parameter \#1 \$user of method App\\Http\\Controllers\\Api\\V2\\ComplianceController\:\:checkAdditionalVerificationNeeded\(\) expects App\\Models\\User, App\\Models\\User\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/Http/Controllers/Api/V2/ComplianceController.php
-
-		-
-			message: '#^Parameter \#1 \$user of method App\\Http\\Controllers\\Api\\V2\\ComplianceController\:\:determineRequiredVerifications\(\) expects App\\Models\\User, App\\Models\\User\|null given\.$#'
-			identifier: argument.type
 			count: 1
 			path: app/Http/Controllers/Api/V2/ComplianceController.php
 


### PR DESCRIPTION
## Summary
- Added `@var User` type annotations to fix PHPStan level 8 errors in ComplianceController
- Demonstrates pattern for fixing User|null safety issues across controllers
- Reduces level 8 baseline from **1,294 to 1,278 errors** (16 fixed)

## Changes
Added PHPDoc type annotations for authenticated user access:

```php
/** @var User $user */
$user = $request->user();
```

This pattern should be applied to other controllers with similar User|null errors:
- BankIntegrationController (9 errors)
- TwoFactorAuthController (8 errors) 
- UserProfileService (7 errors)
- And others...

## Baseline Progress

| Change | Errors |
|--------|--------|
| Before | 1,294 |
| After | 1,278 |
| Fixed | 16 |

## Test plan
- [x] PHPStan level 8 passes with 0 errors
- [x] Code style passes (PHP-CS-Fixer)
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)