### PR TITLE
feat(privacy): Add Merkle tree infrastructure for mobile privacy pools

### DIFF
--- a/app/Domain/Privacy/Contracts/MerkleTreeServiceInterface.php
+++ b/app/Domain/Privacy/Contracts/MerkleTreeServiceInterface.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Privacy\Contracts;
+
+use App\Domain\Privacy\ValueObjects\MerklePath;
+use App\Domain\Privacy\ValueObjects\MerkleRoot;
+
+/**
+ * Interface for Merkle tree operations for privacy pool commitments.
+ */
+interface MerkleTreeServiceInterface
+{
+    /**
+     * Get the current Merkle root for a network.
+     */
+    public function getMerkleRoot(string $network): MerkleRoot;
+
+    /**
+     * Get the Merkle proof path for a commitment.
+     *
+     * @throws \App\Domain\Privacy\Exceptions\CommitmentNotFoundException
+     */
+    public function getMerklePath(string $commitment, string $network): MerklePath;
+
+    /**
+     * Verify that a commitment exists in the tree with the given proof.
+     */
+    public function verifyCommitment(string $commitment, MerklePath $path): bool;
+
+    /**
+     * Check if a network is supported.
+     */
+    public function supportsNetwork(string $network): bool;
+
+    /**
+     * Get all supported networks.
+     *
+     * @return array<string>
+     */
+    public function getSupportedNetworks(): array;
+
+    /**
+     * Trigger a sync of the Merkle tree from the blockchain.
+     */
+    public function syncTree(string $network): MerkleRoot;
+
+    /**
+     * Get the tree depth for the privacy pool.
+     */
+    public function getTreeDepth(): int;
+
+    /**
+     * Get the service provider name.
+     */
+    public function getProviderName(): string;
+}

--- a/app/Domain/Privacy/Exceptions/CommitmentNotFoundException.php
+++ b/app/Domain/Privacy/Exceptions/CommitmentNotFoundException.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Privacy\Exceptions;
+
+use Exception;
+
+/**
+ * Exception thrown when a commitment is not found in the Merkle tree.
+ */
+class CommitmentNotFoundException extends Exception
+{
+    public const ERROR_CODE = 'ERR_PRIVACY_306';
+
+    public function __construct(
+        public readonly string $commitment,
+        public readonly string $network,
+        string $message = 'Commitment not found in the Merkle tree.',
+    ) {
+        parent::__construct($message);
+    }
+
+    /**
+     * Get the HTTP status code for this exception.
+     */
+    public function getHttpStatusCode(): int
+    {
+        return 404;
+    }
+
+    /**
+     * Get the error code for API responses.
+     */
+    public function getErrorCode(): string
+    {
+        return self::ERROR_CODE;
+    }
+
+    /**
+     * Get additional context for logging.
+     *
+     * @return array<string, mixed>
+     */
+    public function context(): array
+    {
+        return [
+            'commitment' => $this->commitment,
+            'network'    => $this->network,
+            'error_code' => $this->getErrorCode(),
+        ];
+    }
+}

--- a/app/Domain/Privacy/Services/DemoMerkleTreeService.php
+++ b/app/Domain/Privacy/Services/DemoMerkleTreeService.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Privacy\Services;
+
+use App\Domain\Privacy\Contracts\MerkleTreeServiceInterface;
+use App\Domain\Privacy\Exceptions\CommitmentNotFoundException;
+use App\Domain\Privacy\ValueObjects\MerklePath;
+use App\Domain\Privacy\ValueObjects\MerkleRoot;
+use DateTimeImmutable;
+use Illuminate\Support\Facades\Cache;
+use InvalidArgumentException;
+
+/**
+ * Demo implementation of Merkle tree service for development and testing.
+ *
+ * Returns deterministic responses without requiring blockchain connectivity.
+ */
+class DemoMerkleTreeService implements MerkleTreeServiceInterface
+{
+    private const DEMO_TREE_DEPTH = 32;
+
+    private const CACHE_PREFIX = 'demo_merkle_';
+
+    /**
+     * Demo commitments that are "known" to exist in the tree.
+     *
+     * @var array<string, array<string, int>>
+     */
+    private array $knownCommitments = [];
+
+    public function __construct()
+    {
+        // Seed some demo commitments for each network
+        $this->seedDemoCommitments();
+    }
+
+    public function getMerkleRoot(string $network): MerkleRoot
+    {
+        $this->validateNetwork($network);
+
+        $cacheKey = self::CACHE_PREFIX . 'root_' . $network;
+
+        return Cache::remember($cacheKey, 30, function () use ($network) {
+            return $this->generateDemoRoot($network);
+        });
+    }
+
+    public function getMerklePath(string $commitment, string $network): MerklePath
+    {
+        $this->validateNetwork($network);
+        $this->validateCommitment($commitment);
+
+        // Check if commitment is known
+        $leafIndex = $this->findCommitmentIndex($commitment, $network);
+
+        if ($leafIndex === null) {
+            throw new CommitmentNotFoundException($commitment, $network);
+        }
+
+        $root = $this->getMerkleRoot($network);
+
+        return $this->generateDemoPath($commitment, $network, $leafIndex, $root->root);
+    }
+
+    public function verifyCommitment(string $commitment, MerklePath $path): bool
+    {
+        // Validate path structure
+        if (! $path->isValidForDepth(self::DEMO_TREE_DEPTH)) {
+            return false;
+        }
+
+        // In demo mode, verify by checking if commitment is known
+        $leafIndex = $this->findCommitmentIndex($commitment, $path->network);
+
+        if ($leafIndex === null) {
+            return false;
+        }
+
+        // Verify path indices match leaf index
+        $computedIndex = $this->computeLeafIndexFromPath($path->pathIndices);
+
+        return $computedIndex === $leafIndex;
+    }
+
+    public function supportsNetwork(string $network): bool
+    {
+        return in_array($network, $this->getSupportedNetworks(), true);
+    }
+
+    public function getSupportedNetworks(): array
+    {
+        return config('privacy.merkle.networks', ['polygon', 'base', 'arbitrum']);
+    }
+
+    public function syncTree(string $network): MerkleRoot
+    {
+        $this->validateNetwork($network);
+
+        // Clear cached root to simulate sync
+        $cacheKey = self::CACHE_PREFIX . 'root_' . $network;
+        Cache::forget($cacheKey);
+
+        return $this->getMerkleRoot($network);
+    }
+
+    public function getTreeDepth(): int
+    {
+        return self::DEMO_TREE_DEPTH;
+    }
+
+    public function getProviderName(): string
+    {
+        return 'demo';
+    }
+
+    /**
+     * Add a commitment to the demo tree (for testing).
+     */
+    public function addDemoCommitment(string $commitment, string $network): int
+    {
+        $this->validateNetwork($network);
+        $this->validateCommitment($commitment);
+
+        // Normalize the commitment before storing
+        $normalizedCommitment = $this->normalizeCommitment($commitment);
+
+        if (! isset($this->knownCommitments[$network])) {
+            $this->knownCommitments[$network] = [];
+        }
+
+        // Check if already exists (return existing index)
+        if (isset($this->knownCommitments[$network][$normalizedCommitment])) {
+            return $this->knownCommitments[$network][$normalizedCommitment];
+        }
+
+        $leafIndex = count($this->knownCommitments[$network]);
+        $this->knownCommitments[$network][$normalizedCommitment] = $leafIndex;
+
+        // Update cached root
+        $this->syncTree($network);
+
+        return $leafIndex;
+    }
+
+    private function validateNetwork(string $network): void
+    {
+        if (! $this->supportsNetwork($network)) {
+            throw new InvalidArgumentException(
+                "Unsupported network: {$network}. Supported: " . implode(', ', $this->getSupportedNetworks())
+            );
+        }
+    }
+
+    private function validateCommitment(string $commitment): void
+    {
+        // Accept hex strings with or without 0x prefix, 64 chars
+        if (! preg_match('/^(0x)?[a-fA-F0-9]{64}$/', $commitment)) {
+            throw new InvalidArgumentException('Invalid commitment format. Expected 32-byte hex string.');
+        }
+    }
+
+    private function seedDemoCommitments(): void
+    {
+        // Pre-seed some demo commitments for testing
+        $demoCommitments = [
+            '0x' . str_repeat('1', 64),
+            '0x' . str_repeat('2', 64),
+            '0x' . str_repeat('3', 64),
+            '0xabc123' . str_repeat('0', 58),
+            '0xdef456' . str_repeat('0', 58),
+        ];
+
+        foreach ($this->getSupportedNetworks() as $network) {
+            $this->knownCommitments[$network] = [];
+            foreach ($demoCommitments as $index => $commitment) {
+                $this->knownCommitments[$network][$commitment] = $index;
+            }
+        }
+    }
+
+    private function findCommitmentIndex(string $commitment, string $network): ?int
+    {
+        // Normalize commitment format
+        $normalizedCommitment = $this->normalizeCommitment($commitment);
+
+        return $this->knownCommitments[$network][$normalizedCommitment] ?? null;
+    }
+
+    private function normalizeCommitment(string $commitment): string
+    {
+        // Ensure 0x prefix and lowercase
+        $commitment = strtolower($commitment);
+        if (! str_starts_with($commitment, '0x')) {
+            $commitment = '0x' . $commitment;
+        }
+
+        return $commitment;
+    }
+
+    private function generateDemoRoot(string $network): MerkleRoot
+    {
+        // Generate deterministic root based on network and known commitments
+        $commitmentCount = count($this->knownCommitments[$network] ?? []);
+        $rootSeed = $network . '_' . $commitmentCount . '_' . time();
+
+        return new MerkleRoot(
+            root: '0x' . hash('sha256', $rootSeed),
+            network: $network,
+            leafCount: max(1, $commitmentCount),
+            treeDepth: self::DEMO_TREE_DEPTH,
+            blockNumber: $this->getDemoBlockNumber($network),
+            syncedAt: new DateTimeImmutable(),
+        );
+    }
+
+    private function generateDemoPath(
+        string $commitment,
+        string $network,
+        int $leafIndex,
+        string $root
+    ): MerklePath {
+        $siblings = [];
+        $pathIndices = [];
+
+        // Generate deterministic siblings and path indices based on leaf index
+        for ($i = 0; $i < self::DEMO_TREE_DEPTH; $i++) {
+            // Sibling hash - deterministic based on level and leaf index
+            $siblingData = $network . '_sibling_' . $leafIndex . '_level_' . $i;
+            $siblings[] = '0x' . hash('sha256', $siblingData);
+
+            // Path index - extract from leaf index bits
+            $pathIndices[] = ($leafIndex >> $i) & 1;
+        }
+
+        return new MerklePath(
+            commitment: $this->normalizeCommitment($commitment),
+            root: $root,
+            network: $network,
+            leafIndex: $leafIndex,
+            siblings: $siblings,
+            pathIndices: $pathIndices,
+        );
+    }
+
+    /**
+     * @param array<int, int> $pathIndices
+     */
+    private function computeLeafIndexFromPath(array $pathIndices): int
+    {
+        $index = 0;
+        foreach ($pathIndices as $level => $bit) {
+            $index |= ($bit << $level);
+        }
+
+        return $index;
+    }
+
+    private function getDemoBlockNumber(string $network): int
+    {
+        // Return a realistic-looking block number for each network
+        return match ($network) {
+            'polygon'  => 55000000 + (int) (time() / 2),  // ~2s block time
+            'base'     => 12000000 + (int) (time() / 2),
+            'arbitrum' => 180000000 + (int) (time() / 4), // ~0.25s block time
+            default    => 100000000,
+        };
+    }
+}

