### PR TITLE
feat(mobile-payment): Domain foundation - models, enums, config, migrations

### DIFF
--- a/app/Domain/Commerce/Models/Merchant.php
+++ b/app/Domain/Commerce/Models/Merchant.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Commerce\Models;
+
+use App\Domain\Commerce\Enums\MerchantStatus;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * Merchant entity for payment processing.
+ *
+ * @property string $id
+ * @property string $public_id
+ * @property string $display_name
+ * @property string|null $icon_url
+ * @property array<string> $accepted_assets
+ * @property array<string> $accepted_networks
+ * @property MerchantStatus $status
+ * @property string|null $terminal_id
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ * @property \Carbon\Carbon|null $deleted_at
+ */
+class Merchant extends Model
+{
+    use HasUuids;
+    use SoftDeletes;
+
+    protected $table = 'merchants';
+
+    protected $fillable = [
+        'public_id',
+        'display_name',
+        'icon_url',
+        'accepted_assets',
+        'accepted_networks',
+        'status',
+        'terminal_id',
+    ];
+
+    protected $casts = [
+        'accepted_assets'   => 'array',
+        'accepted_networks' => 'array',
+        'status'            => MerchantStatus::class,
+    ];
+
+    /**
+     * @return HasMany<MerchantWalletAddress, $this>
+     */
+    public function walletAddresses(): HasMany
+    {
+        return $this->hasMany(MerchantWalletAddress::class);
+    }
+
+    public function acceptsAsset(string $asset): bool
+    {
+        return in_array($asset, $this->accepted_assets ?? [], true);
+    }
+
+    public function acceptsNetwork(string $network): bool
+    {
+        return in_array($network, $this->accepted_networks ?? [], true);
+    }
+
+    public function canAcceptPayments(): bool
+    {
+        return $this->status->canAcceptPayments();
+    }
+
+    public function getWalletAddress(string $network): ?string
+    {
+        $wallet = $this->walletAddresses()
+            ->where('network', $network)
+            ->where('is_active', true)
+            ->first();
+
+        return $wallet?->wallet_address;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toApiResponse(): array
+    {
+        return [
+            'merchantId'  => $this->public_id,
+            'displayName' => $this->display_name,
+            'iconUrl'     => $this->icon_url,
+        ];
+    }
+}

--- a/app/Domain/Commerce/Models/MerchantWalletAddress.php
+++ b/app/Domain/Commerce/Models/MerchantWalletAddress.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Commerce\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Merchant wallet address per network.
+ *
+ * @property string $id
+ * @property string $merchant_id
+ * @property string $network
+ * @property string $wallet_address
+ * @property bool $is_active
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ */
+class MerchantWalletAddress extends Model
+{
+    use HasUuids;
+
+    protected $table = 'merchant_wallet_addresses';
+
+    protected $fillable = [
+        'merchant_id',
+        'network',
+        'wallet_address',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+    ];
+
+    /**
+     * @return BelongsTo<Merchant, $this>
+     */
+    public function merchant(): BelongsTo
+    {
+        return $this->belongsTo(Merchant::class);
+    }
+}

--- a/app/Domain/MobilePayment/Contracts/MerchantLookupServiceInterface.php
+++ b/app/Domain/MobilePayment/Contracts/MerchantLookupServiceInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\MobilePayment\Contracts;
+
+use App\Domain\Commerce\Models\Merchant;
+
+interface MerchantLookupServiceInterface
+{
+    /**
+     * Find a merchant by their public ID.
+     *
+     * @throws \App\Domain\MobilePayment\Exceptions\MerchantNotFoundException
+     */
+    public function findByPublicId(string $publicId): Merchant;
+
+    /**
+     * Check if a merchant accepts the given asset on the given network.
+     */
+    public function acceptsPayment(Merchant $merchant, string $asset, string $network): bool;
+}

--- a/app/Domain/MobilePayment/Contracts/PaymentIntentServiceInterface.php
+++ b/app/Domain/MobilePayment/Contracts/PaymentIntentServiceInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\MobilePayment\Contracts;
+
+use App\Domain\MobilePayment\Models\PaymentIntent;
+
+interface PaymentIntentServiceInterface
+{
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function create(int $userId, array $data): PaymentIntent;
+
+    public function get(string $intentId, int $userId): PaymentIntent;
+
+    public function submit(string $intentId, int $userId, string $authType): PaymentIntent;
+
+    public function cancel(string $intentId, int $userId, ?string $reason = null): PaymentIntent;
+}

--- a/app/Domain/MobilePayment/Enums/ActivityItemType.php
+++ b/app/Domain/MobilePayment/Enums/ActivityItemType.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\MobilePayment\Enums;
+
+/**
+ * Types of activity feed items.
+ */
+enum ActivityItemType: string
+{
+    case MERCHANT_PAYMENT = 'merchant_payment';
+    case TRANSFER_IN = 'transfer_in';
+    case TRANSFER_OUT = 'transfer_out';
+    case SHIELD = 'shield';
+    case UNSHIELD = 'unshield';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::MERCHANT_PAYMENT => 'Merchant Payment',
+            self::TRANSFER_IN      => 'Received',
+            self::TRANSFER_OUT     => 'Sent',
+            self::SHIELD           => 'Shield',
+            self::UNSHIELD         => 'Unshield',
+        };
+    }
+
+    public function isOutflow(): bool
+    {
+        return in_array($this, [self::MERCHANT_PAYMENT, self::TRANSFER_OUT, self::SHIELD], true);
+    }
+
+    public function isInflow(): bool
+    {
+        return in_array($this, [self::TRANSFER_IN, self::UNSHIELD], true);
+    }
+
+    /**
+     * Get the filter group for activity feed filtering.
+     */
+    public function filterGroup(): string
+    {
+        return $this->isOutflow() ? 'expenses' : 'income';
+    }
+}

--- a/app/Domain/MobilePayment/Enums/PaymentAsset.php
+++ b/app/Domain/MobilePayment/Enums/PaymentAsset.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\MobilePayment\Enums;
+
+/**
+ * Supported assets for mobile payments (v1: USDC only).
+ */
+enum PaymentAsset: string
+{
+    case USDC = 'USDC';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::USDC => 'USD Coin',
+        };
+    }
+
+    public function decimals(): int
+    {
+        return match ($this) {
+            self::USDC => 6,
+        };
+    }
+
+    /**
+     * @return array<string>
+     */
+    public static function values(): array
+    {
+        return array_map(fn (self $case) => $case->value, self::cases());
+    }
+}

