### PR TITLE
feat(relayer): Add production-ready balance checking for gas station

### DIFF
--- a/app/Domain/Relayer/Contracts/WalletBalanceProviderInterface.php
+++ b/app/Domain/Relayer/Contracts/WalletBalanceProviderInterface.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Relayer\Contracts;
+
+use App\Domain\Relayer\Enums\SupportedNetwork;
+
+/**
+ * Interface for Wallet Balance Providers.
+ *
+ * Provides balance checking capabilities for ERC-20 tokens across supported networks.
+ * Implementations may use different RPC providers (Alchemy, Infura, custom nodes).
+ */
+interface WalletBalanceProviderInterface
+{
+    /**
+     * Get the balance of a token for a wallet address.
+     *
+     * @param  string  $walletAddress  The wallet address (0x prefixed)
+     * @param  string  $token  Token symbol (e.g., 'USDC', 'USDT')
+     * @param  SupportedNetwork  $network  The blockchain network
+     * @return string Balance in token's decimal format (e.g., "100.000000" for USDC)
+     */
+    public function getBalance(
+        string $walletAddress,
+        string $token,
+        SupportedNetwork $network
+    ): string;
+
+    /**
+     * Check if a wallet has sufficient balance for a specific amount.
+     *
+     * @param  string  $walletAddress  The wallet address (0x prefixed)
+     * @param  string  $token  Token symbol (e.g., 'USDC', 'USDT')
+     * @param  float  $amount  Required amount in token decimals
+     * @param  SupportedNetwork  $network  The blockchain network
+     * @return bool True if balance >= amount
+     */
+    public function hasBalance(
+        string $walletAddress,
+        string $token,
+        float $amount,
+        SupportedNetwork $network
+    ): bool;
+
+    /**
+     * Get the token contract address for a specific network.
+     *
+     * @param  string  $token  Token symbol (e.g., 'USDC', 'USDT')
+     * @param  SupportedNetwork  $network  The blockchain network
+     * @return string|null Token contract address or null if not supported
+     */
+    public function getTokenAddress(string $token, SupportedNetwork $network): ?string;
+
+    /**
+     * Get the decimals for a token.
+     *
+     * @param  string  $token  Token symbol
+     * @return int Number of decimals (typically 6 for USDC/USDT, 18 for most tokens)
+     */
+    public function getTokenDecimals(string $token): int;
+
+    /**
+     * Check if a token is supported on a network.
+     *
+     * @param  string  $token  Token symbol
+     * @param  SupportedNetwork  $network  The blockchain network
+     * @return bool True if token is supported on the network
+     */
+    public function isTokenSupported(string $token, SupportedNetwork $network): bool;
+
+    /**
+     * Invalidate cached balance for a wallet.
+     *
+     * @param  string  $walletAddress  The wallet address
+     * @param  string  $token  Token symbol
+     * @param  SupportedNetwork  $network  The blockchain network
+     */
+    public function invalidateCache(
+        string $walletAddress,
+        string $token,
+        SupportedNetwork $network
+    ): void;
+
+    /**
+     * Get the provider name (e.g., 'demo', 'alchemy', 'infura').
+     */
+    public function getProviderName(): string;
+}