--- a/app/Domain/Privacy/Services/MerkleTreeService.php
+++ b/app/Domain/Privacy/Services/MerkleTreeService.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Privacy\Services;
+
+use App\Domain\Privacy\Contracts\MerkleTreeServiceInterface;
+use App\Domain\Privacy\ValueObjects\MerklePath;
+use App\Domain\Privacy\ValueObjects\MerkleRoot;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use InvalidArgumentException;
+use RuntimeException;
+
+/**
+ * Production Merkle tree service that syncs with on-chain privacy pools.
+ *
+ * In production, this would integrate with:
+ * - RAILGUN-style privacy pools
+ * - Aztec Protocol
+ * - Tornado Cash Nova (where legal)
+ * - Custom privacy pool contracts
+ */
+class MerkleTreeService implements MerkleTreeServiceInterface
+{
+    private const CACHE_PREFIX = 'privacy_merkle_';
+
+    private const CACHE_TTL_SECONDS = 30;
+
+    public function __construct()
+    {
+        // In production, inject RPC clients for each network
+    }
+
+    public function getMerkleRoot(string $network): MerkleRoot
+    {
+        $this->validateNetwork($network);
+
+        $cacheKey = self::CACHE_PREFIX . 'root_' . $network;
+
+        return Cache::remember($cacheKey, self::CACHE_TTL_SECONDS, function () use ($network) {
+            return $this->fetchMerkleRootFromChain($network);
+        });
+    }
+
+    public function getMerklePath(string $commitment, string $network): MerklePath
+    {
+        $this->validateNetwork($network);
+        $this->validateCommitment($commitment);
+
+        // Check cache first
+        $cacheKey = self::CACHE_PREFIX . 'path_' . $network . '_' . $commitment;
+        $cached = Cache::get($cacheKey);
+        if ($cached !== null) {
+            return MerklePath::fromArray($cached);
+        }
+
+        // Fetch from chain
+        $path = $this->fetchMerklePathFromChain($commitment, $network);
+
+        // Cache the result
+        Cache::put($cacheKey, $path->toArray(), self::CACHE_TTL_SECONDS);
+
+        return $path;
+    }
+
+    public function verifyCommitment(string $commitment, MerklePath $path): bool
+    {
+        // Verify the path length matches tree depth
+        if (! $path->isValidForDepth($this->getTreeDepth())) {
+            return false;
+        }
+
+        // Compute root from commitment and path
+        $computedRoot = $this->computeRoot($commitment, $path);
+
+        // Get current root from chain
+        $currentRoot = $this->getMerkleRoot($path->network);
+
+        return hash_equals($currentRoot->root, $computedRoot);
+    }
+
+    public function supportsNetwork(string $network): bool
+    {
+        return in_array($network, $this->getSupportedNetworks(), true);
+    }
+
+    public function getSupportedNetworks(): array
+    {
+        return config('privacy.merkle.networks', ['polygon', 'base', 'arbitrum']);
+    }
+
+    public function syncTree(string $network): MerkleRoot
+    {
+        $this->validateNetwork($network);
+
+        // Clear cache to force fresh fetch
+        $cacheKey = self::CACHE_PREFIX . 'root_' . $network;
+        Cache::forget($cacheKey);
+
+        Log::info('Merkle tree sync triggered', ['network' => $network]);
+
+        return $this->getMerkleRoot($network);
+    }
+
+    public function getTreeDepth(): int
+    {
+        return (int) config('privacy.merkle.max_tree_depth', 32);
+    }
+
+    public function getProviderName(): string
+    {
+        return 'production';
+    }
+
+    private function validateNetwork(string $network): void
+    {
+        if (! $this->supportsNetwork($network)) {
+            throw new InvalidArgumentException(
+                "Unsupported network: {$network}. Supported: " . implode(', ', $this->getSupportedNetworks())
+            );
+        }
+    }
+
+    private function validateCommitment(string $commitment): void
+    {
+        // Commitments should be 32-byte hex strings (64 characters + 0x prefix)
+        if (! preg_match('/^0x[a-fA-F0-9]{64}$/', $commitment)) {
+            throw new InvalidArgumentException('Invalid commitment format. Expected 32-byte hex string with 0x prefix.');
+        }
+    }
+
+    private function fetchMerkleRootFromChain(string $network): MerkleRoot
+    {
+        // In production, this would call the privacy pool contract
+        // For now, throw to indicate production implementation needed
+        throw new RuntimeException(
+            'Production Merkle tree sync not implemented. Use DemoMerkleTreeService for development.'
+        );
+    }
+
+    private function fetchMerklePathFromChain(string $commitment, string $network): MerklePath
+    {
+        // In production, this would:
+        // 1. Find the commitment's leaf index
+        // 2. Compute the Merkle proof path
+        throw new RuntimeException(
+            'Production Merkle path fetch not implemented. Use DemoMerkleTreeService for development.'
+        );
+    }
+
+    private function computeRoot(string $commitment, MerklePath $path): string
+    {
+        $current = $commitment;
+
+        foreach ($path->siblings as $index => $sibling) {
+            $pathIndex = $path->pathIndices[$index] ?? 0;
+
+            if ($pathIndex === 0) {
+                // Current is on the left
+                $current = $this->hashPair($current, $sibling);
+            } else {
+                // Current is on the right
+                $current = $this->hashPair($sibling, $current);
+            }
+        }
+
+        return $current;
+    }
+
+    private function hashPair(string $left, string $right): string
+    {
+        // Poseidon hash would be used in production
+        // Using keccak256 as placeholder
+        return '0x' . hash('sha3-256', hex2bin(substr($left, 2)) . hex2bin(substr($right, 2)));
+    }
+}

