### PR TITLE
fix(security): Address v2.6.0 security audit and quality issues

### DIFF
--- a/app/Domain/Relayer/Exceptions/UserOpSigningException.php
+++ b/app/Domain/Relayer/Exceptions/UserOpSigningException.php
@@ -22,12 +22,17 @@ class UserOpSigningException extends RuntimeException
 
     public const CODE_SIGNING_FAILED = 'ERR_RELAYER_205';
 
-    protected string $errorCode;
+    public const CODE_RATE_LIMITED = 'ERR_RELAYER_206';
 
-    public function __construct(string $message, string $errorCode, ?Throwable $previous = null)
+    public readonly string $errorCode;
+
+    public readonly int $httpStatusCode;
+
+    public function __construct(string $message, string $errorCode, int $httpStatusCode = 400, ?Throwable $previous = null)
     {
         parent::__construct($message, 0, $previous);
         $this->errorCode = $errorCode;
+        $this->httpStatusCode = $httpStatusCode;
     }
 
     public function getErrorCode(): string
@@ -42,7 +47,7 @@ class UserOpSigningException extends RuntimeException
             $message .= ": {$details}";
         }
 
-        return new self($message, self::CODE_INVALID_USER_OP_HASH);
+        return new self($message, self::CODE_INVALID_USER_OP_HASH, 400);
     }
 
     public static function invalidDeviceShard(string $details = ''): self
@@ -52,7 +57,7 @@ class UserOpSigningException extends RuntimeException
             $message .= ": {$details}";
         }
 
-        return new self($message, self::CODE_INVALID_DEVICE_SHARD);
+        return new self($message, self::CODE_INVALID_DEVICE_SHARD, 400);
     }
 
     public static function biometricVerificationFailed(string $details = ''): self
@@ -62,7 +67,7 @@ class UserOpSigningException extends RuntimeException
             $message .= ": {$details}";
         }
 
-        return new self($message, self::CODE_BIOMETRIC_FAILED);
+        return new self($message, self::CODE_BIOMETRIC_FAILED, 401);
     }
 
     public static function shardUnavailable(string $details = ''): self
@@ -72,7 +77,7 @@ class UserOpSigningException extends RuntimeException
             $message .= ": {$details}";
         }
 
-        return new self($message, self::CODE_SHARD_UNAVAILABLE);
+        return new self($message, self::CODE_SHARD_UNAVAILABLE, 503);
     }
 
     public static function signingFailed(string $details = ''): self
@@ -82,6 +87,16 @@ class UserOpSigningException extends RuntimeException
             $message .= ": {$details}";
         }
 
-        return new self($message, self::CODE_SIGNING_FAILED);
+        return new self($message, self::CODE_SIGNING_FAILED, 500);
+    }
+
+    public static function rateLimited(string $details = ''): self
+    {
+        $message = 'Rate limit exceeded for UserOperation signing';
+        if ($details !== '') {
+            $message .= ": {$details}";
+        }
+
+        return new self($message, self::CODE_RATE_LIMITED, 429);
     }
 }

--- a/app/Domain/Relayer/Services/GasStationService.php
+++ b/app/Domain/Relayer/Services/GasStationService.php
@@ -77,7 +77,7 @@ class GasStationService
         $feeAmount = $feeToken === 'USDC' ? $feeEstimate['fee_usdc'] : $feeEstimate['fee_usdt'];
 
         // 5. Check if user has sufficient balance
