### PR TITLE
feat(v2.6.0): Relayer Smart Account Management (PR #2)

### DIFF
--- a/app/Domain/Relayer/Contracts/SmartAccountFactoryInterface.php
+++ b/app/Domain/Relayer/Contracts/SmartAccountFactoryInterface.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Relayer\Contracts;
+
+/**
+ * Interface for smart account factory operations.
+ *
+ * Handles deterministic address computation and account deployment.
+ */
+interface SmartAccountFactoryInterface
+{
+    /**
+     * Compute the counterfactual address for a smart account.
+     *
+     * This returns the address the account WILL have once deployed,
+     * without actually deploying it.
+     *
+     * @param string $ownerAddress The EOA owner address
+     * @param string $network The network name (polygon, base, arbitrum)
+     * @param int $salt Optional salt for different accounts per owner
+     * @return string The computed smart account address
+     */
+    public function computeAddress(string $ownerAddress, string $network, int $salt = 0): string;
+
+    /**
+     * Generate the init code for deploying a smart account.
+     *
+     * The init code is used in the first UserOperation to deploy
+     * the account on-chain.
+     *
+     * @param string $ownerAddress The EOA owner address
+     * @param string $network The network name
+     * @param int $salt Optional salt
+     * @return string The init code as hex string
+     */
+    public function getInitCode(string $ownerAddress, string $network, int $salt = 0): string;
+
+    /**
+     * Check if a smart account is deployed on-chain.
+     *
+     * @param string $accountAddress The smart account address
+     * @param string $network The network name
+     * @return bool True if deployed
+     */
+    public function isDeployed(string $accountAddress, string $network): bool;
+
+    /**
+     * Get the factory contract address for a network.
+     *
+     * @param string $network The network name
+     * @return string|null The factory address or null if not configured
+     */
+    public function getFactoryAddress(string $network): ?string;
+
+    /**
+     * Check if a network is supported.
+     */
+    public function supportsNetwork(string $network): bool;
+
+    /**
+     * Get all supported networks.
+     *
+     * @return array<string>
+     */
+    public function getSupportedNetworks(): array;
+}

--- a/app/Domain/Relayer/Exceptions/SmartAccountException.php
+++ b/app/Domain/Relayer/Exceptions/SmartAccountException.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Relayer\Exceptions;
+
+use Exception;
+
+/**
+ * Exception for smart account related errors.
+ */
+class SmartAccountException extends Exception
+{
+    public const CODE_ACCOUNT_EXISTS = 'ERR_RELAYER_101';
+
+    public const CODE_ACCOUNT_NOT_FOUND = 'ERR_RELAYER_102';
+
+    public const CODE_DEPLOYMENT_FAILED = 'ERR_RELAYER_103';
+
+    public const CODE_NONCE_MISMATCH = 'ERR_RELAYER_104';
+
+    public const CODE_INVALID_NETWORK = 'ERR_RELAYER_105';
+
+    public function __construct(
+        string $message,
+        public readonly string $errorCode,
+        public readonly int $httpStatusCode = 400,
+    ) {
+        parent::__construct($message);
+    }
+
+    public static function accountExists(string $ownerAddress, string $network): self
+    {
+        return new self(
+            "Smart account already exists for owner {$ownerAddress} on {$network}",
+            self::CODE_ACCOUNT_EXISTS,
+            409
+        );
+    }
+
+    public static function accountNotFound(string $ownerAddress, string $network): self
+    {
+        return new self(
+            "Smart account not found for owner {$ownerAddress} on {$network}",
+            self::CODE_ACCOUNT_NOT_FOUND,
+            404
+        );
+    }
+
+    public static function deploymentFailed(string $reason): self
+    {
+        return new self(
+            "Smart account deployment failed: {$reason}",
+            self::CODE_DEPLOYMENT_FAILED,
+            500
+        );
+    }
+
+    public static function nonceMismatch(int $expected, int $provided): self
+    {
+        return new self(
+            "Nonce mismatch: expected {$expected}, got {$provided}",
+            self::CODE_NONCE_MISMATCH,
+            400
+        );
+    }
+
+    public static function invalidNetwork(string $network): self
+    {
+        return new self(
+            "Invalid or unsupported network: {$network}",
+            self::CODE_INVALID_NETWORK,
+            400
+        );
+    }
+
+    /**
+     * Get additional context for logging.
+     *
+     * @return array<string, mixed>
+     */
+    public function context(): array
+    {
+        return [
+            'error_code'  => $this->errorCode,
+            'http_status' => $this->httpStatusCode,
+        ];
+    }
+}

--- a/app/Domain/Relayer/Models/SmartAccount.php
+++ b/app/Domain/Relayer/Models/SmartAccount.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Relayer\Models;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Smart Account model for ERC-4337 account abstraction.
+ *
+ * Tracks counterfactual smart account addresses and their deployment status.
+ * Smart accounts are created deterministically from owner address + salt.
+ *
+ * @property string $id
+ * @property string $user_id
+ * @property string $owner_address
+ * @property string $account_address
+ * @property string $network
+ * @property bool $deployed
+ * @property string|null $deploy_tx_hash
+ * @property int $nonce
+ * @property int $pending_ops
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ */
+class SmartAccount extends Model
+{
+    use HasUuids;
+
+    protected $table = 'smart_accounts';
+
+    protected $fillable = [
+        'user_id',
+        'owner_address',
+        'account_address',
+        'network',
+        'deployed',
+        'deploy_tx_hash',
+        'nonce',
+        'pending_ops',
+    ];
+
+    protected $casts = [
+        'deployed'    => 'boolean',
+        'nonce'       => 'integer',
+        'pending_ops' => 'integer',
+    ];
+
+    /**
+     * Get the user that owns this smart account.
+     *
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Check if this account needs deployment.
+     */
+    public function needsDeployment(): bool
+    {
+        return ! $this->deployed;
+    }
+
+    /**
+     * Increment the nonce after a successful operation.
+     */
+    public function incrementNonce(): void
+    {
+        $this->increment('nonce');
+    }
+
+    /**
+     * Increment pending operations count.
+     */
+    public function incrementPendingOps(): void
+    {
+        $this->increment('pending_ops');
+    }
+
+    /**
+     * Decrement pending operations count.
+     */
+    public function decrementPendingOps(): void
+    {
+        $this->decrement('pending_ops');
+        if ($this->pending_ops < 0) {
+            $this->pending_ops = 0;
+            $this->save();
+        }
+    }
+
+    /**
+     * Mark the account as deployed.
+     */
+    public function markAsDeployed(string $txHash): void
+    {
+        $this->update([
+            'deployed'       => true,
+            'deploy_tx_hash' => $txHash,
+        ]);
+    }
+
+    /**
+     * Scope for deployed accounts.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder<SmartAccount> $query
+     * @return \Illuminate\Database\Eloquent\Builder<SmartAccount>
+     */
+    public function scopeDeployed($query)
+    {
+        return $query->where('deployed', true);
+    }
+
+    /**
+     * Scope for undeployed (counterfactual) accounts.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder<SmartAccount> $query
+     * @return \Illuminate\Database\Eloquent\Builder<SmartAccount>
+     */
+    public function scopeUndeployed($query)
+    {
+        return $query->where('deployed', false);
+    }
+
+    /**
+     * Scope by network.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder<SmartAccount> $query
+     * @return \Illuminate\Database\Eloquent\Builder<SmartAccount>
+     */
+    public function scopeForNetwork($query, string $network)
+    {
+        return $query->where('network', $network);
+    }
+
+    /**
+     * Format the model for API responses.
+     *
+     * @return array<string, mixed>
+     */
+    public function toApiResponse(): array
+    {
+        return [
+            'id'              => $this->id,
+            'owner_address'   => $this->owner_address,
+            'account_address' => $this->account_address,
+            'network'         => $this->network,
+            'deployed'        => $this->deployed,
+            'deploy_tx_hash'  => $this->deploy_tx_hash,
+            'nonce'           => $this->nonce,
+            'pending_ops'     => $this->pending_ops,
+            'created_at'      => $this->created_at->toIso8601String(),
+        ];
+    }
+}

--- a/app/Domain/Relayer/Services/DemoSmartAccountFactory.php
+++ b/app/Domain/Relayer/Services/DemoSmartAccountFactory.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Relayer\Services;
+
+use App\Domain\Relayer\Contracts\SmartAccountFactoryInterface;
+use Illuminate\Support\Facades\Cache;
+use InvalidArgumentException;
+
+/**
+ * Demo implementation of smart account factory.
+ *
+ * Computes deterministic addresses without blockchain connectivity.
+ * In production, this would call actual factory contracts.
+ */
+class DemoSmartAccountFactory implements SmartAccountFactoryInterface
+{
+    /**
+     * Supported networks with their demo factory addresses.
+     *
+     * @var array<string, string>
+     */
+    private const DEMO_FACTORY_ADDRESSES = [
+        'polygon'  => '0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789',
+        'base'     => '0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789',
+        'arbitrum' => '0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789',
+    ];
+
+    private const CACHE_PREFIX = 'smart_account_deployed_';
+
+    public function computeAddress(string $ownerAddress, string $network, int $salt = 0): string
+    {
+        // Validate inputs
+        $this->validateOwnerAddress($ownerAddress);
+        $this->validateNetwork($network);
+
+        // Compute deterministic address using CREATE2 formula
+        // address = keccak256(0xff + factory + salt + keccak256(initCode))[12:]
+        $initCodeHash = $this->computeInitCodeHash($ownerAddress, $salt);
+        $factoryAddress = $this->getFactoryAddress($network);
+        
+        if ($factoryAddress === null) {
+            throw new InvalidArgumentException("No factory address for network: {$network}");
+        }
+        
+        $saltBytes = str_pad(dechex($salt), 64, '0', STR_PAD_LEFT);
+
+        // Demo: compute a deterministic address
+        $preImage = '0xff' . substr($factoryAddress, 2) . $saltBytes . $initCodeHash;
+        $binaryData = hex2bin(substr($preImage, 2));
+        
+        if ($binaryData === false) {
+            throw new InvalidArgumentException('Invalid hex data for address computation');
+        }
+        
+        $hash = hash('sha3-256', $binaryData);
+
+        return '0x' . substr($hash, 24); // Take last 20 bytes (40 hex chars)
+    }
+
+    public function getInitCode(string $ownerAddress, string $network, int $salt = 0): string
+    {
+        $this->validateOwnerAddress($ownerAddress);
+        $this->validateNetwork($network);
+
+        // Demo init code structure:
+        // factory address (20 bytes) + createAccount selector (4 bytes) + owner (32 bytes) + salt (32 bytes)
+        $factoryAddress = $this->getFactoryAddress($network);
+        $createAccountSelector = 'createAccount'; // In production: actual function selector
+
+        // Build encoded init code (simplified)
+        $paddedOwner = str_pad(substr($ownerAddress, 2), 64, '0', STR_PAD_LEFT);
+        $paddedSalt = str_pad(dechex($salt), 64, '0', STR_PAD_LEFT);
+
+        // Demo init code: factory address + call data
+        return $factoryAddress . hash('sha3-256', $createAccountSelector . $paddedOwner . $paddedSalt);
+    }
+
+    public function isDeployed(string $accountAddress, string $network): bool
+    {
+        // Demo: track deployment status in cache
+        $cacheKey = self::CACHE_PREFIX . $network . '_' . strtolower($accountAddress);
+
+        return Cache::get($cacheKey, false);
+    }
+
+    public function getFactoryAddress(string $network): ?string
+    {
+        // First check config, then fall back to demo addresses
+        $configKey = strtoupper($network) . '_FACTORY_ADDRESS';
+        $configured = config("relayer.smart_accounts.factory_addresses.{$network}");
+
+        if ($configured) {
+            return $configured;
+        }
+
+        return self::DEMO_FACTORY_ADDRESSES[$network] ?? null;
+    }
+
+    public function supportsNetwork(string $network): bool
+    {
+        return in_array($network, $this->getSupportedNetworks(), true);
+    }
+
+    public function getSupportedNetworks(): array
+    {
+        return array_keys(self::DEMO_FACTORY_ADDRESSES);
+    }
+
+    /**
+     * Mark an account as deployed (for testing).
+     */
+    public function markAsDeployed(string $accountAddress, string $network): void
+    {
+        $cacheKey = self::CACHE_PREFIX . $network . '_' . strtolower($accountAddress);
+        Cache::put($cacheKey, true, now()->addDays(30));
+    }
+
+    /**
+     * Validate owner address format.
+     */
+    private function validateOwnerAddress(string $address): void
+    {
+        if (! preg_match('/^0x[a-fA-F0-9]{40}$/', $address)) {
+            throw new InvalidArgumentException('Invalid owner address format');
+        }
+    }
+
+    /**
+     * Validate network is supported.
+     */
+    private function validateNetwork(string $network): void
+    {
+        if (! $this->supportsNetwork($network)) {
+            throw new InvalidArgumentException(
+                "Unsupported network: {$network}. Supported: " . implode(', ', $this->getSupportedNetworks())
+            );
+        }
+    }
+
+    /**
+     * Compute init code hash for address derivation.
+     */
+    private function computeInitCodeHash(string $ownerAddress, int $salt): string
+    {
+        $initCode = $ownerAddress . '_' . $salt;
+
+        return hash('sha3-256', $initCode);
+    }
+}

--- a/app/Domain/Relayer/Services/SmartAccountService.php
+++ b/app/Domain/Relayer/Services/SmartAccountService.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Relayer\Services;
+
+use App\Domain\Relayer\Contracts\SmartAccountFactoryInterface;
+use App\Domain\Relayer\Exceptions\SmartAccountException;
+use App\Domain\Relayer\Models\SmartAccount;
+use App\Models\User;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Service for managing ERC-4337 smart accounts.
+ *
+ * Handles account creation, deployment tracking, and nonce management.
+ */
+class SmartAccountService
+{
+    public function __construct(
+        private readonly SmartAccountFactoryInterface $factory,
+    ) {
+    }
+
+    /**
+     * Create or retrieve a smart account for a user.
+     *
+     * If the account already exists, returns it. Otherwise creates a new one.
+     *
+     * @throws SmartAccountException If network is invalid
+     */
+    public function getOrCreateAccount(User $user, string $ownerAddress, string $network): SmartAccount
+    {
+        $this->validateNetwork($network);
+        $normalizedOwner = strtolower($ownerAddress);
+
+        // Check for existing account
+        $existing = SmartAccount::where('owner_address', $normalizedOwner)
+            ->where('network', $network)
+            ->first();
+
+        if ($existing) {
+            return $existing;
+        }
+
+        // Compute counterfactual address
+        $accountAddress = $this->factory->computeAddress($ownerAddress, $network);
+
+        // Create the account record
+        $account = SmartAccount::create([
+            'user_id'         => $user->id,
+            'owner_address'   => $normalizedOwner,
+            'account_address' => strtolower($accountAddress),
+            'network'         => $network,
+            'deployed'        => false,
+            'nonce'           => 0,
+            'pending_ops'     => 0,
+        ]);
+
+        Log::info('Smart account created', [
+            'user_id'         => $user->id,
+            'owner_address'   => $normalizedOwner,
+            'account_address' => $accountAddress,
+            'network'         => $network,
+        ]);
+
+        return $account;
+    }
+
+    /**
+     * Get a smart account by owner address and network.
+     */
+    public function getAccount(string $ownerAddress, string $network): ?SmartAccount
+    {
+        return SmartAccount::where('owner_address', strtolower($ownerAddress))
+            ->where('network', $network)
+            ->first();
+    }
+
+    /**
+     * Get a smart account by account address.
+     */
+    public function getByAccountAddress(string $accountAddress, string $network): ?SmartAccount
+    {
+        return SmartAccount::where('account_address', strtolower($accountAddress))
+            ->where('network', $network)
+            ->first();
+    }
+
+    /**
+     * Get all accounts for a user.
+     *
+     * @return \Illuminate\Database\Eloquent\Collection<int, SmartAccount>
+     */
+    public function getUserAccounts(User $user): \Illuminate\Database\Eloquent\Collection
+    {
+        return SmartAccount::where('user_id', $user->id)->get();
+    }
+
+    /**
+     * Get the nonce and pending operations for an account.
+     *
+     * @return array{nonce: int, pending_ops: int, deployed: bool}
+     * @throws SmartAccountException If account not found
+     */
+    public function getNonceInfo(string $ownerAddress, string $network): array
+    {
+        $account = $this->getAccount($ownerAddress, $network);
+
+        if (! $account) {
+            throw SmartAccountException::accountNotFound($ownerAddress, $network);
+        }
+
+        return [
+            'nonce'       => $account->nonce,
+            'pending_ops' => $account->pending_ops,
+            'deployed'    => $account->deployed,
+        ];
+    }
+
+    /**
+     * Get the init code for an account deployment.
+     *
+     * Returns empty string if account is already deployed.
+     */
+    public function getInitCode(string $ownerAddress, string $network): string
+    {
+        $account = $this->getAccount($ownerAddress, $network);
+
+        // If deployed, no init code needed
+        if ($account && $account->deployed) {
+            return '';
+        }
+
+        return $this->factory->getInitCode($ownerAddress, $network);
+    }
+
+    /**
+     * Check if init code is needed for a transaction.
+     */
+    public function needsInitCode(string $ownerAddress, string $network): bool
+    {
+        $account = $this->getAccount($ownerAddress, $network);
+
+        return ! $account || ! $account->deployed;
+    }
+
+    /**
+     * Mark an account as deployed after successful deployment.
+     */
+    public function markDeployed(string $ownerAddress, string $network, string $txHash): void
+    {
+        $account = $this->getAccount($ownerAddress, $network);
+
+        if ($account) {
+            $account->markAsDeployed($txHash);
+
+            Log::info('Smart account marked as deployed', [
+                'account_address' => $account->account_address,
+                'network'         => $network,
+                'tx_hash'         => $txHash,
+            ]);
+        }
+    }
+
+    /**
+     * Increment the pending operations counter.
+     */
+    public function incrementPendingOps(string $ownerAddress, string $network): void
+    {
+        $account = $this->getAccount($ownerAddress, $network);
+        $account?->incrementPendingOps();
+    }
+
+    /**
+     * Process a completed operation (decrement pending, increment nonce).
+     */
+    public function processCompletedOp(string $ownerAddress, string $network): void
+    {
+        $account = $this->getAccount($ownerAddress, $network);
+
+        if ($account) {
+            $account->incrementNonce();
+            $account->decrementPendingOps();
+        }
+    }
+
+    /**
+     * Get supported networks.
+     *
+     * @return array<string>
+     */
+    public function getSupportedNetworks(): array
+    {
+        return $this->factory->getSupportedNetworks();
+    }
+
+    /**
+     * Validate that a network is supported.
+     *
+     * @throws SmartAccountException If network is invalid
+     */
+    private function validateNetwork(string $network): void
+    {
+        if (! $this->factory->supportsNetwork($network)) {
+            throw SmartAccountException::invalidNetwork($network);
+        }
+    }
+}

--- a/app/Http/Controllers/Api/Relayer/SmartAccountController.php
+++ b/app/Http/Controllers/Api/Relayer/SmartAccountController.php
@@ -1,0 +1,316 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Relayer;
+
+use App\Domain\Relayer\Exceptions\SmartAccountException;
+use App\Domain\Relayer\Services\SmartAccountService;
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Smart Account Controller.
+ *
+ * Handles ERC-4337 smart account creation and nonce management.
+ *
+ * @OA\Tag(
+ *     name="Smart Accounts",
+ *     description="ERC-4337 account abstraction management"
+ * )
+ */
+class SmartAccountController extends Controller
+{
+    public function __construct(
+        private readonly SmartAccountService $smartAccountService,
+    ) {
+    }
+
+    /**
+     * Create or retrieve a smart account.
+     *
+     * Returns the counterfactual smart account address for the given owner.
+     * The account is computed deterministically but not deployed on-chain
+     * until the first transaction.
+     *
+     * @OA\Post(
+     *     path="/api/v1/relayer/account",
+     *     summary="Create or retrieve a smart account",
+     *     tags={"Smart Accounts"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"owner_address", "network"},
+     *             @OA\Property(property="owner_address", type="string", example="0x742d35Cc6634C0532925a3b844Bc454e4438f44e"),
+     *             @OA\Property(property="network", type="string", enum={"polygon", "base", "arbitrum"}, example="polygon")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Smart account details",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="string", format="uuid"),
+     *                 @OA\Property(property="owner_address", type="string"),
+     *                 @OA\Property(property="account_address", type="string"),
+     *                 @OA\Property(property="network", type="string"),
+     *                 @OA\Property(property="deployed", type="boolean"),
+     *                 @OA\Property(property="nonce", type="integer"),
+     *                 @OA\Property(property="pending_ops", type="integer")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=400, description="Invalid request"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
+    public function createAccount(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'owner_address' => 'required|string|regex:/^0x[a-fA-F0-9]{40}$/',
+            'network'       => 'required|string|in:polygon,base,arbitrum',
+        ]);
+
+        try {
+            /** @var User $user */
+            $user = $request->user();
+
+            $account = $this->smartAccountService->getOrCreateAccount(
+                $user,
+                $validated['owner_address'],
+                $validated['network']
+            );
+
+            return response()->json([
+                'success' => true,
+                'data'    => $account->toApiResponse(),
+            ]);
+        } catch (SmartAccountException $e) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => $e->errorCode,
+                    'message' => $e->getMessage(),
+                ],
+            ], $e->httpStatusCode);
+        } catch (Throwable $e) {
+            Log::error('Smart account creation failed', [
+                'error'         => $e->getMessage(),
+                'owner_address' => $validated['owner_address'],
+            ]);
+
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'ERR_RELAYER_100',
+                    'message' => 'Failed to create smart account',
+                ],
+            ], 500);
+        }
+    }
+
+    /**
+     * Get nonce and pending operations for a smart account.
+     *
+     * @OA\Get(
+     *     path="/api/v1/relayer/nonce/{address}",
+     *     summary="Get nonce and pending ops for a smart account",
+     *     tags={"Smart Accounts"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="address",
+     *         in="path",
+     *         required=true,
+     *         description="Owner address (EOA)",
+     *         @OA\Schema(type="string", example="0x742d35Cc6634C0532925a3b844Bc454e4438f44e")
+     *     ),
+     *     @OA\Parameter(
+     *         name="network",
+     *         in="query",
+     *         required=true,
+     *         @OA\Schema(type="string", enum={"polygon", "base", "arbitrum"})
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Nonce information",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="nonce", type="integer", example=5),
+     *                 @OA\Property(property="pending_ops", type="integer", example=1),
+     *                 @OA\Property(property="deployed", type="boolean", example=true)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=400, description="Invalid request"),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Account not found")
+     * )
+     */
+    public function getNonce(Request $request, string $address): JsonResponse
+    {
+        // Validate address format
+        if (! preg_match('/^0x[a-fA-F0-9]{40}$/', $address)) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => SmartAccountException::CODE_INVALID_NETWORK,
+                    'message' => 'Invalid address format',
+                ],
+            ], 400);
+        }
+
+        $network = $request->query('network');
+        if (empty($network) || ! in_array($network, ['polygon', 'base', 'arbitrum'])) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => SmartAccountException::CODE_INVALID_NETWORK,
+                    'message' => 'Network parameter is required and must be polygon, base, or arbitrum',
+                ],
+            ], 400);
+        }
+
+        try {
+            $nonceInfo = $this->smartAccountService->getNonceInfo($address, $network);
+
+            return response()->json([
+                'success' => true,
+                'data'    => $nonceInfo,
+            ]);
+        } catch (SmartAccountException $e) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => $e->errorCode,
+                    'message' => $e->getMessage(),
+                ],
+            ], $e->httpStatusCode);
+        }
+    }
+
+    /**
+     * Get init code for a smart account deployment.
+     *
+     * Returns the init code needed to deploy the smart account on first transaction.
+     * Returns empty string if account is already deployed.
+     *
+     * @OA\Get(
+     *     path="/api/v1/relayer/init-code/{address}",
+     *     summary="Get init code for account deployment",
+     *     tags={"Smart Accounts"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="address",
+     *         in="path",
+     *         required=true,
+     *         description="Owner address (EOA)",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="network",
+     *         in="query",
+     *         required=true,
+     *         @OA\Schema(type="string", enum={"polygon", "base", "arbitrum"})
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Init code",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="init_code", type="string"),
+     *                 @OA\Property(property="needs_deployment", type="boolean")
+     *             )
+     *         )
+     *     )
+     * )
+     */
+    public function getInitCode(Request $request, string $address): JsonResponse
+    {
+        if (! preg_match('/^0x[a-fA-F0-9]{40}$/', $address)) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'INVALID_ADDRESS',
+                    'message' => 'Invalid address format',
+                ],
+            ], 400);
+        }
+
+        $network = $request->query('network');
+        if (empty($network) || ! in_array($network, ['polygon', 'base', 'arbitrum'])) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => SmartAccountException::CODE_INVALID_NETWORK,
+                    'message' => 'Network parameter is required',
+                ],
+            ], 400);
+        }
+
+        try {
+            $needsDeployment = $this->smartAccountService->needsInitCode($address, $network);
+            $initCode = $needsDeployment ? $this->smartAccountService->getInitCode($address, $network) : '';
+
+            return response()->json([
+                'success' => true,
+                'data'    => [
+                    'init_code'        => $initCode,
+                    'needs_deployment' => $needsDeployment,
+                ],
+            ]);
+        } catch (Throwable $e) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'ERR_RELAYER_100',
+                    'message' => $e->getMessage(),
+                ],
+            ], 400);
+        }
+    }
+
+    /**
+     * List user's smart accounts.
+     *
+     * @OA\Get(
+     *     path="/api/v1/relayer/accounts",
+     *     summary="List user's smart accounts",
+     *     tags={"Smart Accounts"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="List of smart accounts",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="array", @OA\Items(
+     *                 @OA\Property(property="id", type="string", format="uuid"),
+     *                 @OA\Property(property="owner_address", type="string"),
+     *                 @OA\Property(property="account_address", type="string"),
+     *                 @OA\Property(property="network", type="string"),
+     *                 @OA\Property(property="deployed", type="boolean")
+     *             ))
+     *         )
+     *     )
+     * )
+     */
+    public function listAccounts(Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        $accounts = $this->smartAccountService->getUserAccounts($user);
+
+        return response()->json([
+            'success' => true,
+            'data'    => $accounts->map(fn ($account) => $account->toApiResponse()),
+        ]);
+    }
+}

