### PR TITLE
feat(mobile-payment): Add receipt generation service and endpoint

### DIFF
--- a/app/Domain/MobilePayment/Services/ReceiptService.php
+++ b/app/Domain/MobilePayment/Services/ReceiptService.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\MobilePayment\Services;
+
+use App\Domain\MobilePayment\Enums\PaymentIntentStatus;
+use App\Domain\MobilePayment\Models\PaymentIntent;
+use App\Domain\MobilePayment\Models\PaymentReceipt;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+
+/**
+ * Service for generating and retrieving payment receipts.
+ *
+ * Receipts are generated on-demand for confirmed payment intents and
+ * cached in Redis for the configured TTL (default 24h).
+ */
+class ReceiptService
+{
+    /**
+     * Generate a receipt for a confirmed payment intent.
+     *
+     * Returns an existing receipt if one was already generated for this intent.
+     */
+    public function generateReceipt(string $txId, int $userId): ?PaymentReceipt
+    {
+        // Look up the activity feed item or payment intent by txId
+        $intent = PaymentIntent::where('public_id', $txId)
+            ->where('user_id', $userId)
+            ->first();
+
+        if (! $intent) {
+            return null;
+        }
+
+        if ($intent->status !== PaymentIntentStatus::CONFIRMED) {
+            return null;
+        }
+
+        // Check for existing receipt
+        $existing = PaymentReceipt::where('payment_intent_id', $intent->id)
+            ->where('user_id', $userId)
+            ->first();
+
+        if ($existing) {
+            return $existing;
+        }
+
+        // Generate new receipt
+        $receipt = PaymentReceipt::create([
+            'public_id'         => 'rcpt_' . Str::random(24),
+            'payment_intent_id' => $intent->id,
+            'user_id'           => $userId,
+            'merchant_name'     => $intent->merchant->display_name ?? 'Unknown Merchant',
+            'amount'            => $intent->amount,
+            'asset'             => $intent->asset,
+            'network'           => $intent->network,
+            'tx_hash'           => $intent->tx_hash,
+            'network_fee'       => $this->formatNetworkFee($intent),
+            'share_token'       => Str::random(64),
+            'transaction_at'    => $intent->confirmed_at ?? $intent->created_at,
+        ]);
+
+        // Cache receipt for configured TTL
+        $cacheHours = (int) config('mobile_payment.receipt_cache_hours', 24);
+        Cache::put(
+            "receipt:{$receipt->public_id}",
+            $receipt->toApiResponse(),
+            now()->addHours($cacheHours)
+        );
+
+        return $receipt;
+    }
+
+    /**
+     * Get a receipt by its public ID.
+     */
+    public function getReceipt(string $receiptId, int $userId): ?PaymentReceipt
+    {
+        return PaymentReceipt::where('public_id', $receiptId)
+            ->where('user_id', $userId)
+            ->first();
+    }
+
+    /**
+     * Get a receipt by its share token (public, no auth required).
+     */
+    public function getReceiptByShareToken(string $shareToken): ?PaymentReceipt
+    {
+        return PaymentReceipt::where('share_token', $shareToken)->first();
+    }
+
+    /**
+     * Format the network fee from the payment intent's fee estimate.
+     */
+    private function formatNetworkFee(PaymentIntent $intent): string
+    {
+        $fees = $intent->fees_estimate;
+
+        if (! $fees || ! isset($fees['network_fee'])) {
+            return '~$0.001';
+        }
+
+        return '~$' . number_format((float) $fees['network_fee'], 3);
+    }
+}

--- a/app/Http/Controllers/Api/MobilePayment/ReceiptController.php
+++ b/app/Http/Controllers/Api/MobilePayment/ReceiptController.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\MobilePayment;
+
+use App\Domain\MobilePayment\Services\ReceiptService;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class ReceiptController extends Controller
+{
+    public function __construct(
+        private readonly ReceiptService $receiptService,
+    ) {
+    }
+
+    /**
+     * Generate a receipt for a transaction.
+     *
+     * POST /v1/transactions/{txId}/receipt
+     */
+    public function store(Request $request, string $txId): JsonResponse
+    {
+        /** @var \App\Models\User $user */
+        $user = $request->user();
+
+        $receipt = $this->receiptService->generateReceipt($txId, $user->id);
+
+        if (! $receipt) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'RECEIPT_UNAVAILABLE',
+                    'message' => 'Receipt can only be generated for confirmed transactions.',
+                ],
+            ], 422);
+        }
+
+        return response()->json([
+            'success' => true,
+            'data'    => $receipt->toApiResponse(),
+        ], 201);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -29,6 +29,7 @@ use App\Http\Controllers\Api\MCPToolsController;
 use App\Http\Controllers\Api\MobilePayment\ActivityController;
 use App\Http\Controllers\Api\MobilePayment\NetworkStatusController;
 use App\Http\Controllers\Api\MobilePayment\PaymentIntentController;
+use App\Http\Controllers\Api\MobilePayment\ReceiptController;
 use App\Http\Controllers\Api\MobilePayment\TransactionController as MobileTransactionController;
 use App\Http\Controllers\Api\MobilePayment\WalletReceiveController;
 use App\Http\Controllers\Api\PollController;
