### PR TITLE
feat(mobile): v2.2.0 FormRequest Classes (Phase 5)

### DIFF
--- a/app/Http/Requests/Mobile/BaseMobileRequest.php
+++ b/app/Http/Requests/Mobile/BaseMobileRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Mobile;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+/**
+ * Base form request for Mobile API endpoints.
+ *
+ * Provides consistent error response format across all Mobile API endpoints.
+ */
+abstract class BaseMobileRequest extends FormRequest
+{
+    /**
+     * Handle a failed validation attempt.
+     *
+     * @throws HttpResponseException
+     */
+    protected function failedValidation(Validator $validator): void
+    {
+        throw new HttpResponseException(
+            response()->json([
+                'error' => [
+                    'code'    => 'VALIDATION_ERROR',
+                    'message' => 'Validation failed',
+                    'details' => $validator->errors(),
+                ],
+            ], 422)
+        );
+    }
+}

--- a/app/Http/Requests/Mobile/BlockDeviceRequest.php
+++ b/app/Http/Requests/Mobile/BlockDeviceRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Mobile;
+
+/**
+ * Form request for blocking a mobile device.
+ *
+ * @property string|null $reason Optional reason for blocking
+ */
+class BlockDeviceRequest extends BaseMobileRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'reason' => ['sometimes', 'string', 'max:255'],
+        ];
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'reason.max' => 'Block reason must not exceed 255 characters.',
+        ];
+    }
+
+    /**
+     * Get the reason for blocking, with a default value.
+     */
+    public function getBlockReason(): string
+    {
+        return $this->input('reason', 'User requested block');
+    }
+}

--- a/app/Http/Requests/Mobile/DeviceIdRequest.php
+++ b/app/Http/Requests/Mobile/DeviceIdRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Mobile;
+
+/**
+ * Form request for operations requiring only a device ID.
+ *
+ * Used for: disabling biometric, getting biometric challenge.
+ *
+ * @property string $device_id
+ */
+class DeviceIdRequest extends BaseMobileRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        // For challenge request, no auth required
+        // For disable biometric, auth is required
+        // Authorization is handled at the controller level
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'device_id' => ['required', 'string'],
+        ];
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'device_id.required' => 'Device ID is required.',
+        ];
+    }
+}

--- a/app/Http/Requests/Mobile/EnableBiometricRequest.php
+++ b/app/Http/Requests/Mobile/EnableBiometricRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Mobile;
+
+/**
+ * Form request for enabling biometric authentication on a device.
+ *
+ * @property string $device_id
+ * @property string $public_key Base64 encoded ECDSA P-256 public key
+ * @property string|null $key_id Optional key identifier
+ */
+class EnableBiometricRequest extends BaseMobileRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'device_id'  => ['required', 'string'],
+            'public_key' => ['required', 'string'],
+            'key_id'     => ['nullable', 'string', 'max:100'],
+        ];
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'device_id.required'  => 'Device ID is required.',
+            'public_key.required' => 'Public key is required for biometric enrollment.',
+        ];
+    }
+}

--- a/app/Http/Requests/Mobile/RegisterDeviceRequest.php
+++ b/app/Http/Requests/Mobile/RegisterDeviceRequest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Mobile;
+
+/**
+ * Form request for registering a mobile device.
+ *
+ * @property string $device_id
+ * @property string $platform
+ * @property string $app_version
+ * @property string|null $push_token
+ * @property string|null $device_name
+ * @property string|null $device_model
+ * @property string|null $os_version
+ */
+class RegisterDeviceRequest extends BaseMobileRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'device_id'    => ['required', 'string', 'max:100'],
+            'platform'     => ['required', 'in:ios,android'],
+            'app_version'  => ['required', 'string', 'max:20'],
+            'push_token'   => ['nullable', 'string', 'max:500'],
+            'device_name'  => ['nullable', 'string', 'max:100'],
+            'device_model' => ['nullable', 'string', 'max:100'],
+            'os_version'   => ['nullable', 'string', 'max:50'],
+        ];
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'device_id.required'   => 'Device ID is required.',
+            'device_id.max'        => 'Device ID must not exceed 100 characters.',
+            'platform.required'    => 'Platform is required.',
+            'platform.in'          => 'Platform must be either ios or android.',
+            'app_version.required' => 'App version is required.',
+            'app_version.max'      => 'App version must not exceed 20 characters.',
+        ];
+    }
+}

