### PR TITLE
fix(security): Harden v2.6.0 UserOp signing before release

### DIFF
--- a/app/Domain/Relayer/Services/DemoSmartAccountFactory.php
+++ b/app/Domain/Relayer/Services/DemoSmartAccountFactory.php
@@ -39,21 +39,21 @@ class DemoSmartAccountFactory implements SmartAccountFactoryInterface
         // address = keccak256(0xff + factory + salt + keccak256(initCode))[12:]
         $initCodeHash = $this->computeInitCodeHash($ownerAddress, $salt);
         $factoryAddress = $this->getFactoryAddress($network);
-        
+
         if ($factoryAddress === null) {
             throw new InvalidArgumentException("No factory address for network: {$network}");
         }
-        
+
         $saltBytes = str_pad(dechex($salt), 64, '0', STR_PAD_LEFT);
 
         // Demo: compute a deterministic address
         $preImage = '0xff' . substr($factoryAddress, 2) . $saltBytes . $initCodeHash;
         $binaryData = hex2bin(substr($preImage, 2));
-        
+
         if ($binaryData === false) {
             throw new InvalidArgumentException('Invalid hex data for address computation');
         }
-        
+
         $hash = hash('sha3-256', $binaryData);
 
         return '0x' . substr($hash, 24); // Take last 20 bytes (40 hex chars)

--- a/app/Http/Controllers/Api/Auth/UserOpSigningController.php
+++ b/app/Http/Controllers/Api/Auth/UserOpSigningController.php
@@ -98,9 +98,11 @@ class UserOpSigningController extends Controller
     public function sign(Request $request): JsonResponse
     {
         $validated = $request->validate([
-            'user_op_hash'       => 'required|string|regex:/^0x[a-fA-F0-9]{64}$/',
-            'device_shard_proof' => 'required|string|regex:/^0x[a-fA-F0-9]+$/',
-            'biometric_token'    => 'required|string|min:32',
+            'user_op_hash' => 'required|string|regex:/^0x[a-fA-F0-9]{64}$/',
+            // ECDSA signatures are 65 bytes (130 hex chars) + 0x prefix = max 132 chars
+            // Allow up to 260 hex chars for flexibility with different signature schemes
+            'device_shard_proof' => 'required|string|regex:/^0x[a-fA-F0-9]{1,260}$/',
+            'biometric_token'    => 'required|string|min:32|max:2048',
         ]);
 
         /** @var \App\Models\User $user */

--- a/database/migrations/2026_02_03_000001_create_privacy_merkle_states_table.php
+++ b/database/migrations/2026_02_03_000001_create_privacy_merkle_states_table.php
@@ -12,8 +12,7 @@ use Illuminate\Support\Facades\Schema;
  * This table caches the current Merkle root and tree metadata for each supported
  * privacy pool network. Used for mobile client synchronization.
  */
-return new class extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */

--- a/routes/api.php
+++ b/routes/api.php
@@ -131,7 +131,9 @@ Route::prefix('auth')->middleware('api.rate_limit:auth')->group(function () {
         });
 
         // UserOperation signing with auth shard (v2.6.0)
+        // Rate limited: 10 requests per minute (additional service-level rate limiting applies)
         Route::post('/sign-userop', [App\Http\Controllers\Api\Auth\UserOpSigningController::class, 'sign'])
+            ->middleware('throttle:10,1')
             ->name('api.auth.sign-userop');
     });
 });

--- a/tests/Feature/Api/Auth/UserOpSigningControllerTest.php
+++ b/tests/Feature/Api/Auth/UserOpSigningControllerTest.php
@@ -173,18 +173,14 @@ class UserOpSigningControllerTest extends TestCase
             $response->assertStatus(200);
         }
 
-        // 11th request should be rate limited
+        // 11th request should be rate limited by route-level throttle middleware
+        // Returns 429 Too Many Requests (standard HTTP rate limiting status)
         $response = $this->actingAs($this->user)->postJson('/api/auth/sign-userop', [
             'user_op_hash'       => '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
             'device_shard_proof' => '0xabcdef1234567890',
             'biometric_token'    => str_repeat('a', 32),
         ]);
 
-        $response->assertStatus(400)
-            ->assertJson([
-                'success' => false,
-            ])
-            ->assertJsonPath('error.code', 'ERR_RELAYER_205')
-            ->assertJsonPath('error.message', 'Failed to sign UserOperation: Rate limit exceeded. Try again later.');
+        $response->assertStatus(429);
     }
 }


### PR DESCRIPTION
## Summary

Security hardening for v2.6.0 Mobile Backend based on comprehensive security review.

## Changes

### Security Improvements
- **Route-level rate limiting**: Added `throttle:10,1` middleware to `/sign-userop` endpoint
- **Input validation bounds**: Limited `device_shard_proof` to max 260 hex chars, `biometric_token` to max 2048 chars
- **Atomic rate limiting**: Fixed race condition using `Cache::increment()` instead of get/put pattern
- **Reduced logging exposure**: Hash hint reduced from 10 to 6 chars in logs

### Documentation
- Added comprehensive `@todo` annotations for production requirements
- Clear warnings that demo implementation is not for production use
- Documented HSM integration, JWT verification, and ECDSA signing needs

## Files Changed
- `app/Domain/Relayer/Services/UserOperationSigningService.php` - Rate limiting fix, TODO comments
- `app/Http/Controllers/Api/Auth/UserOpSigningController.php` - Validation bounds
- `routes/api.php` - Route-level throttle middleware
- `tests/Feature/Api/Auth/UserOpSigningControllerTest.php` - Updated for 429 status

## Test Plan
- [x] All existing tests pass (22 tests, 84 assertions)
- [x] PHPStan analysis passes
- [x] PHP-CS-Fixer passes
- [ ] CI pipeline passes

## Security Review Summary

Issues addressed:
| Severity | Issue | Fix |
|----------|-------|-----|
| HIGH | No route-level rate limiting | Added `throttle:10,1` |
| HIGH | Unbounded input length | Added max length validation |
| MEDIUM | Race condition in rate limiting | Use `Cache::increment()` |
| MEDIUM | Excessive hash logging | Reduced to 6 chars |

Deferred (documented with TODOs):
- CRITICAL: Proper biometric JWT verification (requires mobile attestation)
- CRITICAL: HSM-backed ECDSA signing (demo implementation clearly marked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)