--- a/app/Providers/RelayerServiceProvider.php
+++ b/app/Providers/RelayerServiceProvider.php
@@ -6,14 +6,16 @@ namespace App\Providers;
 
 use App\Domain\Relayer\Contracts\BundlerInterface;
 use App\Domain\Relayer\Contracts\PaymasterInterface;
+use App\Domain\Relayer\Contracts\SmartAccountFactoryInterface;
 use App\Domain\Relayer\Services\DemoBundlerService;
 use App\Domain\Relayer\Services\DemoPaymasterService;
+use App\Domain\Relayer\Services\DemoSmartAccountFactory;
 use Illuminate\Support\ServiceProvider;
 
 /**
  * Service provider for the Relayer domain (ERC-4337 Gas Abstraction).
  *
- * Binds bundler and paymaster contracts to implementations.
+ * Binds bundler, paymaster, and smart account factory contracts to implementations.
  * In production, swap with real ERC-4337 bundler services like:
  * - Pimlico, Stackup, Alchemy Account Abstraction
  */
@@ -34,6 +36,12 @@ class RelayerServiceProvider extends ServiceProvider
         // For production, integrate with your actual paymaster contract
         $this->app->bind(PaymasterInterface::class, function ($app) {
             return new DemoPaymasterService();
+        });
+
+        // Bind the smart account factory interface (v2.6.0)
+        // For production, implement with actual factory contract calls
+        $this->app->bind(SmartAccountFactoryInterface::class, function ($app) {
+            return new DemoSmartAccountFactory();
         });
     }
 

