### PR TITLE
refactor(mobile): Standardize API response format and improve user messages

### DIFF
--- a/tests/Feature/Api/MobileControllerTest.php
+++ b/tests/Feature/Api/MobileControllerTest.php
@@ -352,7 +352,9 @@ class MobileControllerTest extends TestCase
                 'data' => [
                     '*' => ['id', 'type', 'title', 'body', 'status', 'created_at'],
                 ],
-                'unread_count',
+                'meta' => [
+                    'unread_count',
+                ],
             ]);
     }
 
@@ -396,7 +398,7 @@ class MobileControllerTest extends TestCase
         $response = $this->withToken($this->token)->postJson('/api/mobile/notifications/read-all');
 
         $response->assertOk()
-            ->assertJsonPath('count', 2);
+            ->assertJsonPath('data.count', 2);
 
         $this->assertEquals(0, MobilePushNotification::where('user_id', $this->user->id)->unread()->count());
     }


### PR DESCRIPTION
## Summary
- Standardize all Mobile API responses to use consistent `{ data: {}, message?: "", meta?: {} }` format
- Add `is_current` field to device and session list responses for better client-side UX
- Move metadata like `unread_count` and `stats` into dedicated `meta` object
- Improve user-facing error messages for better readability

## Changes Made

### Response Format Standardization
| Endpoint | Before | After |
|----------|--------|-------|
| `listSessions()` | `sessions`, `stats` at root | `data`, `meta.stats` |
| `getNotifications()` | `data`, `unread_count` at root | `data`, `meta.unread_count` |
| `markNotificationRead()` | `message` only | `data.id`, `data.read_at`, `message` |
| `markAllNotificationsRead()` | `message`, `count` at root | `data.count`, `message` |
| `refreshToken()` | `token`, `expires_at` at root | `data.token`, `data.expires_at` |
| `getNotificationPreferences()` | `preferences`, `available_types` at root | `data.preferences`, `data.available_types` |
| `updateNotificationPreferences()` | `message`, `preferences` at root | `data.preferences`, `message` |

### New Fields
- `is_current` added to device list and single device responses (compares with `X-Device-ID` header)
- `is_current` added to session list responses (compares with current session token)

### Improved User Messages
| Old Message | New Message |
|-------------|-------------|
| "Device registered successfully" | "Your device has been registered" |
| "Biometric verification failed" | "Unable to verify your identity. Please try again." |
| "Invalid public key format" | "Unable to set up biometric authentication" |
| "Device not found" | "The requested device could not be found" |

## Test plan
- [x] Run `./vendor/bin/pest tests/Feature/Api/MobileControllerTest.php` - all 19 tests pass
- [x] Run `./bin/pre-commit-check.sh --fix` - PHPStan and code style checks pass
- [ ] Verify mobile app handles new response format correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)