### PR TITLE
test(compliance): Add Compliance domain value object tests (34 tests)

### DIFF
--- a/tests/Domain/Compliance/ValueObjects/AlertSeverityTest.php
+++ b/tests/Domain/Compliance/ValueObjects/AlertSeverityTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Domain\Compliance\ValueObjects;
+
+use App\Domain\Compliance\ValueObjects\AlertSeverity;
+use InvalidArgumentException;
+use Tests\UnitTestCase;
+
+class AlertSeverityTest extends UnitTestCase
+{
+    // ===========================================
+    // Constructor Tests
+    // ===========================================
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_creates_with_valid_severity(): void
+    {
+        $severity = new AlertSeverity('high');
+
+        expect($severity->value())->toBe('high');
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_accepts_all_valid_severities(): void
+    {
+        $validSeverities = ['low', 'medium', 'high', 'critical'];
+
+        foreach ($validSeverities as $severityValue) {
+            $severity = new AlertSeverity($severityValue);
+            expect($severity->value())->toBe($severityValue);
+        }
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_normalizes_to_lowercase(): void
+    {
+        $severity1 = new AlertSeverity('HIGH');
+        $severity2 = new AlertSeverity('Critical');
+        $severity3 = new AlertSeverity('MEDIUM');
+
+        expect($severity1->value())->toBe('high');
+        expect($severity2->value())->toBe('critical');
+        expect($severity3->value())->toBe('medium');
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_throws_for_invalid_severity(): void
+    {
+        expect(fn () => new AlertSeverity('invalid'))
+            ->toThrow(InvalidArgumentException::class, 'Invalid alert severity: invalid');
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_throws_for_empty_severity(): void
+    {
+        expect(fn () => new AlertSeverity(''))
+            ->toThrow(InvalidArgumentException::class);
+    }
+
+    // ===========================================
+    // priority Tests
+    // ===========================================
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_returns_correct_priority(): void
+    {
+        expect((new AlertSeverity('low'))->priority())->toBe(1);
+        expect((new AlertSeverity('medium'))->priority())->toBe(2);
+        expect((new AlertSeverity('high'))->priority())->toBe(3);
+        expect((new AlertSeverity('critical'))->priority())->toBe(4);
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_priorities_increase_with_severity(): void
+    {
+        $low = new AlertSeverity('low');
+        $medium = new AlertSeverity('medium');
+        $high = new AlertSeverity('high');
+        $critical = new AlertSeverity('critical');
+
+        expect($low->priority())->toBeLessThan($medium->priority());
+        expect($medium->priority())->toBeLessThan($high->priority());
+        expect($high->priority())->toBeLessThan($critical->priority());
+    }
+
+    // ===========================================
+    // isHigherThan Tests
+    // ===========================================
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_compares_higher_severity(): void
+    {
+        $low = new AlertSeverity('low');
+        $medium = new AlertSeverity('medium');
+        $high = new AlertSeverity('high');
+        $critical = new AlertSeverity('critical');
+
+        expect($critical->isHigherThan($high))->toBeTrue();
+        expect($high->isHigherThan($medium))->toBeTrue();
+        expect($medium->isHigherThan($low))->toBeTrue();
+        expect($low->isHigherThan($critical))->toBeFalse();
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_returns_false_when_comparing_equal_severity(): void
+    {
+        $high1 = new AlertSeverity('high');
+        $high2 = new AlertSeverity('high');
+
+        expect($high1->isHigherThan($high2))->toBeFalse();
+    }
+
+    // ===========================================
+    // isLowerThan Tests
+    // ===========================================
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_compares_lower_severity(): void
+    {
+        $low = new AlertSeverity('low');
+        $medium = new AlertSeverity('medium');
+        $high = new AlertSeverity('high');
+        $critical = new AlertSeverity('critical');
+
+        expect($low->isLowerThan($medium))->toBeTrue();
+        expect($medium->isLowerThan($high))->toBeTrue();
+        expect($high->isLowerThan($critical))->toBeTrue();
+        expect($critical->isLowerThan($low))->toBeFalse();
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_returns_false_when_comparing_equal_severity_for_lower(): void
+    {
+        $medium1 = new AlertSeverity('medium');
+        $medium2 = new AlertSeverity('medium');
+
+        expect($medium1->isLowerThan($medium2))->toBeFalse();
+    }
+
+    // ===========================================
+    // isCritical Tests
+    // ===========================================
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_identifies_critical_severity(): void
+    {
+        $critical = new AlertSeverity('critical');
+        $high = new AlertSeverity('high');
+
+        expect($critical->isCritical())->toBeTrue();
+        expect($high->isCritical())->toBeFalse();
+    }
+
+    // ===========================================
+    // isHigh Tests
+    // ===========================================
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_identifies_high_severity(): void
+    {
+        $high = new AlertSeverity('high');
+        $medium = new AlertSeverity('medium');
+        $critical = new AlertSeverity('critical');
+
+        expect($high->isHigh())->toBeTrue();
+        expect($medium->isHigh())->toBeFalse();
+        expect($critical->isHigh())->toBeFalse();
+    }
+
+    // ===========================================
+    // requiresImmediateAction Tests
+    // ===========================================
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_requires_immediate_action_for_critical_and_high(): void
+    {
+        $critical = new AlertSeverity('critical');
+        $high = new AlertSeverity('high');
+        $medium = new AlertSeverity('medium');
+        $low = new AlertSeverity('low');
+
+        expect($critical->requiresImmediateAction())->toBeTrue();
+        expect($high->requiresImmediateAction())->toBeTrue();
+        expect($medium->requiresImmediateAction())->toBeFalse();
+        expect($low->requiresImmediateAction())->toBeFalse();
+    }
+
+    // ===========================================
+    // __toString Tests
+    // ===========================================
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_converts_to_string(): void
+    {
+        $severity = new AlertSeverity('critical');
+
+        expect((string) $severity)->toBe('critical');
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_can_be_used_in_string_context(): void
+    {
+        $severity = new AlertSeverity('high');
+
+        expect("Severity: {$severity}")->toBe('Severity: high');
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_preserves_lowercase_in_string_output(): void
+    {
+        $severity = new AlertSeverity('CRITICAL');
+
+        expect((string) $severity)->toBe('critical');
+    }
+}

--- a/tests/Domain/Compliance/ValueObjects/AlertStatusTest.php
+++ b/tests/Domain/Compliance/ValueObjects/AlertStatusTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Domain\Compliance\ValueObjects;
+
+use App\Domain\Compliance\ValueObjects\AlertStatus;
+use InvalidArgumentException;
+use Tests\UnitTestCase;
+
+class AlertStatusTest extends UnitTestCase
+{
+    // ===========================================
+    // Constructor Tests
+    // ===========================================
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_creates_with_valid_status(): void
+    {
+        $status = new AlertStatus('open');
+
+        expect($status->value())->toBe('open');
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_accepts_all_valid_statuses(): void
+    {
+        $validStatuses = [
+            'open',
+            'in_review',
+            'investigating',
+            'escalated',
+            'resolved',
+            'closed',
+            'false_positive',
+        ];
+
+        foreach ($validStatuses as $statusValue) {
+            $status = new AlertStatus($statusValue);
+            expect($status->value())->toBe($statusValue);
+        }
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_throws_for_invalid_status(): void
+    {
+        expect(fn () => new AlertStatus('invalid'))
+            ->toThrow(InvalidArgumentException::class, 'Invalid alert status: invalid');
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_throws_for_empty_status(): void
+    {
+        expect(fn () => new AlertStatus(''))
+            ->toThrow(InvalidArgumentException::class);
+    }
+
+    // ===========================================
+    // isOpen Tests
+    // ===========================================
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_identifies_open_status(): void
+    {
+        $open = new AlertStatus('open');
+        $investigating = new AlertStatus('investigating');
+
+        expect($open->isOpen())->toBeTrue();
+        expect($investigating->isOpen())->toBeFalse();
+    }
+
+    // ===========================================
+    // isInvestigating Tests
+    // ===========================================
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_identifies_investigating_status(): void
+    {
+        $investigating = new AlertStatus('investigating');
+        $open = new AlertStatus('open');
+
+        expect($investigating->isInvestigating())->toBeTrue();
+        expect($open->isInvestigating())->toBeFalse();
+    }
+
+    // ===========================================
+    // isEscalated Tests
+    // ===========================================
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_identifies_escalated_status(): void
+    {
+        $escalated = new AlertStatus('escalated');
+        $open = new AlertStatus('open');
+
+        expect($escalated->isEscalated())->toBeTrue();
+        expect($open->isEscalated())->toBeFalse();
+    }
+
+    // ===========================================
+    // isResolved Tests
+    // ===========================================
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_identifies_resolved_status(): void
+    {
+        $resolved = new AlertStatus('resolved');
+        $open = new AlertStatus('open');
+
+        expect($resolved->isResolved())->toBeTrue();
+        expect($open->isResolved())->toBeFalse();
+    }
+
+    // ===========================================
+    // isClosed Tests
+    // ===========================================
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_identifies_closed_status(): void
+    {
+        $closed = new AlertStatus('closed');
+        $resolved = new AlertStatus('resolved');
+        $falsePositive = new AlertStatus('false_positive');
+        $open = new AlertStatus('open');
+
+        expect($closed->isClosed())->toBeTrue();
+        expect($resolved->isClosed())->toBeTrue();
+        expect($falsePositive->isClosed())->toBeTrue();
+        expect($open->isClosed())->toBeFalse();
+    }
+
+    // ===========================================
+    // canTransitionTo Tests
+    // ===========================================
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_allows_valid_transitions_from_open(): void
+    {
+        $open = new AlertStatus('open');
+
+        expect($open->canTransitionTo('investigating'))->toBeTrue();
+        expect($open->canTransitionTo('escalated'))->toBeTrue();
+        expect($open->canTransitionTo('resolved'))->toBeTrue();
+        expect($open->canTransitionTo('false_positive'))->toBeTrue();
+        expect($open->canTransitionTo('closed'))->toBeFalse();
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_allows_valid_transitions_from_investigating(): void
+    {
+        $investigating = new AlertStatus('investigating');
+
+        expect($investigating->canTransitionTo('escalated'))->toBeTrue();
+        expect($investigating->canTransitionTo('resolved'))->toBeTrue();
+        expect($investigating->canTransitionTo('false_positive'))->toBeTrue();
+        expect($investigating->canTransitionTo('closed'))->toBeTrue();
+        expect($investigating->canTransitionTo('open'))->toBeFalse();
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_allows_valid_transitions_from_escalated(): void
+    {
+        $escalated = new AlertStatus('escalated');
+
+        expect($escalated->canTransitionTo('resolved'))->toBeTrue();
+        expect($escalated->canTransitionTo('closed'))->toBeTrue();
+        expect($escalated->canTransitionTo('open'))->toBeFalse();
+        expect($escalated->canTransitionTo('investigating'))->toBeFalse();
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_allows_valid_transitions_from_resolved(): void
+    {
+        $resolved = new AlertStatus('resolved');
+
+        expect($resolved->canTransitionTo('closed'))->toBeTrue();
+        expect($resolved->canTransitionTo('open'))->toBeFalse();
+        expect($resolved->canTransitionTo('escalated'))->toBeFalse();
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_blocks_all_transitions_from_closed(): void
+    {
+        $closed = new AlertStatus('closed');
+
+        expect($closed->canTransitionTo('open'))->toBeFalse();
+        expect($closed->canTransitionTo('investigating'))->toBeFalse();
+        expect($closed->canTransitionTo('escalated'))->toBeFalse();
+        expect($closed->canTransitionTo('resolved'))->toBeFalse();
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_allows_false_positive_to_transition_to_closed_only(): void
+    {
+        $falsePositive = new AlertStatus('false_positive');
+
+        expect($falsePositive->canTransitionTo('closed'))->toBeTrue();
+        expect($falsePositive->canTransitionTo('open'))->toBeFalse();
+        expect($falsePositive->canTransitionTo('investigating'))->toBeFalse();
+    }
+
+    // ===========================================
+    // __toString Tests
+    // ===========================================
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_converts_to_string(): void
+    {
+        $status = new AlertStatus('investigating');
+
+        expect((string) $status)->toBe('investigating');
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function it_can_be_used_in_string_context(): void
+    {
+        $status = new AlertStatus('escalated');
+
+        expect("Status: {$status}")->toBe('Status: escalated');
+    }
+}


### PR DESCRIPTION
## Summary
- Add unit tests for Compliance domain value objects
- 34 tests covering AlertStatus and AlertSeverity

## Test Coverage

| Component | Tests | Description |
|-----------|-------|-------------|
| AlertStatusTest | 18 | Status validation, state checks, transition rules |
| AlertSeverityTest | 16 | Severity levels, priority comparisons, immediate action |

## Key Test Scenarios

### AlertStatus
- Valid/invalid status construction
- State identification (isOpen, isClosed, isEscalated, etc.)
- State transition validation (canTransitionTo)
- Closed states include resolved and false_positive

### AlertSeverity
- Severity normalization to lowercase
- Priority ordering (low=1, medium=2, high=3, critical=4)
- Comparison methods (isHigherThan, isLowerThan)
- Immediate action requirements for critical/high

## Test plan
- [x] All 34 tests pass locally
- [x] PHPStan passes with no errors
- [x] PHP-CS-Fixer applied
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)