### PR TITLE
fix(security): Address 5 actionable security audit findings

### DIFF
--- a/app/Domain/KeyManagement/HSM/DemoHsmProvider.php
+++ b/app/Domain/KeyManagement/HSM/DemoHsmProvider.php
@@ -20,6 +20,13 @@ class DemoHsmProvider implements HsmProviderInterface
 
     private const DEMO_KEY = 'demo-hsm-encryption-key-32bytes!';
 
+    public function __construct()
+    {
+        if (app()->environment('production')) {
+            throw new RuntimeException('DemoHsmProvider cannot be used in production');
+        }
+    }
+
     public function encrypt(string $data, string $keyId): string
     {
         // Simple encryption for demo purposes

--- a/app/Domain/KeyManagement/Services/KeyReconstructionService.php
+++ b/app/Domain/KeyManagement/Services/KeyReconstructionService.php
@@ -31,6 +31,10 @@ class KeyReconstructionService
         string $deviceShardData,
         string $sessionToken
     ): ReconstructedKey {
+        if (! $this->canReconstruct($userUuid)) {
+            throw new RuntimeException('Rate limit exceeded for key reconstruction');
+        }
+
         // Get the auth shard from database
         $authShardRecord = KeyShardRecord::query()
             ->forUser($userUuid)
@@ -70,6 +74,10 @@ class KeyReconstructionService
         string $deviceShardData,
         string $recoveryShardData
     ): ReconstructedKey {
+        if (! $this->canReconstruct($userUuid)) {
+            throw new RuntimeException('Rate limit exceeded for key reconstruction');
+        }
+
         $deviceShard = new KeyShard(
             type: ShardType::DEVICE,
             data: $deviceShardData,

--- a/app/Domain/TrustCert/Services/VerifiableCredentialService.php
+++ b/app/Domain/TrustCert/Services/VerifiableCredentialService.php
@@ -12,6 +12,7 @@ use App\Domain\TrustCert\ValueObjects\TrustChain;
 use DateTimeImmutable;
 use DateTimeInterface;
 use Illuminate\Support\Str;
+use RuntimeException;
 
 /**
  * Service for W3C Verifiable Credentials standard implementation.
@@ -28,6 +29,9 @@ class VerifiableCredentialService
         private readonly string $issuerId = 'did:finaegis:issuer:default',
         private readonly string $signingKey = '',
     ) {
+        if (app()->environment('production') && empty($this->signingKey)) {
+            throw new RuntimeException('Credential signing key must be configured in production');
+        }
     }
 
     /**

--- a/config/trustcert.php
+++ b/config/trustcert.php
@@ -10,7 +10,7 @@ return [
     */
     'certificate_authority' => [
         'ca_id'            => env('TRUSTCERT_CA_ID', 'finaegis-root-ca'),
-        'ca_signing_key'   => env('TRUSTCERT_CA_SIGNING_KEY', ''),
+        'ca_signing_key'   => env('TRUSTCERT_CA_SIGNING_KEY'),
         'default_validity' => [
             'days' => 365,
         ],
@@ -23,8 +23,8 @@ return [
     |--------------------------------------------------------------------------
     */
     'credentials' => [
-        'credential_signing_key'   => env('TRUSTCERT_CREDENTIAL_SIGNING_KEY', ''),
-        'presentation_signing_key' => env('TRUSTCERT_PRESENTATION_SIGNING_KEY', ''),
+        'credential_signing_key'   => env('TRUSTCERT_CREDENTIAL_SIGNING_KEY'),
+        'presentation_signing_key' => env('TRUSTCERT_PRESENTATION_SIGNING_KEY'),
         'default_issuer'           => env('TRUSTCERT_DEFAULT_ISSUER', 'did:finaegis:issuer:default'),
         'supported_proof_types'    => [
             'Ed25519Signature2020',

--- a/tests/Unit/Domain/TrustCert/Services/CertificateAuthorityServiceTest.php
+++ b/tests/Unit/Domain/TrustCert/Services/CertificateAuthorityServiceTest.php
@@ -6,12 +6,14 @@ use App\Domain\TrustCert\Enums\CertificateStatus;
 use App\Domain\TrustCert\Events\CertificateIssued;
 use App\Domain\TrustCert\Events\CertificateRevoked;
 use App\Domain\TrustCert\Services\CertificateAuthorityService;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
 
 uses(Tests\TestCase::class);
 
 describe('CertificateAuthorityService', function (): void {
     beforeEach(function (): void {
+        Cache::flush();
         Event::fake();
         $this->service = new CertificateAuthorityService('test-ca', 'test-signing-key');
     });

--- a/tests/Unit/Domain/TrustCert/Services/TrustFrameworkServiceTest.php
+++ b/tests/Unit/Domain/TrustCert/Services/TrustFrameworkServiceTest.php
@@ -7,12 +7,14 @@ use App\Domain\TrustCert\Enums\TrustLevel;
 use App\Domain\TrustCert\Events\IssuerRegistered;
 use App\Domain\TrustCert\Events\TrustLevelChanged;
 use App\Domain\TrustCert\Services\TrustFrameworkService;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
 
 uses(Tests\TestCase::class);
 
 describe('TrustFrameworkService', function (): void {
     beforeEach(function (): void {
+        Cache::flush();
         Event::fake();
         $this->service = new TrustFrameworkService();
     });

--- a/tests/Unit/Domain/TrustCert/Services/VerifiableCredentialServiceTest.php
+++ b/tests/Unit/Domain/TrustCert/Services/VerifiableCredentialServiceTest.php
@@ -8,12 +8,14 @@ use App\Domain\TrustCert\Enums\TrustLevel;
 use App\Domain\TrustCert\Services\RevocationRegistryService;
 use App\Domain\TrustCert\Services\TrustFrameworkService;
 use App\Domain\TrustCert\Services\VerifiableCredentialService;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
 
 uses(Tests\TestCase::class);
 
 describe('VerifiableCredentialService', function (): void {
     beforeEach(function (): void {
+        Cache::flush();
         Event::fake();
         $this->revocationRegistry = new RevocationRegistryService();
         $this->trustFramework = new TrustFrameworkService();


### PR DESCRIPTION
## Summary
- **DemoHsmProvider production guard**: Constructor now throws `RuntimeException` if instantiated in production environment, preventing accidental use of insecure demo HSM
- **TrustCert signing key hardening**: Removed empty string defaults from `config/trustcert.php` for all signing keys (CA, credential, presentation); added production validation in `CertificateAuthorityService` and `VerifiableCredentialService` constructors
- **TrustFrameworkService cache persistence**: Added Cache-backed persistence for issuer registry and child index, following the same pattern used in `SoulboundTokenService`
- **CertificateAuthorityService fixes**: Added Cache-backed persistence for certificates and subject index; fixed `revokeCertificate()` to remove from `$subjectIndex` and `reinstateCertificate()` to restore it
- **KeyReconstructionService rate limiting**: Enforced `canReconstruct()` rate limiting check at the beginning of both `reconstructWithAuth()` and `reconstructWithRecovery()` methods

## Test plan
- [x] All 209 KeyManagement + TrustCert domain tests pass (564 assertions)
- [x] PHPStan: No errors on all modified files
- [x] PHP CS Fixer: No code style issues
- [x] PHPCS PSR-12: Compliant
- [x] Added `Cache::flush()` to test `beforeEach` for proper isolation with cache persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)