--- a/app/Domain/Privacy/ValueObjects/MerklePath.php
+++ b/app/Domain/Privacy/ValueObjects/MerklePath.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Privacy\ValueObjects;
+
+use JsonSerializable;
+
+/**
+ * Immutable value object representing a Merkle proof path for a commitment.
+ */
+final readonly class MerklePath implements JsonSerializable
+{
+    /**
+     * @param array<int, string> $siblings  Sibling hashes at each level of the tree
+     * @param array<int, int>    $pathIndices  Direction indicators (0 = left, 1 = right) at each level
+     */
+    public function __construct(
+        public string $commitment,
+        public string $root,
+        public string $network,
+        public int $leafIndex,
+        public array $siblings,
+        public array $pathIndices,
+    ) {
+    }
+
+    /**
+     * Get the depth of this proof path.
+     */
+    public function getDepth(): int
+    {
+        return count($this->siblings);
+    }
+
+    /**
+     * Check if this path is valid for a given tree depth.
+     */
+    public function isValidForDepth(int $treeDepth): bool
+    {
+        return $this->getDepth() === $treeDepth
+            && count($this->pathIndices) === $treeDepth;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'commitment'   => $this->commitment,
+            'root'         => $this->root,
+            'network'      => $this->network,
+            'leaf_index'   => $this->leafIndex,
+            'siblings'     => $this->siblings,
+            'path_indices' => $this->pathIndices,
+            'proof_depth'  => $this->getDepth(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            commitment: $data['commitment'],
+            root: $data['root'],
+            network: $data['network'],
+            leafIndex: (int) $data['leaf_index'],
+            siblings: $data['siblings'],
+            pathIndices: $data['path_indices'],
+        );
+    }
+}

--- a/app/Domain/Privacy/ValueObjects/MerkleRoot.php
+++ b/app/Domain/Privacy/ValueObjects/MerkleRoot.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Privacy\ValueObjects;
+
+use DateTimeImmutable;
+use JsonSerializable;
+
+/**
+ * Immutable value object representing a Merkle tree root for privacy pool commitments.
+ */
+final readonly class MerkleRoot implements JsonSerializable
+{
+    public function __construct(
+        public string $root,
+        public string $network,
+        public int $leafCount,
+        public int $treeDepth,
+        public int $blockNumber,
+        public DateTimeImmutable $syncedAt,
+    ) {
+    }
+
+    /**
+     * Check if the root is stale based on the given interval.
+     */
+    public function isStale(int $maxAgeSeconds): bool
+    {
+        $now = new DateTimeImmutable();
+        $age = $now->getTimestamp() - $this->syncedAt->getTimestamp();
+
+        return $age > $maxAgeSeconds;
+    }
+
+    /**
+     * Get the age of this root in seconds.
+     */
+    public function getAgeSeconds(): int
+    {
+        $now = new DateTimeImmutable();
+
+        return max(0, $now->getTimestamp() - $this->syncedAt->getTimestamp());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'root'         => $this->root,
+            'network'      => $this->network,
+            'leaf_count'   => $this->leafCount,
+            'tree_depth'   => $this->treeDepth,
+            'block_number' => $this->blockNumber,
+            'synced_at'    => $this->syncedAt->format('c'),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            root: $data['root'],
+            network: $data['network'],
+            leafCount: (int) $data['leaf_count'],
+            treeDepth: (int) $data['tree_depth'],
+            blockNumber: (int) $data['block_number'],
+            syncedAt: new DateTimeImmutable($data['synced_at']),
+        );
+    }
+}

