### PR TITLE
feat(trustcert): Add certificate details endpoint and PDF export

### DIFF
--- a/app/Domain/TrustCert/Services/CertificateExportService.php
+++ b/app/Domain/TrustCert/Services/CertificateExportService.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\TrustCert\Services;
+
+use Barryvdh\DomPDF\Facade\Pdf;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Service for exporting TrustCert certificates to PDF.
+ *
+ * Generates formatted PDF documents with certificate details,
+ * trust chain info, and verification QR data.
+ */
+class CertificateExportService
+{
+    public function __construct(
+        private readonly CertificateAuthorityService $caService,
+        private readonly PresentationService $presentationService,
+    ) {
+    }
+
+    /**
+     * Get certificate details for API response.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function getCertificateDetails(string $certificateId): ?array
+    {
+        $certificate = $this->caService->getCertificate($certificateId);
+
+        if (! $certificate) {
+            return null;
+        }
+
+        return [
+            'certificateId' => $certificate->certificateId,
+            'subjectId'     => $certificate->subjectId,
+            'subject'       => $certificate->subject,
+            'status'        => $certificate->status->value,
+            'validFrom'     => $certificate->validFrom->format('c'),
+            'validUntil'    => $certificate->validUntil->format('c'),
+            'isValid'       => $certificate->isValid(),
+            'isExpired'     => $certificate->isExpired(),
+            'isRevoked'     => $certificate->isRevoked(),
+            'isRoot'        => $certificate->isRootCertificate(),
+            'fingerprint'   => $certificate->getFingerprint(),
+            'extensions'    => $certificate->extensions,
+            'disclaimer'    => 'This certificate is issued within the FinAegis ecosystem and is valid for identity verification purposes within this ecosystem only.',
+        ];
+    }
+
+    /**
+     * Export a certificate to PDF.
+     *
+     * @return string|null PDF content as string, or null if certificate not found
+     */
+    public function exportToPdf(string $certificateId): ?string
+    {
+        $certificate = $this->caService->getCertificate($certificateId);
+
+        if (! $certificate) {
+            return null;
+        }
+
+        try {
+            // Generate a presentation token for the QR code
+            $presentation = $this->presentationService->generatePresentation(
+                certificateId: $certificateId,
+                requestedClaims: ['certificate_type', 'status', 'valid_from', 'valid_until', 'subject_id'],
+                validityMinutes: 60,
+            );
+
+            $data = [
+                'certificate'     => $certificate,
+                'verificationUrl' => $presentation['verification_url'] ?? null,
+                'qrData'          => $presentation['qr_code_data'] ?? null,
+                'deepLink'        => $presentation['deep_link'] ?? null,
+                'generatedAt'     => now()->toIso8601String(),
+                'disclaimer'      => 'This certificate is issued within the FinAegis ecosystem. It is intended for identity and compliance verification within FinAegis services only.',
+                'branding'        => [
+                    'name'   => 'FinAegis',
+                    'shield' => 'Aegis Shield',
+                ],
+            ];
+
+            /** @var \Barryvdh\DomPDF\PDF $pdf */
+            $pdf = Pdf::loadView('trustcert.certificate-pdf', $data);
+            $pdf->setPaper('a4', 'portrait');
+
+            return $pdf->output();
+        } catch (Throwable $e) {
+            Log::error('Certificate PDF export failed', [
+                'certificate_id' => $certificateId,
+                'error'          => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+    }
+}

--- a/app/Http/Controllers/Api/TrustCert/CertificateController.php
+++ b/app/Http/Controllers/Api/TrustCert/CertificateController.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\TrustCert;
+
+use App\Domain\TrustCert\Services\CertificateExportService;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
+
+class CertificateController extends Controller
+{
+    public function __construct(
+        private readonly CertificateExportService $exportService,
+    ) {
+    }
+
+    /**
+     * Get certificate details.
+     *
+     * GET /v1/trustcert/{certId}/certificate
+     */
+    public function show(string $certId): JsonResponse
+    {
+        $details = $this->exportService->getCertificateDetails($certId);
+
+        if (! $details) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'CERTIFICATE_NOT_FOUND',
+                    'message' => 'Certificate not found.',
+                ],
+            ], 404);
+        }
+
+        return response()->json([
+            'success' => true,
+            'data'    => $details,
+        ]);
+    }
+
+    /**
+     * Export certificate as PDF.
+     *
+     * POST /v1/trustcert/{certId}/export-pdf
+     */
+    public function exportPdf(string $certId): Response|JsonResponse
+    {
+        $pdfContent = $this->exportService->exportToPdf($certId);
+
+        if (! $pdfContent) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'EXPORT_FAILED',
+                    'message' => 'Certificate not found or PDF generation failed.',
+                ],
+            ], 404);
+        }
+
+        return response($pdfContent, 200, [
+            'Content-Type'        => 'application/pdf',
+            'Content-Disposition' => "attachment; filename=\"certificate-{$certId}.pdf\"",
+        ]);
+    }
+}

