### PR TITLE
feat(websocket): Add broadcasting configuration for Soketi (Phase 6)

### DIFF
--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Default Broadcaster
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default broadcaster that will be used by the
+    | framework when an event needs to be broadcast. You may set this to
+    | any of the connections defined in the "connections" array below.
+    |
+    | Supported: "pusher", "ably", "redis", "log", "null"
+    |
+    */
+
+    'default' => env('BROADCAST_CONNECTION', 'log'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Broadcast Connections
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define all of the broadcast connections that will be used
+    | to broadcast events to other systems or over websockets. Samples of
+    | each available type of connection are provided inside this array.
+    |
+    */
+
+    'connections' => [
+
+        'pusher' => [
+            'driver'  => 'pusher',
+            'key'     => env('PUSHER_APP_KEY', 'finaegis-key'),
+            'secret'  => env('PUSHER_APP_SECRET', 'finaegis-secret'),
+            'app_id'  => env('PUSHER_APP_ID', 'finaegis-local'),
+            'options' => [
+                'cluster'   => env('PUSHER_APP_CLUSTER', 'mt1'),
+                'useTLS'    => env('PUSHER_SCHEME', 'http') === 'https',
+                'host'      => env('PUSHER_HOST', '127.0.0.1'),
+                'port'      => env('PUSHER_PORT', 6001),
+                'scheme'    => env('PUSHER_SCHEME', 'http'),
+                'encrypted' => env('PUSHER_SCHEME', 'http') === 'https',
+                // For self-hosted Soketi
+                'curl_options' => [
+                    CURLOPT_SSL_VERIFYHOST => env('PUSHER_SCHEME', 'http') === 'https' ? 2 : 0,
+                    CURLOPT_SSL_VERIFYPEER => env('PUSHER_SCHEME', 'http') === 'https',
+                ],
+            ],
+            'client_options' => [
+                // Guzzle client options for webhook callbacks
+            ],
+        ],
+
+        'ably' => [
+            'driver' => 'ably',
+            'key'    => env('ABLY_KEY'),
+        ],
+
+        'redis' => [
+            'driver'     => 'redis',
+            'connection' => 'default',
+        ],
+
+        'log' => [
+            'driver' => 'log',
+        ],
+
+        'null' => [
+            'driver' => 'null',
+        ],
+
+    ],
+
+];

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -65,3 +65,8 @@ Broadcast::channel('tenant.{tenantId}.exchange', function ($user, string $tenant
 Broadcast::channel('tenant.{tenantId}.wallet.multi-sig', function ($user, string $tenantId) {
     return TenantChannelAuthorizer::authorizeUser($user, $tenantId);
 });
+
+// Tenant-specific mobile device/session updates (v2.2.0)
+Broadcast::channel('tenant.{tenantId}.mobile', function ($user, string $tenantId) {
+    return TenantChannelAuthorizer::authorizeUser($user, $tenantId);
+});


### PR DESCRIPTION
## Summary
- Adds `config/broadcasting.php` with Pusher/Soketi driver configuration
- Adds mobile channel to `routes/channels.php` for device/session events
- WebSocket configuration already exposed via `/api/mobile/config` endpoint

## Phase 6 - WebSocket Broadcasting Infrastructure

This completes the WebSocket infrastructure needed for real-time mobile updates:

| Component | Status |
|-----------|--------|
| Soketi Docker | ✅ `docker-compose.websocket.yml` |
| Broadcasting Config | ✅ `config/broadcasting.php` |
| Channel Authorization | ✅ `routes/channels.php` |
| Mobile Events | ✅ All 10 events implement `ShouldBroadcast` |
| API Config Endpoint | ✅ `/api/mobile/config` returns WS settings |

## Activation Instructions
```bash
# 1. Set environment
BROADCAST_CONNECTION=pusher

# 2. Start Soketi
docker-compose -f docker-compose.websocket.yml up -d

# 3. Verify health
curl http://localhost:6001/health
```

## Test plan
- [x] PHPStan passes
- [x] Code style fixed
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)