### PR TITLE
feat(mobile): Add event listeners for cross-domain integration (Phase 4)

### DIFF
--- a/app/Domain/Mobile/Listeners/LogMobileAuditEventListener.php
+++ b/app/Domain/Mobile/Listeners/LogMobileAuditEventListener.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Mobile\Listeners;
+
+use App\Domain\Mobile\Events\BiometricAuthFailed;
+use App\Domain\Mobile\Events\BiometricAuthSucceeded;
+use App\Domain\Mobile\Events\BiometricDeviceBlocked;
+use App\Domain\Mobile\Events\MobileDeviceBlocked;
+use App\Domain\Mobile\Events\MobileDeviceRegistered;
+use App\Domain\Mobile\Events\MobileSessionCreated;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Logs mobile security events for audit and compliance purposes.
+ */
+class LogMobileAuditEventListener implements ShouldQueue
+{
+    use InteractsWithQueue;
+
+    /**
+     * The queue connection for this listener.
+     */
+    public string $connection = 'redis';
+
+    /**
+     * The queue name for this listener.
+     */
+    public string $queue = 'mobile';
+
+    /**
+     * Handle MobileDeviceRegistered event.
+     */
+    public function handleDeviceRegistered(MobileDeviceRegistered $event): void
+    {
+        Log::channel('audit')->info('Mobile device registered', [
+            'event_type' => 'device.registered',
+            'tenant_id'  => $event->tenantId,
+            'user_id'    => $event->userId,
+            'device_id'  => $event->deviceId,
+            'platform'   => $event->platform,
+            'metadata'   => $event->metadata,
+        ]);
+    }
+
+    /**
+     * Handle MobileDeviceBlocked event.
+     */
+    public function handleDeviceBlocked(MobileDeviceBlocked $event): void
+    {
+        Log::channel('audit')->warning('Mobile device blocked', [
+            'event_type' => 'device.blocked',
+            'tenant_id'  => $event->tenantId,
+            'user_id'    => $event->userId,
+            'device_id'  => $event->deviceId,
+            'reason'     => $event->reason,
+            'blocked_by' => $event->blockedBy,
+            'blocked_at' => $event->blockedAt->toIso8601String(),
+            'metadata'   => $event->metadata,
+        ]);
+    }
+
+    /**
+     * Handle MobileSessionCreated event.
+     */
+    public function handleSessionCreated(MobileSessionCreated $event): void
+    {
+        Log::channel('audit')->info('Mobile session created', [
+            'event_type' => 'session.created',
+            'tenant_id'  => $event->tenantId,
+            'user_id'    => $event->userId,
+            'device_id'  => $event->deviceId,
+            'session_id' => $event->sessionId,
+            'ip_address' => $event->ipAddress,
+            'expires_at' => $event->expiresAt->toIso8601String(),
+            'created_at' => $event->createdAt->toIso8601String(),
+            'metadata'   => $event->metadata,
+        ]);
+    }
+
+    /**
+     * Handle BiometricAuthSucceeded event.
+     */
+    public function handleBiometricSucceeded(BiometricAuthSucceeded $event): void
+    {
+        Log::channel('audit')->info('Biometric authentication succeeded', [
+            'event_type'       => 'biometric.succeeded',
+            'tenant_id'        => $event->tenantId,
+            'user_id'          => $event->userId,
+            'device_id'        => $event->deviceId,
+            'ip_address'       => $event->ipAddress,
+            'authenticated_at' => $event->authenticatedAt->toIso8601String(),
+            'metadata'         => $event->metadata,
+        ]);
+    }
+
+    /**
+     * Handle BiometricAuthFailed event.
+     */
+    public function handleBiometricFailed(BiometricAuthFailed $event): void
+    {
+        Log::channel('audit')->warning('Biometric authentication failed', [
+            'event_type'     => 'biometric.failed',
+            'tenant_id'      => $event->tenantId,
+            'user_id'        => $event->userId,
+            'device_id'      => $event->deviceId,
+            'failure_reason' => $event->failureReason,
+            'failure_count'  => $event->failureCount,
+            'ip_address'     => $event->ipAddress,
+            'failed_at'      => $event->failedAt->toIso8601String(),
+            'metadata'       => $event->metadata,
+        ]);
+    }
+
+    /**
+     * Handle BiometricDeviceBlocked event.
+     */
+    public function handleBiometricBlocked(BiometricDeviceBlocked $event): void
+    {
+        Log::channel('audit')->warning('Device biometric authentication blocked', [
+            'event_type'    => 'biometric.blocked',
+            'tenant_id'     => $event->tenantId,
+            'user_id'       => $event->userId,
+            'device_id'     => $event->deviceId,
+            'failure_count' => $event->failureCount,
+            'blocked_at'    => $event->blockedAt->toIso8601String(),
+            'blocked_until' => $event->blockedUntil->toIso8601String(),
+            'metadata'      => $event->metadata,
+        ]);
+    }
+
+    /**
+     * Register the listener mappings for the events.
+     *
+     * @return array<string, string>
+     */
+    public function subscribe(): array
+    {
+        return [
+            MobileDeviceRegistered::class => 'handleDeviceRegistered',
+            MobileDeviceBlocked::class    => 'handleDeviceBlocked',
+            MobileSessionCreated::class   => 'handleSessionCreated',
+            BiometricAuthSucceeded::class => 'handleBiometricSucceeded',
+            BiometricAuthFailed::class    => 'handleBiometricFailed',
+            BiometricDeviceBlocked::class => 'handleBiometricBlocked',
+        ];
+    }
+}

