### PR TITLE
feat(mobile): Add new API endpoints and services (Phase 3)

### DIFF
--- a/app/Domain/Mobile/Models/MobileNotificationPreference.php
+++ b/app/Domain/Mobile/Models/MobileNotificationPreference.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Mobile\Models;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Mobile notification preference model.
+ *
+ * @property string $id
+ * @property int $user_id
+ * @property string|null $mobile_device_id
+ * @property string $notification_type
+ * @property bool $push_enabled
+ * @property bool $email_enabled
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ */
+class MobileNotificationPreference extends Model
+{
+    use HasFactory;
+    use HasUuids;
+
+    /**
+     * Available notification types.
+     */
+    public const TYPE_TRANSACTION_RECEIVED = 'transaction_received';
+
+    public const TYPE_TRANSACTION_SENT = 'transaction_sent';
+
+    public const TYPE_LOW_BALANCE = 'low_balance';
+
+    public const TYPE_SECURITY_LOGIN = 'security_login';
+
+    public const TYPE_SECURITY_DEVICE = 'security_device';
+
+    public const TYPE_MARKETING = 'marketing';
+
+    public const TYPE_SYSTEM_UPDATE = 'system_update';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'user_id',
+        'mobile_device_id',
+        'notification_type',
+        'push_enabled',
+        'email_enabled',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'push_enabled'  => 'boolean',
+        'email_enabled' => 'boolean',
+    ];
+
+    /**
+     * Get the user that owns this preference.
+     *
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Get the mobile device this preference belongs to, if device-specific.
+     *
+     * @return BelongsTo<MobileDevice, $this>
+     */
+    public function mobileDevice(): BelongsTo
+    {
+        return $this->belongsTo(MobileDevice::class);
+    }
+
+    /**
+     * Get all available notification types.
+     *
+     * @return array<string, string>
+     */
+    public static function getAvailableTypes(): array
+    {
+        return [
+            self::TYPE_TRANSACTION_RECEIVED => 'Transaction received notifications',
+            self::TYPE_TRANSACTION_SENT     => 'Transaction sent notifications',
+            self::TYPE_LOW_BALANCE          => 'Low balance alerts',
+            self::TYPE_SECURITY_LOGIN       => 'New login notifications',
+            self::TYPE_SECURITY_DEVICE      => 'Device security notifications',
+            self::TYPE_MARKETING            => 'Marketing and promotional messages',
+            self::TYPE_SYSTEM_UPDATE        => 'System updates and announcements',
+        ];
+    }
+
+    /**
+     * Get default preferences for a new user.
+     *
+     * @return array<string, array{push_enabled: bool, email_enabled: bool}>
+     */
+    public static function getDefaults(): array
+    {
+        return [
+            self::TYPE_TRANSACTION_RECEIVED => ['push_enabled' => true, 'email_enabled' => false],
+            self::TYPE_TRANSACTION_SENT     => ['push_enabled' => true, 'email_enabled' => false],
+            self::TYPE_LOW_BALANCE          => ['push_enabled' => true, 'email_enabled' => true],
+            self::TYPE_SECURITY_LOGIN       => ['push_enabled' => true, 'email_enabled' => true],
+            self::TYPE_SECURITY_DEVICE      => ['push_enabled' => true, 'email_enabled' => true],
+            self::TYPE_MARKETING            => ['push_enabled' => false, 'email_enabled' => false],
+            self::TYPE_SYSTEM_UPDATE        => ['push_enabled' => true, 'email_enabled' => false],
+        ];
+    }
+}

