### PR TITLE
test(privacy): Add unit tests for MerkleTreeService and ProofOfInnocenceService

### DIFF
--- a/phpstan-baseline-privacy.neon
+++ b/phpstan-baseline-privacy.neon
@@ -53,3 +53,21 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: tests/Unit/Domain/Privacy/ValueObjects/ZkProofTest.php
+
+		-
+			message: '#^Access to an undefined property PHPUnit\\Framework\\TestCase\:\:\$prover\.$#'
+			identifier: property.notFound
+			count: 14
+			path: tests/Unit/Domain/Privacy/Services/ProofOfInnocenceServiceTest.php
+
+		-
+			message: '#^Access to an undefined property PHPUnit\\Framework\\TestCase\:\:\$service\.$#'
+			identifier: property.notFound
+			count: 22
+			path: tests/Unit/Domain/Privacy/Services/ProofOfInnocenceServiceTest.php
+
+		-
+			message: '#^Parameter \#1 \$prover of class App\\Domain\\Privacy\\Services\\ProofOfInnocenceService constructor expects App\\Domain\\Privacy\\Contracts\\ZkProverInterface, Mockery\\MockInterface given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Unit/Domain/Privacy/Services/ProofOfInnocenceServiceTest.php

--- a/tests/Unit/Domain/Privacy/Services/MerkleTreeServiceTest.php
+++ b/tests/Unit/Domain/Privacy/Services/MerkleTreeServiceTest.php
@@ -1,0 +1,543 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Privacy\Services\MerkleTreeService;
+use App\Domain\Privacy\ValueObjects\MerklePath;
+use App\Domain\Privacy\ValueObjects\MerkleRoot;
+use Illuminate\Support\Facades\Cache;
+
+uses(Tests\TestCase::class);
+
+describe('MerkleTreeService', function () {
+    beforeEach(function () {
+        Cache::flush();
+        $this->service = new MerkleTreeService();
+    });
+
+    describe('network support', function () {
+        it('returns supported networks from config', function () {
+            config(['privacy.merkle.networks' => ['polygon', 'base', 'arbitrum']]);
+
+            $networks = $this->service->getSupportedNetworks();
+
+            expect($networks)->toBeArray()
+                ->and($networks)->toContain('polygon')
+                ->and($networks)->toContain('base')
+                ->and($networks)->toContain('arbitrum');
+        });
+
+        it('checks if a network is supported', function () {
+            config(['privacy.merkle.networks' => ['polygon', 'base', 'arbitrum']]);
+
+            expect($this->service->supportsNetwork('polygon'))->toBeTrue()
+                ->and($this->service->supportsNetwork('base'))->toBeTrue()
+                ->and($this->service->supportsNetwork('arbitrum'))->toBeTrue()
+                ->and($this->service->supportsNetwork('ethereum'))->toBeFalse()
+                ->and($this->service->supportsNetwork('solana'))->toBeFalse()
+                ->and($this->service->supportsNetwork(''))->toBeFalse();
+        });
+
+        it('respects custom network configuration', function () {
+            config(['privacy.merkle.networks' => ['ethereum', 'optimism']]);
+
+            expect($this->service->supportsNetwork('ethereum'))->toBeTrue()
+                ->and($this->service->supportsNetwork('optimism'))->toBeTrue()
+                ->and($this->service->supportsNetwork('polygon'))->toBeFalse();
+        });
+    });
+
+    describe('tree depth', function () {
+        it('returns tree depth from config', function () {
+            config(['privacy.merkle.max_tree_depth' => 32]);
+
+            expect($this->service->getTreeDepth())->toBe(32);
+        });
+
+        it('respects custom tree depth configuration', function () {
+            config(['privacy.merkle.max_tree_depth' => 20]);
+
+            expect($this->service->getTreeDepth())->toBe(20);
+        });
+
+        it('defaults to 32 when config key is absent', function () {
+            // Remove the entire privacy.merkle config section so the key is truly absent
+            config(['privacy.merkle' => []]);
+
+            expect($this->service->getTreeDepth())->toBe(32);
+        });
+    });
+
+    describe('provider name', function () {
+        it('returns production provider name', function () {
+            expect($this->service->getProviderName())->toBe('production');
+        });
+    });
+
+    describe('getMerkleRoot', function () {
+        it('throws InvalidArgumentException for unsupported network', function () {
+            config(['privacy.merkle.networks' => ['polygon']]);
+
+            expect(fn () => $this->service->getMerkleRoot('unsupported'))
+                ->toThrow(InvalidArgumentException::class, 'Unsupported network');
+        });
+
+        it('throws RuntimeException because production fetch is not implemented', function () {
+            config(['privacy.merkle.networks' => ['polygon']]);
+
+            expect(fn () => $this->service->getMerkleRoot('polygon'))
+                ->toThrow(RuntimeException::class, 'Production Merkle tree sync not implemented');
+        });
+
+        it('caches the result when available', function () {
+            config(['privacy.merkle.networks' => ['polygon']]);
+
+            // Pre-populate cache so it does not hit the unimplemented fetch
+            $merkleRoot = new MerkleRoot(
+                root: '0x' . str_repeat('a', 64),
+                network: 'polygon',
+                leafCount: 100,
+                treeDepth: 32,
+                blockNumber: 12345,
+                syncedAt: new DateTimeImmutable(),
+            );
+
+            Cache::put('privacy_merkle_root_polygon', $merkleRoot, 30);
+
+            $result = $this->service->getMerkleRoot('polygon');
+
+            expect($result)->toBeInstanceOf(MerkleRoot::class)
+                ->and($result->root)->toBe('0x' . str_repeat('a', 64))
+                ->and($result->network)->toBe('polygon')
+                ->and($result->leafCount)->toBe(100);
+        });
+    });
+
+    describe('getMerklePath', function () {
+        it('throws InvalidArgumentException for unsupported network', function () {
+            config(['privacy.merkle.networks' => ['polygon']]);
+
+            $commitment = '0x' . str_repeat('a', 64);
+
+            expect(fn () => $this->service->getMerklePath($commitment, 'unsupported'))
+                ->toThrow(InvalidArgumentException::class, 'Unsupported network');
+        });
+
+        it('throws InvalidArgumentException for invalid commitment format', function () {
+            config(['privacy.merkle.networks' => ['polygon']]);
+
+            expect(fn () => $this->service->getMerklePath('invalid', 'polygon'))
+                ->toThrow(InvalidArgumentException::class, 'Invalid commitment format');
+        });
+
+        it('throws InvalidArgumentException for commitment without 0x prefix', function () {
+            config(['privacy.merkle.networks' => ['polygon']]);
+
+            $commitment = str_repeat('a', 64);
+
+            expect(fn () => $this->service->getMerklePath($commitment, 'polygon'))
+                ->toThrow(InvalidArgumentException::class, 'Invalid commitment format');
+        });
+
+        it('throws InvalidArgumentException for commitment with wrong length', function () {
+            config(['privacy.merkle.networks' => ['polygon']]);
+
+            $commitment = '0x' . str_repeat('a', 32); // Too short
+
+            expect(fn () => $this->service->getMerklePath($commitment, 'polygon'))
+                ->toThrow(InvalidArgumentException::class, 'Invalid commitment format');
+        });
+
+        it('returns cached path when available', function () {
+            config(['privacy.merkle.networks' => ['polygon']]);
+
+            $commitment = '0x' . str_repeat('b', 64);
+            $pathData = [
+                'commitment'   => $commitment,
+                'root'         => '0x' . str_repeat('c', 64),
+                'network'      => 'polygon',
+                'leaf_index'   => 5,
+                'siblings'     => array_fill(0, 32, '0x' . str_repeat('d', 64)),
+                'path_indices' => array_fill(0, 32, 0),
+            ];
+
+            Cache::put('privacy_merkle_path_polygon_' . $commitment, $pathData, 30);
+
+            $result = $this->service->getMerklePath($commitment, 'polygon');
+
+            expect($result)->toBeInstanceOf(MerklePath::class)
+                ->and($result->commitment)->toBe($commitment)
+                ->and($result->network)->toBe('polygon')
+                ->and($result->leafIndex)->toBe(5);
+        });
+
+        it('throws RuntimeException for uncached commitment on production service', function () {
+            config(['privacy.merkle.networks' => ['polygon']]);
+
+            $commitment = '0x' . str_repeat('e', 64);
+
+            expect(fn () => $this->service->getMerklePath($commitment, 'polygon'))
+                ->toThrow(RuntimeException::class, 'Production Merkle path fetch not implemented');
+        });
+    });
+
+    describe('verifyCommitment', function () {
+        it('returns false for commitment without 0x prefix', function () {
+            $path = createMerklePath(32);
+
+            $result = $this->service->verifyCommitment(str_repeat('a', 64), $path);
+
+            expect($result)->toBeFalse();
+        });
+
+        it('returns false for commitment with wrong hex length', function () {
+            $path = createMerklePath(32);
+
+            $result = $this->service->verifyCommitment('0x' . str_repeat('a', 32), $path);
+
+            expect($result)->toBeFalse();
+        });
+
+        it('returns false for commitment with non-hex characters', function () {
+            $path = createMerklePath(32);
+
+            $result = $this->service->verifyCommitment('0x' . str_repeat('g', 64), $path);
+
+            expect($result)->toBeFalse();
+        });
+
+        it('returns false for empty commitment', function () {
+            $path = createMerklePath(32);
+
+            $result = $this->service->verifyCommitment('', $path);
+
+            expect($result)->toBeFalse();
+        });
+
+        it('returns false when sibling has invalid hex format', function () {
+            $siblings = array_fill(0, 32, '0x' . str_repeat('a', 64));
+            $siblings[5] = 'invalid_hex'; // One invalid sibling
+
+            $path = new MerklePath(
+                commitment: '0x' . str_repeat('1', 64),
+                root: '0x' . str_repeat('b', 64),
+                network: 'polygon',
+                leafIndex: 0,
+                siblings: $siblings,
+                pathIndices: array_fill(0, 32, 0),
+            );
+
+            $result = $this->service->verifyCommitment('0x' . str_repeat('1', 64), $path);
+
+            expect($result)->toBeFalse();
+        });
+
+        it('returns false when path index is not 0 or 1', function () {
+            $pathIndices = array_fill(0, 32, 0);
+            $pathIndices[3] = 2; // Invalid index
+
+            $path = new MerklePath(
+                commitment: '0x' . str_repeat('1', 64),
+                root: '0x' . str_repeat('b', 64),
+                network: 'polygon',
+                leafIndex: 0,
+                siblings: array_fill(0, 32, '0x' . str_repeat('a', 64)),
+                pathIndices: $pathIndices,
+            );
+
+            $result = $this->service->verifyCommitment('0x' . str_repeat('1', 64), $path);
+
+            expect($result)->toBeFalse();
+        });
+
+        it('returns false when path index is negative', function () {
+            $pathIndices = array_fill(0, 32, 0);
+            $pathIndices[0] = -1; // Negative index
+
+            $path = new MerklePath(
+                commitment: '0x' . str_repeat('1', 64),
+                root: '0x' . str_repeat('b', 64),
+                network: 'polygon',
+                leafIndex: 0,
+                siblings: array_fill(0, 32, '0x' . str_repeat('a', 64)),
+                pathIndices: $pathIndices,
+            );
+
+            $result = $this->service->verifyCommitment('0x' . str_repeat('1', 64), $path);
+
+            expect($result)->toBeFalse();
+        });
+
+        it('returns false when path depth does not match tree depth', function () {
+            config(['privacy.merkle.max_tree_depth' => 32]);
+
+            // Create a path with only 10 siblings instead of 32
+            $path = new MerklePath(
+                commitment: '0x' . str_repeat('1', 64),
+                root: '0x' . str_repeat('b', 64),
+                network: 'polygon',
+                leafIndex: 0,
+                siblings: array_fill(0, 10, '0x' . str_repeat('a', 64)),
+                pathIndices: array_fill(0, 10, 0),
+            );
+
+            $result = $this->service->verifyCommitment('0x' . str_repeat('1', 64), $path);
+
+            expect($result)->toBeFalse();
+        });
+
+        it('returns false when root does not match computed root', function () {
+            config([
+                'privacy.merkle.networks'       => ['polygon'],
+                'privacy.merkle.max_tree_depth' => 32,
+            ]);
+
+            $commitment = '0x' . str_repeat('1', 64);
+
+            // Create a valid-format path but with wrong root cached
+            $wrongRoot = new MerkleRoot(
+                root: '0x' . str_repeat('f', 64), // Will not match computed root
+                network: 'polygon',
+                leafCount: 100,
+                treeDepth: 32,
+                blockNumber: 12345,
+                syncedAt: new DateTimeImmutable(),
+            );
+
+            Cache::put('privacy_merkle_root_polygon', $wrongRoot, 30);
+
+            $path = new MerklePath(
+                commitment: $commitment,
+                root: '0x' . str_repeat('b', 64),
+                network: 'polygon',
+                leafIndex: 0,
+                siblings: array_fill(0, 32, '0x' . str_repeat('a', 64)),
+                pathIndices: array_fill(0, 32, 0),
+            );
+
+            $result = $this->service->verifyCommitment($commitment, $path);
+
+            expect($result)->toBeFalse();
+        });
+
+        it('verifies commitment successfully when computed root matches chain root', function () {
+            config([
+                'privacy.merkle.networks'       => ['polygon'],
+                'privacy.merkle.max_tree_depth' => 2,
+            ]);
+
+            $commitment = '0x' . str_repeat('1', 64);
+            $sibling0 = '0x' . str_repeat('2', 64);
+            $sibling1 = '0x' . str_repeat('3', 64);
+
+            // Compute expected root: commitment is left child at both levels
+            // Level 0: hash(commitment, sibling0) with sorted inputs
+            // Level 1: hash(level0Result, sibling1) with sorted inputs
+            $computedRoot = computeExpectedRoot($commitment, [$sibling0, $sibling1], [0, 0]);
+
+            $chainRoot = new MerkleRoot(
+                root: $computedRoot,
+                network: 'polygon',
+                leafCount: 4,
+                treeDepth: 2,
+                blockNumber: 12345,
+                syncedAt: new DateTimeImmutable(),
+            );
+
+            Cache::put('privacy_merkle_root_polygon', $chainRoot, 30);
+
+            $path = new MerklePath(
+                commitment: $commitment,
+                root: $computedRoot,
+                network: 'polygon',
+                leafIndex: 0,
+                siblings: [$sibling0, $sibling1],
+                pathIndices: [0, 0],
+            );
+
+            $result = $this->service->verifyCommitment($commitment, $path);
+
+            expect($result)->toBeTrue();
+        });
+
+        it('computes root correctly when commitment is on the right side', function () {
+            config([
+                'privacy.merkle.networks'       => ['polygon'],
+                'privacy.merkle.max_tree_depth' => 2,
+            ]);
+
+            $commitment = '0x' . str_repeat('1', 64);
+            $sibling0 = '0x' . str_repeat('2', 64);
+            $sibling1 = '0x' . str_repeat('3', 64);
+
+            // pathIndices [1, 0] means commitment is on the right at level 0
+            $computedRoot = computeExpectedRoot($commitment, [$sibling0, $sibling1], [1, 0]);
+
+            $chainRoot = new MerkleRoot(
+                root: $computedRoot,
+                network: 'polygon',
+                leafCount: 4,
+                treeDepth: 2,
+                blockNumber: 12345,
+                syncedAt: new DateTimeImmutable(),
+            );
+
+            Cache::put('privacy_merkle_root_polygon', $chainRoot, 30);
+
+            $path = new MerklePath(
+                commitment: $commitment,
+                root: $computedRoot,
+                network: 'polygon',
+                leafIndex: 1,
+                siblings: [$sibling0, $sibling1],
+                pathIndices: [1, 0],
+            );
+
+            $result = $this->service->verifyCommitment($commitment, $path);
+
+            expect($result)->toBeTrue();
+        });
+    });
+
+    describe('hashPair via integration', function () {
+        it('produces deterministic hashes for same inputs', function () {
+            config([
+                'privacy.merkle.networks'       => ['polygon'],
+                'privacy.merkle.max_tree_depth' => 1,
+            ]);
+
+            $commitment = '0x' . str_repeat('1', 64);
+            $sibling = '0x' . str_repeat('2', 64);
+
+            $root1 = computeExpectedRoot($commitment, [$sibling], [0]);
+            $root2 = computeExpectedRoot($commitment, [$sibling], [0]);
+
+            expect($root1)->toBe($root2);
+        });
+
+        it('sorts inputs for consistent ordering regardless of left-right position', function () {
+            // hashPair sorts inputs so hash(a, b) == hash(b, a) if a < b or a > b
+            // This is by design to prevent second-preimage attacks
+            $a = '0x' . str_repeat('1', 64);
+            $b = '0x' . str_repeat('2', 64);
+
+            // Both orderings should produce the same hash because hashPair sorts
+            $hashAB = testHashPair($a, $b);
+            $hashBA = testHashPair($b, $a);
+
+            expect($hashAB)->toBe($hashBA);
+        });
+
+        it('uses domain separation prefix in hash computation', function () {
+            $a = '0x' . str_repeat('1', 64);
+            $b = '0x' . str_repeat('2', 64);
+
+            $merkleHash = testHashPair($a, $b);
+
+            // Without domain separation - raw concatenation
+            $leftBin = hex2bin(substr($a, 2));
+            $rightBin = hex2bin(substr($b, 2));
+
+            // Compare with strcmp to determine order (same as hashPair)
+            if (strcmp($a, $b) > 0) {
+                [$leftBin, $rightBin] = [$rightBin, $leftBin];
+            }
+
+            $rawHash = '0x' . hash('sha3-256', $leftBin . $rightBin);
+
+            // Merkle hash uses domain separation so it must differ from raw hash
+            expect($merkleHash)->not->toBe($rawHash);
+        });
+
+        it('produces 0x-prefixed 64-character hex output', function () {
+            $a = '0x' . str_repeat('a', 64);
+            $b = '0x' . str_repeat('b', 64);
+
+            $result = testHashPair($a, $b);
+
+            expect($result)->toStartWith('0x')
+                ->and(strlen($result))->toBe(66); // 0x + 64 hex chars
+        });
+    });
+
+    describe('syncTree', function () {
+        it('throws InvalidArgumentException for unsupported network', function () {
+            config(['privacy.merkle.networks' => ['polygon']]);
+
+            expect(fn () => $this->service->syncTree('unsupported'))
+                ->toThrow(InvalidArgumentException::class, 'Unsupported network');
+        });
+
+        it('clears cache before fetching fresh root', function () {
+            config(['privacy.merkle.networks' => ['polygon']]);
+
+            // Pre-populate cache
+            $merkleRoot = new MerkleRoot(
+                root: '0x' . str_repeat('a', 64),
+                network: 'polygon',
+                leafCount: 100,
+                treeDepth: 32,
+                blockNumber: 12345,
+                syncedAt: new DateTimeImmutable(),
+            );
+
+            Cache::put('privacy_merkle_root_polygon', $merkleRoot, 30);
+
+            // syncTree will clear cache and then try to fetch from chain (which throws)
+            expect(fn () => $this->service->syncTree('polygon'))
+                ->toThrow(RuntimeException::class, 'Production Merkle tree sync not implemented');
+
+            // Verify cache was cleared
+            expect(Cache::get('privacy_merkle_root_polygon'))->toBeNull();
+        });
+    });
+});
+
+// Helper: Replicate the hashPair logic for test assertions
+function testHashPair(string $left, string $right): string
+{
+    if (strcmp($left, $right) > 0) {
+        [$left, $right] = [$right, $left];
+    }
+
+    $leftBin = hex2bin(substr($left, 2));
+    $rightBin = hex2bin(substr($right, 2));
+
+    return '0x' . hash('sha3-256', 'merkle_node:' . $leftBin . $rightBin);
+}
+
+/**
+ * Helper: Compute expected root by walking up the tree.
+ *
+ * @param  array<int, string>  $siblings
+ * @param  array<int, int>     $pathIndices
+ */
+function computeExpectedRoot(string $commitment, array $siblings, array $pathIndices): string
+{
+    $current = $commitment;
+
+    foreach ($siblings as $index => $sibling) {
+        $pathIndex = $pathIndices[$index] ?? 0;
+
+        if ($pathIndex === 0) {
+            $current = testHashPair($current, $sibling);
+        } else {
+            $current = testHashPair($sibling, $current);
+        }
+    }
+
+    return $current;
+}
+
+// Helper: Create a MerklePath with valid hex values
+function createMerklePath(int $depth): MerklePath
+{
+    return new MerklePath(
+        commitment: '0x' . str_repeat('1', 64),
+        root: '0x' . str_repeat('b', 64),
+        network: 'polygon',
+        leafIndex: 0,
+        siblings: array_fill(0, $depth, '0x' . str_repeat('a', 64)),
+        pathIndices: array_fill(0, $depth, 0),
+    );
+}

