### PR TITLE
feat(hsm): Add ECDSA signing support to HSM infrastructure (v2.7.0 PR #1)

### DIFF
--- a/app/Domain/KeyManagement/Contracts/HsmProviderInterface.php
+++ b/app/Domain/KeyManagement/Contracts/HsmProviderInterface.php
@@ -40,4 +40,31 @@ interface HsmProviderInterface
      * Get provider name.
      */
     public function getProviderName(): string;
+
+    /**
+     * Sign data using ECDSA with secp256k1 curve.
+     *
+     * @param  string  $messageHash  32-byte hash to sign (hex with 0x prefix)
+     * @param  string  $keyId  Key identifier in HSM
+     * @return string ECDSA signature in compact format (r || s || v, 65 bytes, hex with 0x prefix)
+     */
+    public function sign(string $messageHash, string $keyId): string;
+
+    /**
+     * Verify an ECDSA signature.
+     *
+     * @param  string  $messageHash  32-byte hash that was signed (hex with 0x prefix)
+     * @param  string  $signature  ECDSA signature (hex with 0x prefix)
+     * @param  string  $publicKey  Public key to verify against (hex with 0x prefix)
+     * @return bool True if signature is valid
+     */
+    public function verify(string $messageHash, string $signature, string $publicKey): bool;
+
+    /**
+     * Get the public key for a signing key.
+     *
+     * @param  string  $keyId  Key identifier in HSM
+     * @return string Public key (hex with 0x prefix, 64 bytes uncompressed or 33 bytes compressed)
+     */
+    public function getPublicKey(string $keyId): string;
 }

--- a/app/Domain/KeyManagement/HSM/DemoHsmProvider.php
+++ b/app/Domain/KeyManagement/HSM/DemoHsmProvider.php
@@ -93,4 +93,73 @@ class DemoHsmProvider implements HsmProviderInterface
     {
         return 'demo';
     }
+
+    /**
+     * Sign data using demo ECDSA simulation.
+     *
+     * WARNING: This produces a DETERMINISTIC signature that will NOT verify on-chain.
+     * Use only for testing/development. Production must use actual HSM.
+     *
+     * @todo PRODUCTION: Replace with actual HSM secp256k1 signing
+     */
+    public function sign(string $messageHash, string $keyId): string
+    {
+        // Validate input is 32-byte hex with 0x prefix
+        if (! preg_match('/^0x[a-fA-F0-9]{64}$/', $messageHash)) {
+            throw new RuntimeException('Invalid message hash format. Expected 32-byte hex with 0x prefix.');
+        }
+
+        // Demo: Generate deterministic "signature" from message hash and key ID
+        // This is NOT a real ECDSA signature and will NOT verify on-chain
+        $sigInput = $messageHash . $keyId . self::DEMO_KEY;
+
+        // Create fake r, s values (each 32 bytes)
+        $r = hash('sha256', 'r_component_' . $sigInput);
+        $s = hash('sha256', 's_component_' . $sigInput);
+
+        // v is recovery id (27 or 28 for Ethereum, here we use 0x1b = 27)
+        $v = '1b';
+
+        return '0x' . $r . $s . $v;
+    }
+
+    /**
+     * Verify an ECDSA signature.
+     *
+     * Demo implementation always returns true for non-empty signatures.
+     *
+     * @todo PRODUCTION: Implement actual ECDSA verification with secp256k1
+     */
+    public function verify(string $messageHash, string $signature, string $publicKey): bool
+    {
+        // Validate inputs
+        if (! preg_match('/^0x[a-fA-F0-9]{64}$/', $messageHash)) {
+            return false;
+        }
+
+        if (! preg_match('/^0x[a-fA-F0-9]+$/', $signature)) {
+            return false;
+        }
+
+        // Demo: Accept any well-formed signature
+        // Production would actually verify the ECDSA signature
+        return strlen($signature) >= 130; // 0x + 64 (r) + 64 (s) + 2 (v) = 132 chars minimum
+    }
+
+    /**
+     * Get the public key for a signing key.
+     *
+     * Demo implementation returns a deterministic fake public key.
+     *
+     * @todo PRODUCTION: Return actual public key from HSM
+     */
+    public function getPublicKey(string $keyId): string
+    {
+        // Demo: Generate deterministic public key from key ID
+        $pubKeyHash = hash('sha256', 'public_key_' . $keyId . self::DEMO_KEY);
+
+        // Return as compressed public key format (33 bytes = 66 hex chars)
+        // First byte 02 or 03 indicates even/odd y coordinate
+        return '0x02' . substr($pubKeyHash, 0, 64);
+    }
 }

--- a/app/Domain/KeyManagement/HSM/HsmIntegrationService.php
+++ b/app/Domain/KeyManagement/HSM/HsmIntegrationService.php
@@ -61,6 +61,48 @@ class HsmIntegrationService
         return $this->provider->getProviderName();
     }
 