--- a/app/Domain/Mobile/Services/MobileSessionService.php
+++ b/app/Domain/Mobile/Services/MobileSessionService.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Mobile\Services;
+
+use App\Domain\Mobile\Models\MobileDevice;
+use App\Domain\Mobile\Models\MobileDeviceSession;
+use App\Models\User;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Service for managing mobile device sessions.
+ */
+class MobileSessionService
+{
+    /**
+     * Get active sessions for a user.
+     *
+     * @return Collection<int, MobileDeviceSession>
+     */
+    public function getUserSessions(User $user): Collection
+    {
+        return MobileDeviceSession::where('user_id', $user->id)
+            ->active()
+            ->with('mobileDevice')
+            ->orderBy('last_activity_at', 'desc')
+            ->get();
+    }
+
+    /**
+     * Get paginated active sessions for a user.
+     *
+     * @return LengthAwarePaginator<int, MobileDeviceSession>
+     */
+    public function getUserSessionsPaginated(User $user, int $perPage = 10): LengthAwarePaginator
+    {
+        return MobileDeviceSession::where('user_id', $user->id)
+            ->active()
+            ->with('mobileDevice')
+            ->orderBy('last_activity_at', 'desc')
+            ->paginate($perPage);
+    }
+
+    /**
+     * Get a session by ID for a user.
+     */
+    public function findSessionForUser(string $sessionId, User $user): ?MobileDeviceSession
+    {
+        return MobileDeviceSession::where('id', $sessionId)
+            ->where('user_id', $user->id)
+            ->first();
+    }
+
+    /**
+     * Revoke a specific session.
+     */
+    public function revokeSession(MobileDeviceSession $session): bool
+    {
+        $session->invalidate();
+
+        Log::info('Mobile session revoked', [
+            'session_id' => $session->id,
+            'user_id'    => $session->user_id,
+            'device_id'  => $session->mobile_device_id,
+        ]);
+
+        return true;
+    }
+
+    /**
+     * Revoke all sessions for a user, optionally excluding the current session.
+     */
+    public function revokeAllUserSessions(User $user, ?string $exceptSessionId = null): int
+    {
+        $query = MobileDeviceSession::where('user_id', $user->id)
+            ->active();
+
+        if ($exceptSessionId !== null) {
+            $query->where('id', '!=', $exceptSessionId);
+        }
+
+        $sessions = $query->get();
+        $count = $sessions->count();
+
+        foreach ($sessions as $session) {
+            $session->invalidate();
+        }
+
+        Log::info('All mobile sessions revoked', [
+            'user_id'           => $user->id,
+            'count'             => $count,
+            'except_session_id' => $exceptSessionId,
+        ]);
+
+        return $count;
+    }
+
+    /**
+     * Revoke all sessions for a specific device.
+     */
+    public function revokeDeviceSessions(MobileDevice $device): int
+    {
+        $sessions = MobileDeviceSession::where('mobile_device_id', $device->id)
+            ->active()
+            ->get();
+
+        $count = $sessions->count();
+
+        foreach ($sessions as $session) {
+            $session->invalidate();
+        }
+
+        Log::info('Device sessions revoked', [
+            'device_id' => $device->id,
+            'user_id'   => $device->user_id,
+            'count'     => $count,
+        ]);
+
+        return $count;
+    }
+
+    /**
+     * Extend a session's expiration time.
+     */
+    public function extendSession(MobileDeviceSession $session, int $minutes = 60): MobileDeviceSession
+    {
+        $session->extend($minutes);
+
+        return $session;
+    }
+
+    /**
+     * Get session statistics for a user.
+     *
+     * @return array<string, mixed>
+     */
+    public function getSessionStats(User $user): array
+    {
+        $activeSessions = MobileDeviceSession::where('user_id', $user->id)
+            ->active()
+            ->count();
+
+        $devices = MobileDevice::where('user_id', $user->id)
+            ->where('is_blocked', false)
+            ->count();
+
+        $biometricDevices = MobileDevice::where('user_id', $user->id)
+            ->where('is_blocked', false)
+            ->where('biometric_enabled', true)
+            ->count();
+
+        return [
+            'active_sessions'    => $activeSessions,
+            'registered_devices' => $devices,
+            'biometric_devices'  => $biometricDevices,
+        ];
+    }
+
+    /**
+     * Cleanup expired sessions.
+     */
+    public function cleanupExpiredSessions(): int
+    {
+        $count = MobileDeviceSession::expired()->delete();
+
+        Log::info('Expired mobile sessions cleaned up', [
+            'count' => $count,
+        ]);
+
+        return $count;
+    }
+}