--- a/tests/Unit/Domain/Privacy/Services/ProofOfInnocenceServiceTest.php
+++ b/tests/Unit/Domain/Privacy/Services/ProofOfInnocenceServiceTest.php
@@ -1,0 +1,421 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Privacy\Contracts\ZkProverInterface;
+use App\Domain\Privacy\Enums\ProofType;
+use App\Domain\Privacy\Events\ProofOfInnocenceGenerated;
+use App\Domain\Privacy\Services\ProofOfInnocenceResult;
+use App\Domain\Privacy\Services\ProofOfInnocenceService;
+use App\Domain\Privacy\ValueObjects\ZkProof;
+use Illuminate\Support\Facades\Event;
+
+uses(Tests\TestCase::class);
+
+describe('ProofOfInnocenceService', function () {
+    beforeEach(function () {
+        Event::fake();
+
+        $this->prover = Mockery::mock(ZkProverInterface::class);
+        $this->service = new ProofOfInnocenceService($this->prover);
+    });
+
+    describe('generateSanctionsClearanceProof', function () {
+        it('generates a sanctions clearance proof', function () {
+            $userId = 'user-123';
+            $transactionHistory = ['0xtx1', '0xtx2'];
+            $sanctionsRoot = '0x' . str_repeat('a', 64);
+
+            $expectedProof = createTestProof([
+                'sanctions_list_root' => $sanctionsRoot,
+            ]);
+
+            $this->prover
+                ->shouldReceive('generateProof')
+                ->once()
+                ->withArgs(function (ProofType $type, array $privateInputs, array $publicInputs) use ($userId, $sanctionsRoot, $transactionHistory) {
+                    return $type === ProofType::SANCTIONS_CLEAR
+                        && $privateInputs['identity_hash'] === hash('sha256', $userId)
+                        && $privateInputs['sanctions_list_hash'] === $sanctionsRoot
+                        && $privateInputs['transaction_hashes'] === $transactionHistory
+                        && $publicInputs['sanctions_list_root'] === $sanctionsRoot
+                        && isset($publicInputs['user_commitment'])
+                        && isset($publicInputs['proof_timestamp']);
+                })
+                ->andReturn($expectedProof);
+
+            $proof = $this->service->generateSanctionsClearanceProof(
+                $userId,
+                $transactionHistory,
+                $sanctionsRoot,
+            );
+
+            expect($proof)->toBeInstanceOf(ZkProof::class)
+                ->and($proof->type)->toBe(ProofType::SANCTIONS_CLEAR);
+        });
+
+        it('dispatches ProofOfInnocenceGenerated event', function () {
+            $expectedProof = createTestProof();
+
+            $this->prover
+                ->shouldReceive('generateProof')
+                ->once()
+                ->andReturn($expectedProof);
+
+            $this->service->generateSanctionsClearanceProof(
+                'user-456',
+                ['0xtx1'],
+                '0x' . str_repeat('b', 64),
+            );
+
+            Event::assertDispatched(ProofOfInnocenceGenerated::class, function ($event) {
+                return $event->userId === 'user-456'
+                    && $event->proofType === 'sanctions_clearance'
+                    && ! empty($event->proofHash);
+            });
+        });
+
+        it('passes identity hash as SHA-256 of user ID', function () {
+            $userId = 'unique-user-id';
+            $expectedHash = hash('sha256', $userId);
+            $expectedProof = createTestProof();
+
+            $this->prover
+                ->shouldReceive('generateProof')
+                ->once()
+                ->withArgs(function (ProofType $type, array $privateInputs) use ($expectedHash) {
+                    return $privateInputs['identity_hash'] === $expectedHash;
+                })
+                ->andReturn($expectedProof);
+
+            $this->service->generateSanctionsClearanceProof(
+                $userId,
+                [],
+                '0x' . str_repeat('c', 64),
+            );
+        });
+
+        it('generates unique user commitments with random nonces', function () {
+            $capturedPublicInputs = [];
+
+            $this->prover
+                ->shouldReceive('generateProof')
+                ->twice()
+                ->withArgs(function (ProofType $type, array $privateInputs, array $publicInputs) use (&$capturedPublicInputs) {
+                    $capturedPublicInputs[] = $publicInputs['user_commitment'];
+
+                    return true;
+                })
+                ->andReturn(createTestProof());
+
+            $this->service->generateSanctionsClearanceProof(
+                'user-123',
+                [],
+                '0x' . str_repeat('a', 64),
+            );
+
+            $this->service->generateSanctionsClearanceProof(
+                'user-123',
+                [],
+                '0x' . str_repeat('a', 64),
+            );
+
+            // Same user, same inputs, but commitments should differ due to random nonce
+            expect($capturedPublicInputs)->toHaveCount(2)
+                ->and($capturedPublicInputs[0])->not->toBe($capturedPublicInputs[1]);
+        });
+
+        it('includes proof timestamp in public inputs', function () {
+            $timeBefore = time();
+            $expectedProof = createTestProof();
+
+            $this->prover
+                ->shouldReceive('generateProof')
+                ->once()
+                ->withArgs(function (ProofType $type, array $privateInputs, array $publicInputs) use ($timeBefore) {
+                    return $publicInputs['proof_timestamp'] >= $timeBefore
+                        && $publicInputs['proof_timestamp'] <= time();
+                })
+                ->andReturn($expectedProof);
+
+            $this->service->generateSanctionsClearanceProof(
+                'user-123',
+                [],
+                '0x' . str_repeat('a', 64),
+            );
+        });
+    });
+
+    describe('generateSourceClearanceProof', function () {
+        it('generates a source clearance proof', function () {
+            $transactionId = 'tx-789';
+            $sourceAddresses = ['0xaddr1', '0xaddr2'];
+            $illicitRoot = '0x' . str_repeat('d', 64);
+            $merkleProof = ['0xproof1', '0xproof2'];
+
+            $expectedProof = createTestProof([
+                'illicit_list_root' => $illicitRoot,
+            ]);
+
+            $this->prover
+                ->shouldReceive('generateProof')
+                ->once()
+                ->withArgs(function (ProofType $type, array $privateInputs, array $publicInputs) use ($transactionId, $illicitRoot, $sourceAddresses, $merkleProof) {
+                    return $type === ProofType::SANCTIONS_CLEAR
+                        && $privateInputs['identity_hash'] === hash('sha256', $transactionId)
+                        && $privateInputs['sanctions_list_hash'] === $illicitRoot
+                        && $privateInputs['source_addresses'] === $sourceAddresses
+                        && $privateInputs['merkle_proof'] === $merkleProof
+                        && $publicInputs['illicit_list_root'] === $illicitRoot
+                        && isset($publicInputs['transaction_commitment'])
+                        && isset($publicInputs['proof_timestamp']);
+                })
+                ->andReturn($expectedProof);
+
+            $proof = $this->service->generateSourceClearanceProof(
+                $transactionId,
+                $sourceAddresses,
+                $illicitRoot,
+                $merkleProof,
+            );
+
+            expect($proof)->toBeInstanceOf(ZkProof::class);
+        });
+
+        it('generates unique transaction commitments with random nonces', function () {
+            $capturedPublicInputs = [];
+
+            $this->prover
+                ->shouldReceive('generateProof')
+                ->twice()
+                ->withArgs(function (ProofType $type, array $privateInputs, array $publicInputs) use (&$capturedPublicInputs) {
+                    $capturedPublicInputs[] = $publicInputs['transaction_commitment'];
+
+                    return true;
+                })
+                ->andReturn(createTestProof());
+
+            $this->service->generateSourceClearanceProof(
+                'tx-123',
+                ['0xaddr1'],
+                '0x' . str_repeat('a', 64),
+                ['0xproof1'],
+            );
+
+            $this->service->generateSourceClearanceProof(
+                'tx-123',
+                ['0xaddr1'],
+                '0x' . str_repeat('a', 64),
+                ['0xproof1'],
+            );
+
+            expect($capturedPublicInputs)->toHaveCount(2)
+                ->and($capturedPublicInputs[0])->not->toBe($capturedPublicInputs[1]);
+        });
+    });
+
+    describe('verifyProofOfInnocence', function () {
+        it('returns valid result for a valid non-expired proof with matching sanctions root', function () {
+            $sanctionsRoot = '0x' . str_repeat('a', 64);
+            $expiresAt = new DateTimeImmutable('+30 days');
+
+            $proof = createTestProof([
+                'sanctions_list_root' => $sanctionsRoot,
+            ], $expiresAt);
+
+            $this->prover
+                ->shouldReceive('verifyProof')
+                ->once()
+                ->with($proof)
+                ->andReturn(true);
+
+            $result = $this->service->verifyProofOfInnocence($proof, $sanctionsRoot);
+
+            expect($result)->toBeInstanceOf(ProofOfInnocenceResult::class)
+                ->and($result->valid)->toBeTrue()
+                ->and($result->reason)->toBeNull()
+                ->and($result->validUntil)->toBe($expiresAt);
+        });
+
+        it('returns invalid result when sanctions list root does not match', function () {
+            $proofRoot = '0x' . str_repeat('a', 64);
+            $currentRoot = '0x' . str_repeat('b', 64);
+
+            $proof = createTestProof([
+                'sanctions_list_root' => $proofRoot,
+            ]);
+
+            // Prover should NOT be called when roots mismatch
+            $this->prover->shouldNotReceive('verifyProof');
+
+            $result = $this->service->verifyProofOfInnocence($proof, $currentRoot);
+
+            expect($result->valid)->toBeFalse()
+                ->and($result->reason)->toBe('Proof generated against outdated sanctions list');
+        });
+
+        it('returns invalid result when ZK proof verification fails', function () {
+            $sanctionsRoot = '0x' . str_repeat('a', 64);
+
+            $proof = createTestProof([
+                'sanctions_list_root' => $sanctionsRoot,
+            ]);
+
+            $this->prover
+                ->shouldReceive('verifyProof')
+                ->once()
+                ->with($proof)
+                ->andReturn(false);
+
+            $result = $this->service->verifyProofOfInnocence($proof, $sanctionsRoot);
+
+            expect($result->valid)->toBeFalse()
+                ->and($result->reason)->toBe('Invalid ZK proof');
+        });
+
+        it('returns invalid result when proof has expired', function () {
+            $sanctionsRoot = '0x' . str_repeat('a', 64);
+
+            $proof = createTestProof(
+                ['sanctions_list_root' => $sanctionsRoot],
+                new DateTimeImmutable('-1 day'), // Already expired
+            );
+
+            $this->prover
+                ->shouldReceive('verifyProof')
+                ->once()
+                ->andReturn(true);
+
+            $result = $this->service->verifyProofOfInnocence($proof, $sanctionsRoot);
+
+            expect($result->valid)->toBeFalse()
+                ->and($result->reason)->toBe('Proof has expired');
+        });
+
+        it('checks sanctions root before verifying the ZK proof', function () {
+            // When sanctions root does not match, verifyProof should not be called
+            $proof = createTestProof([
+                'sanctions_list_root' => '0x' . str_repeat('a', 64),
+            ]);
+
+            $this->prover->shouldNotReceive('verifyProof');
+
+            $this->service->verifyProofOfInnocence($proof, '0x' . str_repeat('b', 64));
+        });
+
+        it('checks expiration after ZK proof verification', function () {
+            $sanctionsRoot = '0x' . str_repeat('a', 64);
+
+            // Valid ZK proof but expired
+            $proof = createTestProof(
+                ['sanctions_list_root' => $sanctionsRoot],
+                new DateTimeImmutable('-10 days'),
+            );
+
+            $this->prover
+                ->shouldReceive('verifyProof')
+                ->once()
+                ->andReturn(true);
+
+            $result = $this->service->verifyProofOfInnocence($proof, $sanctionsRoot);
+
+            // Should report expired even though ZK proof was valid
+            expect($result->valid)->toBeFalse()
+                ->and($result->reason)->toBe('Proof has expired');
+        });
+    });
+
+    describe('isProofRenewalNeeded', function () {
+        it('returns true when sanctions list root has changed', function () {
+            $proof = createTestProof([
+                'sanctions_list_root' => '0x' . str_repeat('a', 64),
+            ], new DateTimeImmutable('+60 days'));
+
+            $newRoot = '0x' . str_repeat('b', 64);
+
+            $result = $this->service->isProofRenewalNeeded($proof, $newRoot);
+
+            expect($result)->toBeTrue();
+        });
+
+        it('returns true when proof is expiring within threshold', function () {
+            $proof = createTestProof(
+                ['sanctions_list_root' => '0x' . str_repeat('a', 64)],
+                new DateTimeImmutable('+15 days'), // Less than 30-day default threshold
+            );
+
+            $result = $this->service->isProofRenewalNeeded(
+                $proof,
+                '0x' . str_repeat('a', 64),
+            );
+
+            expect($result)->toBeTrue();
+        });
+
+        it('returns false when proof is valid and not expiring soon', function () {
+            $sanctionsRoot = '0x' . str_repeat('a', 64);
+
+            $proof = createTestProof(
+                ['sanctions_list_root' => $sanctionsRoot],
+                new DateTimeImmutable('+60 days'), // Well above 30-day threshold
+            );
+
+            $result = $this->service->isProofRenewalNeeded($proof, $sanctionsRoot);
+
+            expect($result)->toBeFalse();
+        });
+
+        it('respects custom renewal threshold', function () {
+            $sanctionsRoot = '0x' . str_repeat('a', 64);
+
+            $proof = createTestProof(
+                ['sanctions_list_root' => $sanctionsRoot],
+                new DateTimeImmutable('+15 days'),
+            );
+
+            // With default threshold (30 days), renewal would be needed
+            $resultDefaultThreshold = $this->service->isProofRenewalNeeded($proof, $sanctionsRoot);
+
+            // With lower threshold (10 days), renewal is not needed
+            $resultLowThreshold = $this->service->isProofRenewalNeeded($proof, $sanctionsRoot, 10);
+
+            expect($resultDefaultThreshold)->toBeTrue()
+                ->and($resultLowThreshold)->toBeFalse();
+        });
+
+        it('returns true when proof is already expired', function () {
+            $sanctionsRoot = '0x' . str_repeat('a', 64);
+
+            $proof = createTestProof(
+                ['sanctions_list_root' => $sanctionsRoot],
+                new DateTimeImmutable('-5 days'), // Already expired
+            );
+
+            $result = $this->service->isProofRenewalNeeded($proof, $sanctionsRoot);
+
+            expect($result)->toBeTrue();
+        });
+    });
+});
+
+/**
+ * Helper: Create a test ZkProof with configurable public inputs and expiration.
+ *
+ * @param  array<string, mixed>  $publicInputs
+ */
+function createTestProof(array $publicInputs = [], ?DateTimeImmutable $expiresAt = null): ZkProof
+{
+    return new ZkProof(
+        type: ProofType::SANCTIONS_CLEAR,
+        proof: base64_encode((string) json_encode([
+            'statement'  => 'sanctions_clearance_test',
+            'commitment' => 'test_commitment',
+            'challenge'  => 'test_challenge',
+            'response'   => 'test_response',
+        ])),
+        publicInputs: $publicInputs,
+        verifierAddress: '0x' . str_repeat('0', 40),
+        createdAt: new DateTimeImmutable(),
+        expiresAt: $expiresAt ?? new DateTimeImmutable('+90 days'),
+    );
+}


### PR DESCRIPTION
## Summary
- Add 33 unit tests for `MerkleTreeService` covering network validation, tree depth config, cache behavior, hex validation, path index bounds checking, domain-separated hash computation, and Merkle root verification
- Add 18 unit tests for `ProofOfInnocenceService` covering sanctions clearance proof generation, source clearance proofs, proof verification with expired/invalid/mismatched data, renewal threshold logic, and random nonce commitment generation
- Update `phpstan-baseline-privacy.neon` with baseline entries for Pest dynamic property access patterns

## Test plan
- [x] All 51 tests pass (99 assertions)
- [x] PHP CS Fixer reports no violations
- [x] PHPStan Level 8 passes with no errors
- [x] Tests follow existing Pest describe/it pattern from Privacy domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)