@@ -1284,6 +1285,11 @@ Route::prefix('v1')->middleware(['auth:sanctum', 'check.token.expiration'])->gro
     Route::get('/transactions/{txId}', [MobileTransactionController::class, 'show'])
         ->middleware('api.rate_limit:query')
         ->name('mobile.transactions.show');
+
+    // Receipt Generation
+    Route::post('/transactions/{txId}/receipt', [ReceiptController::class, 'store'])
+        ->middleware('api.rate_limit:mutation')
+        ->name('mobile.transactions.receipt');
 
     // Wallet Receive Address
     Route::get('/wallet/receive', WalletReceiveController::class)

--- a/tests/Unit/Domain/MobilePayment/Services/ReceiptServiceTest.php
+++ b/tests/Unit/Domain/MobilePayment/Services/ReceiptServiceTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\MobilePayment\Services\ReceiptService;
+
+describe('ReceiptService', function (): void {
+    it('can be instantiated', function (): void {
+        $service = new ReceiptService();
+
+        expect($service)->toBeInstanceOf(ReceiptService::class);
+    });
+
+    it('has generateReceipt method with correct parameters', function (): void {
+        $service = new ReceiptService();
+        $reflection = new ReflectionClass($service);
+        $method = $reflection->getMethod('generateReceipt');
+
+        expect($method->isPublic())->toBeTrue();
+        expect($method->getNumberOfParameters())->toBe(2);
+
+        $params = $method->getParameters();
+        expect($params[0]->getName())->toBe('txId');
+        expect($params[0]->getType()->getName())->toBe('string');
+        expect($params[1]->getName())->toBe('userId');
+        expect($params[1]->getType()->getName())->toBe('int');
+    });
+
+    it('has getReceipt method', function (): void {
+        $service = new ReceiptService();
+        $reflection = new ReflectionClass($service);
+        $method = $reflection->getMethod('getReceipt');
+
+        expect($method->isPublic())->toBeTrue();
+        expect($method->getNumberOfParameters())->toBe(2);
+    });
+
+    it('has getReceiptByShareToken method', function (): void {
+        $service = new ReceiptService();
+        $reflection = new ReflectionClass($service);
+        $method = $reflection->getMethod('getReceiptByShareToken');
+
+        expect($method->isPublic())->toBeTrue();
+        expect($method->getNumberOfParameters())->toBe(1);
+
+        $params = $method->getParameters();
+        expect($params[0]->getName())->toBe('shareToken');
+    });
+
+    it('formats network fee with default when no estimate', function (): void {
+        $service = new ReceiptService();
+        $reflection = new ReflectionClass($service);
+        $method = $reflection->getMethod('formatNetworkFee');
+        $method->setAccessible(true);
+
+        // Create a mock intent with no fees_estimate
+        $intent = new App\Domain\MobilePayment\Models\PaymentIntent();
+        $intent->fees_estimate = null;
+
+        $fee = $method->invoke($service, $intent);
+
+        expect($fee)->toBe('~$0.001');
+    });
+
+    it('formats network fee from estimate', function (): void {
+        $service = new ReceiptService();
+        $reflection = new ReflectionClass($service);
+        $method = $reflection->getMethod('formatNetworkFee');
+        $method->setAccessible(true);
+
+        $intent = new App\Domain\MobilePayment\Models\PaymentIntent();
+        $intent->fees_estimate = ['network_fee' => '0.005'];
+
+        $fee = $method->invoke($service, $intent);
+
+        expect($fee)->toBe('~$0.005');
+    });
+
+    it('formats network fee without network_fee key as default', function (): void {
+        $service = new ReceiptService();
+        $reflection = new ReflectionClass($service);
+        $method = $reflection->getMethod('formatNetworkFee');
+        $method->setAccessible(true);
+
+        $intent = new App\Domain\MobilePayment\Models\PaymentIntent();
+        $intent->fees_estimate = ['total' => '0.01'];
+
+        $fee = $method->invoke($service, $intent);
+
+        expect($fee)->toBe('~$0.001');
+    });
+});


### PR DESCRIPTION
## Summary
- **ReceiptService**: On-demand receipt generation for confirmed payment intents, idempotent (returns existing if already created), Redis caching with configurable TTL, share URL via unique 64-char token
- **ReceiptController**: `POST /v1/transactions/{txId}/receipt` endpoint with 201 response for new receipts, 422 for non-confirmed transactions

## New Files (3)
- `app/Domain/MobilePayment/Services/ReceiptService.php` - Core receipt logic
- `app/Http/Controllers/Api/MobilePayment/ReceiptController.php` - API endpoint
- `tests/Unit/Domain/MobilePayment/Services/ReceiptServiceTest.php` - 7 tests

## Routes Added
| Method | Path | Description |
|--------|------|-------------|
| POST | `/v1/transactions/{txId}/receipt` | Generate payment receipt |

## Test plan
- [x] 7 unit tests passing (15 assertions)
- [x] PHPStan clean (no errors)
- [x] Code style fixed via php-cs-fixer
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)