--- a/app/Http/Controllers/Api/Privacy/PrivacyController.php
+++ b/app/Http/Controllers/Api/Privacy/PrivacyController.php
@@ -1,0 +1,333 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Privacy;
+
+use App\Domain\Privacy\Contracts\MerkleTreeServiceInterface;
+use App\Domain\Privacy\Exceptions\CommitmentNotFoundException;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use InvalidArgumentException;
+
+/**
+ * Privacy API Controller.
+ *
+ * Handles privacy pool Merkle tree operations for mobile clients.
+ *
+ * @OA\Tag(
+ *     name="Privacy",
+ *     description="Privacy pool Merkle tree and proof endpoints"
+ * )
+ */
+class PrivacyController extends Controller
+{
+    public function __construct(
+        private readonly MerkleTreeServiceInterface $merkleService,
+    ) {
+    }
+
+    /**
+     * Get the current Merkle root for a network.
+     *
+     * @OA\Get(
+     *     path="/api/v1/privacy/merkle-root",
+     *     operationId="getMerkleRoot",
+     *     tags={"Privacy"},
+     *     summary="Get the current Merkle root for a privacy pool",
+     *     security={{"sanctum":{}}},
+     *     @OA\Parameter(
+     *         name="network",
+     *         in="query",
+     *         required=true,
+     *         description="Blockchain network (polygon, base, arbitrum)",
+     *         @OA\Schema(type="string", enum={"polygon", "base", "arbitrum"})
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Current Merkle root",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="root", type="string", example="0x1234..."),
+     *                 @OA\Property(property="network", type="string", example="polygon"),
+     *                 @OA\Property(property="leaf_count", type="integer", example=1000),
+     *                 @OA\Property(property="tree_depth", type="integer", example=32),
+     *                 @OA\Property(property="block_number", type="integer", example=55000000),
+     *                 @OA\Property(property="synced_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=400, description="Invalid network"),
+     *     @OA\Response(response=401, description="Unauthenticated")
+     * )
+     */
+    public function getMerkleRoot(Request $request): JsonResponse
+    {
+        $network = $request->query('network');
+
+        if (empty($network) || ! is_string($network)) {
+            return response()->json([
+                'error' => [
+                    'code'    => 'ERR_PRIVACY_306',
+                    'message' => 'Network parameter is required',
+                ],
+            ], 400);
+        }
+
+        try {
+            $root = $this->merkleService->getMerkleRoot($network);
+
+            return response()->json([
+                'data' => $root->toArray(),
+            ]);
+        } catch (InvalidArgumentException $e) {
+            return response()->json([
+                'error' => [
+                    'code'               => 'ERR_PRIVACY_307',
+                    'message'            => $e->getMessage(),
+                    'supported_networks' => $this->merkleService->getSupportedNetworks(),
+                ],
+            ], 400);
+        }
+    }
+
+    /**
+     * Get the Merkle proof path for a commitment.
+     *
+     * @OA\Post(
+     *     path="/api/v1/privacy/merkle-path",
+     *     operationId="getMerklePath",
+     *     tags={"Privacy"},
+     *     summary="Get Merkle proof path for a commitment",
+     *     security={{"sanctum":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"commitment", "network"},
+     *             @OA\Property(property="commitment", type="string", description="32-byte hex commitment with 0x prefix"),
+     *             @OA\Property(property="network", type="string", enum={"polygon", "base", "arbitrum"})
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Merkle proof path",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="commitment", type="string"),
+     *                 @OA\Property(property="root", type="string"),
+     *                 @OA\Property(property="network", type="string"),
+     *                 @OA\Property(property="leaf_index", type="integer"),
+     *                 @OA\Property(property="siblings", type="array", @OA\Items(type="string")),
+     *                 @OA\Property(property="path_indices", type="array", @OA\Items(type="integer")),
+     *                 @OA\Property(property="proof_depth", type="integer")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=400, description="Invalid parameters"),
+     *     @OA\Response(response=401, description="Unauthenticated"),
+     *     @OA\Response(response=404, description="Commitment not found in tree")
+     * )
+     */
+    public function getMerklePath(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'commitment' => 'required|string|regex:/^(0x)?[a-fA-F0-9]{64}$/',
+            'network'    => 'required|string',
+        ]);
+
+        try {
+            $path = $this->merkleService->getMerklePath(
+                $validated['commitment'],
+                $validated['network']
+            );
+
+            return response()->json([
+                'data' => $path->toArray(),
+            ]);
+        } catch (CommitmentNotFoundException $e) {
+            return response()->json([
+                'error' => [
+                    'code'       => $e->getErrorCode(),
+                    'message'    => $e->getMessage(),
+                    'commitment' => $e->commitment,
+                    'network'    => $e->network,
+                ],
+            ], $e->getHttpStatusCode());
+        } catch (InvalidArgumentException $e) {
+            return response()->json([
+                'error' => [
+                    'code'               => 'ERR_PRIVACY_307',
+                    'message'            => $e->getMessage(),
+                    'supported_networks' => $this->merkleService->getSupportedNetworks(),
+                ],
+            ], 400);
+        }
+    }
+
+    /**
+     * Verify a commitment against a Merkle proof.
+     *
+     * @OA\Post(
+     *     path="/api/v1/privacy/verify-commitment",
+     *     operationId="verifyCommitment",
+     *     tags={"Privacy"},
+     *     summary="Verify a commitment exists in the tree",
+     *     security={{"sanctum":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"commitment", "network", "siblings", "path_indices"},
+     *             @OA\Property(property="commitment", type="string"),
+     *             @OA\Property(property="network", type="string"),
+     *             @OA\Property(property="root", type="string"),
+     *             @OA\Property(property="leaf_index", type="integer"),
+     *             @OA\Property(property="siblings", type="array", @OA\Items(type="string")),
+     *             @OA\Property(property="path_indices", type="array", @OA\Items(type="integer"))
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Verification result",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="valid", type="boolean"),
+     *                 @OA\Property(property="commitment", type="string"),
+     *                 @OA\Property(property="network", type="string")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=400, description="Invalid parameters"),
+     *     @OA\Response(response=401, description="Unauthenticated")
+     * )
+     */
+    public function verifyCommitment(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'commitment'     => 'required|string|regex:/^(0x)?[a-fA-F0-9]{64}$/',
+            'network'        => 'required|string',
+            'root'           => 'required|string|regex:/^(0x)?[a-fA-F0-9]{64}$/',
+            'leaf_index'     => 'required|integer|min:0',
+            'siblings'       => 'required|array',
+            'siblings.*'     => 'required|string|regex:/^(0x)?[a-fA-F0-9]{64}$/',
+            'path_indices'   => 'required|array',
+            'path_indices.*' => 'required|integer|min:0|max:1',
+        ]);
+
+        try {
+            $path = \App\Domain\Privacy\ValueObjects\MerklePath::fromArray([
+                'commitment'   => $validated['commitment'],
+                'root'         => $validated['root'],
+                'network'      => $validated['network'],
+                'leaf_index'   => $validated['leaf_index'],
+                'siblings'     => $validated['siblings'],
+                'path_indices' => $validated['path_indices'],
+            ]);
+
+            $isValid = $this->merkleService->verifyCommitment($validated['commitment'], $path);
+
+            return response()->json([
+                'data' => [
+                    'valid'      => $isValid,
+                    'commitment' => $validated['commitment'],
+                    'network'    => $validated['network'],
+                ],
+            ]);
+        } catch (InvalidArgumentException $e) {
+            return response()->json([
+                'error' => [
+                    'code'    => 'ERR_PRIVACY_308',
+                    'message' => $e->getMessage(),
+                ],
+            ], 400);
+        }
+    }
+
+    /**
+     * Get supported networks.
+     *
+     * @OA\Get(
+     *     path="/api/v1/privacy/networks",
+     *     operationId="getPrivacyNetworks",
+     *     tags={"Privacy"},
+     *     summary="Get supported privacy pool networks",
+     *     @OA\Response(
+     *         response=200,
+     *         description="Supported networks",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="networks", type="array", @OA\Items(type="string")),
+     *                 @OA\Property(property="tree_depth", type="integer"),
+     *                 @OA\Property(property="provider", type="string")
+     *             )
+     *         )
+     *     )
+     * )
+     */
+    public function getNetworks(): JsonResponse
+    {
+        return response()->json([
+            'data' => [
+                'networks'   => $this->merkleService->getSupportedNetworks(),
+                'tree_depth' => $this->merkleService->getTreeDepth(),
+                'provider'   => $this->merkleService->getProviderName(),
+            ],
+        ]);
+    }
+
+    /**
+     * Trigger a Merkle tree sync.
+     *
+     * @OA\Post(
+     *     path="/api/v1/privacy/sync",
+     *     operationId="syncMerkleTree",
+     *     tags={"Privacy"},
+     *     summary="Trigger a Merkle tree sync from the blockchain",
+     *     security={{"sanctum":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"network"},
+     *             @OA\Property(property="network", type="string", enum={"polygon", "base", "arbitrum"})
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Sync completed",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="root", type="string"),
+     *                 @OA\Property(property="network", type="string"),
+     *                 @OA\Property(property="synced_at", type="string", format="date-time")
+     *             ),
+     *             @OA\Property(property="message", type="string")
+     *         )
+     *     ),
+     *     @OA\Response(response=400, description="Invalid network"),
+     *     @OA\Response(response=401, description="Unauthenticated")
+     * )
+     */
+    public function syncTree(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'network' => 'required|string',
+        ]);
+
+        try {
+            $root = $this->merkleService->syncTree($validated['network']);
+
+            return response()->json([
+                'data'    => $root->toArray(),
+                'message' => 'Merkle tree synced successfully',
+            ]);
+        } catch (InvalidArgumentException $e) {
+            return response()->json([
+                'error' => [
+                    'code'               => 'ERR_PRIVACY_307',
+                    'message'            => $e->getMessage(),
+                    'supported_networks' => $this->merkleService->getSupportedNetworks(),
+                ],
+            ], 400);
+        }
+    }
+}

