### PR TITLE
feat(mobile-payment): Payment Intent API endpoints

### DIFF
--- a/app/Domain/MobilePayment/Services/DemoMerchantLookupService.php
+++ b/app/Domain/MobilePayment/Services/DemoMerchantLookupService.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\MobilePayment\Services;
+
+use App\Domain\Commerce\Enums\MerchantStatus;
+use App\Domain\Commerce\Models\Merchant;
+use App\Domain\MobilePayment\Contracts\MerchantLookupServiceInterface;
+use App\Domain\MobilePayment\Exceptions\MerchantNotFoundException;
+
+/**
+ * Demo implementation of MerchantLookupService.
+ *
+ * Returns a fake merchant for any valid-looking public_id.
+ * In production, this would query the merchants table.
+ */
+class DemoMerchantLookupService implements MerchantLookupServiceInterface
+{
+    /** @var array<string, array<string, mixed>> */
+    private array $demoMerchants = [
+        'merchant_starbolt' => [
+            'display_name'      => 'Starbolt Coffee',
+            'icon_url'          => 'https://cdn.finaegis.com/merchants/starbolt.png',
+            'accepted_assets'   => ['USDC'],
+            'accepted_networks' => ['SOLANA', 'TRON'],
+        ],
+        'merchant_jumia' => [
+            'display_name'      => 'Jumia Marketplace',
+            'icon_url'          => 'https://cdn.finaegis.com/merchants/jumia.png',
+            'accepted_assets'   => ['USDC'],
+            'accepted_networks' => ['SOLANA', 'TRON'],
+        ],
+        'merchant_netflix' => [
+            'display_name'      => 'Netflix Subscription',
+            'icon_url'          => 'https://cdn.finaegis.com/merchants/netflix.png',
+            'accepted_assets'   => ['USDC'],
+            'accepted_networks' => ['SOLANA'],
+        ],
+    ];
+
+    public function findByPublicId(string $publicId): Merchant
+    {
+        // Check known demo merchants first
+        if (isset($this->demoMerchants[$publicId])) {
+            return $this->buildMerchant($publicId, $this->demoMerchants[$publicId]);
+        }
+
+        // Try database
+        $merchant = Merchant::where('public_id', $publicId)->first();
+        if ($merchant) {
+            return $merchant;
+        }
+
+        // In demo mode, accept any merchant_ prefixed ID
+        if (str_starts_with($publicId, 'merchant_')) {
+            return $this->buildMerchant($publicId, [
+                'display_name'      => 'Demo Merchant',
+                'icon_url'          => null,
+                'accepted_assets'   => ['USDC'],
+                'accepted_networks' => ['SOLANA', 'TRON'],
+            ]);
+        }
+
+        throw new MerchantNotFoundException($publicId);
+    }
+
+    public function acceptsPayment(Merchant $merchant, string $asset, string $network): bool
+    {
+        return $merchant->acceptsAsset($asset) && $merchant->acceptsNetwork($network);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function buildMerchant(string $publicId, array $data): Merchant
+    {
+        $merchant = new Merchant();
+        $merchant->id = (string) \Illuminate\Support\Str::uuid();
+        $merchant->public_id = $publicId;
+        $merchant->display_name = $data['display_name'];
+        $merchant->icon_url = $data['icon_url'];
+        $merchant->accepted_assets = $data['accepted_assets'];
+        $merchant->accepted_networks = $data['accepted_networks'];
+        $merchant->status = MerchantStatus::ACTIVE;
+
+        return $merchant;
+    }
+}

--- a/app/Domain/MobilePayment/Services/FeeEstimationService.php
+++ b/app/Domain/MobilePayment/Services/FeeEstimationService.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\MobilePayment\Services;
+
+use App\Domain\MobilePayment\Enums\PaymentNetwork;
+use App\Domain\MobilePayment\ValueObjects\FeeEstimate;
+
+class FeeEstimationService
+{
+    /**
+     * Estimate network fees for a payment on the given network.
+     */
+    public function estimate(PaymentNetwork $network, string $amount, bool $shieldEnabled): FeeEstimate
+    {
+        $base = FeeEstimate::forNetwork($network);
+
+        if ($shieldEnabled) {
+            // Shield transactions cost ~2x due to privacy overhead
+            $multipliedAmount = bcmul($base->amount, '2', 8);
+            $multipliedUsd = bcmul($base->usdApprox, '2', 2);
+
+            return new FeeEstimate(
+                nativeAsset: $base->nativeAsset,
+                amount: $multipliedAmount,
+                usdApprox: $multipliedUsd,
+            );
+        }
+
+        return $base;
+    }
+}

--- a/app/Domain/MobilePayment/Services/PaymentIntentService.php
+++ b/app/Domain/MobilePayment/Services/PaymentIntentService.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\MobilePayment\Services;
+
+use App\Domain\MobilePayment\Contracts\MerchantLookupServiceInterface;
+use App\Domain\MobilePayment\Contracts\PaymentIntentServiceInterface;
+use App\Domain\MobilePayment\Enums\PaymentErrorCode;
+use App\Domain\MobilePayment\Enums\PaymentIntentStatus;
+use App\Domain\MobilePayment\Enums\PaymentNetwork;
+use App\Domain\MobilePayment\Exceptions\PaymentIntentException;
+use App\Domain\MobilePayment\Models\PaymentIntent;
+use Illuminate\Support\Str;
+
+class PaymentIntentService implements PaymentIntentServiceInterface
+{
+    public function __construct(
+        private readonly MerchantLookupServiceInterface $merchantLookup,
+        private readonly FeeEstimationService $feeEstimation,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function create(int $userId, array $data): PaymentIntent
+    {
+        $merchantId = (string) $data['merchantId'];
+        $asset = (string) $data['asset'];
+        $network = (string) $data['preferredNetwork'];
+        $amount = (string) $data['amount'];
+        $shield = (bool) ($data['shield'] ?? false);
+
+        // Look up merchant
+        $merchant = $this->merchantLookup->findByPublicId($merchantId);
+
+        // Verify merchant can accept payments
+        if (! $merchant->canAcceptPayments()) {
+            throw new PaymentIntentException(
+                PaymentErrorCode::MERCHANT_UNREACHABLE,
+                details: ['merchantId' => $merchantId],
+            );
+        }
+
+        // Validate merchant accepts this asset+network
+        if (! $this->merchantLookup->acceptsPayment($merchant, $asset, $network)) {
+            if (! $merchant->acceptsAsset($asset)) {
+                throw new PaymentIntentException(
+                    PaymentErrorCode::WRONG_TOKEN,
+                    details: ['merchantId' => $merchantId, 'asset' => $asset],
+                );
+            }
+
+            throw new PaymentIntentException(
+                PaymentErrorCode::WRONG_NETWORK,
+                details: ['merchantId' => $merchantId, 'network' => $network],
+            );
+        }
+
+        // Estimate fees
+        $networkEnum = PaymentNetwork::from($network);
+        $fees = $this->feeEstimation->estimate($networkEnum, $amount, $shield);
+
+        // Create the intent
+        $expiryMinutes = (int) config('mobile_payment.expiry_minutes', 15);
+
+        $intent = PaymentIntent::create([
+            'public_id'              => 'pi_' . Str::random(20),
+            'user_id'                => $userId,
+            'merchant_id'            => $merchant->id,
+            'asset'                  => $asset,
+            'network'                => $network,
+            'amount'                 => $amount,
+            'status'                 => PaymentIntentStatus::AWAITING_AUTH,
+            'shield_enabled'         => $shield,
+            'fees_estimate'          => $fees->toArray(),
+            'required_confirmations' => $networkEnum->requiredConfirmations(),
+            'idempotency_key'        => $data['idempotencyKey'] ?? null,
+            'expires_at'             => now()->addMinutes($expiryMinutes),
+        ]);
+
+        $intent->setRelation('merchant', $merchant);
+
+        return $intent;
+    }
+
+    public function get(string $intentId, int $userId): PaymentIntent
+    {
+        $intent = PaymentIntent::with('merchant')
+            ->where('public_id', $intentId)
+            ->where('user_id', $userId)
+            ->firstOrFail();
+
+        // Lazy expiry check
+        $intent->expireIfStale();
+
+        return $intent;
+    }
+
+    public function submit(string $intentId, int $userId, string $authType): PaymentIntent
+    {
+        $intent = $this->get($intentId, $userId);
+
+        // Check if already submitted
+        if (in_array($intent->status, [PaymentIntentStatus::SUBMITTING, PaymentIntentStatus::PENDING], true)) {
+            throw new PaymentIntentException(
+                PaymentErrorCode::INTENT_ALREADY_SUBMITTED,
+                details: ['intentId' => $intentId, 'currentStatus' => $intent->status->value],
+            );
+        }
+
+        // Check if expired
+        if ($intent->status === PaymentIntentStatus::EXPIRED) {
+            throw new PaymentIntentException(
+                PaymentErrorCode::INTENT_EXPIRED,
+                details: ['intentId' => $intentId],
+            );
+        }
+
+        // Transition to SUBMITTING
+        $intent->transitionTo(PaymentIntentStatus::SUBMITTING);
+
+        // In demo mode, simulate immediate submission success
+        if (config('mobile_payment.demo_mode', true)) {
+            $this->simulateDemoSubmission($intent);
+        }
+
+        return $intent->fresh(['merchant']) ?? $intent;
+    }
+
+    public function cancel(string $intentId, int $userId, ?string $reason = null): PaymentIntent
+    {
+        $intent = $this->get($intentId, $userId);
+
+        if (! $intent->status->isCancellable()) {
+            $errorCode = match (true) {
+                $intent->status === PaymentIntentStatus::EXPIRED                                                 => PaymentErrorCode::INTENT_EXPIRED,
+                in_array($intent->status, [PaymentIntentStatus::SUBMITTING, PaymentIntentStatus::PENDING], true) => PaymentErrorCode::INTENT_ALREADY_SUBMITTED,
+                default                                                                                          => PaymentErrorCode::INTENT_ALREADY_SUBMITTED,
+            };
+
+            throw new PaymentIntentException(
+                $errorCode,
+                details: ['intentId' => $intentId, 'currentStatus' => $intent->status->value],
+            );
+        }
+
+        $intent->cancel_reason = $reason ?? 'user_cancelled';
+        $intent->save();
+
+        $intent->transitionTo(PaymentIntentStatus::CANCELLED);
+
+        return $intent->fresh(['merchant']) ?? $intent;
+    }
+
+    /**
+     * Simulate a successful demo payment submission.
+     */
+    private function simulateDemoSubmission(PaymentIntent $intent): void
+    {
+        $network = PaymentNetwork::from($intent->network);
+        $demoTxHash = $this->generateDemoTxHash($network);
+
+        $intent->update([
+            'tx_hash'         => $demoTxHash,
+            'tx_explorer_url' => $network->explorerUrl($demoTxHash),
+            'status'          => PaymentIntentStatus::PENDING,
+            'confirmations'   => 0,
+        ]);
+    }
+
+    private function generateDemoTxHash(PaymentNetwork $network): string
+    {
+        return match ($network) {
+            PaymentNetwork::SOLANA => Str::random(88),
+            PaymentNetwork::TRON   => Str::random(64),
+        };
+    }
+}

--- a/app/Http/Controllers/Api/MobilePayment/PaymentIntentController.php
+++ b/app/Http/Controllers/Api/MobilePayment/PaymentIntentController.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\MobilePayment;
+
+use App\Domain\MobilePayment\Contracts\PaymentIntentServiceInterface;
+use App\Domain\MobilePayment\Exceptions\MerchantNotFoundException;
+use App\Domain\MobilePayment\Exceptions\PaymentIntentException;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\MobilePayment\CreatePaymentIntentRequest;
+use App\Http\Requests\MobilePayment\SubmitPaymentIntentRequest;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class PaymentIntentController extends Controller
+{
+    public function __construct(
+        private readonly PaymentIntentServiceInterface $paymentIntentService,
+    ) {
+    }
+
+    /**
+     * Create a new payment intent.
+     *
+     * POST /v1/payments/intents
+     */
+    public function create(CreatePaymentIntentRequest $request): JsonResponse
+    {
+        try {
+            $intent = $this->paymentIntentService->create(
+                $request->user()->id,
+                $request->validated(),
+            );
+
+            return response()->json([
+                'success' => true,
+                'data'    => $intent->toApiResponse(),
+            ], 201);
+        } catch (MerchantNotFoundException $e) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'MERCHANT_NOT_FOUND',
+                    'message' => $e->getMessage(),
+                ],
+            ], 404);
+        } catch (PaymentIntentException $e) {
+            return response()->json($e->toApiResponse(), $e->httpStatus());
+        }
+    }
+
+    /**
+     * Get payment intent status.
+     *
+     * GET /v1/payments/intents/{intentId}
+     */
+    public function show(string $intentId): JsonResponse
+    {
+        try {
+            $intent = $this->paymentIntentService->get(
+                $intentId,
+                (int) request()->user()->id,
+            );
+
+            return response()->json([
+                'success' => true,
+                'data'    => $intent->toApiResponse(),
+            ]);
+        } catch (ModelNotFoundException) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'INTENT_NOT_FOUND',
+                    'message' => 'Payment intent not found.',
+                ],
+            ], 404);
+        }
+    }
+
+    /**
+     * Submit/authorize a payment intent.
+     *
+     * POST /v1/payments/intents/{intentId}/submit
+     */
+    public function submit(SubmitPaymentIntentRequest $request, string $intentId): JsonResponse
+    {
+        try {
+            $authType = $request->input('auth', 'biometric');
+
+            $intent = $this->paymentIntentService->submit(
+                $intentId,
+                $request->user()->id,
+                $authType,
+            );
+
+            return response()->json([
+                'success' => true,
+                'data'    => $intent->toApiResponse(),
+            ]);
+        } catch (ModelNotFoundException) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'INTENT_NOT_FOUND',
+                    'message' => 'Payment intent not found.',
+                ],
+            ], 404);
+        } catch (PaymentIntentException $e) {
+            return response()->json($e->toApiResponse(), $e->httpStatus());
+        }
+    }
+
+    /**
+     * Cancel a payment intent.
+     *
+     * POST /v1/payments/intents/{intentId}/cancel
+     */
+    public function cancel(Request $request, string $intentId): JsonResponse
+    {
+        try {
+            $reason = $request->input('reason');
+
+            $intent = $this->paymentIntentService->cancel(
+                $intentId,
+                $request->user()->id,
+                $reason,
+            );
+
+            return response()->json([
+                'success' => true,
+                'data'    => $intent->toApiResponse(),
+            ]);
+        } catch (ModelNotFoundException) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'INTENT_NOT_FOUND',
+                    'message' => 'Payment intent not found.',
+                ],
+            ], 404);
+        } catch (PaymentIntentException $e) {
+            return response()->json($e->toApiResponse(), $e->httpStatus());
+        }
+    }
+}