+    /**
+     * Sign a message hash using ECDSA with secp256k1.
+     *
+     * @param  string  $messageHash  32-byte hash to sign (hex with 0x prefix)
+     * @param  string|null  $keyId  Optional key ID (defaults to configured key)
+     * @return string ECDSA signature in compact format (hex with 0x prefix)
+     */
+    public function sign(string $messageHash, ?string $keyId = null): string
+    {
+        $this->ensureAvailable();
+
+        return $this->provider->sign($messageHash, $keyId ?? $this->getSigningKeyId());
+    }
+
+    /**
+     * Verify an ECDSA signature.
+     *
+     * @param  string  $messageHash  32-byte hash that was signed (hex with 0x prefix)
+     * @param  string  $signature  ECDSA signature (hex with 0x prefix)
+     * @param  string  $publicKey  Public key to verify against (hex with 0x prefix)
+     * @return bool True if signature is valid
+     */
+    public function verify(string $messageHash, string $signature, string $publicKey): bool
+    {
+        $this->ensureAvailable();
+
+        return $this->provider->verify($messageHash, $signature, $publicKey);
+    }
+
+    /**
+     * Get the public key for signing operations.
+     *
+     * @param  string|null  $keyId  Optional key ID (defaults to configured key)
+     * @return string Public key (hex with 0x prefix)
+     */
+    public function getPublicKey(?string $keyId = null): string
+    {
+        $this->ensureAvailable();
+
+        return $this->provider->getPublicKey($keyId ?? $this->getSigningKeyId());
+    }
+
     private function resolveProvider(): HsmProviderInterface
     {
         $providerType = config('keymanagement.hsm.provider', 'demo');
@@ -76,6 +118,11 @@ class HsmIntegrationService
     private function getKeyId(): string
     {
         return config('keymanagement.hsm.key_id', 'default');
+    }
+
+    private function getSigningKeyId(): string
+    {
+        return config('keymanagement.hsm.signing_key_id', 'signing-default');
     }
 
     private function ensureAvailable(): void

--- a/tests/Unit/Domain/Relayer/Services/UserOperationSigningServiceTest.php
+++ b/tests/Unit/Domain/Relayer/Services/UserOperationSigningServiceTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Domain\Relayer\Services;
 
+use App\Domain\KeyManagement\HSM\HsmIntegrationService;
 use App\Domain\Relayer\Exceptions\UserOpSigningException;
 use App\Domain\Relayer\Services\UserOperationSigningService;
 use App\Models\User;
 use DateTimeInterface;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\RateLimiter;
 use Tests\TestCase;
 
 class UserOperationSigningServiceTest extends TestCase
@@ -23,7 +25,11 @@ class UserOperationSigningServiceTest extends TestCase
         parent::setUp();
 
         Cache::flush();
-        $this->service = new UserOperationSigningService();
+        RateLimiter::clear('userop_signing:' . ($this->user->id ?? ''));
+
+        // Create service with HSM integration
+        $hsm = new HsmIntegrationService();
+        $this->service = new UserOperationSigningService($hsm);
         $this->user ??= User::factory()->create();
     }
 


### PR DESCRIPTION
## Summary
This PR adds ECDSA signing capabilities to the HSM infrastructure, enabling secure UserOperation signing for ERC-4337 account abstraction.

### New HSM Methods
- `sign(messageHash, keyId)` - Sign with secp256k1 ECDSA
- `verify(messageHash, signature, publicKey)` - Verify signature
- `getPublicKey(keyId)` - Get signing public key

### Changes
- **HsmProviderInterface**: Added signing methods to contract
- **DemoHsmProvider**: Demo ECDSA signing implementation (deterministic, NOT for production)
- **HsmIntegrationService**: Exposed signing operations
- **UserOperationSigningService**: Refactored to use HSM for cryptographic operations

### Production Configuration
```env
HSM_PROVIDER=aws|azure|hashicorp  # demo for development
HSM_SIGNING_KEY_ID=your-key-id
```

### Demo vs Production
| Feature | Demo Mode | Production |
|---------|-----------|------------|
| Signatures | Deterministic SHA256 | secp256k1 ECDSA |
| Key Storage | Cache | HSM |
| On-chain Valid | No | Yes |

## Test Plan
- [x] All 43 Relayer domain tests pass
- [x] All 57 KeyManagement domain tests pass
- [x] PHPStan Level 8 passes

## Files Changed
- `app/Domain/KeyManagement/Contracts/HsmProviderInterface.php`
- `app/Domain/KeyManagement/HSM/DemoHsmProvider.php`
- `app/Domain/KeyManagement/HSM/HsmIntegrationService.php`
- `app/Domain/Relayer/Services/UserOperationSigningService.php`
- `tests/Unit/Domain/Relayer/Services/UserOperationSigningServiceTest.php`

## v2.7.0 Progress
- [x] PR #1: HSM Integration ← **This PR**
- [ ] PR #2: Biometric JWT Verification
- [ ] PR #3: Production Balance Checking
- [ ] PR #4: Production Fee Deduction
- [ ] PR #5: Production Nonce Management
- [ ] PR #6: Poseidon Merkle Trees
- [ ] PR #7: AI Query Endpoints
- [ ] PR #8: RegTech Adapters

🤖 Generated with [Claude Code](https://claude.com/claude-code)