--- a/app/Providers/PrivacyServiceProvider.php
+++ b/app/Providers/PrivacyServiceProvider.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use App\Domain\Privacy\Contracts\MerkleTreeServiceInterface;
+use App\Domain\Privacy\Contracts\ZkProverInterface;
+use App\Domain\Privacy\Services\DemoMerkleTreeService;
+use App\Domain\Privacy\Services\DemoZkProver;
+use App\Domain\Privacy\Services\MerkleTreeService;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Service provider for the Privacy domain.
+ *
+ * Binds ZK prover and Merkle tree service contracts to implementations.
+ * In production, swap with real ZK proof systems like:
+ * - Circom/SnarkJS, Noir/Barretenberg
+ * - Polygon ID, Galactica Network
+ * - RAILGUN privacy pools
+ */
+class PrivacyServiceProvider extends ServiceProvider
+{
+    /**
+     * Register any application services.
+     */
+    public function register(): void
+    {
+        // Bind the ZK prover interface based on configuration
+        $this->app->bind(ZkProverInterface::class, function ($app) {
+            $provider = config('privacy.zk.provider', 'demo');
+
+            return match ($provider) {
+                'demo'  => new DemoZkProver(),
+                default => new DemoZkProver(), // Fallback to demo
+            };
+        });
+
+        // Bind the Merkle tree service interface based on configuration
+        $this->app->bind(MerkleTreeServiceInterface::class, function ($app) {
+            $provider = config('privacy.merkle.provider', 'demo');
+
+            return match ($provider) {
+                'demo'       => new DemoMerkleTreeService(),
+                'production' => new MerkleTreeService(),
+                default      => new DemoMerkleTreeService(), // Fallback to demo
+            };
+        });
+    }
+
+    /**
+     * Bootstrap any application services.
+     */
+    public function boot(): void
+    {
+        //
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -24,6 +24,7 @@ return [
     App\Providers\HorizonServiceProvider::class,
     App\Providers\JetstreamServiceProvider::class,
     App\Providers\LendingServiceProvider::class,
+    App\Providers\PrivacyServiceProvider::class,
     App\Providers\RelayerServiceProvider::class,
     App\Providers\StablecoinServiceProvider::class,
     App\Providers\TelescopeServiceProvider::class,

--- a/config/privacy.php
+++ b/config/privacy.php
@@ -144,4 +144,34 @@ return [
         // Risk score threshold for automatic approval (0-1)
         'auto_approval_threshold' => 0.3,
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Merkle Tree Settings (v2.6.0)
+    |--------------------------------------------------------------------------
+    |
+    | Configuration for privacy pool Merkle tree synchronization.
+    |
+    */
+
+    'merkle' => [
+        // Default provider for Merkle tree operations
+        'provider' => env('MERKLE_PROVIDER', 'demo'),
+
+        // Sync interval in seconds
+        'sync_interval_seconds' => (int) env('MERKLE_SYNC_INTERVAL', 30),
+
+        // Maximum tree depth (32 = ~4 billion leaves)
+        'max_tree_depth' => (int) env('MERKLE_TREE_DEPTH', 32),
+
+        // Supported networks for privacy pools
+        'networks' => ['polygon', 'base', 'arbitrum'],
+
+        // Contract addresses per network
+        'pool_addresses' => [
+            'polygon'  => env('MERKLE_POOL_POLYGON'),
+            'base'     => env('MERKLE_POOL_BASE'),
+            'arbitrum' => env('MERKLE_POOL_ARBITRUM'),
+        ],
+    ],
 ];

--- a/database/migrations/2026_02_03_000001_create_privacy_merkle_states_table.php
+++ b/database/migrations/2026_02_03_000001_create_privacy_merkle_states_table.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Creates the privacy_merkle_states table for storing Merkle tree state per network.
+ *
+ * This table caches the current Merkle root and tree metadata for each supported
+ * privacy pool network. Used for mobile client synchronization.
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('privacy_merkle_states', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('network', 20)->unique();
+            $table->string('root', 66)->comment('Current Merkle root (0x + 64 hex chars)');
+            $table->unsignedBigInteger('leaf_count')->default(0);
+            $table->unsignedInteger('tree_depth')->default(32);
+            $table->unsignedBigInteger('block_number')->comment('Block number at last sync');
+            $table->timestamp('synced_at');
+            $table->timestamps();
+
+            $table->index('network');
+            $table->index('synced_at');
+        });
+
+        // Table for tracking known commitments (for demo/testing purposes)
+        Schema::create('privacy_commitments', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('user_id')->nullable();
+            $table->string('commitment', 66)->comment('32-byte commitment hash with 0x prefix');
+            $table->string('network', 20);
+            $table->unsignedBigInteger('leaf_index');
+            $table->string('nullifier', 66)->nullable()->comment('Nullifier hash if spent');
+            $table->boolean('is_spent')->default(false);
+            $table->timestamp('shielded_at')->nullable();
+            $table->timestamp('spent_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['commitment', 'network']);
+            $table->index(['user_id', 'network']);
+            $table->index(['network', 'is_spent']);
+            $table->index('nullifier');
+
+            $table->foreign('user_id')
+                ->references('id')
+                ->on('users')
+                ->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('privacy_commitments');
+        Schema::dropIfExists('privacy_merkle_states');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1183,3 +1183,29 @@ Route::prefix('v1/trustcert')->name('api.trustcert.')->group(function () {
         Route::post('/{certificateId}/present', [PresentationController::class, 'present'])->name('present');
     });
 });
+
+/*
+|--------------------------------------------------------------------------
+| Privacy API Routes (v2.6.0)
+|--------------------------------------------------------------------------
+|
+| Merkle tree synchronization and proof endpoints for mobile privacy features.
+|
+*/
+
+use App\Http\Controllers\Api\Privacy\PrivacyController;
+
+Route::prefix('v1/privacy')->name('api.privacy.')->group(function () {
+    // Public endpoint for supported networks
+    Route::get('/networks', [PrivacyController::class, 'getNetworks'])->name('networks');
+
+    // Authenticated endpoints
+    Route::middleware(['auth:sanctum', 'check.token.expiration'])->group(function () {
+        Route::get('/merkle-root', [PrivacyController::class, 'getMerkleRoot'])->name('merkle-root');
+        Route::post('/merkle-path', [PrivacyController::class, 'getMerklePath'])->name('merkle-path');
+        Route::post('/verify-commitment', [PrivacyController::class, 'verifyCommitment'])->name('verify-commitment');
+        Route::post('/sync', [PrivacyController::class, 'syncTree'])
+            ->middleware('transaction.rate_limit:privacy_sync')
+            ->name('sync');
+    });
+});

--- a/tests/Feature/Api/Privacy/PrivacyControllerTest.php
+++ b/tests/Feature/Api/Privacy/PrivacyControllerTest.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\Privacy;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class PrivacyControllerTest extends TestCase
+{
+    protected User $user;
+
+    protected string $token;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+
+        $this->user = User::factory()->create();
+        $this->token = $this->user->createToken('test-token', ['read', 'write'])->plainTextToken;
+    }
+
+    public function test_get_networks_returns_supported_networks(): void
+    {
+        $response = $this->getJson('/api/v1/privacy/networks');
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'data' => [
+                    'networks',
+                    'tree_depth',
+                    'provider',
+                ],
+            ]);
+
+        $data = $response->json('data');
+        $this->assertContains('polygon', $data['networks']);
+        $this->assertContains('base', $data['networks']);
+        $this->assertContains('arbitrum', $data['networks']);
+        $this->assertEquals(32, $data['tree_depth']);
+        $this->assertEquals('demo', $data['provider']);
+    }
+
+    public function test_get_merkle_root_requires_authentication(): void
+    {
+        $response = $this->getJson('/api/v1/privacy/merkle-root?network=polygon');
+
+        $response->assertUnauthorized();
+    }
+
+    public function test_get_merkle_root_requires_network_parameter(): void
+    {
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/privacy/merkle-root');
+
+        $response->assertStatus(400)
+            ->assertJsonPath('error.code', 'ERR_PRIVACY_306');
+    }
+
+    public function test_get_merkle_root_returns_valid_root(): void
+    {
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/privacy/merkle-root?network=polygon');
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'data' => [
+                    'root',
+                    'network',
+                    'leaf_count',
+                    'tree_depth',
+                    'block_number',
+                    'synced_at',
+                ],
+            ]);
+
+        $data = $response->json('data');
+        $this->assertEquals('polygon', $data['network']);
+        $this->assertEquals(32, $data['tree_depth']);
+        $this->assertStringStartsWith('0x', $data['root']);
+    }
+
+    public function test_get_merkle_root_rejects_invalid_network(): void
+    {
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/privacy/merkle-root?network=invalid');
+
+        $response->assertStatus(400)
+            ->assertJsonPath('error.code', 'ERR_PRIVACY_307')
+            ->assertJsonStructure([
+                'error' => [
+                    'code',
+                    'message',
+                    'supported_networks',
+                ],
+            ]);
+    }
+
+    public function test_get_merkle_path_requires_authentication(): void
+    {
+        $response = $this->postJson('/api/v1/privacy/merkle-path', [
+            'commitment' => '0x' . str_repeat('1', 64),
+            'network'    => 'polygon',
+        ]);
+
+        $response->assertUnauthorized();
+    }
+
+    public function test_get_merkle_path_validates_required_fields(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/privacy/merkle-path', []);
+
+        $response->assertUnprocessable();
+    }
+
+    public function test_get_merkle_path_validates_commitment_format(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/privacy/merkle-path', [
+                'commitment' => 'invalid',
+                'network'    => 'polygon',
+            ]);
+
+        $response->assertUnprocessable();
+    }
+
+    public function test_get_merkle_path_for_known_commitment(): void
+    {
+        // Use a pre-seeded demo commitment
+        $commitment = '0x' . str_repeat('1', 64);
+
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/privacy/merkle-path', [
+                'commitment' => $commitment,
+                'network'    => 'polygon',
+            ]);
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'data' => [
+                    'commitment',
+                    'root',
+                    'network',
+                    'leaf_index',
+                    'siblings',
+                    'path_indices',
+                    'proof_depth',
+                ],
+            ]);
+
+        $data = $response->json('data');
+        $this->assertEquals('polygon', $data['network']);
+        $this->assertCount(32, $data['siblings']);
+        $this->assertCount(32, $data['path_indices']);
+    }
+
+    public function test_get_merkle_path_returns_404_for_unknown_commitment(): void
+    {
+        $unknownCommitment = '0x' . str_repeat('9', 64);
+
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/privacy/merkle-path', [
+                'commitment' => $unknownCommitment,
+                'network'    => 'polygon',
+            ]);
+
+        $response->assertNotFound()
+            ->assertJsonPath('error.code', 'ERR_PRIVACY_306');
+    }
+
+    public function test_verify_commitment_with_valid_proof(): void
+    {
+        // First get a valid path
+        $commitment = '0x' . str_repeat('1', 64);
+        $pathResponse = $this->withToken($this->token)
+            ->postJson('/api/v1/privacy/merkle-path', [
+                'commitment' => $commitment,
+                'network'    => 'polygon',
+            ]);
+
+        $pathData = $pathResponse->json('data');
+
+        // Now verify it
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/privacy/verify-commitment', [
+                'commitment'   => $commitment,
+                'network'      => 'polygon',
+                'root'         => $pathData['root'],
+                'leaf_index'   => $pathData['leaf_index'],
+                'siblings'     => $pathData['siblings'],
+                'path_indices' => $pathData['path_indices'],
+            ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.valid', true)
+            ->assertJsonPath('data.commitment', $commitment);
+    }
+
+    public function test_sync_tree_triggers_merkle_sync(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/privacy/sync', [
+                'network' => 'polygon',
+            ]);
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'data' => [
+                    'root',
+                    'network',
+                    'synced_at',
+                ],
+                'message',
+            ])
+            ->assertJsonPath('data.network', 'polygon');
+    }
+
+    public function test_sync_tree_rejects_invalid_network(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/privacy/sync', [
+                'network' => 'invalid',
+            ]);
+
+        $response->assertStatus(400)
+            ->assertJsonPath('error.code', 'ERR_PRIVACY_307');
+    }
+}