--- a/app/Domain/Relayer/Services/DemoWalletBalanceService.php
+++ b/app/Domain/Relayer/Services/DemoWalletBalanceService.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Relayer\Services;
+
+use App\Domain\Relayer\Contracts\WalletBalanceProviderInterface;
+use App\Domain\Relayer\Enums\SupportedNetwork;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Demo Wallet Balance Provider for development and testing.
+ *
+ * Returns configurable mock balances without making actual RPC calls.
+ * NOT for production use.
+ */
+class DemoWalletBalanceService implements WalletBalanceProviderInterface
+{
+    /**
+     * Token contract addresses by network.
+     *
+     * @var array<string, array<string, string>>
+     */
+    private const TOKEN_ADDRESSES = [
+        'USDC' => [
+            'polygon'  => '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
+            'base'     => '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+            'arbitrum' => '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+            'optimism' => '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
+            'ethereum' => '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        ],
+        'USDT' => [
+            'polygon'  => '0xc2132D05D31c914a87C6611C10748AEb04B58e8F',
+            'ethereum' => '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+            'arbitrum' => '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
+        ],
+    ];
+
+    /**
+     * Token decimals.
+     *
+     * @var array<string, int>
+     */
+    private const TOKEN_DECIMALS = [
+        'USDC' => 6,
+        'USDT' => 6,
+        'WETH' => 18,
+        'WBTC' => 8,
+    ];
+
+    /**
+     * Default balance for demo mode.
+     */
+    private const DEFAULT_DEMO_BALANCE = '1000.000000';
+
+    /**
+     * Cache TTL in seconds.
+     */
+    private const CACHE_TTL_SECONDS = 30;
+
+    private string $cachePrefix;
+
+    public function __construct()
+    {
+        $this->cachePrefix = 'demo_wallet_balance:';
+    }
+
+    /**
+     * Get balance - returns demo balance.
+     */
+    public function getBalance(
+        string $walletAddress,
+        string $token,
+        SupportedNetwork $network
+    ): string {
+        $cacheKey = $this->getCacheKey($walletAddress, $token, $network);
+
+        // Check cache first
+        $cached = Cache::get($cacheKey);
+        if ($cached !== null) {
+            return (string) $cached;
+        }
+
+        // Check configured demo balances
+        $configuredBalances = config('relayer.balance_checking.demo_balances', []);
+        $balance = $configuredBalances[$walletAddress][$token] ?? self::DEFAULT_DEMO_BALANCE;
+
+        // Cache the balance
+        Cache::put($cacheKey, $balance, self::CACHE_TTL_SECONDS);
+
+        Log::debug('Demo balance fetched', [
+            'wallet'  => $walletAddress,
+            'token'   => $token,
+            'network' => $network->value,
+            'balance' => $balance,
+        ]);
+
+        return $balance;
+    }
+
+    /**
+     * Check if wallet has sufficient balance.
+     */
+    public function hasBalance(
+        string $walletAddress,
+        string $token,
+        float $amount,
+        SupportedNetwork $network
+    ): bool {
+        $balance = (float) $this->getBalance($walletAddress, $token, $network);
+
+        $hasSufficient = $balance >= $amount;
+
+        Log::debug('Demo balance check', [
+            'wallet'         => $walletAddress,
+            'token'          => $token,
+            'required'       => $amount,
+            'available'      => $balance,
+            'has_sufficient' => $hasSufficient,
+        ]);
+
+        return $hasSufficient;
+    }
+
+    /**
+     * Get token contract address.
+     */
+    public function getTokenAddress(string $token, SupportedNetwork $network): ?string
+    {
+        return self::TOKEN_ADDRESSES[$token][$network->value] ?? null;
+    }
+
+    /**
+     * Get token decimals.
+     */
+    public function getTokenDecimals(string $token): int
+    {
+        return self::TOKEN_DECIMALS[$token] ?? 18;
+    }
+
+    /**
+     * Check if token is supported on network.
+     */
+    public function isTokenSupported(string $token, SupportedNetwork $network): bool
+    {
+        return isset(self::TOKEN_ADDRESSES[$token][$network->value]);
+    }
+
+    /**
+     * Invalidate cached balance.
+     */
+    public function invalidateCache(
+        string $walletAddress,
+        string $token,
+        SupportedNetwork $network
+    ): void {
+        $cacheKey = $this->getCacheKey($walletAddress, $token, $network);
+        Cache::forget($cacheKey);
+
+        Log::debug('Demo balance cache invalidated', [
+            'wallet'  => $walletAddress,
+            'token'   => $token,
+            'network' => $network->value,
+        ]);
+    }
+
+    /**
+     * Get provider name.
+     */
+    public function getProviderName(): string
+    {
+        return 'demo';
+    }
+
+    /**
+     * Set a specific demo balance for testing.
+     */
+    public function setDemoBalance(
+        string $walletAddress,
+        string $token,
+        SupportedNetwork $network,
+        string $balance
+    ): void {
+        $cacheKey = $this->getCacheKey($walletAddress, $token, $network);
+        Cache::put($cacheKey, $balance, self::CACHE_TTL_SECONDS);
+    }
+
+    /**
+     * Generate cache key.
+     */
+    private function getCacheKey(
+        string $walletAddress,
+        string $token,
+        SupportedNetwork $network
+    ): string {
+        return $this->cachePrefix . strtolower($walletAddress) . ':' . $token . ':' . $network->value;
+    }
+}

--- a/app/Domain/Relayer/Services/WalletBalanceService.php
+++ b/app/Domain/Relayer/Services/WalletBalanceService.php
@@ -1,0 +1,355 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Relayer\Services;
+
+use App\Domain\Relayer\Contracts\WalletBalanceProviderInterface;
+use App\Domain\Relayer\Enums\SupportedNetwork;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Production Wallet Balance Service.
+ *
+ * Queries ERC-20 token balances via RPC providers (Alchemy, Infura, or custom nodes).
+ * Implements caching to reduce RPC calls.
+ *
+ * Production Configuration:
+ * - BALANCE_PROVIDER: 'alchemy', 'infura', or 'custom'
+ * - ALCHEMY_API_KEY: Alchemy API key
+ * - INFURA_PROJECT_ID: Infura project ID
+ * - CUSTOM_RPC_URL_{NETWORK}: Custom RPC URLs per network
+ */
+class WalletBalanceService implements WalletBalanceProviderInterface
+{
+    /**
+     * Token contract addresses by network.
+     *
+     * @var array<string, array<string, string>>
+     */
+    private const TOKEN_ADDRESSES = [
+        'USDC' => [
+            'polygon'  => '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
+            'base'     => '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+            'arbitrum' => '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+            'optimism' => '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
+            'ethereum' => '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        ],
+        'USDT' => [
+            'polygon'  => '0xc2132D05D31c914a87C6611C10748AEb04B58e8F',
+            'ethereum' => '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+            'arbitrum' => '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
+        ],
+    ];
+
+    /**
+     * Token decimals.
+     *
+     * @var array<string, int>
+     */
+    private const TOKEN_DECIMALS = [
+        'USDC' => 6,
+        'USDT' => 6,
+        'WETH' => 18,
+        'WBTC' => 8,
+    ];
+
+    /**
+     * ERC-20 balanceOf function selector.
+     */
+    private const BALANCE_OF_SELECTOR = '0x70a08231';
+
+    private string $provider;
+
+    private int $cacheTtl;
+
+    private string $cachePrefix;
+
+    public function __construct()
+    {
+        $this->provider = (string) config('relayer.balance_checking.provider', 'alchemy');
+        $this->cacheTtl = (int) config('relayer.balance_checking.cache_ttl_seconds', 30);
+        $this->cachePrefix = 'wallet_balance:';
+    }
+
+    /**
+     * Get balance by querying ERC-20 contract.
+     */
+    public function getBalance(
+        string $walletAddress,
+        string $token,
+        SupportedNetwork $network
+    ): string {
+        $cacheKey = $this->getCacheKey($walletAddress, $token, $network);
+
+        // Check cache first
+        $cached = Cache::get($cacheKey);
+        if ($cached !== null) {
+            return (string) $cached;
+        }
+
+        $tokenAddress = $this->getTokenAddress($token, $network);
+        if ($tokenAddress === null) {
+            throw new RuntimeException("Token {$token} not supported on {$network->value}");
+        }
+
+        $balance = $this->queryBalanceFromRpc($walletAddress, $tokenAddress, $network);
+
+        // Convert from wei to token decimals
+        $decimals = $this->getTokenDecimals($token);
+        $formattedBalance = $this->formatBalance($balance, $decimals);
+
+        // Cache the balance
+        Cache::put($cacheKey, $formattedBalance, $this->cacheTtl);
+
+        Log::debug('Balance fetched from RPC', [
+            'wallet'   => $walletAddress,
+            'token'    => $token,
+            'network'  => $network->value,
+            'balance'  => $formattedBalance,
+            'provider' => $this->provider,
+        ]);
+
+        return $formattedBalance;
+    }
+
+    /**
+     * Check if wallet has sufficient balance.
+     */
+    public function hasBalance(
+        string $walletAddress,
+        string $token,
+        float $amount,
+        SupportedNetwork $network
+    ): bool {
+        $balance = (float) $this->getBalance($walletAddress, $token, $network);
+
+        return $balance >= $amount;
+    }
+
+    /**
+     * Get token contract address.
+     */
+    public function getTokenAddress(string $token, SupportedNetwork $network): ?string
+    {
+        // Check config first, then fallback to constants
+        $configured = config("relayer.balance_checking.tokens.{$token}.{$network->value}");
+        if ($configured !== null) {
+            return (string) $configured;
+        }
+
+        return self::TOKEN_ADDRESSES[$token][$network->value] ?? null;
+    }
+
+    /**
+     * Get token decimals.
+     */
+    public function getTokenDecimals(string $token): int
+    {
+        return self::TOKEN_DECIMALS[$token] ?? 18;
+    }
+
+    /**
+     * Check if token is supported on network.
+     */
+    public function isTokenSupported(string $token, SupportedNetwork $network): bool
+    {
+        return $this->getTokenAddress($token, $network) !== null;
+    }
+
+    /**
+     * Invalidate cached balance.
+     */
+    public function invalidateCache(
+        string $walletAddress,
+        string $token,
+        SupportedNetwork $network
+    ): void {
+        $cacheKey = $this->getCacheKey($walletAddress, $token, $network);
+        Cache::forget($cacheKey);
+    }
+
+    /**
+     * Get provider name.
+     */
+    public function getProviderName(): string
+    {
+        return $this->provider;
+    }
+
+    /**
+     * Query balance from RPC provider.
+     */
+    private function queryBalanceFromRpc(
+        string $walletAddress,
+        string $tokenAddress,
+        SupportedNetwork $network
+    ): string {
+        $rpcUrl = $this->getRpcUrl($network);
+
+        // Build eth_call data: balanceOf(address)
+        // Function selector (4 bytes) + address padded to 32 bytes
+        $paddedAddress = str_pad(substr(strtolower($walletAddress), 2), 64, '0', STR_PAD_LEFT);
+        $callData = self::BALANCE_OF_SELECTOR . $paddedAddress;
+
+        $payload = [
+            'jsonrpc' => '2.0',
+            'method'  => 'eth_call',
+            'params'  => [
+                [
+                    'to'   => $tokenAddress,
+                    'data' => $callData,
+                ],
+                'latest',
+            ],
+            'id' => 1,
+        ];
+
+        try {
+            $response = Http::timeout(10)
+                ->post($rpcUrl, $payload)
+                ->throw()
+                ->json();
+
+            if (isset($response['error'])) {
+                throw new RuntimeException('RPC error: ' . ($response['error']['message'] ?? 'Unknown'));
+            }
+
+            $result = $response['result'] ?? '0x0';
+
+            // Remove 0x prefix and convert from hex
+            return $this->hexToDecimal($result);
+        } catch (Throwable $e) {
+            Log::error('Balance RPC call failed', [
+                'wallet'  => $walletAddress,
+                'token'   => $tokenAddress,
+                'network' => $network->value,
+                'error'   => $e->getMessage(),
+            ]);
+            throw new RuntimeException('Failed to fetch balance: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Get RPC URL for a network.
+     */
+    private function getRpcUrl(SupportedNetwork $network): string
+    {
+        return match ($this->provider) {
+            'alchemy' => $this->getAlchemyUrl($network),
+            'infura'  => $this->getInfuraUrl($network),
+            'custom'  => $this->getCustomUrl($network),
+            default   => throw new RuntimeException("Unknown provider: {$this->provider}"),
+        };
+    }
+
+    /**
+     * Get Alchemy RPC URL.
+     */
+    private function getAlchemyUrl(SupportedNetwork $network): string
+    {
+        $apiKey = config('relayer.balance_checking.alchemy_api_key');
+        if (empty($apiKey)) {
+            throw new RuntimeException('ALCHEMY_API_KEY not configured');
+        }
+
+        $subdomain = match ($network) {
+            SupportedNetwork::POLYGON  => 'polygon-mainnet',
+            SupportedNetwork::BASE     => 'base-mainnet',
+            SupportedNetwork::ARBITRUM => 'arb-mainnet',
+            SupportedNetwork::OPTIMISM => 'opt-mainnet',
+            SupportedNetwork::ETHEREUM => 'eth-mainnet',
+        };
+
+        return "https://{$subdomain}.g.alchemy.com/v2/{$apiKey}";
+    }
+
+    /**
+     * Get Infura RPC URL.
+     */
+    private function getInfuraUrl(SupportedNetwork $network): string
+    {
+        $projectId = config('relayer.balance_checking.infura_project_id');
+        if (empty($projectId)) {
+            throw new RuntimeException('INFURA_PROJECT_ID not configured');
+        }
+
+        $subdomain = match ($network) {
+            SupportedNetwork::POLYGON  => 'polygon-mainnet',
+            SupportedNetwork::ARBITRUM => 'arbitrum-mainnet',
+            SupportedNetwork::OPTIMISM => 'optimism-mainnet',
+            SupportedNetwork::ETHEREUM => 'mainnet',
+            SupportedNetwork::BASE     => throw new RuntimeException('Base not supported by Infura'),
+        };
+
+        return "https://{$subdomain}.infura.io/v3/{$projectId}";
+    }
+
+    /**
+     * Get custom RPC URL.
+     */
+    private function getCustomUrl(SupportedNetwork $network): string
+    {
+        $url = config("relayer.balance_checking.custom_rpc.{$network->value}");
+        if (empty($url)) {
+            throw new RuntimeException("Custom RPC URL not configured for {$network->value}");
+        }
+
+        return (string) $url;
+    }
+
+    /**
+     * Convert hex string to decimal string.
+     */
+    private function hexToDecimal(string $hex): string
+    {
+        // Remove 0x prefix
+        $hex = ltrim($hex, '0x');
+
+        // Handle empty or zero
+        if ($hex === '' || $hex === '0') {
+            return '0';
+        }
+
+        // Use bcmath for large numbers
+        $decimal = '0';
+        $len = strlen($hex);
+
+        for ($i = 0; $i < $len; $i++) {
+            $decimal = bcmul($decimal, '16');
+            $decimal = bcadd($decimal, (string) hexdec($hex[$i]));
+        }
+
+        return $decimal;
+    }
+
+    /**
+     * Format balance from wei to decimal.
+     */
+    private function formatBalance(string $weiBalance, int $decimals): string
+    {
+        if ($weiBalance === '0') {
+            return '0.' . str_repeat('0', $decimals);
+        }
+
+        $divisor = bcpow('10', (string) $decimals);
+        $balance = bcdiv($weiBalance, $divisor, $decimals);
+
+        return $balance;
+    }
+
+    /**
+     * Generate cache key.
+     */
+    private function getCacheKey(
+        string $walletAddress,
+        string $token,
+        SupportedNetwork $network
+    ): string {
+        return $this->cachePrefix . strtolower($walletAddress) . ':' . $token . ':' . $network->value;
+    }
+}

--- a/config/relayer.php
+++ b/config/relayer.php
@@ -165,4 +165,57 @@ return [
         'api_key'     => env('PIMLICO_API_KEY'),
         'bundler_url' => env('PIMLICO_BUNDLER_URL'),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Balance Checking Configuration (v2.7.0)
+    |--------------------------------------------------------------------------
+    |
+    | Configuration for ERC-20 balance checking via RPC providers.
+    |
+    */
+
+    'balance_checking' => [
+        // Provider: 'demo', 'alchemy', 'infura', 'custom'
+        'provider' => env('BALANCE_PROVIDER', 'demo'),
+
+        // Cache TTL in seconds
+        'cache_ttl_seconds' => (int) env('BALANCE_CACHE_TTL', 30),
+
+        // Alchemy configuration
+        'alchemy_api_key' => env('ALCHEMY_API_KEY'),
+
+        // Infura configuration
+        'infura_project_id' => env('INFURA_PROJECT_ID'),
+
+        // Custom RPC URLs per network
+        'custom_rpc' => [
+            'polygon'  => env('CUSTOM_RPC_POLYGON'),
+            'base'     => env('CUSTOM_RPC_BASE'),
+            'arbitrum' => env('CUSTOM_RPC_ARBITRUM'),
+            'optimism' => env('CUSTOM_RPC_OPTIMISM'),
+            'ethereum' => env('CUSTOM_RPC_ETHEREUM'),
+        ],
+
+        // Token contract addresses (can override defaults)
+        'tokens' => [
+            'USDC' => [
+                'polygon'  => env('USDC_POLYGON', '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359'),
+                'base'     => env('USDC_BASE', '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'),
+                'arbitrum' => env('USDC_ARBITRUM', '0xaf88d065e77c8cC2239327C5EDb3A432268e5831'),
+                'optimism' => env('USDC_OPTIMISM', '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85'),
+                'ethereum' => env('USDC_ETHEREUM', '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'),
+            ],
+            'USDT' => [
+                'polygon'  => env('USDT_POLYGON', '0xc2132D05D31c914a87C6611C10748AEb04B58e8F'),
+                'ethereum' => env('USDT_ETHEREUM', '0xdAC17F958D2ee523a2206206994597C13D831ec7'),
+                'arbitrum' => env('USDT_ARBITRUM', '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9'),
+            ],
+        ],
+
+        // Demo mode balances (for testing)
+        'demo_balances' => [
+            // Example: '0x123...' => ['USDC' => '1000.000000', 'USDT' => '500.000000']
+        ],
+    ],
 ];

--- a/tests/Unit/Domain/Relayer/Services/WalletBalanceServiceTest.php
+++ b/tests/Unit/Domain/Relayer/Services/WalletBalanceServiceTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Relayer\Services;
+
+use App\Domain\Relayer\Enums\SupportedNetwork;
+use App\Domain\Relayer\Services\DemoWalletBalanceService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class WalletBalanceServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private DemoWalletBalanceService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::flush();
+
+        $this->service = new DemoWalletBalanceService();
+    }
+
+    public function test_returns_default_balance_for_unknown_wallet(): void
+    {
+        $balance = $this->service->getBalance(
+            '0x1234567890123456789012345678901234567890',
+            'USDC',
+            SupportedNetwork::POLYGON
+        );
+
+        $this->assertEquals('1000.000000', $balance);
+    }
+
+    public function test_has_balance_returns_true_when_sufficient(): void
+    {
+        $result = $this->service->hasBalance(
+            '0x1234567890123456789012345678901234567890',
+            'USDC',
+            100.0,
+            SupportedNetwork::POLYGON
+        );
+
+        $this->assertTrue($result);
+    }
+
+    public function test_has_balance_returns_false_when_insufficient(): void
+    {
+        // Set a low demo balance
+        $this->service->setDemoBalance(
+            '0x1234567890123456789012345678901234567890',
+            'USDC',
+            SupportedNetwork::POLYGON,
+            '50.000000'
+        );
+
+        $result = $this->service->hasBalance(
+            '0x1234567890123456789012345678901234567890',
+            'USDC',
+            100.0,
+            SupportedNetwork::POLYGON
+        );
+
+        $this->assertFalse($result);
+    }
+
+    public function test_returns_configured_demo_balance(): void
+    {
+        $this->service->setDemoBalance(
+            '0xtest',
+            'USDC',
+            SupportedNetwork::POLYGON,
+            '500.123456'
+        );
+
+        $balance = $this->service->getBalance('0xtest', 'USDC', SupportedNetwork::POLYGON);
+
+        $this->assertEquals('500.123456', $balance);
+    }
+
+    public function test_caches_balance(): void
+    {
+        $walletAddress = '0xcached';
+
+        // First call
+        $balance1 = $this->service->getBalance($walletAddress, 'USDC', SupportedNetwork::POLYGON);
+
+        // Set different balance (but cache should still have old value)
+        $this->service->setDemoBalance($walletAddress, 'USDC', SupportedNetwork::POLYGON, '999.000000');
+
+        // Second call should return cached value (which we just overwrote)
+        $balance2 = $this->service->getBalance($walletAddress, 'USDC', SupportedNetwork::POLYGON);
+
+        // Both should be the new value since setDemoBalance overwrites cache
+        $this->assertEquals('999.000000', $balance2);
+    }
+
+    public function test_invalidate_cache_clears_cached_balance(): void
+    {
+        $walletAddress = '0xinvalidate';
+
+        // Set a balance
+        $this->service->setDemoBalance($walletAddress, 'USDC', SupportedNetwork::POLYGON, '500.000000');
+
+        // Verify it's cached
+        $this->assertEquals('500.000000', $this->service->getBalance($walletAddress, 'USDC', SupportedNetwork::POLYGON));
+
+        // Invalidate cache
+        $this->service->invalidateCache($walletAddress, 'USDC', SupportedNetwork::POLYGON);
+
+        // Should return default balance now
+        $balance = $this->service->getBalance($walletAddress, 'USDC', SupportedNetwork::POLYGON);
+        $this->assertEquals('1000.000000', $balance);
+    }
+
+    public function test_returns_correct_token_address_for_usdc_polygon(): void
+    {
+        $address = $this->service->getTokenAddress('USDC', SupportedNetwork::POLYGON);
+
+        $this->assertEquals('0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359', $address);
+    }
+
+    public function test_returns_correct_token_address_for_usdc_base(): void
+    {
+        $address = $this->service->getTokenAddress('USDC', SupportedNetwork::BASE);
+
+        $this->assertEquals('0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913', $address);
+    }
+
+    public function test_returns_null_for_unsupported_token_network_combination(): void
+    {
+        // USDT is not supported on Base in demo service
+        $address = $this->service->getTokenAddress('USDT', SupportedNetwork::BASE);
+
+        $this->assertNull($address);
+    }
+
+    public function test_returns_correct_decimals_for_usdc(): void
+    {
+        $decimals = $this->service->getTokenDecimals('USDC');
+
+        $this->assertEquals(6, $decimals);
+    }
+
+    public function test_returns_correct_decimals_for_usdt(): void
+    {
+        $decimals = $this->service->getTokenDecimals('USDT');
+
+        $this->assertEquals(6, $decimals);
+    }
+
+    public function test_returns_18_decimals_for_unknown_token(): void
+    {
+        $decimals = $this->service->getTokenDecimals('UNKNOWN');
+
+        $this->assertEquals(18, $decimals);
+    }
+
+    public function test_is_token_supported_returns_true_for_usdc_polygon(): void
+    {
+        $supported = $this->service->isTokenSupported('USDC', SupportedNetwork::POLYGON);
+
+        $this->assertTrue($supported);
+    }
+
+    public function test_is_token_supported_returns_false_for_unknown_token(): void
+    {
+        $supported = $this->service->isTokenSupported('UNKNOWN_TOKEN', SupportedNetwork::POLYGON);
+
+        $this->assertFalse($supported);
+    }
+
+    public function test_get_provider_name_returns_demo(): void
+    {
+        $name = $this->service->getProviderName();
+
+        $this->assertEquals('demo', $name);
+    }
+
+    public function test_balance_check_works_across_networks(): void
+    {
+        // Set different balances for different networks
+        $walletAddress = '0xmultinetwork';
+
+        $this->service->setDemoBalance($walletAddress, 'USDC', SupportedNetwork::POLYGON, '100.000000');
+        $this->service->setDemoBalance($walletAddress, 'USDC', SupportedNetwork::BASE, '200.000000');
+        $this->service->setDemoBalance($walletAddress, 'USDC', SupportedNetwork::ARBITRUM, '300.000000');
+
+        $polygonBalance = $this->service->getBalance($walletAddress, 'USDC', SupportedNetwork::POLYGON);
+        $baseBalance = $this->service->getBalance($walletAddress, 'USDC', SupportedNetwork::BASE);
+        $arbitrumBalance = $this->service->getBalance($walletAddress, 'USDC', SupportedNetwork::ARBITRUM);
+
+        $this->assertEquals('100.000000', $polygonBalance);
+        $this->assertEquals('200.000000', $baseBalance);
+        $this->assertEquals('300.000000', $arbitrumBalance);
+    }
+
+    public function test_balance_check_works_across_tokens(): void
+    {
+        $walletAddress = '0xmultitokens';
+
+        $this->service->setDemoBalance($walletAddress, 'USDC', SupportedNetwork::POLYGON, '150.000000');
+        $this->service->setDemoBalance($walletAddress, 'USDT', SupportedNetwork::POLYGON, '250.000000');
+
+        $usdcBalance = $this->service->getBalance($walletAddress, 'USDC', SupportedNetwork::POLYGON);
+        $usdtBalance = $this->service->getBalance($walletAddress, 'USDT', SupportedNetwork::POLYGON);
+
+        $this->assertEquals('150.000000', $usdcBalance);
+        $this->assertEquals('250.000000', $usdtBalance);
+    }
+}


### PR DESCRIPTION
## Summary

Implements v2.7.0 PR #3: Production Balance Checking for the Gas Station Service.

- **WalletBalanceProviderInterface**: Contract for balance checking providers
- **WalletBalanceService**: RPC-based balance queries via Alchemy/Infura/custom nodes
- **DemoWalletBalanceService**: Configurable mock balances for testing
- **GasStationService**: Updated to use balance provider instead of always-true stub

## Changes

- `app/Domain/Relayer/Contracts/WalletBalanceProviderInterface.php` - New contract
- `app/Domain/Relayer/Services/WalletBalanceService.php` - Production service
- `app/Domain/Relayer/Services/DemoWalletBalanceService.php` - Demo service
- `app/Domain/Relayer/Services/GasStationService.php` - Balance provider integration
- `app/Providers/RelayerServiceProvider.php` - DI bindings
- `config/relayer.php` - balance_checking config section
- `tests/Unit/Domain/Relayer/Services/WalletBalanceServiceTest.php` - 17 tests

## Test plan

- [x] WalletBalanceServiceTest (17 tests) - all passing
- [x] GasStationServiceTest (9 tests) - all passing
- [x] PHPStan Level 5 - no issues
- [x] PHP-CS-Fixer - clean

## Configuration (Production)

```env
BALANCE_PROVIDER=alchemy  # or infura, custom
ALCHEMY_API_KEY=<api_key>
BALANCE_CACHE_TTL=30
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)