--- a/app/Domain/Mobile/Services/NotificationPreferenceService.php
+++ b/app/Domain/Mobile/Services/NotificationPreferenceService.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Mobile\Services;
+
+use App\Domain\Mobile\Models\MobileDevice;
+use App\Domain\Mobile\Models\MobileNotificationPreference;
+use App\Models\User;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Service for managing mobile notification preferences.
+ */
+class NotificationPreferenceService
+{
+    /**
+     * Get all notification preferences for a user.
+     *
+     * Returns a merged view of global defaults, user preferences, and device-specific preferences.
+     *
+     * @return array<string, array{type: string, description: string, push_enabled: bool, email_enabled: bool}>
+     */
+    public function getUserPreferences(User $user, ?MobileDevice $device = null): array
+    {
+        // Start with defaults
+        $defaults = MobileNotificationPreference::getDefaults();
+        $types = MobileNotificationPreference::getAvailableTypes();
+
+        // Get user's global preferences
+        $userPrefs = MobileNotificationPreference::where('user_id', $user->id)
+            ->whereNull('mobile_device_id')
+            ->get()
+            ->keyBy('notification_type');
+
+        // Get device-specific preferences if device is specified
+        $devicePrefs = new Collection();
+        if ($device !== null) {
+            $devicePrefs = MobileNotificationPreference::where('user_id', $user->id)
+                ->where('mobile_device_id', $device->id)
+                ->get()
+                ->keyBy('notification_type');
+        }
+
+        // Merge preferences: device > user > defaults
+        $result = [];
+        foreach ($types as $type => $description) {
+            $default = $defaults[$type] ?? ['push_enabled' => true, 'email_enabled' => false];
+            $userPref = $userPrefs->get($type);
+            $devicePref = $devicePrefs->get($type);
+
+            // Priority: device-specific > user-global > default
+            if ($devicePref !== null) {
+                $pushEnabled = $devicePref->push_enabled;
+                $emailEnabled = $devicePref->email_enabled;
+            } elseif ($userPref !== null) {
+                $pushEnabled = $userPref->push_enabled;
+                $emailEnabled = $userPref->email_enabled;
+            } else {
+                $pushEnabled = $default['push_enabled'];
+                $emailEnabled = $default['email_enabled'];
+            }
+
+            $result[$type] = [
+                'type'          => $type,
+                'description'   => $description,
+                'push_enabled'  => $pushEnabled,
+                'email_enabled' => $emailEnabled,
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Update notification preferences for a user.
+     *
+     * @param array<string, array{push_enabled?: bool, email_enabled?: bool}> $preferences
+     */
+    public function updatePreferences(User $user, array $preferences, ?MobileDevice $device = null): void
+    {
+        $availableTypes = array_keys(MobileNotificationPreference::getAvailableTypes());
+
+        DB::transaction(function () use ($user, $preferences, $device, $availableTypes) {
+            foreach ($preferences as $type => $settings) {
+                if (! in_array($type, $availableTypes, true)) {
+                    continue;
+                }
+
+                MobileNotificationPreference::updateOrCreate(
+                    [
+                        'user_id'           => $user->id,
+                        'mobile_device_id'  => $device?->id,
+                        'notification_type' => $type,
+                    ],
+                    [
+                        'push_enabled'  => $settings['push_enabled'] ?? true,
+                        'email_enabled' => $settings['email_enabled'] ?? false,
+                    ]
+                );
+            }
+        });
+    }
+
+    /**
+     * Check if a user has push notifications enabled for a specific type.
+     */
+    public function isPushEnabled(User $user, string $notificationType, ?MobileDevice $device = null): bool
+    {
+        // Check device-specific first
+        if ($device !== null) {
+            $devicePref = MobileNotificationPreference::where('user_id', $user->id)
+                ->where('mobile_device_id', $device->id)
+                ->where('notification_type', $notificationType)
+                ->first();
+
+            if ($devicePref !== null) {
+                return $devicePref->push_enabled;
+            }
+        }
+
+        // Check user global preference
+        $userPref = MobileNotificationPreference::where('user_id', $user->id)
+            ->whereNull('mobile_device_id')
+            ->where('notification_type', $notificationType)
+            ->first();
+
+        if ($userPref !== null) {
+            return $userPref->push_enabled;
+        }
+
+        // Return default
+        $defaults = MobileNotificationPreference::getDefaults();
+
+        return $defaults[$notificationType]['push_enabled'] ?? true;
+    }
+
+    /**
+     * Reset preferences to defaults for a user.
+     */
+    public function resetToDefaults(User $user, ?MobileDevice $device = null): void
+    {
+        $query = MobileNotificationPreference::where('user_id', $user->id);
+
+        if ($device !== null) {
+            $query->where('mobile_device_id', $device->id);
+        } else {
+            $query->whereNull('mobile_device_id');
+        }
+
+        $query->delete();
+    }
+
+    /**
+     * Initialize default preferences for a new user.
+     */
+    public function initializeForUser(User $user): void
+    {
+        $defaults = MobileNotificationPreference::getDefaults();
+
+        foreach ($defaults as $type => $settings) {
+            MobileNotificationPreference::firstOrCreate(
+                [
+                    'user_id'           => $user->id,
+                    'mobile_device_id'  => null,
+                    'notification_type' => $type,
+                ],
+                [
+                    'push_enabled'  => $settings['push_enabled'],
+                    'email_enabled' => $settings['email_enabled'],
+                ]
+            );
+        }
+    }
+}

--- a/database/migrations/2026_01_31_000003_create_mobile_notification_preferences_table.php
+++ b/database/migrations/2026_01_31_000003_create_mobile_notification_preferences_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('mobile_notification_preferences', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->uuid('mobile_device_id')->nullable();
+            $table->string('notification_type', 50);
+            $table->boolean('push_enabled')->default(true);
+            $table->boolean('email_enabled')->default(false);
+            $table->timestamps();
+
+            // Unique constraint: one preference per user/device/type combination
+            $table->unique(
+                ['user_id', 'mobile_device_id', 'notification_type'],
+                'uniq_user_device_type'
+            );
+
+            // Index for querying user preferences
+            $table->index(['user_id', 'notification_type']);
+
+            // Foreign key to mobile_devices (nullable for global preferences)
+            $table->foreign('mobile_device_id')
+                ->references('id')
+                ->on('mobile_devices')
+                ->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('mobile_notification_preferences');
+    }
+};

--- a/phpstan-baseline-level6.neon
+++ b/phpstan-baseline-level6.neon
@@ -24361,6 +24361,12 @@ parameters:
 			path: app/Domain/Mobile/Models/MobileDeviceSession.php
 
 		-
+			message: '#^Class App\\Domain\\Mobile\\Models\\MobileNotificationPreference uses generic trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory but does not specify its types\: TFactory$#'
+			identifier: missingType.generics
+			count: 1
+			path: app/Domain/Mobile/Models/MobileNotificationPreference.php
+
+		-
 			message: '#^Class App\\Domain\\Mobile\\Models\\MobilePushNotification uses generic trait Illuminate\\Database\\Eloquent\\Factories\\HasFactory but does not specify its types\: TFactory$#'
 			identifier: missingType.generics
 			count: 1

--- a/routes/api.php
+++ b/routes/api.php
@@ -1067,6 +1067,11 @@ Route::prefix('mobile')->name('api.mobile.')->group(function () {
             Route::get('/{id}', [MobileController::class, 'getDevice'])->name('show');
             Route::delete('/{id}', [MobileController::class, 'unregisterDevice'])->name('destroy');
             Route::patch('/{id}/token', [MobileController::class, 'updatePushToken'])->name('token');
+
+            // Device security actions
+            Route::post('/{id}/block', [MobileController::class, 'blockDevice'])->name('block');
+            Route::post('/{id}/unblock', [MobileController::class, 'unblockDevice'])->name('unblock');
+            Route::post('/{id}/trust', [MobileController::class, 'trustDevice'])->name('trust');
         });
 
         // Biometric management (requires auth to enable/disable)
@@ -1075,11 +1080,25 @@ Route::prefix('mobile')->name('api.mobile.')->group(function () {
             Route::delete('/disable', [MobileController::class, 'disableBiometric'])->name('disable');
         });
 
+        // Token refresh
+        Route::post('/auth/refresh', [MobileController::class, 'refreshToken'])->name('auth.refresh');
+
+        // Session management
+        Route::prefix('sessions')->name('sessions.')->group(function () {
+            Route::get('/', [MobileController::class, 'listSessions'])->name('index');
+            Route::delete('/{id}', [MobileController::class, 'revokeSession'])->name('revoke');
+            Route::delete('/', [MobileController::class, 'revokeAllSessions'])->name('revoke-all');
+        });
+
         // Push notifications
         Route::prefix('notifications')->name('notifications.')->group(function () {
             Route::get('/', [MobileController::class, 'getNotifications'])->name('index');
             Route::post('/{id}/read', [MobileController::class, 'markNotificationRead'])->name('read');
             Route::post('/read-all', [MobileController::class, 'markAllNotificationsRead'])->name('read-all');
+
+            // Notification preferences
+            Route::get('/preferences', [MobileController::class, 'getNotificationPreferences'])->name('preferences.index');
+            Route::put('/preferences', [MobileController::class, 'updateNotificationPreferences'])->name('preferences.update');
         });
     });
 });


### PR DESCRIPTION
## Summary
- Add `MobileSessionService` for session management operations (list, revoke, revoke all)
- Add `NotificationPreferenceService` for user notification preferences
- Add `MobileNotificationPreference` model with migration
- Add new API endpoints:
  - Device security: `POST /devices/{id}/block`, `POST /devices/{id}/unblock`, `POST /devices/{id}/trust`
  - Session management: `GET /sessions`, `DELETE /sessions/{id}`, `DELETE /sessions`
  - Token refresh: `POST /auth/refresh`
  - Notification preferences: `GET /notifications/preferences`, `PUT /notifications/preferences`
- Fix PHPStan errors and update baseline

## Test plan
- [ ] Run PHPStan: `XDEBUG_MODE=off vendor/bin/phpstan analyse app/Domain/Mobile`
- [ ] Run unit tests: `./vendor/bin/pest tests/Unit/Domain/Mobile`
- [ ] CI pipeline passes
- [ ] Verify new endpoints are documented in Swagger

🤖 Generated with [Claude Code](https://claude.com/claude-code)