--- a/tests/Unit/Domain/Privacy/Services/DemoMerkleTreeServiceTest.php
+++ b/tests/Unit/Domain/Privacy/Services/DemoMerkleTreeServiceTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Privacy\Services;
+
+use App\Domain\Privacy\Exceptions\CommitmentNotFoundException;
+use App\Domain\Privacy\Services\DemoMerkleTreeService;
+use App\Domain\Privacy\ValueObjects\MerklePath;
+use App\Domain\Privacy\ValueObjects\MerkleRoot;
+use Illuminate\Support\Facades\Cache;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+class DemoMerkleTreeServiceTest extends TestCase
+{
+    private DemoMerkleTreeService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+        $this->service = new DemoMerkleTreeService();
+    }
+
+    public function test_get_supported_networks(): void
+    {
+        $networks = $this->service->getSupportedNetworks();
+
+        $this->assertIsArray($networks);
+        $this->assertContains('polygon', $networks);
+        $this->assertContains('base', $networks);
+        $this->assertContains('arbitrum', $networks);
+    }
+
+    public function test_supports_network(): void
+    {
+        $this->assertTrue($this->service->supportsNetwork('polygon'));
+        $this->assertTrue($this->service->supportsNetwork('base'));
+        $this->assertTrue($this->service->supportsNetwork('arbitrum'));
+        $this->assertFalse($this->service->supportsNetwork('ethereum'));
+        $this->assertFalse($this->service->supportsNetwork('invalid'));
+    }
+
+    public function test_get_tree_depth(): void
+    {
+        $depth = $this->service->getTreeDepth();
+
+        $this->assertEquals(32, $depth);
+    }
+
+    public function test_get_provider_name(): void
+    {
+        $this->assertEquals('demo', $this->service->getProviderName());
+    }
+
+    public function test_get_merkle_root_returns_valid_root(): void
+    {
+        $root = $this->service->getMerkleRoot('polygon');
+
+        $this->assertInstanceOf(MerkleRoot::class, $root);
+        $this->assertEquals('polygon', $root->network);
+        $this->assertStringStartsWith('0x', $root->root);
+        $this->assertEquals(64 + 2, strlen($root->root)); // 0x + 64 hex chars
+        $this->assertEquals(32, $root->treeDepth);
+        $this->assertGreaterThan(0, $root->blockNumber);
+    }
+
+    public function test_get_merkle_root_throws_for_invalid_network(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported network');
+
+        $this->service->getMerkleRoot('invalid');
+    }
+
+    public function test_get_merkle_path_for_known_commitment(): void
+    {
+        // Use a pre-seeded demo commitment
+        $commitment = '0x' . str_repeat('1', 64);
+
+        $path = $this->service->getMerklePath($commitment, 'polygon');
+
+        $this->assertInstanceOf(MerklePath::class, $path);
+        $this->assertEquals(strtolower($commitment), $path->commitment);
+        $this->assertEquals('polygon', $path->network);
+        $this->assertCount(32, $path->siblings);
+        $this->assertCount(32, $path->pathIndices);
+    }
+
+    public function test_get_merkle_path_throws_for_unknown_commitment(): void
+    {
+        $this->expectException(CommitmentNotFoundException::class);
+
+        $unknownCommitment = '0x' . str_repeat('9', 64);
+        $this->service->getMerklePath($unknownCommitment, 'polygon');
+    }
+
+    public function test_get_merkle_path_throws_for_invalid_network(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->service->getMerklePath('0x' . str_repeat('1', 64), 'invalid');
+    }
+
+    public function test_get_merkle_path_throws_for_invalid_commitment_format(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid commitment format');
+
+        $this->service->getMerklePath('invalid', 'polygon');
+    }
+
+    public function test_add_demo_commitment(): void
+    {
+        $newCommitment = '0x' . str_repeat('f', 64);
+
+        $leafIndex = $this->service->addDemoCommitment($newCommitment, 'polygon');
+
+        $this->assertIsInt($leafIndex);
+        $this->assertGreaterThanOrEqual(0, $leafIndex);
+
+        // Should now be able to get the path
+        $path = $this->service->getMerklePath($newCommitment, 'polygon');
+        $this->assertEquals($leafIndex, $path->leafIndex);
+    }
+
+    public function test_verify_commitment_with_valid_path(): void
+    {
+        $commitment = '0x' . str_repeat('1', 64);
+        $path = $this->service->getMerklePath($commitment, 'polygon');
+
+        $isValid = $this->service->verifyCommitment($commitment, $path);
+
+        $this->assertTrue($isValid);
+    }
+
+    public function test_verify_commitment_with_wrong_path_depth(): void
+    {
+        // Create a path with wrong depth
+        $path = new MerklePath(
+            commitment: '0x' . str_repeat('1', 64),
+            root: '0x' . str_repeat('b', 64),
+            network: 'polygon',
+            leafIndex: 0,
+            siblings: ['0x' . str_repeat('a', 64)], // Only 1 sibling instead of 32
+            pathIndices: [0],
+        );
+
+        $isValid = $this->service->verifyCommitment('0x' . str_repeat('1', 64), $path);
+
+        $this->assertFalse($isValid);
+    }
+
+    public function test_sync_tree_clears_cache_and_returns_fresh_root(): void
+    {
+        // Get initial root
+        $initialRoot = $this->service->getMerkleRoot('polygon');
+
+        // Wait a moment to ensure different timestamp
+        usleep(100000); // 100ms
+
+        // Sync and get new root
+        $syncedRoot = $this->service->syncTree('polygon');
+
+        $this->assertInstanceOf(MerkleRoot::class, $syncedRoot);
+        $this->assertEquals('polygon', $syncedRoot->network);
+        // The synced_at should be newer
+        $this->assertGreaterThanOrEqual(
+            $initialRoot->syncedAt->getTimestamp(),
+            $syncedRoot->syncedAt->getTimestamp()
+        );
+    }
+
+    public function test_commitment_normalization_handles_case_insensitivity(): void
+    {
+        // Add a new commitment with uppercase
+        $upperCommitment = '0x' . str_repeat('A', 64);
+        $lowerCommitment = '0x' . str_repeat('a', 64);
+
+        // Add the commitment (will be stored normalized to lowercase)
+        $addedIndex = $this->service->addDemoCommitment($upperCommitment, 'polygon');
+
+        // Both uppercase and lowercase lookups should return the same path
+        $path1 = $this->service->getMerklePath($upperCommitment, 'polygon');
+        $path2 = $this->service->getMerklePath($lowerCommitment, 'polygon');
+
+        $this->assertEquals($path1->commitment, $path2->commitment);
+        $this->assertEquals($path1->leafIndex, $path2->leafIndex);
+        $this->assertEquals($addedIndex, $path1->leafIndex);
+    }
+
+    public function test_commitment_normalization_handles_missing_prefix(): void
+    {
+        // Add commitment without 0x prefix
+        $commitmentNoPrefix = str_repeat('e', 64);
+        $leafIndex = $this->service->addDemoCommitment($commitmentNoPrefix, 'polygon');
+
+        // Should be retrievable with 0x prefix (normalized form)
+        $path = $this->service->getMerklePath('0x' . $commitmentNoPrefix, 'polygon');
+
+        $this->assertEquals($leafIndex, $path->leafIndex);
+        $this->assertEquals('0x' . $commitmentNoPrefix, $path->commitment);
+    }
+}