-        if (! $this->hassufficientBalance($userAddress, $feeToken, $feeAmount)) {
+        if (! $this->hasSufficientBalance($userAddress, $feeToken, $feeAmount)) {
             throw new RuntimeException("Insufficient {$feeToken} balance for gas fee");
         }
 

--- a/app/Http/Controllers/Api/Privacy/DelegatedProofController.php
+++ b/app/Http/Controllers/Api/Privacy/DelegatedProofController.php
@@ -64,11 +64,13 @@ class DelegatedProofController extends Controller
      */
     public function requestProof(Request $request): JsonResponse
     {
+        // Validate with size constraints to prevent DoS
         $validated = $request->validate([
             'proof_type'               => 'required|string|in:shield_1_1,unshield_2_1,transfer_2_2,proof_of_innocence',
             'network'                  => 'required|string|in:polygon,base,arbitrum',
-            'public_inputs'            => 'required|array',
-            'encrypted_private_inputs' => 'required|string',
+            'public_inputs'            => 'required|array|max:50', // Max 50 keys
+            'public_inputs.*'          => 'string|max:1000', // Each value max 1KB
+            'encrypted_private_inputs' => ['required', 'string', 'min:32', 'max:102400'], // Min 32 chars, max 100KB
         ]);
 
         try {

--- a/app/Http/Controllers/Api/Relayer/RelayerController.php
+++ b/app/Http/Controllers/Api/Relayer/RelayerController.php
@@ -72,13 +72,14 @@ class RelayerController extends Controller
      */
     public function sponsor(Request $request): JsonResponse
     {
+        // Max lengths: call_data 50KB (100000 hex chars), signature 132 chars (65 bytes), init_code 20KB
         $validated = $request->validate([
             'user_address' => 'required|string|regex:/^0x[a-fA-F0-9]{40}$/',
-            'call_data'    => 'required|string|regex:/^0x[a-fA-F0-9]*$/',
-            'signature'    => 'required|string|regex:/^0x[a-fA-F0-9]*$/',
+            'call_data'    => ['required', 'string', 'regex:/^0x[a-fA-F0-9]+$/', 'max:100002'],
+            'signature'    => ['required', 'string', 'regex:/^0x[a-fA-F0-9]+$/', 'min:4', 'max:1000'],
             'network'      => 'nullable|string|in:polygon,arbitrum,optimism,base,ethereum',
             'fee_token'    => 'nullable|string|in:USDC,USDT',
-            'init_code'    => 'nullable|string|regex:/^0x[a-fA-F0-9]*$/',
+            'init_code'    => ['nullable', 'string', 'regex:/^0x[a-fA-F0-9]+$/', 'max:40002'],
         ]);
 
         try {

--- a/tests/Unit/Domain/Relayer/Services/GasStationServiceTest.php
+++ b/tests/Unit/Domain/Relayer/Services/GasStationServiceTest.php
@@ -1,0 +1,364 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Relayer\Services;
+
+use App\Domain\Relayer\Contracts\BundlerInterface;
+use App\Domain\Relayer\Contracts\PaymasterInterface;
+use App\Domain\Relayer\Enums\SupportedNetwork;
+use App\Domain\Relayer\Services\GasStationService;
+use App\Domain\Relayer\ValueObjects\UserOperation;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Mockery;
+use Mockery\MockInterface;
+use RuntimeException;
+use Tests\TestCase;
+
+class GasStationServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private GasStationService $service;
+
+    private PaymasterInterface&MockInterface $paymaster;
+
+    private BundlerInterface&MockInterface $bundler;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Event::fake();
+
+        $this->paymaster = Mockery::mock(PaymasterInterface::class);
+        $this->bundler = Mockery::mock(BundlerInterface::class);
+        $this->service = new GasStationService($this->paymaster, $this->bundler);
+    }
+
+    public function test_sponsors_transaction_successfully(): void
+    {
+        $userAddress = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
+        $callData = '0xabcdef1234567890';
+        $signature = '0x1234567890abcdef';
+        $network = SupportedNetwork::POLYGON;
+
+        $this->bundler->shouldReceive('estimateUserOperationGas')
+            ->once()
+            ->andReturn([
+                'callGasLimit'         => 100000,
+                'verificationGasLimit' => 50000,
+                'preVerificationGas'   => 21000,
+            ]);
+
+        $this->paymaster->shouldReceive('estimateFee')
+            ->once()
+            ->andReturn([
+                'gas_estimate' => 150000,
+                'fee_usdc'     => 0.05,
+                'fee_usdt'     => 0.05,
+            ]);
+
+        $this->paymaster->shouldReceive('getPaymasterData')
+            ->once()
+            ->andReturn('0xpaymasterdata');
+
+        $this->bundler->shouldReceive('submitUserOperation')
+            ->once()
+            ->andReturn('0xuseroperationhash123456789');
+
+        $result = $this->service->sponsorTransaction(
+            userAddress: $userAddress,
+            callData: $callData,
+            signature: $signature,
+            network: $network,
+            feeToken: 'USDC'
+        );
+
+        $this->assertArrayHasKey('user_op_hash', $result);
+        $this->assertArrayHasKey('fee_charged', $result);
+        $this->assertArrayHasKey('fee_currency', $result);
+        $this->assertArrayHasKey('is_deployment', $result);
+        $this->assertFalse($result['is_deployment']);
+        $this->assertEquals('USDC', $result['fee_currency']);
+    }
+
+    public function test_sponsors_deployment_transaction(): void
+    {
+        $userAddress = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
+        $callData = '0xabcdef1234567890';
+        $signature = '0x1234567890abcdef';
+        $initCode = '0xabcdef1234567890abcdef12';
+        $network = SupportedNetwork::POLYGON;
+
+        $this->bundler->shouldReceive('estimateUserOperationGas')
+            ->once()
+            ->andReturn([
+                'callGasLimit'         => 200000,
+                'verificationGasLimit' => 100000,
+                'preVerificationGas'   => 50000,
+            ]);
+
+        $this->paymaster->shouldReceive('estimateFee')
+            ->once()
+            ->andReturn([
+                'gas_estimate' => 350000,
+                'fee_usdc'     => 0.15,
+                'fee_usdt'     => 0.15,
+            ]);
+
+        $this->paymaster->shouldReceive('getPaymasterData')
+            ->once()
+            ->andReturn('0xpaymasterdata');
+
+        $this->bundler->shouldReceive('submitUserOperation')
+            ->once()
+            ->andReturn('0xuseroperationhash123456789');
+
+        $result = $this->service->sponsorTransaction(
+            userAddress: $userAddress,
+            callData: $callData,
+            signature: $signature,
+            network: $network,
+            feeToken: 'USDC',
+            initCode: $initCode
+        );
+
+        $this->assertTrue($result['is_deployment']);
+    }
+
+    public function test_rejects_invalid_init_code_format(): void
+    {
+        $userAddress = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
+        $callData = '0xabcdef1234567890';
+        $signature = '0x1234567890abcdef';
+        $invalidInitCode = 'not_valid_hex'; // Missing 0x prefix and not valid hex
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid initCode format');
+
+        $this->service->sponsorTransaction(
+            userAddress: $userAddress,
+            callData: $callData,
+            signature: $signature,
+            initCode: $invalidInitCode
+        );
+    }
+
+    public function test_empty_init_code_is_not_treated_as_deployment(): void
+    {
+        $userAddress = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
+        $callData = '0xabcdef1234567890';
+        $signature = '0x1234567890abcdef';
+
+        $this->bundler->shouldReceive('estimateUserOperationGas')
+            ->once()
+            ->andReturn([
+                'callGasLimit'         => 100000,
+                'verificationGasLimit' => 50000,
+                'preVerificationGas'   => 21000,
+            ]);
+
+        $this->paymaster->shouldReceive('estimateFee')
+            ->once()
+            ->andReturn([
+                'gas_estimate' => 150000,
+                'fee_usdc'     => 0.05,
+                'fee_usdt'     => 0.05,
+            ]);
+
+        $this->paymaster->shouldReceive('getPaymasterData')
+            ->once()
+            ->andReturn('0xpaymasterdata');
+
+        $this->bundler->shouldReceive('submitUserOperation')
+            ->once()
+            ->andReturn('0xuseroperationhash');
+
+        // Empty string should NOT be treated as deployment
+        $result = $this->service->sponsorTransaction(
+            userAddress: $userAddress,
+            callData: $callData,
+            signature: $signature,
+            initCode: ''
+        );
+
+        $this->assertFalse($result['is_deployment']);
+    }
+
+    public function test_estimates_fee_for_transaction(): void
+    {
+        $callData = '0xabcdef1234567890';
+        $network = SupportedNetwork::POLYGON;
+
+        $this->paymaster->shouldReceive('estimateFee')
+            ->once()
+            ->with($callData, $network)
+            ->andReturn([
+                'gas_estimate' => 150000,
+                'fee_usdc'     => 0.05,
+                'fee_usdt'     => 0.05,
+            ]);
+
+        $result = $this->service->estimateFee($callData, $network);
+
+        $this->assertArrayHasKey('estimated_gas', $result);
+        $this->assertArrayHasKey('fee_usdc', $result);
+        $this->assertArrayHasKey('fee_usdt', $result);
+        $this->assertArrayHasKey('network', $result);
+        $this->assertEquals(150000, $result['estimated_gas']);
+        $this->assertEquals('polygon', $result['network']);
+    }
+
+    public function test_returns_supported_networks(): void
+    {
+        $networks = $this->service->getSupportedNetworks();
+
+        $this->assertIsArray($networks);
+        $this->assertNotEmpty($networks);
+
+        foreach ($networks as $network) {
+            $this->assertArrayHasKey('chain_id', $network);
+            $this->assertArrayHasKey('name', $network);
+            $this->assertArrayHasKey('entrypoint_address', $network);
+            $this->assertArrayHasKey('factory_address', $network);
+            $this->assertArrayHasKey('paymaster_address', $network);
+            $this->assertArrayHasKey('current_gas_price', $network);
+            $this->assertArrayHasKey('average_fee_usdc', $network);
+            $this->assertArrayHasKey('congestion_level', $network);
+            $this->assertArrayHasKey('fee_token', $network);
+
+            // Validate chain IDs
+            $this->assertIsInt($network['chain_id']);
+            $this->assertGreaterThan(0, $network['chain_id']);
+
+            // Validate addresses are hex format
+            $this->assertStringStartsWith('0x', $network['entrypoint_address']);
+        }
+    }
+
+    public function test_supports_usdt_fee_token(): void
+    {
+        $userAddress = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
+        $callData = '0xabcdef1234567890';
+        $signature = '0x1234567890abcdef';
+
+        $this->bundler->shouldReceive('estimateUserOperationGas')
+            ->once()
+            ->andReturn([
+                'callGasLimit'         => 100000,
+                'verificationGasLimit' => 50000,
+                'preVerificationGas'   => 21000,
+            ]);
+
+        $this->paymaster->shouldReceive('estimateFee')
+            ->once()
+            ->andReturn([
+                'gas_estimate' => 150000,
+                'fee_usdc'     => 0.05,
+                'fee_usdt'     => 0.06,
+            ]);
+
+        $this->paymaster->shouldReceive('getPaymasterData')
+            ->once()
+            ->andReturn('0xpaymasterdata');
+
+        $this->bundler->shouldReceive('submitUserOperation')
+            ->once()
+            ->andReturn('0xuseroperationhash');
+
+        $result = $this->service->sponsorTransaction(
+            userAddress: $userAddress,
+            callData: $callData,
+            signature: $signature,
+            feeToken: 'USDT'
+        );
+
+        $this->assertEquals('USDT', $result['fee_currency']);
+        $this->assertEquals('0.060000', $result['fee_charged']);
+    }
+
+    public function test_works_with_different_networks(): void
+    {
+        $userAddress = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
+        $callData = '0xabcdef1234567890';
+        $signature = '0x1234567890abcdef';
+
+        foreach ([SupportedNetwork::POLYGON, SupportedNetwork::ARBITRUM, SupportedNetwork::BASE] as $network) {
+            $this->bundler->shouldReceive('estimateUserOperationGas')
+                ->once()
+                ->andReturn([
+                    'callGasLimit'         => 100000,
+                    'verificationGasLimit' => 50000,
+                    'preVerificationGas'   => 21000,
+                ]);
+
+            $this->paymaster->shouldReceive('estimateFee')
+                ->once()
+                ->andReturn([
+                    'gas_estimate' => 150000,
+                    'fee_usdc'     => 0.05,
+                    'fee_usdt'     => 0.05,
+                ]);
+
+            $this->paymaster->shouldReceive('getPaymasterData')
+                ->once()
+                ->andReturn('0xpaymasterdata');
+
+            $this->bundler->shouldReceive('submitUserOperation')
+                ->once()
+                ->andReturn('0xuseroperationhash');
+
+            $result = $this->service->sponsorTransaction(
+                userAddress: $userAddress,
+                callData: $callData,
+                signature: $signature,
+                network: $network
+            );
+
+            $this->assertArrayHasKey('user_op_hash', $result);
+        }
+    }
+
+    public function test_only_0x_init_code_is_not_treated_as_deployment(): void
+    {
+        $userAddress = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
+        $callData = '0xabcdef1234567890';
+        $signature = '0x1234567890abcdef';
+
+        $this->bundler->shouldReceive('estimateUserOperationGas')
+            ->once()
+            ->andReturn([
+                'callGasLimit'         => 100000,
+                'verificationGasLimit' => 50000,
+                'preVerificationGas'   => 21000,
+            ]);
+
+        $this->paymaster->shouldReceive('estimateFee')
+            ->once()
+            ->andReturn([
+                'gas_estimate' => 150000,
+                'fee_usdc'     => 0.05,
+                'fee_usdt'     => 0.05,
+            ]);
+
+        $this->paymaster->shouldReceive('getPaymasterData')
+            ->once()
+            ->andReturn('0xpaymasterdata');
+
+        $this->bundler->shouldReceive('submitUserOperation')
+            ->once()
+            ->andReturn('0xuseroperationhash');
+
+        // "0x" alone should NOT be treated as deployment
+        $result = $this->service->sponsorTransaction(
+            userAddress: $userAddress,
+            callData: $callData,
+            signature: $signature,
+            initCode: '0x'
+        );
+
+        $this->assertFalse($result['is_deployment']);
+    }
+}

--- a/tests/Unit/Domain/Relayer/Services/SmartAccountServiceTest.php
+++ b/tests/Unit/Domain/Relayer/Services/SmartAccountServiceTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Relayer\Services;
+
+use App\Domain\Relayer\Contracts\SmartAccountFactoryInterface;
+use App\Domain\Relayer\Exceptions\SmartAccountException;
+use App\Domain\Relayer\Models\SmartAccount;
+use App\Domain\Relayer\Services\SmartAccountService;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Mockery\MockInterface;
+use Tests\TestCase;
+
+class SmartAccountServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private SmartAccountService $service;
+
+    private SmartAccountFactoryInterface&MockInterface $factory;
+
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = Mockery::mock(SmartAccountFactoryInterface::class);
+        $this->service = new SmartAccountService($this->factory);
+        $this->user = User::factory()->create();
+    }
+
+    public function test_creates_new_account_when_none_exists(): void
+    {
+        $ownerAddress = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
+        $accountAddress = '0x1234567890abcdef1234567890abcdef12345678';
+        $network = 'polygon';
+
+        $this->factory->shouldReceive('supportsNetwork')
+            ->with($network)
+            ->andReturn(true);
+
+        $this->factory->shouldReceive('computeAddress')
+            ->once()
+            ->with($ownerAddress, $network)
+            ->andReturn($accountAddress);
+
+        $account = $this->service->getOrCreateAccount($this->user, $ownerAddress, $network);
+
+        $this->assertInstanceOf(SmartAccount::class, $account);
+        $this->assertEquals(strtolower($ownerAddress), $account->owner_address);
+        $this->assertEquals(strtolower($accountAddress), $account->account_address);
+        $this->assertEquals($network, $account->network);
+        $this->assertFalse($account->deployed);
+        $this->assertEquals(0, $account->nonce);
+        $this->assertEquals(0, $account->pending_ops);
+    }
+
+    public function test_returns_existing_account(): void
+    {
+        $ownerAddress = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
+        $network = 'polygon';
+
+        // Pre-create an account
+        $existingAccount = SmartAccount::create([
+            'user_id'         => $this->user->id,
+            'owner_address'   => strtolower($ownerAddress),
+            'account_address' => '0x1234567890abcdef1234567890abcdef12345678',
+            'network'         => $network,
+            'deployed'        => false,
+            'nonce'           => 0,
+            'pending_ops'     => 0,
+        ]);
+
+        // Factory should check network support but NOT compute address for existing account
+        $this->factory->shouldReceive('supportsNetwork')
+            ->with($network)
+            ->andReturn(true);
+        $this->factory->shouldNotReceive('computeAddress');
+
+        $account = $this->service->getOrCreateAccount($this->user, $ownerAddress, $network);
+
+        $this->assertEquals($existingAccount->id, $account->id);
+    }
+
+    public function test_normalizes_owner_address_to_lowercase(): void
+    {
+        $ownerAddress = '0x742D35CC6634C0532925A3B844BC454E4438F44E'; // Mixed case
+        $network = 'polygon';
+
+        $this->factory->shouldReceive('supportsNetwork')
+            ->with($network)
+            ->andReturn(true);
+
+        $this->factory->shouldReceive('computeAddress')
+            ->once()
+            ->andReturn('0x1234567890abcdef1234567890abcdef12345678');
+
+        $account = $this->service->getOrCreateAccount($this->user, $ownerAddress, $network);
+
+        $this->assertEquals(strtolower($ownerAddress), $account->owner_address);
+    }
+
+    public function test_increments_pending_ops(): void
+    {
+        $ownerAddress = '0x742d35cc6634c0532925a3b844bc454e4438f44e';
+        $network = 'polygon';
+
+        $account = SmartAccount::create([
+            'user_id'         => $this->user->id,
+            'owner_address'   => $ownerAddress,
+            'account_address' => '0x1234567890abcdef1234567890abcdef12345678',
+            'network'         => $network,
+            'deployed'        => false,
+            'nonce'           => 0,
+            'pending_ops'     => 0,
+        ]);
+
+        $this->service->incrementPendingOps($ownerAddress, $network);
+
+        $account->refresh();
+        $this->assertEquals(1, $account->pending_ops);
+    }
+
+    public function test_processes_completed_op(): void
+    {
+        $ownerAddress = '0x742d35cc6634c0532925a3b844bc454e4438f44e';
+        $network = 'polygon';
+
+        $account = SmartAccount::create([
+            'user_id'         => $this->user->id,
+            'owner_address'   => $ownerAddress,
+            'account_address' => '0x1234567890abcdef1234567890abcdef12345678',
+            'network'         => $network,
+            'deployed'        => false,
+            'nonce'           => 0,
+            'pending_ops'     => 2,
+        ]);
+
+        $this->service->processCompletedOp($ownerAddress, $network);
+
+        $account->refresh();
+        $this->assertEquals(1, $account->nonce);
+        $this->assertEquals(1, $account->pending_ops);
+    }
+
+    public function test_marks_account_as_deployed(): void
+    {
+        $ownerAddress = '0x742d35cc6634c0532925a3b844bc454e4438f44e';
+        $accountAddress = '0x1234567890abcdef1234567890abcdef12345678';
+        $network = 'polygon';
+        $txHash = '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab';
+
+        $account = SmartAccount::create([
+            'user_id'         => $this->user->id,
+            'owner_address'   => $ownerAddress,
+            'account_address' => $accountAddress,
+            'network'         => $network,
+            'deployed'        => false,
+            'nonce'           => 0,
+            'pending_ops'     => 0,
+        ]);
+
+        // markDeployed uses owner address, not account address
+        $this->service->markDeployed($ownerAddress, $network, $txHash);
+
+        $account->refresh();
+        $this->assertTrue($account->deployed);
+        $this->assertEquals($txHash, $account->deploy_tx_hash);
+    }
+
+    public function test_get_nonce_info_returns_account_state(): void
+    {
+        $ownerAddress = '0x742d35cc6634c0532925a3b844bc454e4438f44e';
+        $network = 'polygon';
+
+        SmartAccount::create([
+            'user_id'         => $this->user->id,
+            'owner_address'   => $ownerAddress,
+            'account_address' => '0x1234567890abcdef1234567890abcdef12345678',
+            'network'         => $network,
+            'deployed'        => true,
+            'nonce'           => 5,
+            'pending_ops'     => 2,
+        ]);
+
+        $info = $this->service->getNonceInfo($ownerAddress, $network);
+
+        $this->assertEquals(5, $info['nonce']);
+        $this->assertEquals(2, $info['pending_ops']);
+        $this->assertTrue($info['deployed']);
+    }
+
+    public function test_throws_exception_when_account_not_found_for_nonce(): void
+    {
+        $this->expectException(SmartAccountException::class);
+
+        $this->service->getNonceInfo(
+            '0x0000000000000000000000000000000000000000',
+            'polygon'
+        );
+    }
+
+    public function test_creates_accounts_for_different_networks(): void
+    {
+        $ownerAddress = '0x742d35cc6634c0532925a3b844bc454e4438f44e';
+
+        $this->factory->shouldReceive('supportsNetwork')
+            ->andReturn(true);
+
+        $this->factory->shouldReceive('computeAddress')
+            ->twice()
+            ->andReturn(
+                '0x1111111111111111111111111111111111111111',
+                '0x2222222222222222222222222222222222222222'
+            );
+
+        $polygonAccount = $this->service->getOrCreateAccount($this->user, $ownerAddress, 'polygon');
+        $baseAccount = $this->service->getOrCreateAccount($this->user, $ownerAddress, 'base');
+
+        $this->assertNotEquals($polygonAccount->id, $baseAccount->id);
+        $this->assertEquals('polygon', $polygonAccount->network);
+        $this->assertEquals('base', $baseAccount->network);
+    }
+
+    public function test_pending_ops_does_not_go_below_zero(): void
+    {
+        $ownerAddress = '0x742d35cc6634c0532925a3b844bc454e4438f44e';
+        $network = 'polygon';
+
+        $account = SmartAccount::create([
+            'user_id'         => $this->user->id,
+            'owner_address'   => $ownerAddress,
+            'account_address' => '0x1234567890abcdef1234567890abcdef12345678',
+            'network'         => $network,
+            'deployed'        => false,
+            'nonce'           => 0,
+            'pending_ops'     => 0,
+        ]);
+
+        // Try to decrement when already at 0
+        $account->decrementPendingOps();
+        $account->refresh();
+
+        $this->assertEquals(0, $account->pending_ops);
+    }
+}


### PR DESCRIPTION
## Summary
This PR addresses security and code quality issues identified during the v2.6.0 review.

### Security Fixes
- **Fixed method typo**: `hassufficientBalance` → `hasSufficientBalance` in GasStationService (was causing call to undefined method)
- **Input validation with max lengths**: Prevent DoS via oversized payloads
  - `call_data`: max 100KB (100002 chars)
  - `signature`: max 1KB, min 4 chars
  - `init_code`: max 40KB
  - `public_inputs`: max 50 keys, each value max 1KB
  - `encrypted_private_inputs`: min 32 chars, max 100KB
- **Fixed rate limiting race condition**: Replaced manual Cache increment with Laravel's atomic RateLimiter
- **Added HTTP status codes**: `UserOpSigningException` now includes proper HTTP status codes for consistent error handling

### Code Quality
- Added `ERR_RELAYER_206` rate limit error code
- Made `$errorCode` and `$httpStatusCode` readonly in `UserOpSigningException`

### Test Coverage
- Added `SmartAccountServiceTest` (10 test cases)
- Added `GasStationServiceTest` (9 test cases)
- Total Relayer domain tests: 24 → 43 (+19 tests)

## Test plan
- [x] All Relayer domain tests pass (43 tests)
- [x] PHPStan passes (Level 8)
- [x] PHP-CS-Fixer passes

## Files Changed
- `app/Domain/Relayer/Exceptions/UserOpSigningException.php`
- `app/Domain/Relayer/Services/GasStationService.php`
- `app/Domain/Relayer/Services/UserOperationSigningService.php`
- `app/Http/Controllers/Api/Privacy/DelegatedProofController.php`
- `app/Http/Controllers/Api/Relayer/RelayerController.php`
- `tests/Unit/Domain/Relayer/Services/GasStationServiceTest.php` (new)
- `tests/Unit/Domain/Relayer/Services/SmartAccountServiceTest.php` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)