--- a/app/Http/Requests/MobilePayment/CreatePaymentIntentRequest.php
+++ b/app/Http/Requests/MobilePayment/CreatePaymentIntentRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\MobilePayment;
+
+use App\Domain\MobilePayment\Enums\PaymentAsset;
+use App\Domain\MobilePayment\Enums\PaymentNetwork;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class CreatePaymentIntentRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'merchantId'       => ['required', 'string', 'max:64'],
+            'amount'           => ['required', 'numeric', 'gt:0', 'max:999999999'],
+            'asset'            => ['required', 'string', Rule::in(PaymentAsset::values())],
+            'preferredNetwork' => ['required', 'string', Rule::in(PaymentNetwork::values())],
+            'shield'           => ['sometimes', 'boolean'],
+            'idempotencyKey'   => ['sometimes', 'string', 'max:128'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'asset.in'            => 'Only USDC is supported for v1.',
+            'preferredNetwork.in' => 'Only SOLANA and TRON networks are supported for v1.',
+            'amount.gt'           => 'Payment amount must be greater than zero.',
+        ];
+    }
+}

--- a/app/Http/Requests/MobilePayment/SubmitPaymentIntentRequest.php
+++ b/app/Http/Requests/MobilePayment/SubmitPaymentIntentRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\MobilePayment;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SubmitPaymentIntentRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'auth'   => ['sometimes', 'string', 'in:biometric,pin'],
+            'shield' => ['sometimes', 'boolean'],
+        ];
+    }
+}