--- a/tests/Unit/Domain/Privacy/ValueObjects/MerklePathTest.php
+++ b/tests/Unit/Domain/Privacy/ValueObjects/MerklePathTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Privacy\ValueObjects;
+
+use App\Domain\Privacy\ValueObjects\MerklePath;
+use Tests\TestCase;
+
+class MerklePathTest extends TestCase
+{
+    private function createSamplePath(int $depth = 32): MerklePath
+    {
+        $siblings = [];
+        $pathIndices = [];
+
+        for ($i = 0; $i < $depth; $i++) {
+            $siblings[] = '0x' . str_repeat(dechex($i % 16), 64);
+            $pathIndices[] = $i % 2;
+        }
+
+        return new MerklePath(
+            commitment: '0x' . str_repeat('a', 64),
+            root: '0x' . str_repeat('b', 64),
+            network: 'polygon',
+            leafIndex: 42,
+            siblings: $siblings,
+            pathIndices: $pathIndices,
+        );
+    }
+
+    public function test_can_create_merkle_path(): void
+    {
+        $path = $this->createSamplePath();
+
+        $this->assertEquals('0x' . str_repeat('a', 64), $path->commitment);
+        $this->assertEquals('0x' . str_repeat('b', 64), $path->root);
+        $this->assertEquals('polygon', $path->network);
+        $this->assertEquals(42, $path->leafIndex);
+        $this->assertCount(32, $path->siblings);
+        $this->assertCount(32, $path->pathIndices);
+    }
+
+    public function test_get_depth(): void
+    {
+        $path16 = $this->createSamplePath(16);
+        $path32 = $this->createSamplePath(32);
+
+        $this->assertEquals(16, $path16->getDepth());
+        $this->assertEquals(32, $path32->getDepth());
+    }
+
+    public function test_is_valid_for_depth(): void
+    {
+        $path = $this->createSamplePath(32);
+
+        $this->assertTrue($path->isValidForDepth(32));
+        $this->assertFalse($path->isValidForDepth(16));
+        $this->assertFalse($path->isValidForDepth(64));
+    }
+
+    public function test_to_array(): void
+    {
+        $path = $this->createSamplePath(4);
+
+        $array = $path->toArray();
+
+        $this->assertEquals('0x' . str_repeat('a', 64), $array['commitment']);
+        $this->assertEquals('0x' . str_repeat('b', 64), $array['root']);
+        $this->assertEquals('polygon', $array['network']);
+        $this->assertEquals(42, $array['leaf_index']);
+        $this->assertCount(4, $array['siblings']);
+        $this->assertCount(4, $array['path_indices']);
+        $this->assertEquals(4, $array['proof_depth']);
+    }
+
+    public function test_json_serializable(): void
+    {
+        $path = $this->createSamplePath(4);
+
+        $json = json_encode($path);
+        $this->assertIsString($json);
+
+        $decoded = json_decode($json, true);
+        $this->assertEquals('polygon', $decoded['network']);
+        $this->assertEquals(42, $decoded['leaf_index']);
+    }
+
+    public function test_from_array(): void
+    {
+        $data = [
+            'commitment'   => '0x' . str_repeat('c', 64),
+            'root'         => '0x' . str_repeat('d', 64),
+            'network'      => 'base',
+            'leaf_index'   => 100,
+            'siblings'     => ['0x' . str_repeat('1', 64), '0x' . str_repeat('2', 64)],
+            'path_indices' => [0, 1],
+        ];
+
+        $path = MerklePath::fromArray($data);
+
+        $this->assertEquals($data['commitment'], $path->commitment);
+        $this->assertEquals($data['root'], $path->root);
+        $this->assertEquals('base', $path->network);
+        $this->assertEquals(100, $path->leafIndex);
+        $this->assertCount(2, $path->siblings);
+        $this->assertCount(2, $path->pathIndices);
+    }
+}