--- a/app/Domain/MobilePayment/Enums/PaymentErrorCode.php
+++ b/app/Domain/MobilePayment/Enums/PaymentErrorCode.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\MobilePayment\Enums;
+
+/**
+ * Error codes for mobile payment operations.
+ */
+enum PaymentErrorCode: string
+{
+    case MERCHANT_UNREACHABLE = 'MERCHANT_UNREACHABLE';
+    case WRONG_NETWORK = 'WRONG_NETWORK';
+    case WRONG_TOKEN = 'WRONG_TOKEN';
+    case INSUFFICIENT_FEES = 'INSUFFICIENT_FEES';
+    case INSUFFICIENT_FUNDS = 'INSUFFICIENT_FUNDS';
+    case NETWORK_BUSY = 'NETWORK_BUSY';
+    case INTENT_EXPIRED = 'INTENT_EXPIRED';
+    case INTENT_ALREADY_SUBMITTED = 'INTENT_ALREADY_SUBMITTED';
+
+    public function httpStatus(): int
+    {
+        return match ($this) {
+            self::MERCHANT_UNREACHABLE,
+            self::WRONG_NETWORK,
+            self::WRONG_TOKEN,
+            self::INSUFFICIENT_FEES,
+            self::INSUFFICIENT_FUNDS => 422,
+            self::NETWORK_BUSY       => 200,
+            self::INTENT_EXPIRED,
+            self::INTENT_ALREADY_SUBMITTED => 409,
+        };
+    }
+
+    public function message(): string
+    {
+        return match ($this) {
+            self::MERCHANT_UNREACHABLE     => 'We couldn\'t connect to the merchant terminal.',
+            self::WRONG_NETWORK            => 'The merchant does not accept payments on this network.',
+            self::WRONG_TOKEN              => 'The merchant does not accept this token.',
+            self::INSUFFICIENT_FEES        => 'Not enough native token to cover network fees.',
+            self::INSUFFICIENT_FUNDS       => 'Insufficient token balance for this payment.',
+            self::NETWORK_BUSY             => 'The network is experiencing high traffic. Your transaction may take longer than usual.',
+            self::INTENT_EXPIRED           => 'This payment intent has expired. Please create a new one.',
+            self::INTENT_ALREADY_SUBMITTED => 'This payment has already been submitted.',
+        };
+    }
+
+    public function isInformational(): bool
+    {
+        return $this === self::NETWORK_BUSY;
+    }
+}

--- a/app/Domain/MobilePayment/Enums/PaymentIntentStatus.php
+++ b/app/Domain/MobilePayment/Enums/PaymentIntentStatus.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\MobilePayment\Enums;
+
+/**
+ * Payment Intent state machine.
+ *
+ * Flow: CREATED -> AWAITING_AUTH -> SUBMITTING -> PENDING -> CONFIRMED/FAILED
+ * Cancel: CREATED|AWAITING_AUTH -> CANCELLED
+ * Expiry: CREATED|AWAITING_AUTH -> EXPIRED
+ */
+enum PaymentIntentStatus: string
+{
+    case CREATED = 'created';
+    case AWAITING_AUTH = 'awaiting_auth';
+    case SUBMITTING = 'submitting';
+    case PENDING = 'pending';
+    case CONFIRMED = 'confirmed';
+    case FAILED = 'failed';
+    case CANCELLED = 'cancelled';
+    case EXPIRED = 'expired';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::CREATED       => 'Created',
+            self::AWAITING_AUTH => 'Awaiting Authorization',
+            self::SUBMITTING    => 'Submitting',
+            self::PENDING       => 'Pending',
+            self::CONFIRMED     => 'Confirmed',
+            self::FAILED        => 'Failed',
+            self::CANCELLED     => 'Cancelled',
+            self::EXPIRED       => 'Expired',
+        };
+    }
+
+    public function canTransitionTo(PaymentIntentStatus $newStatus): bool
+    {
+        return in_array($newStatus, $this->allowedTransitions(), true);
+    }
+
+    /**
+     * @return array<PaymentIntentStatus>
+     */
+    public function allowedTransitions(): array
+    {
+        return match ($this) {
+            self::CREATED       => [self::AWAITING_AUTH, self::CANCELLED, self::EXPIRED],
+            self::AWAITING_AUTH => [self::SUBMITTING, self::CANCELLED, self::EXPIRED],
+            self::SUBMITTING    => [self::PENDING, self::FAILED],
+            self::PENDING       => [self::CONFIRMED, self::FAILED],
+            self::CONFIRMED     => [],
+            self::FAILED        => [],
+            self::CANCELLED     => [],
+            self::EXPIRED       => [],
+        };
+    }
+
+    public function isFinal(): bool
+    {
+        return in_array($this, [self::CONFIRMED, self::FAILED, self::CANCELLED, self::EXPIRED], true);
+    }
+
+    public function isCancellable(): bool
+    {
+        return in_array($this, [self::CREATED, self::AWAITING_AUTH], true);
+    }
+
+    public function isActive(): bool
+    {
+        return in_array($this, [self::CREATED, self::AWAITING_AUTH, self::SUBMITTING, self::PENDING], true);
+    }
+}

--- a/app/Domain/MobilePayment/Enums/PaymentNetwork.php
+++ b/app/Domain/MobilePayment/Enums/PaymentNetwork.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\MobilePayment\Enums;
+
+/**
+ * Supported blockchain networks for mobile payments (v1: Solana + Tron only).
+ */
+enum PaymentNetwork: string
+{
+    case SOLANA = 'SOLANA';
+    case TRON = 'TRON';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::SOLANA => 'Solana',
+            self::TRON   => 'Tron',
+        };
+    }
+
+    public function nativeAsset(): string
+    {
+        return match ($this) {
+            self::SOLANA => 'SOL',
+            self::TRON   => 'TRX',
+        };
+    }
+
+    public function averageGasCostUsd(): float
+    {
+        return match ($this) {
+            self::SOLANA => 0.001,
+            self::TRON   => 0.50,
+        };
+    }
+
+    public function explorerBaseUrl(): string
+    {
+        return match ($this) {
+            self::SOLANA => 'https://solscan.io/tx/',
+            self::TRON   => 'https://tronscan.org/#/transaction/',
+        };
+    }
+
+    public function explorerUrl(string $txHash): string
+    {
+        return $this->explorerBaseUrl() . $txHash;
+    }
+
+    public function requiredConfirmations(): int
+    {
+        return match ($this) {
+            self::SOLANA => 32,
+            self::TRON   => 20,
+        };
+    }
+
+    public function addressPattern(): string
+    {
+        return match ($this) {
+            self::SOLANA => '/^[1-9A-HJ-NP-Za-km-z]{32,44}$/',
+            self::TRON   => '/^T[1-9A-HJ-NP-Za-km-z]{33}$/',
+        };
+    }
+
+    /**
+     * @return array<string>
+     */
+    public static function values(): array
+    {
+        return array_map(fn (self $case) => $case->value, self::cases());
+    }
+}