--- a/config/relayer.php
+++ b/config/relayer.php
@@ -126,4 +126,43 @@ return [
         // Max sponsored value per user per day (in USD)
         'per_user_daily_value' => env('RELAYER_DAILY_VALUE_LIMIT', 1000),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Smart Account Configuration (v2.6.0)
+    |--------------------------------------------------------------------------
+    |
+    | Configuration for ERC-4337 smart account factories.
+    |
+    */
+
+    'smart_accounts' => [
+        // Factory contract addresses per network (SimpleAccountFactory or custom)
+        'factory_addresses' => [
+            'polygon'  => env('POLYGON_FACTORY_ADDRESS'),
+            'base'     => env('BASE_FACTORY_ADDRESS'),
+            'arbitrum' => env('ARBITRUM_FACTORY_ADDRESS'),
+        ],
+
+        // Paymaster contract addresses per network
+        'paymaster_addresses' => [
+            'polygon'  => env('POLYGON_PAYMASTER_ADDRESS'),
+            'base'     => env('BASE_PAYMASTER_ADDRESS'),
+            'arbitrum' => env('ARBITRUM_PAYMASTER_ADDRESS'),
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pimlico Integration (v2.6.0)
+    |--------------------------------------------------------------------------
+    |
+    | Configuration for Pimlico bundler service.
+    |
+    */
+
+    'pimlico' => [
+        'api_key'     => env('PIMLICO_API_KEY'),
+        'bundler_url' => env('PIMLICO_BUNDLER_URL'),
+    ],
 ];

--- a/database/migrations/2026_02_03_000002_create_smart_accounts_table.php
+++ b/database/migrations/2026_02_03_000002_create_smart_accounts_table.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Creates the smart_accounts table for ERC-4337 account abstraction.
+ *
+ * Smart accounts are counterfactual addresses computed from owner EOA + factory.
+ * The deployed flag tracks whether the account exists on-chain.
+ */
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('smart_accounts', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('user_id');
+            $table->string('owner_address', 42)->comment('EOA owner address with 0x prefix');
+            $table->string('account_address', 42)->comment('Smart account address with 0x prefix');
+            $table->string('network', 20);
+            $table->boolean('deployed')->default(false);
+            $table->string('deploy_tx_hash', 66)->nullable()->comment('Deployment transaction hash');
+            $table->unsignedBigInteger('nonce')->default(0)->comment('Next expected nonce');
+            $table->unsignedInteger('pending_ops')->default(0)->comment('Operations awaiting confirmation');
+            $table->timestamps();
+
+            // Unique constraint: one smart account per owner per network
+            $table->unique(['owner_address', 'network']);
+
+            // Indexes for lookups
+            $table->index('account_address');
+            $table->index(['network', 'deployed']);
+            $table->index('user_id');
+
+            $table->foreign('user_id')
+                ->references('id')
+                ->on('users')
+                ->cascadeOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('smart_accounts');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1148,6 +1148,7 @@ Route::prefix('webhooks/card-issuer')->name('api.webhooks.card.')
 */
 
 use App\Http\Controllers\Api\Relayer\RelayerController;
+use App\Http\Controllers\Api\Relayer\SmartAccountController;
 
 Route::prefix('v1/relayer')->name('api.relayer.')->group(function () {
     // Public endpoint for supported networks
@@ -1159,6 +1160,14 @@ Route::prefix('v1/relayer')->name('api.relayer.')->group(function () {
             ->middleware('transaction.rate_limit:relayer')
             ->name('sponsor');
         Route::post('/estimate', [RelayerController::class, 'estimate'])->name('estimate');
+
+        // Smart Account Management (v2.6.0)
+        Route::post('/account', [SmartAccountController::class, 'createAccount'])
+            ->middleware('transaction.rate_limit:relayer')
+            ->name('account.create');
+        Route::get('/accounts', [SmartAccountController::class, 'listAccounts'])->name('accounts.list');
+        Route::get('/nonce/{address}', [SmartAccountController::class, 'getNonce'])->name('nonce');
+        Route::get('/init-code/{address}', [SmartAccountController::class, 'getInitCode'])->name('init-code');
     });
 });
 

--- a/tests/Feature/Api/Relayer/SmartAccountControllerTest.php
+++ b/tests/Feature/Api/Relayer/SmartAccountControllerTest.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\Relayer;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class SmartAccountControllerTest extends TestCase
+{
+    protected User $user;
+
+    protected string $token;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+
+        $this->user = User::factory()->create();
+        $this->token = $this->user->createToken('test-token', ['read', 'write'])->plainTextToken;
+    }
+
+    public function test_create_account_requires_authentication(): void
+    {
+        $response = $this->postJson('/api/v1/relayer/account', [
+            'owner_address' => '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+            'network'       => 'polygon',
+        ]);
+
+        $response->assertUnauthorized();
+    }
+
+    public function test_create_account_validates_required_fields(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/relayer/account', []);
+
+        $response->assertUnprocessable();
+    }
+
+    public function test_create_account_validates_owner_address_format(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/relayer/account', [
+                'owner_address' => 'invalid',
+                'network'       => 'polygon',
+            ]);
+
+        $response->assertUnprocessable();
+    }
+
+    public function test_create_account_validates_network(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/relayer/account', [
+                'owner_address' => '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+                'network'       => 'invalid',
+            ]);
+
+        $response->assertUnprocessable();
+    }
+
+    public function test_create_account_returns_smart_account(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/relayer/account', [
+                'owner_address' => '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+                'network'       => 'polygon',
+            ]);
+
+        $response->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonStructure([
+                'success',
+                'data' => [
+                    'id',
+                    'owner_address',
+                    'account_address',
+                    'network',
+                    'deployed',
+                    'nonce',
+                    'pending_ops',
+                ],
+            ]);
+
+        $data = $response->json('data');
+        $this->assertEquals('polygon', $data['network']);
+        $this->assertFalse($data['deployed']);
+        $this->assertEquals(0, $data['nonce']);
+        $this->assertStringStartsWith('0x', $data['account_address']);
+    }
+
+    public function test_create_account_returns_existing_account(): void
+    {
+        $ownerAddress = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
+
+        // Create first account
+        $response1 = $this->withToken($this->token)
+            ->postJson('/api/v1/relayer/account', [
+                'owner_address' => $ownerAddress,
+                'network'       => 'polygon',
+            ]);
+
+        $accountId1 = $response1->json('data.id');
+
+        // Create again should return same account
+        $response2 = $this->withToken($this->token)
+            ->postJson('/api/v1/relayer/account', [
+                'owner_address' => $ownerAddress,
+                'network'       => 'polygon',
+            ]);
+
+        $accountId2 = $response2->json('data.id');
+
+        $this->assertEquals($accountId1, $accountId2);
+    }
+
+    public function test_create_account_creates_different_accounts_per_network(): void
+    {
+        $ownerAddress = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
+
+        $polygonResponse = $this->withToken($this->token)
+            ->postJson('/api/v1/relayer/account', [
+                'owner_address' => $ownerAddress,
+                'network'       => 'polygon',
+            ]);
+
+        $baseResponse = $this->withToken($this->token)
+            ->postJson('/api/v1/relayer/account', [
+                'owner_address' => $ownerAddress,
+                'network'       => 'base',
+            ]);
+
+        $this->assertNotEquals(
+            $polygonResponse->json('data.id'),
+            $baseResponse->json('data.id')
+        );
+    }
+
+    public function test_get_nonce_requires_authentication(): void
+    {
+        $response = $this->getJson('/api/v1/relayer/nonce/0x742d35Cc6634C0532925a3b844Bc454e4438f44e?network=polygon');
+
+        $response->assertUnauthorized();
+    }
+
+    public function test_get_nonce_requires_network_parameter(): void
+    {
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/relayer/nonce/0x742d35Cc6634C0532925a3b844Bc454e4438f44e');
+
+        $response->assertStatus(400)
+            ->assertJsonPath('error.code', 'ERR_RELAYER_105');
+    }
+
+    public function test_get_nonce_returns_404_for_unknown_account(): void
+    {
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/relayer/nonce/0x742d35Cc6634C0532925a3b844Bc454e4438f44e?network=polygon');
+
+        $response->assertNotFound()
+            ->assertJsonPath('error.code', 'ERR_RELAYER_102');
+    }
+
+    public function test_get_nonce_returns_nonce_info(): void
+    {
+        $ownerAddress = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
+
+        // Create account first
+        $this->withToken($this->token)
+            ->postJson('/api/v1/relayer/account', [
+                'owner_address' => $ownerAddress,
+                'network'       => 'polygon',
+            ]);
+
+        // Get nonce
+        $response = $this->withToken($this->token)
+            ->getJson("/api/v1/relayer/nonce/{$ownerAddress}?network=polygon");
+
+        $response->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonStructure([
+                'success',
+                'data' => [
+                    'nonce',
+                    'pending_ops',
+                    'deployed',
+                ],
+            ]);
+
+        $data = $response->json('data');
+        $this->assertEquals(0, $data['nonce']);
+        $this->assertEquals(0, $data['pending_ops']);
+        $this->assertFalse($data['deployed']);
+    }
+
+    public function test_get_init_code_returns_init_code_for_undeployed(): void
+    {
+        $ownerAddress = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
+
+        // Create account first
+        $this->withToken($this->token)
+            ->postJson('/api/v1/relayer/account', [
+                'owner_address' => $ownerAddress,
+                'network'       => 'polygon',
+            ]);
+
+        // Get init code
+        $response = $this->withToken($this->token)
+            ->getJson("/api/v1/relayer/init-code/{$ownerAddress}?network=polygon");
+
+        $response->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.needs_deployment', true);
+
+        $initCode = $response->json('data.init_code');
+        $this->assertNotEmpty($initCode);
+        $this->assertStringStartsWith('0x', $initCode);
+    }
+
+    public function test_list_accounts_returns_user_accounts(): void
+    {
+        $ownerAddress = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
+
+        // Create accounts on multiple networks
+        $this->withToken($this->token)
+            ->postJson('/api/v1/relayer/account', [
+                'owner_address' => $ownerAddress,
+                'network'       => 'polygon',
+            ]);
+
+        $this->withToken($this->token)
+            ->postJson('/api/v1/relayer/account', [
+                'owner_address' => $ownerAddress,
+                'network'       => 'base',
+            ]);
+
+        // List accounts
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/relayer/accounts');
+
+        $response->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonCount(2, 'data');
+    }
+
+    public function test_list_accounts_does_not_return_other_user_accounts(): void
+    {
+        // Create account for first user
+        $this->withToken($this->token)
+            ->postJson('/api/v1/relayer/account', [
+                'owner_address' => '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+                'network'       => 'polygon',
+            ]);
+
+        // Create second user and switch auth context using Sanctum::actingAs
+        // (withToken doesn't properly switch auth context mid-test)
+        $otherUser = User::factory()->create();
+        Sanctum::actingAs($otherUser, ['read', 'write']);
+
+        // List accounts as other user (should be empty)
+        $response = $this->getJson('/api/v1/relayer/accounts');
+
+        $response->assertOk()
+            ->assertJsonCount(0, 'data');
+    }
+}

