### PR TITLE
test(keymanagement): Add unit tests for KeyReconstruction and ShardDistribution

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -32,7 +32,8 @@ parameters:
     ignoreErrors:
         # Mockery methods
         - '#Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::with\(\)#'
-        - '#Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::(once|twice|times|never|andReturn|andReturnTrue|andReturnFalse)\(\)#'
+        - '#Call to an undefined method Mockery\\ExpectationInterface\|Mockery\\HigherOrderMessage::(once|twice|times|never|andReturn|andReturnTrue|andReturnFalse|byDefault)\(\)#'
+        - '#Call to an undefined method Mockery\\ExpectationInterface::(byDefault|andThrow)\(\)#'
         # Eloquent model magic methods
         - '#Call to an undefined static method App\\Domain\\[a-zA-Z\\]+\\Projections\\[a-zA-Z]+::#'
         - '#Access to an undefined property App\\Domain\\[a-zA-Z\\]+\\Projections\\[a-zA-Z]+::\$#'
@@ -151,7 +152,12 @@ parameters:
 
         # Pest PHP specific ignores
         - '#Call to an undefined method PHPUnit\\Framework\\TestCase::(browse|artisan|actingAs|get|post|put|patch|delete|json|getJson|postJson|putJson|patchJson|deleteJson|assertAuthenticated|assertGuest|assertDatabaseHas|assertDatabaseMissing|assertDatabaseCount|assertModelExists|assertModelMissing|assertSoftDeleted|assertNotSoftDeleted|assertStatus|assertOk|assertCreated|assertNoContent|assertNotFound|assertForbidden|assertUnauthorized|assertUnprocessable|assertSuccessful|assertServerError|assertRedirect|assertHeader|assertHeaderMissing|assertLocation|assertContent|assertSee|assertSeeInOrder|assertSeeText|assertSeeTextInOrder|assertDontSee|assertDontSeeText|assertJson|assertJsonCount|assertJsonFragment|assertJsonMissing|assertJsonMissingExact|assertJsonPath|assertJsonMissingPath|assertJsonStructure|assertJsonValidationErrors|assertJsonMissingValidationErrors|assertJsonIsArray|assertJsonIsObject|assertExactJson|assertSimilarJson|assertJsonStringEqualsJsonString|assertJsonStringNotEqualsJsonString|assertCookie|assertCookieMissing|assertCookieNotExpired|assertCookieExpired|assertPlainCookie|assertSessionHas|assertSessionHasAll|assertSessionHasInput|assertSessionHasErrors|assertSessionHasErrorsIn|assertSessionHasNoErrors|assertSessionDoesntHaveErrors|assertSessionMissing|assertViewHas|assertViewHasAll|assertViewMissing|assertViewIs|assertValid|assertInvalid|expectsEvents|doesntExpectEvents|expectsJobs|doesntExpectJobs|withServerVariables|withoutMiddleware|withMiddleware|withCookie|withCookies|withUnencryptedCookie|withUnencryptedCookies|withSession|followingRedirects|disableCookieEncryption|from|assertAuthenticated|assertGuest|be|seed|withoutExceptionHandling|withExceptionHandling|handleValidationExceptions|travel|travelTo|travelBack|freezeTime|freezeSecond|withHeaders|withHeader|withToken|flushHeaders|withoutVite|withViewErrors|shareFormRequests|withCredentials|withPrefetch|actingAs|be|assertAuthenticatedAs|assertCredentials|assertInvalidCredentials|hasUser|forgetGuards|assertAuthenticated|assertGuest|assertAuthenticatedAs|actingAs)\(\)#'
-        - '#Access to an undefined property PHPUnit\\Framework\\TestCase::\$(app|user|business_user|account|positionId|ownerId)#'
+        # Mockery mock type mismatches in test constructors (standard testing pattern)
+        - '#Parameter \$[a-zA-Z]+ of class App\\Domain\\[a-zA-Z\\]+\\Services\\[a-zA-Z]+Service constructor expects .+, Mockery\\MockInterface given#'
+        - '#Parameter \$[a-zA-Z]+ of class App\\Domain\\[a-zA-Z\\]+\\HSM\\[a-zA-Z]+Service constructor expects .+, Mockery\\MockInterface given#'
+        # Null-safe property access on firstWhere/first results in tests
+        - '#Cannot access property \$[a-zA-Z_]+ on App\\Domain\\[a-zA-Z\\]+\\Models\\[a-zA-Z]+\|null#'
+        - '#Access to an undefined property PHPUnit\\Framework\\TestCase::\$(app|user|business_user|account|positionId|ownerId|service|device|shamirService|request|userUuid|hsm|encryption)#'
         - '#Call to an undefined static method PHPUnit\\Framework\\TestCase::uses\(\)#'
         - '#Call to function (it|test|expect|beforeEach|afterEach|beforeAll|afterAll|dataset|uses|covers|group|skip|todo)\(\) not found#'
         - '#Function method_exists\(\) with .* and .* will always evaluate to true#'

