### PR TITLE
fix(phpstan): Correct aggregate return type annotations

### DIFF
--- a/app/Domain/Account/Aggregates/AssetTransactionAggregate.php
+++ b/app/Domain/Account/Aggregates/AssetTransactionAggregate.php
@@ -66,7 +66,7 @@ class AssetTransactionAggregate extends AggregateRoot
     }
 
     /**
-     * @return AssetTransactionAggregate
+     * @return $this
      */
     public function applyAssetBalanceAdded(AssetBalanceAdded $event): static
     {
@@ -95,7 +95,7 @@ class AssetTransactionAggregate extends AggregateRoot
     }
 
     /**
-     * @return AssetTransactionAggregate
+     * @return $this
      */
     public function debit(string $assetCode, int $amount): static
     {
@@ -121,7 +121,7 @@ class AssetTransactionAggregate extends AggregateRoot
     }
 
     /**
-     * @return AssetTransactionAggregate
+     * @return $this
      */
     public function applyAssetBalanceSubtracted(AssetBalanceSubtracted $event): static
     {

--- a/app/Domain/Account/Aggregates/AssetTransferAggregate.php
+++ b/app/Domain/Account/Aggregates/AssetTransferAggregate.php
@@ -68,7 +68,7 @@ class AssetTransferAggregate extends AggregateRoot
     }
 
     /**
-     * @return AssetTransferAggregate
+     * @return $this
      */
     public function applyAssetTransferred(AssetTransferred $event): static
     {

--- a/app/Domain/Account/Aggregates/TransactionAggregate.php
+++ b/app/Domain/Account/Aggregates/TransactionAggregate.php
@@ -63,7 +63,7 @@ class TransactionAggregate extends AggregateRoot
     }
 
     /**
-     * @return TransactionAggregate
+     * @return $this
      */
     public function applyMoneyAdded(MoneyAdded $event): static
     {
@@ -87,7 +87,7 @@ class TransactionAggregate extends AggregateRoot
     }
 
     /**
-     * @return TransactionAggregate
+     * @return $this
      */
     public function debit(Money $money): static
     {
@@ -112,7 +112,7 @@ class TransactionAggregate extends AggregateRoot
     }
 
     /**
-     * @return TransactionAggregate
+     * @return $this
      */
     public function applyMoneySubtracted(MoneySubtracted $event): static
     {

--- a/app/Domain/Account/Aggregates/TransferAggregate.php
+++ b/app/Domain/Account/Aggregates/TransferAggregate.php
@@ -60,7 +60,7 @@ class TransferAggregate extends AggregateRoot
     }
 
     /**
-     * @return TransferAggregate
+     * @return $this
      */
     public function applyMoneyTransferred(MoneyTransferred $event): static
     {


### PR DESCRIPTION
## Summary

- Fix PHPStan level 8 errors in Account domain aggregates
- Change `@return` annotations from concrete class names to `$this`

## Changes

| File | Methods Fixed |
|------|---------------|
| `TransactionAggregate.php` | 3 (`applyMoneyAdded`, `debit`, `applyMoneySubtracted`) |
| `AssetTransactionAggregate.php` | 3 (`applyAssetBalanceAdded`, `debit`, `applyAssetBalanceSubtracted`) |
| `AssetTransferAggregate.php` | 1 (`applyAssetTransferred`) |
| `TransferAggregate.php` | 1 (`applyMoneyTransferred`) |

## Technical Details

When using native return type `static` combined with `return $this`, PHPStan level 8 requires the PHPDoc annotation to use `@return $this` or `@return static`, not the concrete class name.

**Before:**
```php
/**
 * @return TransactionAggregate  // PHPStan error
 */
public function applyMoneyAdded(MoneyAdded $event): static
```

**After:**
```php
/**
 * @return $this  // Correct
 */
public function applyMoneyAdded(MoneyAdded $event): static
```

## Test plan
- [x] PHPStan passes on affected files
- [x] No new errors introduced

**Part of v1.1.0 release - Code Quality theme**

🤖 Generated with [Claude Code](https://claude.com/claude-code)