--- a/tests/Unit/Domain/Relayer/Services/DemoSmartAccountFactoryTest.php
+++ b/tests/Unit/Domain/Relayer/Services/DemoSmartAccountFactoryTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Relayer\Services;
+
+use App\Domain\Relayer\Services\DemoSmartAccountFactory;
+use Illuminate\Support\Facades\Cache;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+class DemoSmartAccountFactoryTest extends TestCase
+{
+    private DemoSmartAccountFactory $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+        $this->factory = new DemoSmartAccountFactory();
+    }
+
+    public function test_get_supported_networks(): void
+    {
+        $networks = $this->factory->getSupportedNetworks();
+
+        $this->assertIsArray($networks);
+        $this->assertContains('polygon', $networks);
+        $this->assertContains('base', $networks);
+        $this->assertContains('arbitrum', $networks);
+    }
+
+    public function test_supports_network(): void
+    {
+        $this->assertTrue($this->factory->supportsNetwork('polygon'));
+        $this->assertTrue($this->factory->supportsNetwork('base'));
+        $this->assertTrue($this->factory->supportsNetwork('arbitrum'));
+        $this->assertFalse($this->factory->supportsNetwork('ethereum'));
+        $this->assertFalse($this->factory->supportsNetwork('invalid'));
+    }
+
+    public function test_compute_address_returns_valid_address(): void
+    {
+        $ownerAddress = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
+
+        $accountAddress = $this->factory->computeAddress($ownerAddress, 'polygon');
+
+        $this->assertStringStartsWith('0x', $accountAddress);
+        $this->assertEquals(42, strlen($accountAddress)); // 0x + 40 hex chars
+    }
+
+    public function test_compute_address_is_deterministic(): void
+    {
+        $ownerAddress = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
+
+        $address1 = $this->factory->computeAddress($ownerAddress, 'polygon');
+        $address2 = $this->factory->computeAddress($ownerAddress, 'polygon');
+
+        $this->assertEquals($address1, $address2);
+    }
+
+    public function test_compute_address_differs_by_network(): void
+    {
+        $ownerAddress = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
+
+        $polygonAddress = $this->factory->computeAddress($ownerAddress, 'polygon');
+        $baseAddress = $this->factory->computeAddress($ownerAddress, 'base');
+
+        // Addresses may be different due to different factory addresses
+        // In demo mode with same factories, they might be the same
+        $this->assertStringStartsWith('0x', $polygonAddress);
+        $this->assertStringStartsWith('0x', $baseAddress);
+    }
+
+    public function test_compute_address_differs_by_salt(): void
+    {
+        $ownerAddress = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
+
+        $address0 = $this->factory->computeAddress($ownerAddress, 'polygon', 0);
+        $address1 = $this->factory->computeAddress($ownerAddress, 'polygon', 1);
+
+        $this->assertNotEquals($address0, $address1);
+    }
+
+    public function test_compute_address_throws_for_invalid_owner(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid owner address');
+
+        $this->factory->computeAddress('invalid', 'polygon');
+    }
+
+    public function test_compute_address_throws_for_invalid_network(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported network');
+
+        $this->factory->computeAddress('0x742d35Cc6634C0532925a3b844Bc454e4438f44e', 'invalid');
+    }
+
+    public function test_get_init_code_returns_hex_string(): void
+    {
+        $ownerAddress = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
+
+        $initCode = $this->factory->getInitCode($ownerAddress, 'polygon');
+
+        $this->assertStringStartsWith('0x', $initCode);
+        $this->assertMatchesRegularExpression('/^0x[a-fA-F0-9]+$/', $initCode);
+    }
+
+    public function test_is_deployed_returns_false_by_default(): void
+    {
+        $accountAddress = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
+
+        $deployed = $this->factory->isDeployed($accountAddress, 'polygon');
+
+        $this->assertFalse($deployed);
+    }
+
+    public function test_mark_as_deployed_updates_status(): void
+    {
+        $accountAddress = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
+
+        $this->assertFalse($this->factory->isDeployed($accountAddress, 'polygon'));
+
+        $this->factory->markAsDeployed($accountAddress, 'polygon');
+
+        $this->assertTrue($this->factory->isDeployed($accountAddress, 'polygon'));
+    }
+
+    public function test_get_factory_address(): void
+    {
+        $address = $this->factory->getFactoryAddress('polygon');
+
+        $this->assertNotNull($address);
+        $this->assertStringStartsWith('0x', $address);
+        $this->assertEquals(42, strlen($address));
+    }
+
+    public function test_get_factory_address_returns_null_for_unsupported(): void
+    {
+        $address = $this->factory->getFactoryAddress('unsupported');
+
+        $this->assertNull($address);
+    }
+}