--- a/app/Http/Requests/Mobile/UpdateNotificationPreferencesRequest.php
+++ b/app/Http/Requests/Mobile/UpdateNotificationPreferencesRequest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Mobile;
+
+/**
+ * Form request for updating notification preferences.
+ *
+ * @property array<string, array{push_enabled?: bool, email_enabled?: bool}> $preferences
+ * @property string|null $device_id Optional device ID for device-specific preferences
+ */
+class UpdateNotificationPreferencesRequest extends BaseMobileRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'preferences'                 => ['required', 'array'],
+            'preferences.*'               => ['array'],
+            'preferences.*.push_enabled'  => ['sometimes', 'boolean'],
+            'preferences.*.email_enabled' => ['sometimes', 'boolean'],
+            'device_id'                   => ['sometimes', 'uuid'],
+        ];
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'preferences.required' => 'Preferences are required.',
+            'preferences.array'    => 'Preferences must be an array.',
+            'device_id.uuid'       => 'Device ID must be a valid UUID.',
+        ];
+    }
+
+    /**
+     * Get the validated preferences.
+     *
+     * @return array<string, array{push_enabled?: bool, email_enabled?: bool}>
+     */
+    public function getPreferences(): array
+    {
+        /** @var array<string, array{push_enabled?: bool, email_enabled?: bool}> $preferences */
+        $preferences = $this->input('preferences', []);
+
+        return $preferences;
+    }
+}

--- a/app/Http/Requests/Mobile/UpdatePushTokenRequest.php
+++ b/app/Http/Requests/Mobile/UpdatePushTokenRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Mobile;
+
+/**
+ * Form request for updating a device's push notification token.
+ *
+ * @property string $push_token
+ */
+class UpdatePushTokenRequest extends BaseMobileRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'push_token' => ['required', 'string', 'max:500'],
+        ];
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'push_token.required' => 'Push token is required.',
+            'push_token.max'      => 'Push token must not exceed 500 characters.',
+        ];
+    }
+}

--- a/app/Http/Requests/Mobile/VerifyBiometricRequest.php
+++ b/app/Http/Requests/Mobile/VerifyBiometricRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Mobile;
+
+/**
+ * Form request for verifying biometric authentication.
+ *
+ * @property string $device_id
+ * @property string $challenge The challenge string to verify
+ * @property string $signature Base64 encoded ECDSA signature
+ */
+class VerifyBiometricRequest extends BaseMobileRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * This is a public endpoint - no auth required.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'device_id' => ['required', 'string'],
+            'challenge' => ['required', 'string'],
+            'signature' => ['required', 'string'],
+        ];
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'device_id.required' => 'Device ID is required.',
+            'challenge.required' => 'Challenge is required.',
+            'signature.required' => 'Signature is required for verification.',
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

Phase 5 of v2.2.0 Mobile Backend implementation - FormRequest classes for API validation.

### New FormRequest Classes

| Class | Purpose |
|-------|---------|
| `BaseMobileRequest` | Base class with consistent error response format |
| `RegisterDeviceRequest` | Device registration validation |
| `UpdatePushTokenRequest` | Push token update validation |
| `EnableBiometricRequest` | Biometric enrollment validation |
| `DeviceIdRequest` | Device ID operations (challenge, disable biometric) |
| `VerifyBiometricRequest` | Biometric signature verification |
| `BlockDeviceRequest` | Device blocking with optional reason |
| `UpdateNotificationPreferencesRequest` | Notification preferences validation |

### Benefits

- **Cleaner controller code**: Removed ~150 lines of inline validation from `MobileController`
- **Reusable validation rules**: FormRequest classes can be reused across endpoints
- **Consistent error format**: All validation errors return standardized JSON structure
- **Better separation of concerns**: Follows Single Responsibility Principle
- **Self-documenting**: Validation rules serve as API contract documentation

### Changes

- Updated `MobileController` to use FormRequest type hints
- Removed `Validator` facade usage from controller
- Added custom `failedValidation()` method in base class for error format

## Test plan

- [x] All 19 MobileController feature tests pass
- [x] All 71 Mobile domain unit tests pass
- [x] PHPStan Level 8 passes
- [x] Code style compliant

🤖 Generated with [Claude Code](https://claude.com/claude-code)