--- a/resources/views/trustcert/certificate-pdf.blade.php
+++ b/resources/views/trustcert/certificate-pdf.blade.php
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style>
+        body {
+            font-family: DejaVu Sans, sans-serif;
+            color: #1a1a2e;
+            margin: 0;
+            padding: 40px;
+            font-size: 12px;
+            line-height: 1.6;
+        }
+        .header {
+            text-align: center;
+            border-bottom: 3px solid #16213e;
+            padding-bottom: 20px;
+            margin-bottom: 30px;
+        }
+        .header h1 {
+            font-size: 24px;
+            color: #16213e;
+            margin: 0 0 5px;
+        }
+        .header .subtitle {
+            font-size: 14px;
+            color: #0f3460;
+        }
+        .header .shield {
+            font-size: 11px;
+            color: #53599a;
+            margin-top: 5px;
+        }
+        .section {
+            margin-bottom: 25px;
+        }
+        .section h2 {
+            font-size: 14px;
+            color: #16213e;
+            border-bottom: 1px solid #e0e0e0;
+            padding-bottom: 5px;
+            margin-bottom: 10px;
+        }
+        .field {
+            margin-bottom: 8px;
+        }
+        .field .label {
+            font-weight: bold;
+            color: #0f3460;
+            display: inline-block;
+            min-width: 160px;
+        }
+        .field .value {
+            color: #333;
+        }
+        .status-active {
+            color: #27ae60;
+            font-weight: bold;
+        }
+        .status-revoked, .status-expired {
+            color: #e74c3c;
+            font-weight: bold;
+        }
+        .status-suspended, .status-pending {
+            color: #f39c12;
+            font-weight: bold;
+        }
+        .fingerprint {
+            font-family: monospace;
+            font-size: 10px;
+            word-break: break-all;
+            background: #f5f5f5;
+            padding: 8px;
+            border-radius: 4px;
+        }
+        .disclaimer {
+            margin-top: 40px;
+            padding: 15px;
+            background: #f8f9fa;
+            border-left: 4px solid #16213e;
+            font-size: 10px;
+            color: #666;
+        }
+        .footer {
+            margin-top: 30px;
+            text-align: center;
+            font-size: 9px;
+            color: #999;
+            border-top: 1px solid #e0e0e0;
+            padding-top: 15px;
+        }
+        .verification {
+            margin-top: 20px;
+            padding: 15px;
+            border: 1px solid #e0e0e0;
+            border-radius: 4px;
+        }
+        .verification h3 {
+            margin: 0 0 10px;
+            font-size: 12px;
+            color: #16213e;
+        }
+        .verification .url {
+            font-family: monospace;
+            font-size: 9px;
+            word-break: break-all;
+            color: #0f3460;
+        }
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>{{ $branding['name'] ?? 'FinAegis' }} Certificate</h1>
+        <div class="subtitle">Digital Trust Certificate</div>
+        <div class="shield">Secured by {{ $branding['shield'] ?? 'Aegis Shield' }}</div>
+    </div>
+
+    <div class="section">
+        <h2>Certificate Details</h2>
+        <div class="field">
+            <span class="label">Certificate ID:</span>
+            <span class="value">{{ $certificate->certificateId }}</span>
+        </div>
+        <div class="field">
+            <span class="label">Subject:</span>
+            <span class="value">{{ $certificate->subjectId }}</span>
+        </div>
+        <div class="field">
+            <span class="label">Status:</span>
+            <span class="value status-{{ strtolower($certificate->status->value) }}">
+                {{ strtoupper($certificate->status->value) }}
+            </span>
+        </div>
+        <div class="field">
+            <span class="label">Root Certificate:</span>
+            <span class="value">{{ $certificate->isRootCertificate() ? 'Yes' : 'No' }}</span>
+        </div>
+    </div>
+
+    <div class="section">
+        <h2>Validity Period</h2>
+        <div class="field">
+            <span class="label">Valid From:</span>
+            <span class="value">{{ $certificate->validFrom->format('Y-m-d H:i:s T') }}</span>
+        </div>
+        <div class="field">
+            <span class="label">Valid Until:</span>
+            <span class="value">{{ $certificate->validUntil->format('Y-m-d H:i:s T') }}</span>
+        </div>
+        <div class="field">
+            <span class="label">Currently Valid:</span>
+            <span class="value">{{ $certificate->isValid() ? 'Yes' : 'No' }}</span>
+        </div>
+    </div>
+
+    <div class="section">
+        <h2>Certificate Fingerprint</h2>
+        <div class="fingerprint">{{ $certificate->getFingerprint() }}</div>
+    </div>
+
+    @if($verificationUrl)
+    <div class="verification">
+        <h3>Verification</h3>
+        <p>Scan or visit the following URL to verify this certificate:</p>
+        <div class="url">{{ $verificationUrl }}</div>
+        @if($deepLink)
+        <p style="margin-top: 8px; font-size: 10px;">
+            Deep Link: <span class="url">{{ $deepLink }}</span>
+        </p>
+        @endif
+    </div>
+    @endif
+
+    <div class="disclaimer">
+        <strong>Disclaimer:</strong> {{ $disclaimer }}
+    </div>
+
+    <div class="footer">
+        <p>Generated on {{ now()->format('Y-m-d H:i:s T') }}</p>
+        <p>{{ $branding['name'] ?? 'FinAegis' }} &mdash; Digital Trust Infrastructure</p>
+    </div>
+</body>
+</html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1193,6 +1193,7 @@ Route::prefix('v1/relayer')->name('api.relayer.')->group(function () {
 |
 */
 
+use App\Http\Controllers\Api\TrustCert\CertificateController;
 use App\Http\Controllers\Api\TrustCert\PresentationController;
 
 Route::prefix('v1/trustcert')->name('api.trustcert.')->group(function () {
@@ -1202,6 +1203,10 @@ Route::prefix('v1/trustcert')->name('api.trustcert.')->group(function () {
     // Authenticated endpoints
     Route::middleware(['auth:sanctum', 'check.token.expiration'])->group(function () {
         Route::post('/{certificateId}/present', [PresentationController::class, 'present'])->name('present');
+
+        // Certificate details and PDF export
+        Route::get('/{certId}/certificate', [CertificateController::class, 'show'])->name('certificate.show');
+        Route::post('/{certId}/export-pdf', [CertificateController::class, 'exportPdf'])->name('certificate.export');
     });
 });
 

--- a/tests/Unit/Domain/TrustCert/Services/CertificateExportServiceTest.php
+++ b/tests/Unit/Domain/TrustCert/Services/CertificateExportServiceTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\TrustCert\Enums\CertificateStatus;
+use App\Domain\TrustCert\Services\CertificateAuthorityService;
+use App\Domain\TrustCert\Services\CertificateExportService;
+use App\Domain\TrustCert\Services\PresentationService;
+use App\Domain\TrustCert\ValueObjects\Certificate;
+
+describe('CertificateExportService', function (): void {
+    it('can be instantiated with dependencies', function (): void {
+        $caService = Mockery::mock(CertificateAuthorityService::class);
+        $presentationService = Mockery::mock(PresentationService::class);
+
+        $service = new CertificateExportService($caService, $presentationService);
+
+        expect($service)->toBeInstanceOf(CertificateExportService::class);
+    });
+
+    it('returns null for non-existent certificate details', function (): void {
+        $caService = Mockery::mock(CertificateAuthorityService::class);
+        $caService->shouldReceive('getCertificate')
+            ->with('cert_nonexistent')
+            ->andReturn(null);
+
+        $presentationService = Mockery::mock(PresentationService::class);
+
+        $service = new CertificateExportService($caService, $presentationService);
+        $details = $service->getCertificateDetails('cert_nonexistent');
+
+        expect($details)->toBeNull();
+    });
+
+    it('returns formatted certificate details', function (): void {
+        $certificate = Certificate::fromArray([
+            'certificate_id'        => 'cert_test123',
+            'subject_id'            => 'user_456',
+            'subject'               => ['name' => 'Test User', 'type' => 'individual'],
+            'public_key'            => base64_encode('test-public-key'),
+            'signature'             => 'test-signature',
+            'valid_from'            => '2026-01-01T00:00:00Z',
+            'valid_until'           => '2027-01-01T00:00:00Z',
+            'status'                => CertificateStatus::ACTIVE->value,
+            'parent_certificate_id' => null,
+            'extensions'            => ['usage' => 'identity'],
+        ]);
+
+        $caService = Mockery::mock(CertificateAuthorityService::class);
+        $caService->shouldReceive('getCertificate')
+            ->with('cert_test123')
+            ->andReturn($certificate);
+
+        $presentationService = Mockery::mock(PresentationService::class);
+
+        $service = new CertificateExportService($caService, $presentationService);
+        $details = $service->getCertificateDetails('cert_test123');
+
+        expect($details)->not->toBeNull();
+        expect($details['certificateId'])->toBe('cert_test123');
+        expect($details['subjectId'])->toBe('user_456');
+        expect($details['status'])->toBe('active');
+        expect($details['isRoot'])->toBeTrue();
+        expect($details['disclaimer'])->toContain('FinAegis');
+        expect($details)->toHaveKeys([
+            'certificateId', 'subjectId', 'subject', 'status',
+            'validFrom', 'validUntil', 'isValid', 'isExpired',
+            'isRevoked', 'isRoot', 'fingerprint', 'extensions', 'disclaimer',
+        ]);
+    });
+
+    it('returns null PDF for non-existent certificate', function (): void {
+        $caService = Mockery::mock(CertificateAuthorityService::class);
+        $caService->shouldReceive('getCertificate')
+            ->with('cert_missing')
+            ->andReturn(null);
+
+        $presentationService = Mockery::mock(PresentationService::class);
+
+        $service = new CertificateExportService($caService, $presentationService);
+        $pdf = $service->exportToPdf('cert_missing');
+
+        expect($pdf)->toBeNull();
+    });
+
+    it('includes FinAegis branding in disclaimer', function (): void {
+        $certificate = Certificate::fromArray([
+            'certificate_id'        => 'cert_brand',
+            'subject_id'            => 'user_brand',
+            'subject'               => ['name' => 'Brand Test'],
+            'public_key'            => base64_encode('pk'),
+            'signature'             => 'sig',
+            'valid_from'            => '2026-01-01T00:00:00Z',
+            'valid_until'           => '2027-01-01T00:00:00Z',
+            'status'                => CertificateStatus::ACTIVE->value,
+            'parent_certificate_id' => null,
+            'extensions'            => [],
+        ]);
+
+        $caService = Mockery::mock(CertificateAuthorityService::class);
+        $caService->shouldReceive('getCertificate')
+            ->with('cert_brand')
+            ->andReturn($certificate);
+
+        $presentationService = Mockery::mock(PresentationService::class);
+
+        $service = new CertificateExportService($caService, $presentationService);
+        $details = $service->getCertificateDetails('cert_brand');
+
+        expect($details['disclaimer'])->toContain('FinAegis ecosystem');
+        expect($details['disclaimer'])->not->toContain('ShieldPay');
+    });
+});


### PR DESCRIPTION
## Summary
- **CertificateExportService**: Retrieves certificate details with FinAegis-branded disclaimer, generates PDF via dompdf with verification URL and deep link
- **CertificateController**: `GET /{certId}/certificate` for JSON details, `POST /{certId}/export-pdf` for PDF download
- **PDF template**: A4 Blade template with certificate details, validity period, fingerprint, verification link, and branding

## New Files (4)
- `app/Domain/TrustCert/Services/CertificateExportService.php`
- `app/Http/Controllers/Api/TrustCert/CertificateController.php`
- `resources/views/trustcert/certificate-pdf.blade.php`
- `tests/Unit/Domain/TrustCert/Services/CertificateExportServiceTest.php`

## Routes Added
| Method | Path | Description |
|--------|------|-------------|
| GET | `/v1/trustcert/{certId}/certificate` | Certificate details |
| POST | `/v1/trustcert/{certId}/export-pdf` | PDF download |

## Spec Compliance
- Branding: "FinAegis" / "Aegis Shield" (not "ShieldPay")
- Disclaimer references "FinAegis ecosystem"

## Test plan
- [x] 5 unit tests passing (24 assertions)
- [x] PHPStan clean (no errors)
- [x] Code style fixed via php-cs-fixer
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)