--- a/app/Providers/MobilePaymentServiceProvider.php
+++ b/app/Providers/MobilePaymentServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use App\Domain\MobilePayment\Contracts\MerchantLookupServiceInterface;
+use App\Domain\MobilePayment\Contracts\PaymentIntentServiceInterface;
+use App\Domain\MobilePayment\Services\DemoMerchantLookupService;
+use App\Domain\MobilePayment\Services\PaymentIntentService;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Service provider for the MobilePayment domain.
+ */
+class MobilePaymentServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->bind(
+            PaymentIntentServiceInterface::class,
+            PaymentIntentService::class,
+        );
+
+        // In production, swap DemoMerchantLookupService for a real implementation
+        $this->app->bind(
+            MerchantLookupServiceInterface::class,
+            DemoMerchantLookupService::class,
+        );
+    }
+
+    public function boot(): void
+    {
+        //
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -24,6 +24,7 @@ return [
     App\Providers\HorizonServiceProvider::class,
     App\Providers\JetstreamServiceProvider::class,
     App\Providers\LendingServiceProvider::class,
+    App\Providers\MobilePaymentServiceProvider::class,
     App\Providers\PrivacyServiceProvider::class,
     App\Providers\RelayerServiceProvider::class,
     App\Providers\StablecoinServiceProvider::class,

--- a/routes/api.php
+++ b/routes/api.php
@@ -26,6 +26,7 @@ use App\Http\Controllers\Api\ExchangeRateController;
 use App\Http\Controllers\Api\GdprController;
 use App\Http\Controllers\Api\KycController;
 use App\Http\Controllers\Api\MCPToolsController;
+use App\Http\Controllers\Api\MobilePayment\PaymentIntentController;
 use App\Http\Controllers\Api\PollController;
 use App\Http\Controllers\Api\RegulatoryReportingController;
 use App\Http\Controllers\Api\RiskAnalysisController;
@@ -1245,4 +1246,28 @@ Route::prefix('v1/privacy')->name('api.privacy.')->group(function () {
         // SRS download tracking for analytics
         Route::post('/srs-downloaded', [PrivacyController::class, 'trackSrsDownload'])->name('srs-downloaded');
     });
+});
+
+/*
+|--------------------------------------------------------------------------
+| Mobile Payment API (v2.7.0)
+|--------------------------------------------------------------------------
+|
+| Payment Intent lifecycle for the mobile wallet app.
+| Supports USDC payments on Solana + Tron networks.
+|
+*/
+Route::prefix('v1')->middleware(['auth:sanctum', 'check.token.expiration'])->group(function () {
+    // Payment Intents
+    Route::post('/payments/intents', [PaymentIntentController::class, 'create'])
+        ->middleware('transaction.rate_limit:payment_intent')
+        ->name('mobile.payments.intents.create');
+    Route::get('/payments/intents/{intentId}', [PaymentIntentController::class, 'show'])
+        ->middleware('api.rate_limit:query')
+        ->name('mobile.payments.intents.show');
+    Route::post('/payments/intents/{intentId}/submit', [PaymentIntentController::class, 'submit'])
+        ->middleware('transaction.rate_limit:payment_submit')
+        ->name('mobile.payments.intents.submit');
+    Route::post('/payments/intents/{intentId}/cancel', [PaymentIntentController::class, 'cancel'])
+        ->name('mobile.payments.intents.cancel');
 });