### PR DESCRIPTION
## Summary

Implements P0 Smart Account Management for v2.6.0 mobile ERC-4337 support:

- **SmartAccount model**: Tracks counterfactual addresses with UUID primary keys
- **SmartAccountFactoryInterface**: Contract for address computation and deployment tracking
- **DemoSmartAccountFactory**: Demo implementation with CREATE2-style deterministic addressing
- **SmartAccountService**: Account lifecycle management (create, nonce, init-code)
- **SmartAccountController**: RESTful API with full OpenAPI documentation

### API Endpoints

| Endpoint | Method | Description |
|----------|--------|-------------|
| `/api/v1/relayer/account` | POST | Create/retrieve smart account |
| `/api/v1/relayer/accounts` | GET | List user's smart accounts |
| `/api/v1/relayer/nonce/{address}` | GET | Get nonce + pending ops |
| `/api/v1/relayer/init-code/{address}` | GET | Get deployment init code |

### Error Codes

- `ERR_RELAYER_101`: Account already exists
- `ERR_RELAYER_102`: Account not found
- `ERR_RELAYER_103`: Deployment failed
- `ERR_RELAYER_104`: Nonce mismatch
- `ERR_RELAYER_105`: Invalid network

### Database Schema

```sql
CREATE TABLE smart_accounts (
    id UUID PRIMARY KEY,
    user_id UUID NOT NULL,
    owner_address VARCHAR(42),
    account_address VARCHAR(42),
    network VARCHAR(20),
    deployed BOOLEAN DEFAULT FALSE,
    deploy_tx_hash VARCHAR(66),
    nonce BIGINT DEFAULT 0,
    pending_ops INT DEFAULT 0,
    UNIQUE(owner_address, network)
);
```

## Test Plan

- [x] 13 unit tests for DemoSmartAccountFactory
- [x] 14 feature tests for SmartAccountController
- [x] User isolation verification (accounts not visible to other users)
- [x] Network validation tests
- [x] Authentication enforcement tests

## Related

- Blocks: PR #6 (Enhanced Relayer), PR #7 (UserOp Signing)
- Part of: v2.6.0 Mobile Backend Requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)