--- a/app/Domain/MobilePayment/Exceptions/InvalidStateTransitionException.php
+++ b/app/Domain/MobilePayment/Exceptions/InvalidStateTransitionException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\MobilePayment\Exceptions;
+
+use App\Domain\MobilePayment\Enums\PaymentIntentStatus;
+use RuntimeException;
+
+class InvalidStateTransitionException extends RuntimeException
+{
+    public function __construct(
+        public readonly PaymentIntentStatus $from,
+        public readonly PaymentIntentStatus $to,
+    ) {
+        parent::__construct(
+            "Cannot transition payment intent from '{$from->value}' to '{$to->value}'."
+        );
+    }
+}

--- a/app/Domain/MobilePayment/Exceptions/MerchantNotFoundException.php
+++ b/app/Domain/MobilePayment/Exceptions/MerchantNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\MobilePayment\Exceptions;
+
+use RuntimeException;
+
+class MerchantNotFoundException extends RuntimeException
+{
+    public function __construct(string $merchantId)
+    {
+        parent::__construct("Merchant '{$merchantId}' not found.");
+    }
+}

--- a/app/Domain/MobilePayment/Exceptions/PaymentIntentException.php
+++ b/app/Domain/MobilePayment/Exceptions/PaymentIntentException.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\MobilePayment\Exceptions;
+
+use App\Domain\MobilePayment\Enums\PaymentErrorCode;
+use RuntimeException;
+
+class PaymentIntentException extends RuntimeException
+{
+    public function __construct(
+        public readonly PaymentErrorCode $errorCode,
+        ?string $message = null,
+        /** @var array<string, mixed> */
+        public readonly array $details = [],
+    ) {
+        parent::__construct($message ?? $errorCode->message());
+    }
+
+    public function httpStatus(): int
+    {
+        return $this->errorCode->httpStatus();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toApiResponse(): array
+    {
+        return [
+            'success' => false,
+            'error'   => [
+                'code'    => $this->errorCode->value,
+                'message' => $this->getMessage(),
+                'details' => $this->details,
+            ],
+        ];
+    }
+}

--- a/app/Domain/MobilePayment/Models/ActivityFeedItem.php
+++ b/app/Domain/MobilePayment/Models/ActivityFeedItem.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\MobilePayment\Models;
+
+use App\Domain\MobilePayment\Enums\ActivityItemType;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+/**
+ * Denormalized activity feed item (CQRS read model).
+ *
+ * @property string $id
+ * @property int $user_id
+ * @property ActivityItemType $activity_type
+ * @property string|null $merchant_name
+ * @property string|null $merchant_icon_url
+ * @property string $amount
+ * @property string $asset
+ * @property string|null $network
+ * @property string $status
+ * @property bool $protected
+ * @property string|null $reference_type
+ * @property string|null $reference_id
+ * @property string|null $from_address
+ * @property string|null $to_address
+ * @property \Carbon\Carbon $occurred_at
+ * @property array<string, mixed>|null $metadata
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ */
+class ActivityFeedItem extends Model
+{
+    use HasUuids;
+
+    protected $table = 'activity_feed_items';
+
+    protected $fillable = [
+        'user_id',
+        'activity_type',
+        'merchant_name',
+        'merchant_icon_url',
+        'amount',
+        'asset',
+        'network',
+        'status',
+        'protected',
+        'reference_type',
+        'reference_id',
+        'from_address',
+        'to_address',
+        'occurred_at',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'activity_type' => ActivityItemType::class,
+        'protected'     => 'boolean',
+        'metadata'      => 'array',
+        'occurred_at'   => 'datetime',
+    ];
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return MorphTo<Model, $this>
+     */
+    public function reference(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder<ActivityFeedItem> $query
+     * @return \Illuminate\Database\Eloquent\Builder<ActivityFeedItem>
+     */
+    public function scopeForUser($query, int $userId)
+    {
+        return $query->where('user_id', $userId);
+    }
+
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder<ActivityFeedItem> $query
+     * @return \Illuminate\Database\Eloquent\Builder<ActivityFeedItem>
+     */
+    public function scopeIncome($query)
+    {
+        return $query->whereIn('activity_type', [
+            ActivityItemType::TRANSFER_IN,
+            ActivityItemType::UNSHIELD,
+        ]);
+    }
+
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder<ActivityFeedItem> $query
+     * @return \Illuminate\Database\Eloquent\Builder<ActivityFeedItem>
+     */
+    public function scopeExpenses($query)
+    {
+        return $query->whereIn('activity_type', [
+            ActivityItemType::MERCHANT_PAYMENT,
+            ActivityItemType::TRANSFER_OUT,
+            ActivityItemType::SHIELD,
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toApiResponse(): array
+    {
+        $response = [
+            'id'        => $this->id,
+            'type'      => $this->activity_type->value,
+            'amount'    => $this->amount,
+            'asset'     => $this->asset,
+            'timestamp' => $this->occurred_at->toIso8601String(),
+            'status'    => $this->status,
+            'protected' => $this->protected,
+        ];
+
+        if ($this->merchant_name) {
+            $response['merchantName'] = $this->merchant_name;
+            $response['merchantIconUrl'] = $this->merchant_icon_url;
+        }
+
+        if ($this->from_address) {
+            $response['fromAddress'] = $this->from_address;
+        }
+
+        if ($this->to_address) {
+            $response['toAddress'] = $this->to_address;
+        }
+
+        return $response;
+    }
+}

--- a/app/Domain/MobilePayment/Models/PaymentIntent.php
+++ b/app/Domain/MobilePayment/Models/PaymentIntent.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\MobilePayment\Models;
+
+use App\Domain\Commerce\Models\Merchant;
+use App\Domain\MobilePayment\Enums\PaymentAsset;
+use App\Domain\MobilePayment\Enums\PaymentIntentStatus;
+use App\Domain\MobilePayment\Enums\PaymentNetwork;
+use App\Domain\MobilePayment\Exceptions\InvalidStateTransitionException;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Payment Intent for mobile merchant payments.
+ *
+ * @property string $id
+ * @property string $public_id
+ * @property int $user_id
+ * @property string $merchant_id
+ * @property string $asset
+ * @property string $network
+ * @property string $amount
+ * @property PaymentIntentStatus $status
+ * @property bool $shield_enabled
+ * @property array<string, mixed>|null $fees_estimate
+ * @property string|null $tx_hash
+ * @property string|null $tx_explorer_url
+ * @property int $confirmations
+ * @property int $required_confirmations
+ * @property string|null $error_code
+ * @property string|null $error_message
+ * @property string|null $cancel_reason
+ * @property string|null $idempotency_key
+ * @property array<string, mixed>|null $metadata
+ * @property \Carbon\Carbon $expires_at
+ * @property \Carbon\Carbon|null $submitted_at
+ * @property \Carbon\Carbon|null $confirmed_at
+ * @property \Carbon\Carbon|null $failed_at
+ * @property \Carbon\Carbon|null $cancelled_at
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ */
+class PaymentIntent extends Model
+{
+    use HasUuids;
+
+    protected $table = 'payment_intents';
+
+    protected $fillable = [
+        'public_id',
+        'user_id',
+        'merchant_id',
+        'asset',
+        'network',
+        'amount',
+        'status',
+        'shield_enabled',
+        'fees_estimate',
+        'tx_hash',
+        'tx_explorer_url',
+        'confirmations',
+        'required_confirmations',
+        'error_code',
+        'error_message',
+        'cancel_reason',
+        'idempotency_key',
+        'metadata',
+        'expires_at',
+        'submitted_at',
+        'confirmed_at',
+        'failed_at',
+        'cancelled_at',
+    ];
+
+    protected $casts = [
+        'status'                 => PaymentIntentStatus::class,
+        'shield_enabled'         => 'boolean',
+        'fees_estimate'          => 'array',
+        'metadata'               => 'array',
+        'confirmations'          => 'integer',
+        'required_confirmations' => 'integer',
+        'expires_at'             => 'datetime',
+        'submitted_at'           => 'datetime',
+        'confirmed_at'           => 'datetime',
+        'failed_at'              => 'datetime',
+        'cancelled_at'           => 'datetime',
+    ];
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return BelongsTo<Merchant, $this>
+     */
+    public function merchant(): BelongsTo
+    {
+        return $this->belongsTo(Merchant::class);
+    }
+
+    /**
+     * Transition to a new status with guard check.
+     *
+     * @throws InvalidStateTransitionException
+     */
+    public function transitionTo(PaymentIntentStatus $newStatus): void
+    {
+        if (! $this->status->canTransitionTo($newStatus)) {
+            throw new InvalidStateTransitionException($this->status, $newStatus);
+        }
+
+        $this->status = $newStatus;
+
+        match ($newStatus) {
+            PaymentIntentStatus::SUBMITTING => $this->submitted_at = now(),
+            PaymentIntentStatus::CONFIRMED  => $this->confirmed_at = now(),
+            PaymentIntentStatus::FAILED     => $this->failed_at = now(),
+            PaymentIntentStatus::CANCELLED  => $this->cancelled_at = now(),
+            default                         => null,
+        };
+
+        $this->save();
+    }
+
+    /**
+     * Check if this intent has expired (lazy evaluation).
+     */
+    public function isExpired(): bool
+    {
+        if ($this->status->isFinal()) {
+            return $this->status === PaymentIntentStatus::EXPIRED;
+        }
+
+        return $this->expires_at->isPast();
+    }
+
+    /**
+     * Expire this intent if it's past its TTL and still active.
+     */
+    public function expireIfStale(): bool
+    {
+        if (! $this->isExpired() || $this->status->isFinal()) {
+            return false;
+        }
+
+        $this->transitionTo(PaymentIntentStatus::EXPIRED);
+
+        return true;
+    }
+
+    public function getNetworkEnum(): PaymentNetwork
+    {
+        return PaymentNetwork::from($this->network);
+    }
+
+    public function getAssetEnum(): PaymentAsset
+    {
+        return PaymentAsset::from($this->asset);
+    }
+
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder<PaymentIntent> $query
+     * @return \Illuminate\Database\Eloquent\Builder<PaymentIntent>
+     */
+    public function scopeForUser($query, int $userId)
+    {
+        return $query->where('user_id', $userId);
+    }
+
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder<PaymentIntent> $query
+     * @return \Illuminate\Database\Eloquent\Builder<PaymentIntent>
+     */
+    public function scopeActive($query)
+    {
+        return $query->whereIn('status', [
+            PaymentIntentStatus::CREATED,
+            PaymentIntentStatus::AWAITING_AUTH,
+            PaymentIntentStatus::SUBMITTING,
+            PaymentIntentStatus::PENDING,
+        ]);
+    }
+
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder<PaymentIntent> $query
+     * @return \Illuminate\Database\Eloquent\Builder<PaymentIntent>
+     */
+    public function scopeExpirable($query)
+    {
+        return $query->whereIn('status', [
+            PaymentIntentStatus::CREATED,
+            PaymentIntentStatus::AWAITING_AUTH,
+        ])->where('expires_at', '<', now());
+    }
+
+    /**
+     * Format for API response.
+     *
+     * @return array<string, mixed>
+     */
+    public function toApiResponse(): array
+    {
+        $response = [
+            'intentId'   => $this->public_id,
+            'merchantId' => $this->merchant?->public_id,
+            'merchant'   => $this->merchant ? [
+                'displayName' => $this->merchant->display_name,
+                'iconUrl'     => $this->merchant->icon_url,
+            ] : null,
+            'asset'         => $this->asset,
+            'network'       => $this->network,
+            'amount'        => $this->amount,
+            'status'        => strtoupper($this->status->value),
+            'shieldEnabled' => $this->shield_enabled,
+            'feesEstimate'  => $this->fees_estimate,
+            'createdAt'     => $this->created_at->toIso8601String(),
+            'expiresAt'     => $this->expires_at->toIso8601String(),
+        ];
+
+        if ($this->tx_hash) {
+            $response['tx'] = [
+                'hash'        => $this->tx_hash,
+                'explorerUrl' => $this->tx_explorer_url,
+            ];
+            $response['confirmations'] = $this->confirmations;
+            $response['requiredConfirmations'] = $this->required_confirmations;
+        }
+
+        if ($this->error_code) {
+            $response['error'] = [
+                'code'    => $this->error_code,
+                'message' => $this->error_message,
+            ];
+        }
+
+        return $response;
+    }
+}

--- a/app/Domain/MobilePayment/Models/PaymentReceipt.php
+++ b/app/Domain/MobilePayment/Models/PaymentReceipt.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\MobilePayment\Models;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Payment receipt for completed transactions.
+ *
+ * @property string $id
+ * @property string $public_id
+ * @property string|null $payment_intent_id
+ * @property int $user_id
+ * @property string $merchant_name
+ * @property string $amount
+ * @property string $asset
+ * @property string $network
+ * @property string|null $tx_hash
+ * @property string $network_fee
+ * @property string|null $pdf_path
+ * @property string $share_token
+ * @property \Carbon\Carbon $transaction_at
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ */
+class PaymentReceipt extends Model
+{
+    use HasUuids;
+
+    protected $table = 'payment_receipts';
+
+    protected $fillable = [
+        'public_id',
+        'payment_intent_id',
+        'user_id',
+        'merchant_name',
+        'amount',
+        'asset',
+        'network',
+        'tx_hash',
+        'network_fee',
+        'pdf_path',
+        'share_token',
+        'transaction_at',
+    ];
+
+    protected $casts = [
+        'transaction_at' => 'datetime',
+    ];
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return BelongsTo<PaymentIntent, $this>
+     */
+    public function paymentIntent(): BelongsTo
+    {
+        return $this->belongsTo(PaymentIntent::class);
+    }
+
+    public function getShareUrl(): string
+    {
+        return config('app.url') . '/receipt/' . $this->share_token;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toApiResponse(): array
+    {
+        return [
+            'receiptId'    => $this->public_id,
+            'merchantName' => $this->merchant_name,
+            'amount'       => $this->amount,
+            'asset'        => $this->asset,
+            'dateTime'     => $this->transaction_at->toIso8601String(),
+            'networkFee'   => $this->network_fee,
+            'sharePayload' => $this->getShareUrl(),
+            'pdfUrl'       => $this->pdf_path,
+        ];
+    }
+}

--- a/app/Domain/MobilePayment/ValueObjects/FeeEstimate.php
+++ b/app/Domain/MobilePayment/ValueObjects/FeeEstimate.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\MobilePayment\ValueObjects;
+
+use App\Domain\MobilePayment\Enums\PaymentNetwork;
+
+final readonly class FeeEstimate
+{
+    public function __construct(
+        public string $nativeAsset,
+        public string $amount,
+        public string $usdApprox,
+    ) {
+    }
+
+    public static function forNetwork(PaymentNetwork $network): self
+    {
+        return match ($network) {
+            PaymentNetwork::SOLANA => new self(
+                nativeAsset: 'SOL',
+                amount: '0.00004',
+                usdApprox: '0.01',
+            ),
+            PaymentNetwork::TRON => new self(
+                nativeAsset: 'TRX',
+                amount: '5.0',
+                usdApprox: '0.50',
+            ),
+        };
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function toArray(): array
+    {
+        return [
+            'nativeAsset' => $this->nativeAsset,
+            'amount'      => $this->amount,
+            'usdApprox'   => $this->usdApprox,
+        ];
+    }
+}

--- a/config/mobile_payment.php
+++ b/config/mobile_payment.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Allowed Networks
+    |--------------------------------------------------------------------------
+    |
+    | Networks supported for mobile payments. v1: Solana + Tron only.
+    |
+    */
+    'allowed_networks' => explode(',', env('MOBILE_PAYMENT_NETWORKS', 'SOLANA,TRON')),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Allowed Assets
+    |--------------------------------------------------------------------------
+    |
+    | Assets supported for mobile payments. v1: USDC only.
+    |
+    */
+    'allowed_assets' => explode(',', env('MOBILE_PAYMENT_ASSETS', 'USDC')),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Payment Intent Expiry
+    |--------------------------------------------------------------------------
+    |
+    | How many minutes before an unsubmitted payment intent expires.
+    |
+    */
+    'expiry_minutes' => (int) env('MOBILE_PAYMENT_EXPIRY_MINUTES', 15),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Receipt Cache TTL
+    |--------------------------------------------------------------------------
+    |
+    | How many hours to cache generated receipts in Redis.
+    |
+    */
+    'receipt_cache_hours' => (int) env('MOBILE_PAYMENT_RECEIPT_CACHE_HOURS', 24),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Demo Mode
+    |--------------------------------------------------------------------------
+    |
+    | Use demo/stub implementations for blockchain interactions.
+    |
+    */
+    'demo_mode' => (bool) env('MOBILE_PAYMENT_DEMO_MODE', true),
+];

--- a/database/migrations/2026_02_07_000001_create_merchants_table.php
+++ b/database/migrations/2026_02_07_000001_create_merchants_table.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Creates the merchants and merchant_wallet_addresses tables.
+ */
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('merchants', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('public_id', 64)->unique()->comment('Public-facing ID (merchant_...)');
+            $table->string('display_name');
+            $table->string('icon_url')->nullable();
+            $table->json('accepted_assets')->comment('Array of accepted asset codes');
+            $table->json('accepted_networks')->comment('Array of accepted network codes');
+            $table->string('status', 20)->default('pending');
+            $table->string('terminal_id', 64)->nullable()->index();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        Schema::create('merchant_wallet_addresses', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('merchant_id')->constrained('merchants')->cascadeOnDelete();
+            $table->string('network', 20);
+            $table->string('wallet_address', 64);
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+
+            $table->unique(['merchant_id', 'network']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('merchant_wallet_addresses');
+        Schema::dropIfExists('merchants');
+    }
+};

--- a/database/migrations/2026_02_07_000002_create_payment_intents_table.php
+++ b/database/migrations/2026_02_07_000002_create_payment_intents_table.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Creates the payment_intents table for mobile merchant payment lifecycle.
+ */
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('payment_intents', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('public_id', 64)->unique()->comment('Public-facing ID (pi_...)');
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignUuid('merchant_id')->constrained('merchants')->cascadeOnDelete();
+            $table->string('asset', 10);
+            $table->string('network', 20);
+            $table->decimal('amount', 20, 8);
+            $table->string('status', 20)->default('created');
+            $table->boolean('shield_enabled')->default(false);
+            $table->json('fees_estimate')->nullable();
+            $table->string('tx_hash', 128)->nullable()->index();
+            $table->string('tx_explorer_url')->nullable();
+            $table->unsignedInteger('confirmations')->default(0);
+            $table->unsignedInteger('required_confirmations')->default(1);
+            $table->string('error_code', 50)->nullable();
+            $table->text('error_message')->nullable();
+            $table->string('cancel_reason', 50)->nullable();
+            $table->string('idempotency_key', 128)->nullable()->unique();
+            $table->json('metadata')->nullable();
+            $table->timestamp('expires_at');
+            $table->timestamp('submitted_at')->nullable();
+            $table->timestamp('confirmed_at')->nullable();
+            $table->timestamp('failed_at')->nullable();
+            $table->timestamp('cancelled_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['user_id', 'created_at']);
+            $table->index(['status', 'expires_at']);
+            $table->index(['merchant_id', 'status', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('payment_intents');
+    }
+};

--- a/database/migrations/2026_02_07_000003_create_payment_receipts_table.php
+++ b/database/migrations/2026_02_07_000003_create_payment_receipts_table.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Creates the payment_receipts table for transaction receipt generation.
+ */
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('payment_receipts', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('public_id', 64)->unique()->comment('Public-facing ID (rcpt_...)');
+            $table->foreignUuid('payment_intent_id')->nullable()->constrained('payment_intents')->nullOnDelete();
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->string('merchant_name')->comment('Snapshot at receipt creation time');
+            $table->decimal('amount', 20, 8);
+            $table->string('asset', 10);
+            $table->string('network', 20);
+            $table->string('tx_hash', 128)->nullable();
+            $table->string('network_fee', 50)->comment('Display string like "0.01 USD"');
+            $table->string('pdf_path')->nullable();
+            $table->string('share_token', 64)->unique();
+            $table->timestamp('transaction_at');
+            $table->timestamps();
+
+            $table->index(['user_id', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('payment_receipts');
+    }
+};

--- a/database/migrations/2026_02_07_000004_create_activity_feed_items_table.php
+++ b/database/migrations/2026_02_07_000004_create_activity_feed_items_table.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Creates the activity_feed_items table (CQRS read model for activity feed).
+ */
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('activity_feed_items', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->string('activity_type', 30);
+            $table->string('merchant_name')->nullable();
+            $table->string('merchant_icon_url')->nullable();
+            $table->decimal('amount', 20, 8)->comment('Signed: negative = outflow');
+            $table->string('asset', 10);
+            $table->string('network', 20)->nullable();
+            $table->string('status', 20)->default('pending');
+            $table->boolean('protected')->default(false)->comment('Shield/privacy status');
+            $table->string('reference_type')->nullable()->comment('Polymorphic type');
+            $table->uuid('reference_id')->nullable()->comment('Polymorphic ID');
+            $table->string('from_address', 64)->nullable();
+            $table->string('to_address', 64)->nullable();
+            $table->timestamp('occurred_at');
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+
+            $table->index(['user_id', 'occurred_at', 'id'], 'afi_cursor_idx');
+            $table->index(['user_id', 'activity_type', 'occurred_at'], 'afi_filtered_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('activity_feed_items');
+    }
+};

--- a/tests/Unit/Domain/MobilePayment/Enums/PaymentIntentStatusTest.php
+++ b/tests/Unit/Domain/MobilePayment/Enums/PaymentIntentStatusTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\MobilePayment\Enums\PaymentIntentStatus;
+
+describe('PaymentIntentStatus Enum', function (): void {
+    it('has all expected statuses', function (): void {
+        $statuses = PaymentIntentStatus::cases();
+
+        expect($statuses)->toHaveCount(8);
+        expect(PaymentIntentStatus::CREATED->value)->toBe('created');
+        expect(PaymentIntentStatus::AWAITING_AUTH->value)->toBe('awaiting_auth');
+        expect(PaymentIntentStatus::SUBMITTING->value)->toBe('submitting');
+        expect(PaymentIntentStatus::PENDING->value)->toBe('pending');
+        expect(PaymentIntentStatus::CONFIRMED->value)->toBe('confirmed');
+        expect(PaymentIntentStatus::FAILED->value)->toBe('failed');
+        expect(PaymentIntentStatus::CANCELLED->value)->toBe('cancelled');
+        expect(PaymentIntentStatus::EXPIRED->value)->toBe('expired');
+    });
+
+    it('returns correct labels', function (): void {
+        expect(PaymentIntentStatus::CREATED->label())->toBe('Created');
+        expect(PaymentIntentStatus::AWAITING_AUTH->label())->toBe('Awaiting Authorization');
+        expect(PaymentIntentStatus::CONFIRMED->label())->toBe('Confirmed');
+    });
+
+    it('validates forward transitions correctly', function (): void {
+        // CREATED -> AWAITING_AUTH
+        expect(PaymentIntentStatus::CREATED->canTransitionTo(PaymentIntentStatus::AWAITING_AUTH))->toBeTrue();
+        expect(PaymentIntentStatus::CREATED->canTransitionTo(PaymentIntentStatus::CANCELLED))->toBeTrue();
+        expect(PaymentIntentStatus::CREATED->canTransitionTo(PaymentIntentStatus::EXPIRED))->toBeTrue();
+        expect(PaymentIntentStatus::CREATED->canTransitionTo(PaymentIntentStatus::CONFIRMED))->toBeFalse();
+
+        // AWAITING_AUTH -> SUBMITTING or CANCELLED
+        expect(PaymentIntentStatus::AWAITING_AUTH->canTransitionTo(PaymentIntentStatus::SUBMITTING))->toBeTrue();
+        expect(PaymentIntentStatus::AWAITING_AUTH->canTransitionTo(PaymentIntentStatus::CANCELLED))->toBeTrue();
+        expect(PaymentIntentStatus::AWAITING_AUTH->canTransitionTo(PaymentIntentStatus::CONFIRMED))->toBeFalse();
+
+        // SUBMITTING -> PENDING or FAILED
+        expect(PaymentIntentStatus::SUBMITTING->canTransitionTo(PaymentIntentStatus::PENDING))->toBeTrue();
+        expect(PaymentIntentStatus::SUBMITTING->canTransitionTo(PaymentIntentStatus::FAILED))->toBeTrue();
+        expect(PaymentIntentStatus::SUBMITTING->canTransitionTo(PaymentIntentStatus::CANCELLED))->toBeFalse();
+
+        // PENDING -> CONFIRMED or FAILED
+        expect(PaymentIntentStatus::PENDING->canTransitionTo(PaymentIntentStatus::CONFIRMED))->toBeTrue();
+        expect(PaymentIntentStatus::PENDING->canTransitionTo(PaymentIntentStatus::FAILED))->toBeTrue();
+        expect(PaymentIntentStatus::PENDING->canTransitionTo(PaymentIntentStatus::CANCELLED))->toBeFalse();
+    });
+
+    it('prevents transitions from final states', function (): void {
+        foreach ([PaymentIntentStatus::CONFIRMED, PaymentIntentStatus::FAILED, PaymentIntentStatus::CANCELLED, PaymentIntentStatus::EXPIRED] as $final) {
+            expect($final->allowedTransitions())->toBeEmpty();
+        }
+    });
+
+    it('correctly identifies final states', function (): void {
+        expect(PaymentIntentStatus::CONFIRMED->isFinal())->toBeTrue();
+        expect(PaymentIntentStatus::FAILED->isFinal())->toBeTrue();
+        expect(PaymentIntentStatus::CANCELLED->isFinal())->toBeTrue();
+        expect(PaymentIntentStatus::EXPIRED->isFinal())->toBeTrue();
+
+        expect(PaymentIntentStatus::CREATED->isFinal())->toBeFalse();
+        expect(PaymentIntentStatus::PENDING->isFinal())->toBeFalse();
+    });
+
+    it('correctly identifies cancellable states', function (): void {
+        expect(PaymentIntentStatus::CREATED->isCancellable())->toBeTrue();
+        expect(PaymentIntentStatus::AWAITING_AUTH->isCancellable())->toBeTrue();
+
+        expect(PaymentIntentStatus::SUBMITTING->isCancellable())->toBeFalse();
+        expect(PaymentIntentStatus::PENDING->isCancellable())->toBeFalse();
+        expect(PaymentIntentStatus::CONFIRMED->isCancellable())->toBeFalse();
+    });
+
+    it('correctly identifies active states', function (): void {
+        expect(PaymentIntentStatus::CREATED->isActive())->toBeTrue();
+        expect(PaymentIntentStatus::AWAITING_AUTH->isActive())->toBeTrue();
+        expect(PaymentIntentStatus::SUBMITTING->isActive())->toBeTrue();
+        expect(PaymentIntentStatus::PENDING->isActive())->toBeTrue();
+
+        expect(PaymentIntentStatus::CONFIRMED->isActive())->toBeFalse();
+        expect(PaymentIntentStatus::FAILED->isActive())->toBeFalse();
+    });
+
+    it('returns allowed transitions', function (): void {
+        $transitions = PaymentIntentStatus::CREATED->allowedTransitions();
+        expect($transitions)->toContain(PaymentIntentStatus::AWAITING_AUTH);
+        expect($transitions)->toContain(PaymentIntentStatus::CANCELLED);
+        expect($transitions)->toContain(PaymentIntentStatus::EXPIRED);
+        expect($transitions)->toHaveCount(3);
+    });
+});

--- a/tests/Unit/Domain/MobilePayment/Enums/PaymentNetworkTest.php
+++ b/tests/Unit/Domain/MobilePayment/Enums/PaymentNetworkTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\MobilePayment\Enums\PaymentNetwork;
+
+describe('PaymentNetwork Enum', function (): void {
+    it('has only Solana and Tron for v1', function (): void {
+        $networks = PaymentNetwork::cases();
+
+        expect($networks)->toHaveCount(2);
+        expect(PaymentNetwork::SOLANA->value)->toBe('SOLANA');
+        expect(PaymentNetwork::TRON->value)->toBe('TRON');
+    });
+
+    it('returns correct labels', function (): void {
+        expect(PaymentNetwork::SOLANA->label())->toBe('Solana');
+        expect(PaymentNetwork::TRON->label())->toBe('Tron');
+    });
+
+    it('returns correct native assets', function (): void {
+        expect(PaymentNetwork::SOLANA->nativeAsset())->toBe('SOL');
+        expect(PaymentNetwork::TRON->nativeAsset())->toBe('TRX');
+    });
+
+    it('returns explorer URLs', function (): void {
+        $url = PaymentNetwork::SOLANA->explorerUrl('abc123');
+        expect($url)->toBe('https://solscan.io/tx/abc123');
+
+        $url = PaymentNetwork::TRON->explorerUrl('def456');
+        expect($url)->toBe('https://tronscan.org/#/transaction/def456');
+    });
+
+    it('returns required confirmations', function (): void {
+        expect(PaymentNetwork::SOLANA->requiredConfirmations())->toBeGreaterThan(0);
+        expect(PaymentNetwork::TRON->requiredConfirmations())->toBeGreaterThan(0);
+    });
+
+    it('returns address patterns', function (): void {
+        expect(PaymentNetwork::SOLANA->addressPattern())->toBeString();
+        expect(PaymentNetwork::TRON->addressPattern())->toBeString();
+    });
+
+    it('returns all values as array', function (): void {
+        $values = PaymentNetwork::values();
+        expect($values)->toBe(['SOLANA', 'TRON']);
+    });
+
+    it('returns average gas cost', function (): void {
+        expect(PaymentNetwork::SOLANA->averageGasCostUsd())->toBeFloat();
+        expect(PaymentNetwork::TRON->averageGasCostUsd())->toBeFloat();
+    });
+});

--- a/tests/Unit/Domain/MobilePayment/Models/PaymentIntentTest.php
+++ b/tests/Unit/Domain/MobilePayment/Models/PaymentIntentTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\MobilePayment\Enums\PaymentAsset;
+use App\Domain\MobilePayment\Enums\PaymentIntentStatus;
+use App\Domain\MobilePayment\Enums\PaymentNetwork;
+use App\Domain\MobilePayment\Exceptions\InvalidStateTransitionException;
+use App\Domain\MobilePayment\Models\PaymentIntent;
+
+describe('PaymentIntent Model', function (): void {
+    it('casts status to enum', function (): void {
+        $intent = new PaymentIntent();
+        $intent->status = PaymentIntentStatus::CREATED;
+
+        expect($intent->status)->toBe(PaymentIntentStatus::CREATED);
+        expect($intent->status)->toBeInstanceOf(PaymentIntentStatus::class);
+    });
+
+    it('casts shield_enabled to boolean', function (): void {
+        $intent = new PaymentIntent();
+        $intent->shield_enabled = true;
+
+        expect($intent->shield_enabled)->toBeTrue();
+    });
+
+    it('casts fees_estimate to array', function (): void {
+        $intent = new PaymentIntent();
+        $intent->fees_estimate = ['nativeAsset' => 'SOL', 'amount' => '0.00004'];
+
+        expect($intent->fees_estimate)->toBeArray();
+        expect($intent->fees_estimate['nativeAsset'])->toBe('SOL');
+    });
+
+    it('transitions from CREATED to AWAITING_AUTH', function (): void {
+        $mock = Mockery::mock(PaymentIntent::class)->makePartial();
+        $mock->status = PaymentIntentStatus::CREATED;
+        $mock->shouldReceive('save')->andReturnTrue();
+
+        $mock->transitionTo(PaymentIntentStatus::AWAITING_AUTH);
+        expect($mock->status)->toBe(PaymentIntentStatus::AWAITING_AUTH);
+    });
+
+    it('transitions from SUBMITTING to PENDING', function (): void {
+        $mock = Mockery::mock(PaymentIntent::class)->makePartial();
+        $mock->status = PaymentIntentStatus::SUBMITTING;
+        $mock->shouldReceive('save')->andReturnTrue();
+
+        $mock->transitionTo(PaymentIntentStatus::PENDING);
+        expect($mock->status)->toBe(PaymentIntentStatus::PENDING);
+    });
+
+    it('throws on invalid state transition from CONFIRMED', function (): void {
+        $mock = Mockery::mock(PaymentIntent::class)->makePartial();
+        $mock->status = PaymentIntentStatus::CONFIRMED;
+
+        $mock->transitionTo(PaymentIntentStatus::PENDING);
+    })->throws(InvalidStateTransitionException::class);
+
+    it('throws on invalid state transition - cannot cancel SUBMITTING', function (): void {
+        $mock = Mockery::mock(PaymentIntent::class)->makePartial();
+        $mock->status = PaymentIntentStatus::SUBMITTING;
+
+        $mock->transitionTo(PaymentIntentStatus::CANCELLED);
+    })->throws(InvalidStateTransitionException::class);
+
+    it('throws on invalid state transition - cannot cancel PENDING', function (): void {
+        $mock = Mockery::mock(PaymentIntent::class)->makePartial();
+        $mock->status = PaymentIntentStatus::PENDING;
+
+        $mock->transitionTo(PaymentIntentStatus::CANCELLED);
+    })->throws(InvalidStateTransitionException::class);
+
+    it('throws on invalid transition - cannot skip to CONFIRMED from CREATED', function (): void {
+        $mock = Mockery::mock(PaymentIntent::class)->makePartial();
+        $mock->status = PaymentIntentStatus::CREATED;
+
+        $mock->transitionTo(PaymentIntentStatus::CONFIRMED);
+    })->throws(InvalidStateTransitionException::class);
+
+    it('resolves network enum', function (): void {
+        $intent = new PaymentIntent();
+        $intent->network = 'SOLANA';
+
+        expect($intent->getNetworkEnum())->toBe(PaymentNetwork::SOLANA);
+    });
+
+    it('resolves asset enum', function (): void {
+        $intent = new PaymentIntent();
+        $intent->asset = 'USDC';
+
+        expect($intent->getAssetEnum())->toBe(PaymentAsset::USDC);
+    });
+
+    it('has correct fillable attributes', function (): void {
+        $intent = new PaymentIntent();
+
+        expect($intent->getFillable())->toContain('public_id');
+        expect($intent->getFillable())->toContain('user_id');
+        expect($intent->getFillable())->toContain('merchant_id');
+        expect($intent->getFillable())->toContain('asset');
+        expect($intent->getFillable())->toContain('network');
+        expect($intent->getFillable())->toContain('amount');
+        expect($intent->getFillable())->toContain('status');
+        expect($intent->getFillable())->toContain('shield_enabled');
+        expect($intent->getFillable())->toContain('idempotency_key');
+        expect($intent->getFillable())->toContain('tx_hash');
+        expect($intent->getFillable())->toContain('error_code');
+    });
+
+    it('uses UUID primary key', function (): void {
+        $intent = new PaymentIntent();
+
+        expect($intent->getKeyType())->toBe('string');
+        expect($intent->getIncrementing())->toBeFalse();
+    });
+
+    it('has correct table name', function (): void {
+        $intent = new PaymentIntent();
+
+        expect($intent->getTable())->toBe('payment_intents');
+    });
+
+    it('has correct casts configured', function (): void {
+        $intent = new PaymentIntent();
+        $casts = $intent->getCasts();
+
+        expect($casts['status'])->toBe(PaymentIntentStatus::class);
+        expect($casts['shield_enabled'])->toBe('boolean');
+        expect($casts['fees_estimate'])->toBe('array');
+        expect($casts['metadata'])->toBe('array');
+        expect($casts['confirmations'])->toBe('integer');
+        expect($casts['required_confirmations'])->toBe('integer');
+    });
+});


### PR DESCRIPTION
## Summary
- New `MobilePayment` bounded context for crypto merchant payments with blockchain settlement
- PaymentIntent state machine enum with 8 states and guard-checked transitions
- Eloquent models: PaymentIntent, PaymentReceipt, ActivityFeedItem, Merchant, MerchantWalletAddress
- 4 migrations with indexes optimized for cursor pagination, expiry queries, and user lookups
- Config for allowed networks (Solana/Tron), assets (USDC), and intent expiry (15 min)

## New Files (24)
- `app/Domain/MobilePayment/Enums/` - 5 enums (PaymentIntentStatus, PaymentNetwork, PaymentAsset, PaymentErrorCode, ActivityItemType)
- `app/Domain/MobilePayment/Models/` - 3 models (PaymentIntent, PaymentReceipt, ActivityFeedItem)
- `app/Domain/MobilePayment/Contracts/` - 2 interfaces
- `app/Domain/MobilePayment/Exceptions/` - 3 exceptions
- `app/Domain/MobilePayment/ValueObjects/FeeEstimate.php`
- `app/Domain/Commerce/Models/` - 2 models (Merchant, MerchantWalletAddress)
- `config/mobile_payment.php`
- `database/migrations/2026_02_07_*` - 4 migrations

## Test plan
- [x] 31 unit tests passing (enums, state machine, model structure)
- [x] PHP CS Fixer clean
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)