--- a/tests/Feature/Api/MobilePayment/PaymentIntentControllerTest.php
+++ b/tests/Feature/Api/MobilePayment/PaymentIntentControllerTest.php
@@ -1,0 +1,304 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\MobilePayment;
+
+use App\Domain\Commerce\Enums\MerchantStatus;
+use App\Domain\Commerce\Models\Merchant;
+use App\Domain\MobilePayment\Enums\PaymentIntentStatus;
+use App\Domain\MobilePayment\Models\PaymentIntent;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class PaymentIntentControllerTest extends TestCase
+{
+    protected User $user;
+
+    protected string $token;
+
+    protected Merchant $merchant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+
+        $this->user = User::factory()->create();
+        $this->token = $this->user->createToken('test-token', ['read', 'write'])->plainTextToken;
+
+        // Create a test merchant in the DB
+        $this->merchant = Merchant::create([
+            'public_id'         => 'merchant_test_' . Str::random(8),
+            'display_name'      => 'Test Merchant',
+            'icon_url'          => 'https://example.com/icon.png',
+            'accepted_assets'   => ['USDC'],
+            'accepted_networks' => ['SOLANA', 'TRON'],
+            'status'            => MerchantStatus::ACTIVE,
+        ]);
+    }
+
+    public function test_create_intent_requires_authentication(): void
+    {
+        $response = $this->postJson('/api/v1/payments/intents', [
+            'merchantId'       => $this->merchant->public_id,
+            'amount'           => '12.00',
+            'asset'            => 'USDC',
+            'preferredNetwork' => 'SOLANA',
+        ]);
+
+        $response->assertUnauthorized();
+    }
+
+    public function test_create_intent_validates_required_fields(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/payments/intents', []);
+
+        $response->assertUnprocessable();
+    }
+
+    public function test_create_intent_rejects_unsupported_asset(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/payments/intents', [
+                'merchantId'       => $this->merchant->public_id,
+                'amount'           => '12.00',
+                'asset'            => 'ETH',
+                'preferredNetwork' => 'SOLANA',
+            ]);
+
+        $response->assertUnprocessable();
+    }
+
+    public function test_create_intent_rejects_unsupported_network(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/payments/intents', [
+                'merchantId'       => $this->merchant->public_id,
+                'amount'           => '12.00',
+                'asset'            => 'USDC',
+                'preferredNetwork' => 'ETHEREUM',
+            ]);
+
+        $response->assertUnprocessable();
+    }
+
+    public function test_create_intent_rejects_zero_amount(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/payments/intents', [
+                'merchantId'       => $this->merchant->public_id,
+                'amount'           => '0',
+                'asset'            => 'USDC',
+                'preferredNetwork' => 'SOLANA',
+            ]);
+
+        $response->assertUnprocessable();
+    }
+
+    public function test_create_intent_returns_201_with_valid_data(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/payments/intents', [
+                'merchantId'       => $this->merchant->public_id,
+                'amount'           => '12.00',
+                'asset'            => 'USDC',
+                'preferredNetwork' => 'SOLANA',
+                'shield'           => true,
+            ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('success', true)
+            ->assertJsonStructure([
+                'success',
+                'data' => [
+                    'intentId',
+                    'merchantId',
+                    'merchant' => ['displayName', 'iconUrl'],
+                    'asset',
+                    'network',
+                    'amount',
+                    'status',
+                    'shieldEnabled',
+                    'feesEstimate' => ['nativeAsset', 'amount', 'usdApprox'],
+                    'createdAt',
+                    'expiresAt',
+                ],
+            ])
+            ->assertJsonPath('data.asset', 'USDC')
+            ->assertJsonPath('data.network', 'SOLANA')
+            ->assertJsonPath('data.status', 'AWAITING_AUTH')
+            ->assertJsonPath('data.shieldEnabled', true);
+    }
+
+    public function test_create_intent_returns_404_for_unknown_merchant(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/payments/intents', [
+                'merchantId'       => 'nonexistent_merchant',
+                'amount'           => '12.00',
+                'asset'            => 'USDC',
+                'preferredNetwork' => 'SOLANA',
+            ]);
+
+        $response->assertNotFound()
+            ->assertJsonPath('success', false);
+    }
+
+    public function test_show_intent_returns_200(): void
+    {
+        $intent = PaymentIntent::create([
+            'public_id'              => 'pi_' . Str::random(20),
+            'user_id'                => $this->user->id,
+            'merchant_id'            => $this->merchant->id,
+            'asset'                  => 'USDC',
+            'network'                => 'SOLANA',
+            'amount'                 => '25.00',
+            'status'                 => PaymentIntentStatus::AWAITING_AUTH,
+            'shield_enabled'         => false,
+            'fees_estimate'          => ['nativeAsset' => 'SOL', 'amount' => '0.00004', 'usdApprox' => '0.01'],
+            'required_confirmations' => 32,
+            'expires_at'             => now()->addMinutes(15),
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->getJson("/api/v1/payments/intents/{$intent->public_id}");
+
+        $response->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.intentId', $intent->public_id)
+            ->assertJsonPath('data.status', 'AWAITING_AUTH');
+    }
+
+    public function test_show_intent_returns_404_for_other_users_intent(): void
+    {
+        $otherUser = User::factory()->create();
+
+        $intent = PaymentIntent::create([
+            'public_id'              => 'pi_' . Str::random(20),
+            'user_id'                => $otherUser->id,
+            'merchant_id'            => $this->merchant->id,
+            'asset'                  => 'USDC',
+            'network'                => 'SOLANA',
+            'amount'                 => '25.00',
+            'status'                 => PaymentIntentStatus::AWAITING_AUTH,
+            'shield_enabled'         => false,
+            'required_confirmations' => 32,
+            'expires_at'             => now()->addMinutes(15),
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->getJson("/api/v1/payments/intents/{$intent->public_id}");
+
+        $response->assertNotFound();
+    }
+
+    public function test_submit_intent_returns_200(): void
+    {
+        $intent = PaymentIntent::create([
+            'public_id'              => 'pi_' . Str::random(20),
+            'user_id'                => $this->user->id,
+            'merchant_id'            => $this->merchant->id,
+            'asset'                  => 'USDC',
+            'network'                => 'SOLANA',
+            'amount'                 => '12.00',
+            'status'                 => PaymentIntentStatus::AWAITING_AUTH,
+            'shield_enabled'         => false,
+            'fees_estimate'          => ['nativeAsset' => 'SOL', 'amount' => '0.00004', 'usdApprox' => '0.01'],
+            'required_confirmations' => 32,
+            'expires_at'             => now()->addMinutes(15),
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson("/api/v1/payments/intents/{$intent->public_id}/submit", [
+                'auth' => 'biometric',
+            ]);
+
+        $response->assertOk()
+            ->assertJsonPath('success', true);
+
+        // In demo mode, should have transitioned to PENDING with a tx_hash
+        $intent->refresh();
+        $this->assertEquals(PaymentIntentStatus::PENDING, $intent->status);
+        $this->assertNotNull($intent->tx_hash);
+    }
+
+    public function test_submit_already_submitted_intent_returns_409(): void
+    {
+        $intent = PaymentIntent::create([
+            'public_id'              => 'pi_' . Str::random(20),
+            'user_id'                => $this->user->id,
+            'merchant_id'            => $this->merchant->id,
+            'asset'                  => 'USDC',
+            'network'                => 'SOLANA',
+            'amount'                 => '12.00',
+            'status'                 => PaymentIntentStatus::PENDING,
+            'shield_enabled'         => false,
+            'required_confirmations' => 32,
+            'expires_at'             => now()->addMinutes(15),
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson("/api/v1/payments/intents/{$intent->public_id}/submit", [
+                'auth' => 'biometric',
+            ]);
+
+        $response->assertStatus(409)
+            ->assertJsonPath('success', false)
+            ->assertJsonPath('error.code', 'INTENT_ALREADY_SUBMITTED');
+    }
+
+    public function test_cancel_intent_returns_200(): void
+    {
+        $intent = PaymentIntent::create([
+            'public_id'              => 'pi_' . Str::random(20),
+            'user_id'                => $this->user->id,
+            'merchant_id'            => $this->merchant->id,
+            'asset'                  => 'USDC',
+            'network'                => 'SOLANA',
+            'amount'                 => '14.99',
+            'status'                 => PaymentIntentStatus::AWAITING_AUTH,
+            'shield_enabled'         => false,
+            'required_confirmations' => 32,
+            'expires_at'             => now()->addMinutes(15),
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson("/api/v1/payments/intents/{$intent->public_id}/cancel", [
+                'reason' => 'user_cancelled',
+            ]);
+
+        $response->assertOk()
+            ->assertJsonPath('success', true);
+
+        $intent->refresh();
+        $this->assertEquals(PaymentIntentStatus::CANCELLED, $intent->status);
+        $this->assertEquals('user_cancelled', $intent->cancel_reason);
+    }
+
+    public function test_cancel_submitted_intent_returns_409(): void
+    {
+        $intent = PaymentIntent::create([
+            'public_id'              => 'pi_' . Str::random(20),
+            'user_id'                => $this->user->id,
+            'merchant_id'            => $this->merchant->id,
+            'asset'                  => 'USDC',
+            'network'                => 'SOLANA',
+            'amount'                 => '14.99',
+            'status'                 => PaymentIntentStatus::PENDING,
+            'shield_enabled'         => false,
+            'required_confirmations' => 32,
+            'expires_at'             => now()->addMinutes(15),
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson("/api/v1/payments/intents/{$intent->public_id}/cancel", [
+                'reason' => 'user_cancelled',
+            ]);
+
+        $response->assertStatus(409);
+    }
+}

--- a/tests/Unit/Domain/MobilePayment/Services/PaymentIntentServiceTest.php
+++ b/tests/Unit/Domain/MobilePayment/Services/PaymentIntentServiceTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Commerce\Enums\MerchantStatus;
+use App\Domain\Commerce\Models\Merchant;
+use App\Domain\MobilePayment\Contracts\MerchantLookupServiceInterface;
+use App\Domain\MobilePayment\Enums\PaymentErrorCode;
+use App\Domain\MobilePayment\Enums\PaymentIntentStatus;
+use App\Domain\MobilePayment\Exceptions\MerchantNotFoundException;
+use App\Domain\MobilePayment\Exceptions\PaymentIntentException;
+use App\Domain\MobilePayment\Models\PaymentIntent;
+use App\Domain\MobilePayment\Services\FeeEstimationService;
+use App\Domain\MobilePayment\Services\PaymentIntentService;
+use Illuminate\Support\Str;
+
+describe('PaymentIntentService', function (): void {
+    beforeEach(function (): void {
+        $this->merchantLookup = Mockery::mock(MerchantLookupServiceInterface::class);
+        $this->feeEstimation = new FeeEstimationService();
+        $this->service = new PaymentIntentService($this->merchantLookup, $this->feeEstimation);
+
+        // Create a test merchant
+        $this->merchant = new Merchant();
+        $this->merchant->id = (string) Str::uuid();
+        $this->merchant->public_id = 'merchant_test123';
+        $this->merchant->display_name = 'Test Merchant';
+        $this->merchant->icon_url = 'https://example.com/icon.png';
+        $this->merchant->accepted_assets = ['USDC'];
+        $this->merchant->accepted_networks = ['SOLANA', 'TRON'];
+        $this->merchant->status = MerchantStatus::ACTIVE;
+    });
+
+    it('throws MerchantNotFoundException when merchant is not found', function (): void {
+        $this->merchantLookup->shouldReceive('findByPublicId')
+            ->with('merchant_unknown')
+            ->andThrow(new MerchantNotFoundException('merchant_unknown'));
+
+        $this->service->create(1, [
+            'merchantId'       => 'merchant_unknown',
+            'amount'           => '12.00',
+            'asset'            => 'USDC',
+            'preferredNetwork' => 'SOLANA',
+        ]);
+    })->throws(MerchantNotFoundException::class);
+
+    it('throws when merchant cannot accept payments', function (): void {
+        $inactiveMerchant = clone $this->merchant;
+        $inactiveMerchant->status = MerchantStatus::SUSPENDED;
+
+        $this->merchantLookup->shouldReceive('findByPublicId')
+            ->andReturn($inactiveMerchant);
+
+        try {
+            $this->service->create(1, [
+                'merchantId'       => 'merchant_test123',
+                'amount'           => '12.00',
+                'asset'            => 'USDC',
+                'preferredNetwork' => 'SOLANA',
+            ]);
+            $this->fail('Expected PaymentIntentException');
+        } catch (PaymentIntentException $e) {
+            expect($e->errorCode)->toBe(PaymentErrorCode::MERCHANT_UNREACHABLE);
+        }
+    });
+
+    it('throws WRONG_TOKEN when merchant does not accept the asset', function (): void {
+        $this->merchantLookup->shouldReceive('findByPublicId')
+            ->andReturn($this->merchant);
+        $this->merchantLookup->shouldReceive('acceptsPayment')
+            ->andReturn(false);
+
+        // Merchant doesn't accept the asset
+        $this->merchant->accepted_assets = ['ETH'];
+
+        try {
+            $this->service->create(1, [
+                'merchantId'       => 'merchant_test123',
+                'amount'           => '12.00',
+                'asset'            => 'USDC',
+                'preferredNetwork' => 'SOLANA',
+            ]);
+            $this->fail('Expected PaymentIntentException');
+        } catch (PaymentIntentException $e) {
+            expect($e->errorCode)->toBe(PaymentErrorCode::WRONG_TOKEN);
+        }
+    });
+
+    it('throws WRONG_NETWORK when merchant does not accept the network', function (): void {
+        $this->merchantLookup->shouldReceive('findByPublicId')
+            ->andReturn($this->merchant);
+        $this->merchantLookup->shouldReceive('acceptsPayment')
+            ->andReturn(false);
+
+        // Merchant accepts USDC but not on TRON
+        $this->merchant->accepted_networks = ['SOLANA'];
+
+        try {
+            $this->service->create(1, [
+                'merchantId'       => 'merchant_test123',
+                'amount'           => '12.00',
+                'asset'            => 'USDC',
+                'preferredNetwork' => 'TRON',
+            ]);
+            $this->fail('Expected PaymentIntentException');
+        } catch (PaymentIntentException $e) {
+            expect($e->errorCode)->toBe(PaymentErrorCode::WRONG_NETWORK);
+        }
+    });
+
+    it('throws INTENT_ALREADY_SUBMITTED when submitting an already submitted intent', function (): void {
+        $intent = Mockery::mock(PaymentIntent::class)->makePartial();
+        $intent->status = PaymentIntentStatus::SUBMITTING;
+        $intent->public_id = 'pi_test';
+
+        // Mock the get method
+        $service = Mockery::mock(PaymentIntentService::class, [$this->merchantLookup, $this->feeEstimation])
+            ->makePartial();
+        $service->shouldReceive('get')
+            ->with('pi_test', 1)
+            ->andReturn($intent);
+
+        try {
+            $service->submit('pi_test', 1, 'biometric');
+            $this->fail('Expected PaymentIntentException');
+        } catch (PaymentIntentException $e) {
+            expect($e->errorCode)->toBe(PaymentErrorCode::INTENT_ALREADY_SUBMITTED);
+        }
+    });
+
+    it('throws INTENT_EXPIRED when submitting an expired intent', function (): void {
+        $intent = Mockery::mock(PaymentIntent::class)->makePartial();
+        $intent->status = PaymentIntentStatus::EXPIRED;
+        $intent->public_id = 'pi_test';
+
+        $service = Mockery::mock(PaymentIntentService::class, [$this->merchantLookup, $this->feeEstimation])
+            ->makePartial();
+        $service->shouldReceive('get')
+            ->with('pi_test', 1)
+            ->andReturn($intent);
+
+        try {
+            $service->submit('pi_test', 1, 'biometric');
+            $this->fail('Expected PaymentIntentException');
+        } catch (PaymentIntentException $e) {
+            expect($e->errorCode)->toBe(PaymentErrorCode::INTENT_EXPIRED);
+        }
+    });
+
+    it('throws when cancelling a non-cancellable intent', function (): void {
+        $intent = Mockery::mock(PaymentIntent::class)->makePartial();
+        $intent->status = PaymentIntentStatus::PENDING;
+        $intent->public_id = 'pi_test';
+
+        $service = Mockery::mock(PaymentIntentService::class, [$this->merchantLookup, $this->feeEstimation])
+            ->makePartial();
+        $service->shouldReceive('get')
+            ->with('pi_test', 1)
+            ->andReturn($intent);
+
+        try {
+            $service->cancel('pi_test', 1, 'user_cancelled');
+            $this->fail('Expected PaymentIntentException');
+        } catch (PaymentIntentException $e) {
+            expect($e->errorCode)->toBe(PaymentErrorCode::INTENT_ALREADY_SUBMITTED);
+        }
+    });
+});
+
+describe('FeeEstimationService', function (): void {
+    it('estimates standard fees for Solana', function (): void {
+        $service = new FeeEstimationService();
+        $fee = $service->estimate(App\Domain\MobilePayment\Enums\PaymentNetwork::SOLANA, '100.00', false);
+
+        expect($fee->nativeAsset)->toBe('SOL');
+        expect($fee->amount)->toBe('0.00004');
+        expect($fee->usdApprox)->toBe('0.01');
+    });
+
+    it('estimates standard fees for Tron', function (): void {
+        $service = new FeeEstimationService();
+        $fee = $service->estimate(App\Domain\MobilePayment\Enums\PaymentNetwork::TRON, '100.00', false);
+
+        expect($fee->nativeAsset)->toBe('TRX');
+        expect($fee->amount)->toBe('5.0');
+        expect($fee->usdApprox)->toBe('0.50');
+    });
+
+    it('doubles fees for shield-enabled transactions', function (): void {
+        $service = new FeeEstimationService();
+        $fee = $service->estimate(App\Domain\MobilePayment\Enums\PaymentNetwork::SOLANA, '100.00', true);
+
+        expect($fee->nativeAsset)->toBe('SOL');
+        expect($fee->amount)->toBe('0.00008000');
+        expect($fee->usdApprox)->toBe('0.02');
+    });
+});


### PR DESCRIPTION
## Summary
- Payment Intent lifecycle: create, show, submit, cancel (`/v1/payments/intents`)
- PaymentIntentService with merchant validation, fee estimation, state machine guards
- DemoMerchantLookupService for demo mode + DB fallback
- Proper error codes: MERCHANT_UNREACHABLE, WRONG_NETWORK, WRONG_TOKEN, INTENT_EXPIRED, INTENT_ALREADY_SUBMITTED
- Demo mode simulates blockchain submission with tx hash generation

## New Files (11)
- `app/Domain/MobilePayment/Services/` - PaymentIntentService, DemoMerchantLookupService, FeeEstimationService
- `app/Http/Controllers/Api/MobilePayment/PaymentIntentController.php`
- `app/Http/Requests/MobilePayment/` - CreatePaymentIntentRequest, SubmitPaymentIntentRequest
- `app/Providers/MobilePaymentServiceProvider.php`

## Modified Files (2)
- `bootstrap/providers.php` - Register MobilePaymentServiceProvider
- `routes/api.php` - Add 4 payment intent routes

## Test plan
- [x] 10 unit tests passing (service error handling, fee estimation)
- [x] 12 feature tests (auth, validation, CRUD, error codes)
- [x] PHP CS Fixer clean
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)