--- a/app/Domain/Mobile/Listeners/SendSecurityAlertListener.php
+++ b/app/Domain/Mobile/Listeners/SendSecurityAlertListener.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Mobile\Listeners;
+
+use App\Domain\Mobile\Events\BiometricAuthFailed;
+use App\Domain\Mobile\Events\BiometricDeviceBlocked;
+use App\Domain\Mobile\Events\MobileDeviceBlocked;
+use App\Domain\Mobile\Models\MobileNotificationPreference;
+use App\Domain\Mobile\Services\NotificationPreferenceService;
+use App\Domain\Mobile\Services\PushNotificationService;
+use App\Models\User;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Listens to security events and sends push notification alerts.
+ */
+class SendSecurityAlertListener implements ShouldQueue
+{
+    use InteractsWithQueue;
+
+    /**
+     * The queue connection for this listener.
+     */
+    public string $connection = 'redis';
+
+    /**
+     * The queue name for this listener.
+     */
+    public string $queue = 'mobile';
+
+    /**
+     * The number of times the job may be attempted.
+     */
+    public int $tries = 3;
+
+    public function __construct(
+        private readonly PushNotificationService $pushService,
+        private readonly NotificationPreferenceService $preferenceService,
+    ) {
+    }
+
+    /**
+     * Handle MobileDeviceBlocked event.
+     */
+    public function handleDeviceBlocked(MobileDeviceBlocked $event): void
+    {
+        try {
+            $user = User::find($event->userId);
+
+            if ($user === null) {
+                return;
+            }
+
+            // Check if security notifications are enabled
+            if (! $this->preferenceService->isPushEnabled($user, MobileNotificationPreference::TYPE_SECURITY_DEVICE)) {
+                return;
+            }
+
+            $this->pushService->sendToUser(
+                $user,
+                'security_alert',
+                'Device Blocked',
+                'One of your devices has been blocked for security reasons: ' . $event->reason,
+                [
+                    'device_id'  => $event->deviceId,
+                    'reason'     => $event->reason,
+                    'blocked_at' => $event->blockedAt->toIso8601String(),
+                ],
+                'high'
+            );
+
+            Log::info('Device blocked security alert sent', [
+                'user_id'   => $event->userId,
+                'device_id' => $event->deviceId,
+                'reason'    => $event->reason,
+            ]);
+        } catch (Throwable $e) {
+            Log::error('Failed to send device blocked notification', [
+                'user_id'   => $event->userId,
+                'device_id' => $event->deviceId,
+                'error'     => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Handle BiometricDeviceBlocked event.
+     */
+    public function handleBiometricBlocked(BiometricDeviceBlocked $event): void
+    {
+        try {
+            $user = User::find($event->userId);
+
+            if ($user === null) {
+                return;
+            }
+
+            // Check if security notifications are enabled
+            if (! $this->preferenceService->isPushEnabled($user, MobileNotificationPreference::TYPE_SECURITY_DEVICE)) {
+                return;
+            }
+
+            $this->pushService->sendToUser(
+                $user,
+                'security_alert',
+                'Biometric Authentication Blocked',
+                'Biometric authentication has been temporarily blocked due to multiple failed attempts.',
+                [
+                    'device_id'     => $event->deviceId,
+                    'blocked_until' => $event->blockedUntil->toIso8601String(),
+                    'blocked_at'    => $event->blockedAt->toIso8601String(),
+                ],
+                'high'
+            );
+
+            Log::info('Biometric blocked security alert sent', [
+                'user_id'   => $event->userId,
+                'device_id' => $event->deviceId,
+            ]);
+        } catch (Throwable $e) {
+            Log::error('Failed to send biometric blocked notification', [
+                'user_id'   => $event->userId,
+                'device_id' => $event->deviceId,
+                'error'     => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Handle BiometricAuthFailed event.
+     *
+     * Only sends notification after multiple failures.
+     */
+    public function handleBiometricFailed(BiometricAuthFailed $event): void
+    {
+        try {
+            // Only alert on third or more failure
+            if ($event->failureCount < 3) {
+                return;
+            }
+
+            $user = User::find($event->userId);
+
+            if ($user === null) {
+                return;
+            }
+
+            // Check if security notifications are enabled
+            if (! $this->preferenceService->isPushEnabled($user, MobileNotificationPreference::TYPE_SECURITY_DEVICE)) {
+                return;
+            }
+
+            $this->pushService->sendToUser(
+                $user,
+                'security_alert',
+                'Failed Biometric Attempts',
+                'Multiple failed biometric authentication attempts detected on your device.',
+                [
+                    'device_id'     => $event->deviceId,
+                    'failure_count' => $event->failureCount,
+                    'failed_at'     => $event->failedAt->toIso8601String(),
+                ],
+                'high'
+            );
+
+            Log::info('Biometric failed security alert sent', [
+                'user_id'       => $event->userId,
+                'device_id'     => $event->deviceId,
+                'failure_count' => $event->failureCount,
+            ]);
+        } catch (Throwable $e) {
+            Log::error('Failed to send biometric failed notification', [
+                'user_id'   => $event->userId,
+                'device_id' => $event->deviceId,
+                'error'     => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Register the listener mappings for the events.
+     *
+     * @return array<string, string>
+     */
+    public function subscribe(): array
+    {
+        return [
+            MobileDeviceBlocked::class    => 'handleDeviceBlocked',
+            BiometricDeviceBlocked::class => 'handleBiometricBlocked',
+            BiometricAuthFailed::class    => 'handleBiometricFailed',
+        ];
+    }
+}

--- a/app/Domain/Mobile/Listeners/SendTransactionPushNotificationListener.php
+++ b/app/Domain/Mobile/Listeners/SendTransactionPushNotificationListener.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Mobile\Listeners;
+
+use App\Domain\Account\Events\MoneyTransferred;
+use App\Domain\Account\Models\Account;
+use App\Domain\Mobile\Models\MobileNotificationPreference;
+use App\Domain\Mobile\Services\NotificationPreferenceService;
+use App\Domain\Mobile\Services\PushNotificationService;
+use App\Models\User;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Listens to money transfer events and sends push notifications.
+ */
+class SendTransactionPushNotificationListener implements ShouldQueue
+{
+    use InteractsWithQueue;
+
+    /**
+     * The queue connection for this listener.
+     */
+    public string $connection = 'redis';
+
+    /**
+     * The queue name for this listener.
+     */
+    public string $queue = 'mobile';
+
+    /**
+     * The number of times the job may be attempted.
+     */
+    public int $tries = 3;
+
+    public function __construct(
+        private readonly PushNotificationService $pushService,
+        private readonly NotificationPreferenceService $preferenceService,
+    ) {
+    }
+
+    /**
+     * Handle the MoneyTransferred event.
+     */
+    public function handle(MoneyTransferred $event): void
+    {
+        try {
+            $this->notifyRecipient($event);
+            $this->notifySender($event);
+        } catch (Throwable $e) {
+            Log::error('Failed to send transaction push notification', [
+                'from_account' => (string) $event->from,
+                'to_account'   => (string) $event->to,
+                'error'        => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Notify the recipient of a transfer.
+     */
+    private function notifyRecipient(MoneyTransferred $event): void
+    {
+        $toAccount = Account::where('uuid', (string) $event->to)->first();
+
+        if ($toAccount === null) {
+            return;
+        }
+
+        $recipient = User::where('uuid', $toAccount->user_uuid)->first();
+
+        if ($recipient === null) {
+            return;
+        }
+
+        // Check if push notifications are enabled for this type
+        if (! $this->preferenceService->isPushEnabled($recipient, MobileNotificationPreference::TYPE_TRANSACTION_RECEIVED)) {
+            return;
+        }
+
+        $fromAccount = Account::where('uuid', (string) $event->from)->first();
+        $sender = $fromAccount !== null
+            ? User::where('uuid', $fromAccount->user_uuid)->first()
+            : null;
+
+        $senderName = $sender !== null ? $sender->name : 'Unknown';
+        $amount = $this->formatAmount($event->money->getAmount());
+        $currency = 'GCU'; // Default platform currency
+
+        $this->pushService->sendTransactionReceived(
+            $recipient,
+            $amount,
+            $currency,
+            $senderName
+        );
+
+        Log::info('Transaction received push notification sent', [
+            'user_id'      => $recipient->id,
+            'from_account' => (string) $event->from,
+            'to_account'   => (string) $event->to,
+            'amount'       => $amount,
+            'currency'     => $currency,
+        ]);
+    }
+
+    /**
+     * Notify the sender of a completed transfer.
+     */
+    private function notifySender(MoneyTransferred $event): void
+    {
+        $fromAccount = Account::where('uuid', (string) $event->from)->first();
+
+        if ($fromAccount === null) {
+            return;
+        }
+
+        $sender = User::where('uuid', $fromAccount->user_uuid)->first();
+
+        if ($sender === null) {
+            return;
+        }
+
+        // Check if push notifications are enabled for this type
+        if (! $this->preferenceService->isPushEnabled($sender, MobileNotificationPreference::TYPE_TRANSACTION_SENT)) {
+            return;
+        }
+
+        $toAccount = Account::where('uuid', (string) $event->to)->first();
+        $recipient = $toAccount !== null
+            ? User::where('uuid', $toAccount->user_uuid)->first()
+            : null;
+
+        $recipientName = $recipient !== null ? $recipient->name : 'Unknown';
+        $amount = $this->formatAmount($event->money->getAmount());
+        $currency = 'GCU'; // Default platform currency
+
+        $this->pushService->sendTransactionSent(
+            $sender,
+            $amount,
+            $currency,
+            $recipientName
+        );
+
+        Log::info('Transaction sent push notification sent', [
+            'user_id'      => $sender->id,
+            'from_account' => (string) $event->from,
+            'to_account'   => (string) $event->to,
+            'amount'       => $amount,
+            'currency'     => $currency,
+        ]);
+    }
+
+    /**
+     * Format the amount for display.
+     *
+     * Converts from minor units (cents) to major units.
+     */
+    private function formatAmount(int $amountInMinorUnits): string
+    {
+        return number_format($amountInMinorUnits / 100, 2);
+    }
+
+    /**
+     * Handle a job failure.
+     */
+    public function failed(MoneyTransferred $event, Throwable $exception): void
+    {
+        Log::error('Transaction push notification listener failed permanently', [
+            'from_account' => (string) $event->from,
+            'to_account'   => (string) $event->to,
+            'error'        => $exception->getMessage(),
+        ]);
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,7 +2,11 @@
 
 namespace App\Providers;
 
+use App\Domain\Account\Events\MoneyTransferred;
 use App\Domain\Account\Listeners\CreateAccountForNewUser;
+use App\Domain\Mobile\Listeners\LogMobileAuditEventListener;
+use App\Domain\Mobile\Listeners\SendSecurityAlertListener;
+use App\Domain\Mobile\Listeners\SendTransactionPushNotificationListener;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 
@@ -17,6 +21,19 @@ class EventServiceProvider extends ServiceProvider
         Registered::class => [
             CreateAccountForNewUser::class,
         ],
+        MoneyTransferred::class => [
+            SendTransactionPushNotificationListener::class,
+        ],
+    ];
+
+    /**
+     * The subscribers to register.
+     *
+     * @var array<int, class-string>
+     */
+    protected $subscribe = [
+        SendSecurityAlertListener::class,
+        LogMobileAuditEventListener::class,
     ];
 
     /**


### PR DESCRIPTION
## Summary
- Add `SendTransactionPushNotificationListener` - listens to MoneyTransferred events and sends push notifications to sender/recipient
- Add `SendSecurityAlertListener` - listens to device blocked, biometric blocked, and biometric failed events and sends security alerts
- Add `LogMobileAuditEventListener` - logs mobile security events for compliance audit trail
- Register listeners in EventServiceProvider using event subscribers

## Implementation Details
- All listeners implement ShouldQueue for async processing
- Listeners use the 'mobile' queue for processing
- Transaction notifications respect user notification preferences
- Security alerts only sent when security notification preference enabled
- Audit log uses 'audit' channel for compliance records

## Test plan
- [ ] Run PHPStan: `XDEBUG_MODE=off vendor/bin/phpstan analyse app/Domain/Mobile/Listeners`
- [ ] CI pipeline passes
- [ ] Verify listeners are registered correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)