--- a/tests/Unit/Domain/KeyManagement/Services/KeyReconstructionServiceTest.php
+++ b/tests/Unit/Domain/KeyManagement/Services/KeyReconstructionServiceTest.php
@@ -1,0 +1,548 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\KeyManagement\Enums\ShardStatus;
+use App\Domain\KeyManagement\Enums\ShardType;
+use App\Domain\KeyManagement\Events\KeyReconstructed;
+use App\Domain\KeyManagement\Events\KeyReconstructionFailed;
+use App\Domain\KeyManagement\Models\KeyReconstructionLog;
+use App\Domain\KeyManagement\Models\KeyShardRecord;
+use App\Domain\KeyManagement\Services\KeyReconstructionService;
+use App\Domain\KeyManagement\Services\ShamirService;
+use App\Domain\KeyManagement\ValueObjects\KeyShard;
+use App\Domain\KeyManagement\ValueObjects\ReconstructedKey;
+use App\Models\User;
+use Illuminate\Support\Facades\Event;
+
+uses(Tests\TestCase::class);
+
+beforeEach(function (): void {
+    Event::fake();
+
+    $this->shamirService = Mockery::mock(ShamirService::class);
+    $this->request = Mockery::mock(Illuminate\Http\Request::class);
+    $this->request->shouldReceive('ip')->andReturn('127.0.0.1')->byDefault();
+    $this->request->shouldReceive('userAgent')->andReturn('TestAgent/1.0')->byDefault();
+    $this->request->shouldReceive('header')->with('X-Device-Id')->andReturn('test-device-001')->byDefault();
+
+    $this->service = new KeyReconstructionService(
+        shamirService: $this->shamirService,
+        request: $this->request
+    );
+
+    $this->user = User::factory()->create();
+    $this->userUuid = $this->user->uuid;
+});
+
+describe('KeyReconstructionService', function (): void {
+    describe('reconstructWithAuth', function (): void {
+        it('reconstructs key using device shard and auth shard from database', function (): void {
+            $deviceShardData = 'device-shard-data-encrypted';
+            $authShardEncryptedData = 'auth-shard-data-encrypted';
+            $sessionToken = 'valid-session-token';
+
+            // Create an active auth shard record in the database
+            KeyShardRecord::create([
+                'user_uuid'       => $this->userUuid,
+                'shard_type'      => ShardType::AUTH,
+                'shard_index'     => 2,
+                'encrypted_data'  => $authShardEncryptedData,
+                'encrypted_for'   => 'hsm',
+                'key_version'     => 'v1',
+                'status'          => ShardStatus::ACTIVE,
+                'public_key_hash' => hash('sha256', 'test-private-key'),
+            ]);
+
+            $expectedReconstructedKey = new ReconstructedKey(
+                privateKey: 'test-private-key',
+                userId: $this->userUuid,
+                reconstructedAt: new DateTimeImmutable(),
+                ttlSeconds: 300
+            );
+
+            $this->shamirService
+                ->shouldReceive('reconstructKey')
+                ->once()
+                ->with(
+                    Mockery::on(fn (KeyShard $shard) => $shard->type === ShardType::DEVICE
+                        && $shard->data === $deviceShardData
+                        && $shard->userId === $this->userUuid
+                        && $shard->index === 1),
+                    Mockery::on(fn (KeyShard $shard) => $shard->type === ShardType::AUTH
+                        && $shard->data === $authShardEncryptedData
+                        && $shard->userId === $this->userUuid
+                        && $shard->index === 2)
+                )
+                ->andReturn($expectedReconstructedKey);
+
+            $result = $this->service->reconstructWithAuth(
+                $this->userUuid,
+                $deviceShardData,
+                $sessionToken
+            );
+
+            expect($result)->toBeInstanceOf(ReconstructedKey::class)
+                ->and($result->privateKey)->toBe('test-private-key')
+                ->and($result->userId)->toBe($this->userUuid);
+
+            Event::assertDispatched(KeyReconstructed::class, function ($event): bool {
+                return $event->userUuid === $this->userUuid
+                    && $event->purpose === 'transaction_signing'
+                    && in_array('device', $event->shardsUsed, true)
+                    && in_array('auth', $event->shardsUsed, true);
+            });
+        });
+
+        it('creates a successful reconstruction log entry', function (): void {
+            $authShardEncryptedData = 'auth-shard-data';
+
+            KeyShardRecord::create([
+                'user_uuid'       => $this->userUuid,
+                'shard_type'      => ShardType::AUTH,
+                'shard_index'     => 2,
+                'encrypted_data'  => $authShardEncryptedData,
+                'encrypted_for'   => 'hsm',
+                'key_version'     => 'v1',
+                'status'          => ShardStatus::ACTIVE,
+                'public_key_hash' => hash('sha256', 'key'),
+            ]);
+
+            $this->shamirService
+                ->shouldReceive('reconstructKey')
+                ->andReturn(new ReconstructedKey(
+                    privateKey: 'key',
+                    userId: $this->userUuid,
+                    reconstructedAt: new DateTimeImmutable(),
+                ));
+
+            $this->service->reconstructWithAuth(
+                $this->userUuid,
+                'device-data',
+                'session-token'
+            );
+
+            $log = KeyReconstructionLog::query()->forUser($this->userUuid)->first();
+            expect($log)->not->toBeNull()
+                ->and($log->success)->toBeTrue()
+                ->and($log->purpose)->toBe('transaction_signing')
+                ->and($log->ip_address)->toBe('127.0.0.1')
+                ->and($log->user_agent)->toBe('TestAgent/1.0')
+                ->and($log->device_id)->toBe('test-device-001')
+                ->and($log->failure_reason)->toBeNull();
+        });
+
+        it('marks auth shard as accessed after successful reconstruction', function (): void {
+            KeyShardRecord::create([
+                'user_uuid'       => $this->userUuid,
+                'shard_type'      => ShardType::AUTH,
+                'shard_index'     => 2,
+                'encrypted_data'  => 'auth-data',
+                'encrypted_for'   => 'hsm',
+                'key_version'     => 'v1',
+                'status'          => ShardStatus::ACTIVE,
+                'public_key_hash' => hash('sha256', 'key'),
+            ]);
+
+            $this->shamirService
+                ->shouldReceive('reconstructKey')
+                ->andReturn(new ReconstructedKey(
+                    privateKey: 'key',
+                    userId: $this->userUuid,
+                    reconstructedAt: new DateTimeImmutable(),
+                ));
+
+            $this->service->reconstructWithAuth(
+                $this->userUuid,
+                'device-data',
+                'session'
+            );
+
+            $authShard = KeyShardRecord::query()
+                ->forUser($this->userUuid)
+                ->ofType(ShardType::AUTH)
+                ->first();
+
+            expect($authShard->last_accessed_at)->not->toBeNull();
+        });
+
+        it('throws exception when no active auth shard exists', function (): void {
+            // No auth shard record in database
+            $this->service->reconstructWithAuth(
+                $this->userUuid,
+                'device-data',
+                'session'
+            );
+        })->throws(Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
+        it('does not use revoked auth shards', function (): void {
+            KeyShardRecord::create([
+                'user_uuid'       => $this->userUuid,
+                'shard_type'      => ShardType::AUTH,
+                'shard_index'     => 2,
+                'encrypted_data'  => 'auth-data',
+                'encrypted_for'   => 'hsm',
+                'key_version'     => 'v1',
+                'status'          => ShardStatus::REVOKED,
+                'public_key_hash' => hash('sha256', 'key'),
+            ]);
+
+            $this->service->reconstructWithAuth(
+                $this->userUuid,
+                'device-data',
+                'session'
+            );
+        })->throws(Illuminate\Database\Eloquent\ModelNotFoundException::class);
+    });
+
+    describe('reconstructWithRecovery', function (): void {
+        it('reconstructs key using device shard and recovery shard', function (): void {
+            $deviceShardData = 'device-shard-data';
+            $recoveryShardData = 'recovery-shard-data';
+
+            // Create an active shard record so the logging query can find key_version
+            KeyShardRecord::create([
+                'user_uuid'       => $this->userUuid,
+                'shard_type'      => ShardType::DEVICE,
+                'shard_index'     => 1,
+                'encrypted_data'  => hash('sha256', $deviceShardData),
+                'encrypted_for'   => 'device-enclave',
+                'key_version'     => 'v1',
+                'status'          => ShardStatus::ACTIVE,
+                'public_key_hash' => hash('sha256', 'test-key'),
+            ]);
+
+            $expectedReconstructedKey = new ReconstructedKey(
+                privateKey: 'test-private-key',
+                userId: $this->userUuid,
+                reconstructedAt: new DateTimeImmutable(),
+                ttlSeconds: 300
+            );
+
+            $this->shamirService
+                ->shouldReceive('reconstructKey')
+                ->once()
+                ->with(
+                    Mockery::on(fn (KeyShard $shard) => $shard->type === ShardType::DEVICE
+                        && $shard->data === $deviceShardData
+                        && $shard->index === 1),
+                    Mockery::on(fn (KeyShard $shard) => $shard->type === ShardType::RECOVERY
+                        && $shard->data === $recoveryShardData
+                        && $shard->index === 3)
+                )
+                ->andReturn($expectedReconstructedKey);
+
+            $result = $this->service->reconstructWithRecovery(
+                $this->userUuid,
+                $deviceShardData,
+                $recoveryShardData
+            );
+
+            expect($result)->toBeInstanceOf(ReconstructedKey::class)
+                ->and($result->privateKey)->toBe('test-private-key');
+
+            Event::assertDispatched(KeyReconstructed::class, function ($event): bool {
+                return $event->userUuid === $this->userUuid
+                    && $event->purpose === 'device_recovery'
+                    && in_array('device', $event->shardsUsed, true)
+                    && in_array('recovery', $event->shardsUsed, true);
+            });
+        });
+
+        it('creates reconstruction log with device_recovery purpose', function (): void {
+            KeyShardRecord::create([
+                'user_uuid'       => $this->userUuid,
+                'shard_type'      => ShardType::DEVICE,
+                'shard_index'     => 1,
+                'encrypted_data'  => 'device-hash',
+                'encrypted_for'   => 'device-enclave',
+                'key_version'     => 'v1',
+                'status'          => ShardStatus::ACTIVE,
+                'public_key_hash' => hash('sha256', 'key'),
+            ]);
+
+            $this->shamirService
+                ->shouldReceive('reconstructKey')
+                ->andReturn(new ReconstructedKey(
+                    privateKey: 'key',
+                    userId: $this->userUuid,
+                    reconstructedAt: new DateTimeImmutable(),
+                ));
+
+            $this->service->reconstructWithRecovery(
+                $this->userUuid,
+                'device-data',
+                'recovery-data'
+            );
+
+            $log = KeyReconstructionLog::query()->forUser($this->userUuid)->first();
+            expect($log)->not->toBeNull()
+                ->and($log->purpose)->toBe('device_recovery')
+                ->and($log->success)->toBeTrue();
+        });
+    });
+
+    describe('reconstruct', function (): void {
+        it('throws exception when not exactly 2 shards are provided', function (): void {
+            $shard = new KeyShard(
+                type: ShardType::DEVICE,
+                data: 'data',
+                encryptedFor: 'device-enclave',
+                userId: $this->userUuid,
+                index: 1
+            );
+
+            $this->service->reconstruct(
+                $this->userUuid,
+                [$shard],
+                'test'
+            );
+        })->throws(RuntimeException::class, 'Exactly 2 shards required for reconstruction');
+
+        it('throws exception when more than 2 shards are provided', function (): void {
+            $shards = [
+                new KeyShard(ShardType::DEVICE, 'data1', 'device-enclave', $this->userUuid, 1),
+                new KeyShard(ShardType::AUTH, 'data2', 'hsm', $this->userUuid, 2),
+                new KeyShard(ShardType::RECOVERY, 'data3', 'user-cloud', $this->userUuid, 3),
+            ];
+
+            $this->service->reconstruct(
+                $this->userUuid,
+                $shards,
+                'test'
+            );
+        })->throws(RuntimeException::class, 'Exactly 2 shards required for reconstruction');
+
+        it('logs failure and dispatches event when ShamirService throws', function (): void {
+            $deviceShard = new KeyShard(ShardType::DEVICE, 'bad-data', 'device-enclave', $this->userUuid, 1);
+            $authShard = new KeyShard(ShardType::AUTH, 'bad-data', 'hsm', $this->userUuid, 2);
+
+            $this->shamirService
+                ->shouldReceive('reconstructKey')
+                ->andThrow(new RuntimeException('Invalid shard format'));
+
+            try {
+                $this->service->reconstruct(
+                    $this->userUuid,
+                    [$deviceShard, $authShard],
+                    'transaction_signing'
+                );
+            } catch (RuntimeException) {
+                // Expected
+            }
+
+            $log = KeyReconstructionLog::query()->forUser($this->userUuid)->first();
+            expect($log)->not->toBeNull()
+                ->and($log->success)->toBeFalse()
+                ->and($log->failure_reason)->toBe('Invalid shard format');
+
+            Event::assertDispatched(KeyReconstructionFailed::class, function ($event): bool {
+                return $event->userUuid === $this->userUuid
+                    && $event->reason === 'Invalid shard format';
+            });
+        });
+
+        it('re-throws the original exception after logging failure', function (): void {
+            $deviceShard = new KeyShard(ShardType::DEVICE, 'data', 'device-enclave', $this->userUuid, 1);
+            $authShard = new KeyShard(ShardType::AUTH, 'data', 'hsm', $this->userUuid, 2);
+
+            $this->shamirService
+                ->shouldReceive('reconstructKey')
+                ->andThrow(new RuntimeException('Decryption failed'));
+
+            expect(fn () => $this->service->reconstruct(
+                $this->userUuid,
+                [$deviceShard, $authShard],
+                'signing'
+            ))->toThrow(RuntimeException::class, 'Decryption failed');
+        });
+
+        it('does not mark device shard as accessed in database', function (): void {
+            // Device shard is client-stored, so marking it in DB should be skipped
+            KeyShardRecord::create([
+                'user_uuid'       => $this->userUuid,
+                'shard_type'      => ShardType::DEVICE,
+                'shard_index'     => 1,
+                'encrypted_data'  => 'device-hash',
+                'encrypted_for'   => 'device-enclave',
+                'key_version'     => 'v1',
+                'status'          => ShardStatus::ACTIVE,
+                'public_key_hash' => hash('sha256', 'key'),
+            ]);
+
+            KeyShardRecord::create([
+                'user_uuid'       => $this->userUuid,
+                'shard_type'      => ShardType::AUTH,
+                'shard_index'     => 2,
+                'encrypted_data'  => 'auth-data',
+                'encrypted_for'   => 'hsm',
+                'key_version'     => 'v1',
+                'status'          => ShardStatus::ACTIVE,
+                'public_key_hash' => hash('sha256', 'key'),
+            ]);
+
+            $this->shamirService
+                ->shouldReceive('reconstructKey')
+                ->andReturn(new ReconstructedKey(
+                    privateKey: 'key',
+                    userId: $this->userUuid,
+                    reconstructedAt: new DateTimeImmutable(),
+                ));
+
+            $deviceShard = new KeyShard(ShardType::DEVICE, 'data', 'device-enclave', $this->userUuid, 1);
+            $authShard = new KeyShard(ShardType::AUTH, 'data', 'hsm', $this->userUuid, 2);
+
+            $this->service->reconstruct($this->userUuid, [$deviceShard, $authShard], 'signing');
+
+            $deviceRecord = KeyShardRecord::query()
+                ->forUser($this->userUuid)
+                ->ofType(ShardType::DEVICE)
+                ->first();
+
+            // Device shard should NOT be marked as accessed
+            expect($deviceRecord->last_accessed_at)->toBeNull();
+        });
+    });
+
+    describe('canReconstruct', function (): void {
+        it('returns true when no recent attempts exist', function (): void {
+            expect($this->service->canReconstruct($this->userUuid))->toBeTrue();
+        });
+
+        it('returns true when recent attempts are below the threshold', function (): void {
+            // Create 5 recent attempts
+            for ($i = 0; $i < 5; $i++) {
+                KeyReconstructionLog::create([
+                    'user_uuid'   => $this->userUuid,
+                    'key_version' => 'v1',
+                    'shards_used' => ['device', 'auth'],
+                    'purpose'     => 'transaction_signing',
+                    'ip_address'  => '127.0.0.1',
+                    'success'     => true,
+                ]);
+            }
+
+            expect($this->service->canReconstruct($this->userUuid))->toBeTrue();
+        });
+
+        it('returns false when recent attempts reach the limit', function (): void {
+            // Create 10 recent attempts (default max is 10)
+            for ($i = 0; $i < 10; $i++) {
+                KeyReconstructionLog::create([
+                    'user_uuid'   => $this->userUuid,
+                    'key_version' => 'v1',
+                    'shards_used' => ['device', 'auth'],
+                    'purpose'     => 'transaction_signing',
+                    'ip_address'  => '127.0.0.1',
+                    'success'     => true,
+                ]);
+            }
+
+            expect($this->service->canReconstruct($this->userUuid))->toBeFalse();
+        });
+
+        it('respects custom max attempts parameter', function (): void {
+            // Create 3 recent attempts
+            for ($i = 0; $i < 3; $i++) {
+                KeyReconstructionLog::create([
+                    'user_uuid'   => $this->userUuid,
+                    'key_version' => 'v1',
+                    'shards_used' => ['device', 'auth'],
+                    'purpose'     => 'transaction_signing',
+                    'ip_address'  => '127.0.0.1',
+                    'success'     => true,
+                ]);
+            }
+
+            expect($this->service->canReconstruct($this->userUuid, 3))->toBeFalse()
+                ->and($this->service->canReconstruct($this->userUuid, 5))->toBeTrue();
+        });
+
+        it('does not count attempts older than one hour', function (): void {
+            // Create 10 attempts more than an hour ago
+            for ($i = 0; $i < 10; $i++) {
+                $log = KeyReconstructionLog::create([
+                    'user_uuid'   => $this->userUuid,
+                    'key_version' => 'v1',
+                    'shards_used' => ['device', 'auth'],
+                    'purpose'     => 'transaction_signing',
+                    'ip_address'  => '127.0.0.1',
+                    'success'     => true,
+                ]);
+                // Manually backdate the record
+                $log->forceFill(['created_at' => now()->subHours(2)])->save();
+            }
+
+            expect($this->service->canReconstruct($this->userUuid))->toBeTrue();
+        });
+    });
+
+    describe('getRecentLogs', function (): void {
+        it('returns recent reconstruction logs ordered by newest first', function (): void {
+            for ($i = 1; $i <= 3; $i++) {
+                KeyReconstructionLog::create([
+                    'user_uuid'   => $this->userUuid,
+                    'key_version' => "v{$i}",
+                    'shards_used' => ['device', 'auth'],
+                    'purpose'     => 'transaction_signing',
+                    'ip_address'  => '127.0.0.1',
+                    'success'     => true,
+                ]);
+            }
+
+            $logs = $this->service->getRecentLogs($this->userUuid);
+
+            expect($logs)->toHaveCount(3);
+        });
+
+        it('respects the limit parameter', function (): void {
+            for ($i = 1; $i <= 5; $i++) {
+                KeyReconstructionLog::create([
+                    'user_uuid'   => $this->userUuid,
+                    'key_version' => "v{$i}",
+                    'shards_used' => ['device', 'auth'],
+                    'purpose'     => 'signing',
+                    'ip_address'  => '127.0.0.1',
+                    'success'     => true,
+                ]);
+            }
+
+            $logs = $this->service->getRecentLogs($this->userUuid, 2);
+
+            expect($logs)->toHaveCount(2);
+        });
+
+        it('returns empty collection when no logs exist', function (): void {
+            $logs = $this->service->getRecentLogs($this->userUuid);
+
+            expect($logs)->toBeEmpty();
+        });
+
+        it('only returns logs for the specified user', function (): void {
+            $otherUser = User::factory()->create();
+
+            KeyReconstructionLog::create([
+                'user_uuid'   => $this->userUuid,
+                'key_version' => 'v1',
+                'shards_used' => ['device', 'auth'],
+                'purpose'     => 'signing',
+                'ip_address'  => '127.0.0.1',
+                'success'     => true,
+            ]);
+
+            KeyReconstructionLog::create([
+                'user_uuid'   => $otherUser->uuid,
+                'key_version' => 'v1',
+                'shards_used' => ['device', 'recovery'],
+                'purpose'     => 'recovery',
+                'ip_address'  => '127.0.0.1',
+                'success'     => true,
+            ]);
+
+            $logs = $this->service->getRecentLogs($this->userUuid);
+
+            expect($logs)->toHaveCount(1)
+                ->and($logs->first()->user_uuid)->toBe($this->userUuid);
+        });
+    });
+});

--- a/tests/Unit/Domain/KeyManagement/Services/ShardDistributionServiceTest.php
+++ b/tests/Unit/Domain/KeyManagement/Services/ShardDistributionServiceTest.php
@@ -1,0 +1,525 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\KeyManagement\Enums\ShardStatus;
+use App\Domain\KeyManagement\Enums\ShardType;
+use App\Domain\KeyManagement\Events\KeyShardsCreated;
+use App\Domain\KeyManagement\Events\KeyShardsRotated;
+use App\Domain\KeyManagement\HSM\HsmIntegrationService;
+use App\Domain\KeyManagement\Models\KeyShardRecord;
+use App\Domain\KeyManagement\Models\RecoveryBackup;
+use App\Domain\KeyManagement\Services\EncryptionService;
+use App\Domain\KeyManagement\Services\ShamirService;
+use App\Domain\KeyManagement\Services\ShardDistributionService;
+use App\Domain\KeyManagement\ValueObjects\KeyShard;
+use App\Models\User;
+use Illuminate\Support\Facades\Event;
+
+uses(Tests\TestCase::class);
+
+beforeEach(function (): void {
+    Event::fake();
+
+    $this->shamirService = Mockery::mock(ShamirService::class);
+    $this->hsm = Mockery::mock(HsmIntegrationService::class);
+    $this->encryption = Mockery::mock(EncryptionService::class);
+
+    $this->service = new ShardDistributionService(
+        shamirService: $this->shamirService,
+        hsm: $this->hsm,
+        encryption: $this->encryption
+    );
+
+    $this->user = User::factory()->create();
+    $this->userUuid = $this->user->uuid;
+});
+
+describe('ShardDistributionService', function (): void {
+    describe('createAndDistribute', function (): void {
+        it('splits key and returns device shard with storage confirmation', function (): void {
+            $privateKey = 'test-private-key-for-splitting';
+            $deviceShardData = 'device-shard-base64-data';
+            $authShardData = 'auth-shard-hsm-encrypted';
+            $recoveryShardData = 'recovery-shard-user-encrypted';
+
+            $this->shamirService
+                ->shouldReceive('splitKey')
+                ->once()
+                ->with($privateKey, $this->userUuid)
+                ->andReturn([
+                    'device'   => new KeyShard(ShardType::DEVICE, $deviceShardData, 'device-enclave', $this->userUuid, 1),
+                    'auth'     => new KeyShard(ShardType::AUTH, $authShardData, 'hsm', $this->userUuid, 2),
+                    'recovery' => new KeyShard(ShardType::RECOVERY, $recoveryShardData, 'user-cloud', $this->userUuid, 3),
+                ]);
+
+            $this->hsm
+                ->shouldReceive('store')
+                ->once()
+                ->with(Mockery::pattern('/^auth-shard:' . preg_quote($this->userUuid, '/') . ':v\d+$/'), $authShardData)
+                ->andReturn(true);
+
+            $result = $this->service->createAndDistribute($privateKey, $this->userUuid);
+
+            expect($result)->toBeArray()
+                ->and($result['device'])->toBe($deviceShardData)
+                ->and($result['auth_stored'])->toBeTrue()
+                ->and($result['recovery_stored'])->toBeTrue()
+                ->and($result['key_version'])->toStartWith('v');
+        });
+
+        it('creates a recovery backup record in the database', function (): void {
+            $recoveryShardData = 'recovery-encrypted-data';
+
+            $this->shamirService
+                ->shouldReceive('splitKey')
+                ->andReturn([
+                    'device'   => new KeyShard(ShardType::DEVICE, 'device-data', 'device-enclave', $this->userUuid, 1),
+                    'auth'     => new KeyShard(ShardType::AUTH, 'auth-data', 'hsm', $this->userUuid, 2),
+                    'recovery' => new KeyShard(ShardType::RECOVERY, $recoveryShardData, 'user-cloud', $this->userUuid, 3),
+                ]);
+
+            $this->hsm->shouldReceive('store')->andReturn(true);
+
+            $this->service->createAndDistribute('private-key', $this->userUuid);
+
+            $backup = RecoveryBackup::query()->forUser($this->userUuid)->first();
+            expect($backup)->not->toBeNull()
+                ->and($backup->encrypted_backup)->toBe($recoveryShardData)
+                ->and($backup->encryption_method)->toBe('aes-256-gcm')
+                ->and($backup->backup_hash)->toBe(hash('sha256', $recoveryShardData))
+                ->and($backup->is_verified)->toBeFalse()
+                ->and($backup->usage_count)->toBe(0);
+        });
+
+        it('creates shard records for all three shard types', function (): void {
+            $privateKey = 'my-secret-key';
+            $deviceData = 'device-data';
+            $authData = 'auth-data';
+            $recoveryData = 'recovery-data';
+
+            $this->shamirService
+                ->shouldReceive('splitKey')
+                ->andReturn([
+                    'device'   => new KeyShard(ShardType::DEVICE, $deviceData, 'device-enclave', $this->userUuid, 1),
+                    'auth'     => new KeyShard(ShardType::AUTH, $authData, 'hsm', $this->userUuid, 2),
+                    'recovery' => new KeyShard(ShardType::RECOVERY, $recoveryData, 'user-cloud', $this->userUuid, 3),
+                ]);
+
+            $this->hsm->shouldReceive('store')->andReturn(true);
+
+            $this->service->createAndDistribute($privateKey, $this->userUuid);
+
+            $shardRecords = KeyShardRecord::query()->forUser($this->userUuid)->get();
+            expect($shardRecords)->toHaveCount(3);
+
+            // Device shard should store only a hash, not the actual data
+            $deviceRecord = $shardRecords->firstWhere('shard_type', ShardType::DEVICE);
+            expect($deviceRecord)->not->toBeNull()
+                ->and($deviceRecord->encrypted_data)->toBe(hash('sha256', $deviceData))
+                ->and($deviceRecord->shard_index)->toBe(1)
+                ->and($deviceRecord->encrypted_for)->toBe('device-enclave')
+                ->and($deviceRecord->status)->toBe(ShardStatus::ACTIVE);
+
+            // Auth shard stores actual encrypted data
+            $authRecord = $shardRecords->firstWhere('shard_type', ShardType::AUTH);
+            expect($authRecord)->not->toBeNull()
+                ->and($authRecord->encrypted_data)->toBe($authData)
+                ->and($authRecord->shard_index)->toBe(2)
+                ->and($authRecord->encrypted_for)->toBe('hsm');
+
+            // Recovery shard stores actual encrypted data
+            $recoveryRecord = $shardRecords->firstWhere('shard_type', ShardType::RECOVERY);
+            expect($recoveryRecord)->not->toBeNull()
+                ->and($recoveryRecord->encrypted_data)->toBe($recoveryData)
+                ->and($recoveryRecord->shard_index)->toBe(3)
+                ->and($recoveryRecord->encrypted_for)->toBe('user-cloud');
+        });
+
+        it('stores the public key hash in shard records', function (): void {
+            $privateKey = 'my-private-key';
+
+            $this->shamirService
+                ->shouldReceive('splitKey')
+                ->andReturn([
+                    'device'   => new KeyShard(ShardType::DEVICE, 'd', 'device-enclave', $this->userUuid, 1),
+                    'auth'     => new KeyShard(ShardType::AUTH, 'a', 'hsm', $this->userUuid, 2),
+                    'recovery' => new KeyShard(ShardType::RECOVERY, 'r', 'user-cloud', $this->userUuid, 3),
+                ]);
+
+            $this->hsm->shouldReceive('store')->andReturn(true);
+
+            $this->service->createAndDistribute($privateKey, $this->userUuid);
+
+            $records = KeyShardRecord::query()->forUser($this->userUuid)->get();
+            $expectedHash = hash('sha256', $privateKey);
+
+            foreach ($records as $record) {
+                expect($record->public_key_hash)->toBe($expectedHash);
+            }
+        });
+
+        it('dispatches KeyShardsCreated event', function (): void {
+            $this->shamirService
+                ->shouldReceive('splitKey')
+                ->andReturn([
+                    'device'   => new KeyShard(ShardType::DEVICE, 'd', 'device-enclave', $this->userUuid, 1),
+                    'auth'     => new KeyShard(ShardType::AUTH, 'a', 'hsm', $this->userUuid, 2),
+                    'recovery' => new KeyShard(ShardType::RECOVERY, 'r', 'user-cloud', $this->userUuid, 3),
+                ]);
+
+            $this->hsm->shouldReceive('store')->andReturn(true);
+
+            $result = $this->service->createAndDistribute('key', $this->userUuid);
+
+            Event::assertDispatched(KeyShardsCreated::class, function ($event) use ($result): bool {
+                return $event->userUuid === $this->userUuid
+                    && $event->keyVersion === $result['key_version'];
+            });
+        });
+
+        it('stores auth shard in HSM with correct secret ID format', function (): void {
+            $authData = 'auth-encrypted-shard';
+
+            $this->shamirService
+                ->shouldReceive('splitKey')
+                ->andReturn([
+                    'device'   => new KeyShard(ShardType::DEVICE, 'd', 'device-enclave', $this->userUuid, 1),
+                    'auth'     => new KeyShard(ShardType::AUTH, $authData, 'hsm', $this->userUuid, 2),
+                    'recovery' => new KeyShard(ShardType::RECOVERY, 'r', 'user-cloud', $this->userUuid, 3),
+                ]);
+
+            $this->hsm
+                ->shouldReceive('store')
+                ->once()
+                ->with(
+                    Mockery::on(function (string $secretId): bool {
+                        // Format: auth-shard:{userUuid}:{keyVersion}
+                        return str_starts_with($secretId, "auth-shard:{$this->userUuid}:v");
+                    }),
+                    $authData
+                )
+                ->andReturn(true);
+
+            $this->service->createAndDistribute('key', $this->userUuid);
+        });
+    });
+
+    describe('rotateShards', function (): void {
+        it('marks old shards as rotated and creates new ones', function (): void {
+            $oldKeyVersion = 'v-old-123';
+
+            // Create existing shards with old version
+            foreach (ShardType::cases() as $index => $type) {
+                KeyShardRecord::create([
+                    'user_uuid'       => $this->userUuid,
+                    'shard_type'      => $type,
+                    'shard_index'     => $index + 1,
+                    'encrypted_data'  => "old-data-{$type->value}",
+                    'encrypted_for'   => 'test',
+                    'key_version'     => $oldKeyVersion,
+                    'status'          => ShardStatus::ACTIVE,
+                    'public_key_hash' => hash('sha256', 'old-key'),
+                ]);
+            }
+
+            $this->shamirService
+                ->shouldReceive('splitKey')
+                ->andReturn([
+                    'device'   => new KeyShard(ShardType::DEVICE, 'new-d', 'device-enclave', $this->userUuid, 1),
+                    'auth'     => new KeyShard(ShardType::AUTH, 'new-a', 'hsm', $this->userUuid, 2),
+                    'recovery' => new KeyShard(ShardType::RECOVERY, 'new-r', 'user-cloud', $this->userUuid, 3),
+                ]);
+
+            $this->hsm->shouldReceive('store')->andReturn(true);
+
+            $result = $this->service->rotateShards('new-private-key', $this->userUuid, $oldKeyVersion);
+
+            // Old shards should be marked as rotated
+            $oldShards = KeyShardRecord::query()
+                ->forUser($this->userUuid)
+                ->where('key_version', $oldKeyVersion)
+                ->get();
+
+            foreach ($oldShards as $shard) {
+                expect($shard->status)->toBe(ShardStatus::ROTATED);
+            }
+
+            // New shards should be active
+            expect($result['device'])->toBe('new-d')
+                ->and($result['auth_stored'])->toBeTrue()
+                ->and($result['recovery_stored'])->toBeTrue()
+                ->and($result['key_version'])->not->toBe($oldKeyVersion);
+        });
+
+        it('dispatches KeyShardsRotated event with old and new versions', function (): void {
+            $oldKeyVersion = 'v-old';
+
+            $this->shamirService
+                ->shouldReceive('splitKey')
+                ->andReturn([
+                    'device'   => new KeyShard(ShardType::DEVICE, 'd', 'device-enclave', $this->userUuid, 1),
+                    'auth'     => new KeyShard(ShardType::AUTH, 'a', 'hsm', $this->userUuid, 2),
+                    'recovery' => new KeyShard(ShardType::RECOVERY, 'r', 'user-cloud', $this->userUuid, 3),
+                ]);
+
+            $this->hsm->shouldReceive('store')->andReturn(true);
+
+            $result = $this->service->rotateShards('key', $this->userUuid, $oldKeyVersion);
+
+            Event::assertDispatched(KeyShardsRotated::class, function ($event) use ($oldKeyVersion, $result): bool {
+                return $event->userUuid === $this->userUuid
+                    && $event->oldKeyVersion === $oldKeyVersion
+                    && $event->newKeyVersion === $result['key_version'];
+            });
+        });
+
+        it('dispatches both KeyShardsCreated and KeyShardsRotated events', function (): void {
+            $this->shamirService
+                ->shouldReceive('splitKey')
+                ->andReturn([
+                    'device'   => new KeyShard(ShardType::DEVICE, 'd', 'device-enclave', $this->userUuid, 1),
+                    'auth'     => new KeyShard(ShardType::AUTH, 'a', 'hsm', $this->userUuid, 2),
+                    'recovery' => new KeyShard(ShardType::RECOVERY, 'r', 'user-cloud', $this->userUuid, 3),
+                ]);
+
+            $this->hsm->shouldReceive('store')->andReturn(true);
+
+            $this->service->rotateShards('key', $this->userUuid, 'v-old');
+
+            Event::assertDispatched(KeyShardsCreated::class);
+            Event::assertDispatched(KeyShardsRotated::class);
+        });
+    });
+
+    describe('revokeAllShards', function (): void {
+        it('revokes all active shards for a user', function (): void {
+            foreach (ShardType::cases() as $index => $type) {
+                KeyShardRecord::create([
+                    'user_uuid'       => $this->userUuid,
+                    'shard_type'      => $type,
+                    'shard_index'     => $index + 1,
+                    'encrypted_data'  => "data-{$type->value}",
+                    'encrypted_for'   => 'test',
+                    'key_version'     => 'v1',
+                    'status'          => ShardStatus::ACTIVE,
+                    'public_key_hash' => hash('sha256', 'key'),
+                ]);
+            }
+
+            $revokedCount = $this->service->revokeAllShards($this->userUuid);
+
+            expect($revokedCount)->toBe(3);
+
+            $activeShards = KeyShardRecord::query()
+                ->forUser($this->userUuid)
+                ->active()
+                ->count();
+
+            expect($activeShards)->toBe(0);
+
+            $revokedShards = KeyShardRecord::query()
+                ->forUser($this->userUuid)
+                ->where('status', ShardStatus::REVOKED)
+                ->count();
+
+            expect($revokedShards)->toBe(3);
+        });
+
+        it('returns zero when no active shards exist', function (): void {
+            $revokedCount = $this->service->revokeAllShards($this->userUuid);
+
+            expect($revokedCount)->toBe(0);
+        });
+
+        it('does not revoke shards belonging to other users', function (): void {
+            $otherUser = User::factory()->create();
+
+            // Create shards for both users
+            foreach ([$this->userUuid, $otherUser->uuid] as $uuid) {
+                KeyShardRecord::create([
+                    'user_uuid'       => $uuid,
+                    'shard_type'      => ShardType::DEVICE,
+                    'shard_index'     => 1,
+                    'encrypted_data'  => 'data',
+                    'encrypted_for'   => 'device-enclave',
+                    'key_version'     => 'v1',
+                    'status'          => ShardStatus::ACTIVE,
+                    'public_key_hash' => hash('sha256', 'key'),
+                ]);
+            }
+
+            $this->service->revokeAllShards($this->userUuid);
+
+            // Other user's shard should still be active
+            $otherUserShard = KeyShardRecord::query()
+                ->forUser($otherUser->uuid)
+                ->first();
+
+            expect($otherUserShard->status)->toBe(ShardStatus::ACTIVE);
+        });
+
+        it('does not affect already revoked or rotated shards', function (): void {
+            KeyShardRecord::create([
+                'user_uuid'       => $this->userUuid,
+                'shard_type'      => ShardType::DEVICE,
+                'shard_index'     => 1,
+                'encrypted_data'  => 'data',
+                'encrypted_for'   => 'device-enclave',
+                'key_version'     => 'v1',
+                'status'          => ShardStatus::REVOKED,
+                'public_key_hash' => hash('sha256', 'key'),
+            ]);
+
+            KeyShardRecord::create([
+                'user_uuid'       => $this->userUuid,
+                'shard_type'      => ShardType::AUTH,
+                'shard_index'     => 2,
+                'encrypted_data'  => 'data',
+                'encrypted_for'   => 'hsm',
+                'key_version'     => 'v1',
+                'status'          => ShardStatus::ROTATED,
+                'public_key_hash' => hash('sha256', 'key'),
+            ]);
+
+            $revokedCount = $this->service->revokeAllShards($this->userUuid);
+
+            expect($revokedCount)->toBe(0);
+        });
+    });
+
+    describe('getShardsSummary', function (): void {
+        it('returns summary for all shard types', function (): void {
+            KeyShardRecord::create([
+                'user_uuid'        => $this->userUuid,
+                'shard_type'       => ShardType::DEVICE,
+                'shard_index'      => 1,
+                'encrypted_data'   => 'data',
+                'encrypted_for'    => 'device-enclave',
+                'key_version'      => 'v1',
+                'status'           => ShardStatus::ACTIVE,
+                'public_key_hash'  => hash('sha256', 'key'),
+                'last_accessed_at' => now(),
+            ]);
+
+            KeyShardRecord::create([
+                'user_uuid'       => $this->userUuid,
+                'shard_type'      => ShardType::AUTH,
+                'shard_index'     => 2,
+                'encrypted_data'  => 'data',
+                'encrypted_for'   => 'hsm',
+                'key_version'     => 'v1',
+                'status'          => ShardStatus::ACTIVE,
+                'public_key_hash' => hash('sha256', 'key'),
+            ]);
+
+            $summary = $this->service->getShardsSummary($this->userUuid);
+
+            expect($summary)->toHaveKeys(['device', 'auth', 'recovery'])
+                ->and($summary['device']['exists'])->toBeTrue()
+                ->and($summary['device']['last_accessed'])->not->toBeNull()
+                ->and($summary['auth']['exists'])->toBeTrue()
+                ->and($summary['auth']['last_accessed'])->toBeNull()
+                ->and($summary['recovery']['exists'])->toBeFalse()
+                ->and($summary['recovery']['last_accessed'])->toBeNull();
+        });
+
+        it('returns all non-existing when user has no shards', function (): void {
+            $summary = $this->service->getShardsSummary($this->userUuid);
+
+            foreach (ShardType::cases() as $type) {
+                expect($summary[$type->value]['exists'])->toBeFalse()
+                    ->and($summary[$type->value]['last_accessed'])->toBeNull();
+            }
+        });
+    });
+
+    describe('verifyRecoveryShard', function (): void {
+        it('returns true when recovery shard matches verified backup', function (): void {
+            $decryptedData = 'decrypted-recovery-shard-content';
+            $encryptedData = 'encrypted-recovery-shard';
+
+            RecoveryBackup::create([
+                'user_uuid'         => $this->userUuid,
+                'encrypted_backup'  => $encryptedData,
+                'encryption_method' => 'aes-256-gcm',
+                'key_version'       => 'v1',
+                'backup_hash'       => hash('sha256', $decryptedData),
+                'is_verified'       => true,
+                'usage_count'       => 0,
+            ]);
+
+            $this->encryption
+                ->shouldReceive('decryptForUser')
+                ->once()
+                ->with($encryptedData, $this->userUuid)
+                ->andReturn($decryptedData);
+
+            $isValid = $this->service->verifyRecoveryShard($this->userUuid, $encryptedData);
+
+            expect($isValid)->toBeTrue();
+        });
+
+        it('returns false when no verified backup exists', function (): void {
+            $isValid = $this->service->verifyRecoveryShard($this->userUuid, 'some-data');
+
+            expect($isValid)->toBeFalse();
+        });
+
+        it('returns false when backup exists but is not verified', function (): void {
+            RecoveryBackup::create([
+                'user_uuid'         => $this->userUuid,
+                'encrypted_backup'  => 'data',
+                'encryption_method' => 'aes-256-gcm',
+                'key_version'       => 'v1',
+                'backup_hash'       => hash('sha256', 'data'),
+                'is_verified'       => false,
+                'usage_count'       => 0,
+            ]);
+
+            $isValid = $this->service->verifyRecoveryShard($this->userUuid, 'data');
+
+            expect($isValid)->toBeFalse();
+        });
+
+        it('returns false when decryption fails', function (): void {
+            RecoveryBackup::create([
+                'user_uuid'         => $this->userUuid,
+                'encrypted_backup'  => 'data',
+                'encryption_method' => 'aes-256-gcm',
+                'key_version'       => 'v1',
+                'backup_hash'       => hash('sha256', 'original'),
+                'is_verified'       => true,
+                'usage_count'       => 0,
+            ]);
+
+            $this->encryption
+                ->shouldReceive('decryptForUser')
+                ->andThrow(new RuntimeException('Decryption failed'));
+
+            $isValid = $this->service->verifyRecoveryShard($this->userUuid, 'corrupted-data');
+
+            expect($isValid)->toBeFalse();
+        });
+
+        it('returns false when hash does not match', function (): void {
+            RecoveryBackup::create([
+                'user_uuid'         => $this->userUuid,
+                'encrypted_backup'  => 'data',
+                'encryption_method' => 'aes-256-gcm',
+                'key_version'       => 'v1',
+                'backup_hash'       => hash('sha256', 'original-content'),
+                'is_verified'       => true,
+                'usage_count'       => 0,
+            ]);
+
+            $this->encryption
+                ->shouldReceive('decryptForUser')
+                ->andReturn('different-content');
+
+            $isValid = $this->service->verifyRecoveryShard($this->userUuid, 'data');
+
+            expect($isValid)->toBeFalse();
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Add 21 unit tests for `KeyReconstructionService` covering key reconstruction with auth/recovery shards, shard count validation, failure logging with event dispatch, rate limiting via `canReconstruct()`, and reconstruction log retrieval
- Add 20 unit tests for `ShardDistributionService` covering shard creation and distribution, recovery backup storage, shard rotation with old shard marking, emergency revocation, shard summary retrieval, and recovery shard verification
- Update `phpstan.neon` to cover Mockery mock type patterns and null-safe property access patterns used in Pest test closures

These are security-critical services handling Shamir's Secret Sharing key sharding that were previously untested. All 41 new tests pass with 113 assertions.

## Test plan
- [x] All 41 new tests pass: `./vendor/bin/pest tests/Unit/Domain/KeyManagement/Services/`
- [x] Full KeyManagement domain test suite passes (98 tests, 230 assertions)
- [x] Code style verified via `php-cs-fixer fix`
- [x] PHPStan Level 8 passes with no errors on new test files
- [x] Existing tests not affected by phpstan.neon changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)