--- a/tests/Unit/Domain/Privacy/ValueObjects/MerkleRootTest.php
+++ b/tests/Unit/Domain/Privacy/ValueObjects/MerkleRootTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Privacy\ValueObjects;
+
+use App\Domain\Privacy\ValueObjects\MerkleRoot;
+use DateTimeImmutable;
+use Tests\TestCase;
+
+class MerkleRootTest extends TestCase
+{
+    public function test_can_create_merkle_root(): void
+    {
+        $root = new MerkleRoot(
+            root: '0x' . str_repeat('a', 64),
+            network: 'polygon',
+            leafCount: 1000,
+            treeDepth: 32,
+            blockNumber: 55000000,
+            syncedAt: new DateTimeImmutable('2026-02-03T12:00:00Z'),
+        );
+
+        $this->assertEquals('0x' . str_repeat('a', 64), $root->root);
+        $this->assertEquals('polygon', $root->network);
+        $this->assertEquals(1000, $root->leafCount);
+        $this->assertEquals(32, $root->treeDepth);
+        $this->assertEquals(55000000, $root->blockNumber);
+    }
+
+    public function test_is_stale_returns_true_when_older_than_max_age(): void
+    {
+        $root = new MerkleRoot(
+            root: '0x' . str_repeat('a', 64),
+            network: 'polygon',
+            leafCount: 1000,
+            treeDepth: 32,
+            blockNumber: 55000000,
+            syncedAt: new DateTimeImmutable('-2 minutes'),
+        );
+
+        $this->assertTrue($root->isStale(60)); // 60 seconds max age
+    }
+
+    public function test_is_stale_returns_false_when_recent(): void
+    {
+        $root = new MerkleRoot(
+            root: '0x' . str_repeat('a', 64),
+            network: 'polygon',
+            leafCount: 1000,
+            treeDepth: 32,
+            blockNumber: 55000000,
+            syncedAt: new DateTimeImmutable('-10 seconds'),
+        );
+
+        $this->assertFalse($root->isStale(60));
+    }
+
+    public function test_get_age_seconds(): void
+    {
+        $root = new MerkleRoot(
+            root: '0x' . str_repeat('a', 64),
+            network: 'polygon',
+            leafCount: 1000,
+            treeDepth: 32,
+            blockNumber: 55000000,
+            syncedAt: new DateTimeImmutable('-30 seconds'),
+        );
+
+        $age = $root->getAgeSeconds();
+        $this->assertGreaterThanOrEqual(29, $age);
+        $this->assertLessThanOrEqual(32, $age);
+    }
+
+    public function test_to_array(): void
+    {
+        $syncedAt = new DateTimeImmutable('2026-02-03T12:00:00Z');
+        $root = new MerkleRoot(
+            root: '0x' . str_repeat('a', 64),
+            network: 'polygon',
+            leafCount: 1000,
+            treeDepth: 32,
+            blockNumber: 55000000,
+            syncedAt: $syncedAt,
+        );
+
+        $array = $root->toArray();
+
+        $this->assertEquals('0x' . str_repeat('a', 64), $array['root']);
+        $this->assertEquals('polygon', $array['network']);
+        $this->assertEquals(1000, $array['leaf_count']);
+        $this->assertEquals(32, $array['tree_depth']);
+        $this->assertEquals(55000000, $array['block_number']);
+        $this->assertEquals($syncedAt->format('c'), $array['synced_at']);
+    }
+
+    public function test_json_serializable(): void
+    {
+        $root = new MerkleRoot(
+            root: '0x' . str_repeat('a', 64),
+            network: 'polygon',
+            leafCount: 1000,
+            treeDepth: 32,
+            blockNumber: 55000000,
+            syncedAt: new DateTimeImmutable('2026-02-03T12:00:00Z'),
+        );
+
+        $json = json_encode($root);
+        $this->assertIsString($json);
+
+        $decoded = json_decode($json, true);
+        $this->assertEquals('polygon', $decoded['network']);
+    }
+
+    public function test_from_array(): void
+    {
+        $data = [
+            'root'         => '0x' . str_repeat('b', 64),
+            'network'      => 'base',
+            'leaf_count'   => 2000,
+            'tree_depth'   => 32,
+            'block_number' => 12000000,
+            'synced_at'    => '2026-02-03T12:00:00Z',
+        ];
+
+        $root = MerkleRoot::fromArray($data);
+
+        $this->assertEquals($data['root'], $root->root);
+        $this->assertEquals('base', $root->network);
+        $this->assertEquals(2000, $root->leafCount);
+        $this->assertEquals(12000000, $root->blockNumber);
+    }
+}


### PR DESCRIPTION
## Summary
- Implements PR #1 of v2.6.0 - Privacy Merkle Tree Infrastructure (P0)
- Adds Merkle tree sync and proof generation for mobile privacy features
- Creates foundation for delegated proving and privacy pool integration

## Changes
- **New Contracts**: `MerkleTreeServiceInterface` for Merkle tree operations
- **New Services**: `MerkleTreeService` (production) + `DemoMerkleTreeService`
- **New Value Objects**: `MerkleRoot`, `MerklePath` for immutable tree data
- **New Exception**: `CommitmentNotFoundException` (ERR_PRIVACY_306)
- **New Controller**: `PrivacyController` with 5 API endpoints
- **New Provider**: `PrivacyServiceProvider` for DI bindings
- **Migration**: `privacy_merkle_states` and `privacy_commitments` tables

## API Endpoints
| Method | Endpoint | Auth | Description |
|--------|----------|------|-------------|
| GET | `/api/v1/privacy/networks` | Public | List supported networks |
| GET | `/api/v1/privacy/merkle-root` | Auth | Get current Merkle root |
| POST | `/api/v1/privacy/merkle-path` | Auth | Get proof path for commitment |
| POST | `/api/v1/privacy/verify-commitment` | Auth | Verify commitment proof |
| POST | `/api/v1/privacy/sync` | Auth | Trigger tree sync |

## Config
```php
'merkle' => [
    'provider' => env('MERKLE_PROVIDER', 'demo'),
    'sync_interval_seconds' => 30,
    'max_tree_depth' => 32,
    'networks' => ['polygon', 'base', 'arbitrum'],
]
```

## Test plan
- [x] Unit tests for MerkleRoot and MerklePath value objects
- [x] Unit tests for DemoMerkleTreeService
- [x] Feature tests for PrivacyController endpoints
- [x] PHPStan analysis passes
- [x] PHP-CS-Fixer passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)