### PR TITLE
fix(mobile-payment): Align response shapes with mobile spec and improve resilience

### DIFF
--- a/app/Domain/MobilePayment/Models/PaymentIntent.php
+++ b/app/Domain/MobilePayment/Models/PaymentIntent.php
@@ -236,21 +236,19 @@ class PaymentIntent extends Model
             'expiresAt'     => $this->expires_at->toIso8601String(),
         ];
 
-        if ($this->tx_hash) {
-            $response['tx'] = [
-                'hash'        => $this->tx_hash,
-                'explorerUrl' => $this->tx_explorer_url,
-            ];
-            $response['confirmations'] = $this->confirmations;
-            $response['requiredConfirmations'] = $this->required_confirmations;
-        }
+        // Always include tx, confirmations, and error per spec (even when null/zero)
+        $response['tx'] = $this->tx_hash ? [
+            'hash'        => $this->tx_hash,
+            'explorerUrl' => $this->tx_explorer_url,
+        ] : null;
 
-        if ($this->error_code) {
-            $response['error'] = [
-                'code'    => $this->error_code,
-                'message' => $this->error_message,
-            ];
-        }
+        $response['confirmations'] = $this->confirmations ?? 0;
+        $response['requiredConfirmations'] = $this->required_confirmations;
+
+        $response['error'] = $this->error_code ? [
+            'code'    => $this->error_code,
+            'message' => $this->error_message,
+        ] : null;
 
         return $response;
     }

--- a/app/Domain/MobilePayment/Models/PaymentReceipt.php
+++ b/app/Domain/MobilePayment/Models/PaymentReceipt.php
@@ -80,7 +80,7 @@ class PaymentReceipt extends Model
 
     public function getShareUrl(): string
     {
-        return config('app.url') . '/receipt/' . $this->share_token;
+        return config('app.url') . '/receipt/' . $this->public_id;
     }
 
     /**

--- a/app/Domain/MobilePayment/Services/PaymentIntentService.php
+++ b/app/Domain/MobilePayment/Services/PaymentIntentService.php
@@ -84,7 +84,7 @@ class PaymentIntentService implements PaymentIntentServiceInterface
             'asset'                  => $asset,
             'network'                => $network,
             'amount'                 => $amount,
-            'status'                 => PaymentIntentStatus::AWAITING_AUTH,
+            'status'                 => PaymentIntentStatus::CREATED,
             'shield_enabled'         => $shield,
             'fees_estimate'          => $fees->toArray(),
             'required_confirmations' => $networkEnum->requiredConfirmations(),
@@ -93,6 +93,9 @@ class PaymentIntentService implements PaymentIntentServiceInterface
         ]);
 
         $intent->setRelation('merchant', $merchant);
+
+        // Transition through the state machine to AWAITING_AUTH
+        $intent->transitionTo(PaymentIntentStatus::AWAITING_AUTH);
 
         return $intent;
     }

--- a/app/Domain/MobilePayment/Services/TransactionDetailService.php
+++ b/app/Domain/MobilePayment/Services/TransactionDetailService.php
@@ -62,9 +62,9 @@ class TransactionDetailService
             }
         }
 
-        if ($item->protected) {
-            $response['privacyNote'] = 'Privacy-preserving by default. Additional disclosure available when legally required.';
-        }
+        $response['privacyNote'] = $item->protected
+            ? 'Privacy-preserving by default. Additional disclosure available when legally required.'
+            : null;
 
         return $response;
     }

--- a/app/Http/Controllers/Api/TrustCert/CertificateController.php
+++ b/app/Http/Controllers/Api/TrustCert/CertificateController.php
@@ -7,7 +7,6 @@ namespace App\Http\Controllers\Api\TrustCert;
 use App\Domain\TrustCert\Services\CertificateExportService;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Response;
 
 class CertificateController extends Controller
 {
@@ -46,11 +45,11 @@ class CertificateController extends Controller
      *
      * POST /v1/trustcert/{certId}/export-pdf
      */
-    public function exportPdf(string $certId): Response|JsonResponse
+    public function exportPdf(string $certId): JsonResponse
     {
-        $pdfContent = $this->exportService->exportToPdf($certId);
+        $result = $this->exportService->exportToPdf($certId);
 
-        if (! $pdfContent) {
+        if (! $result) {
             return response()->json([
                 'success' => false,
                 'error'   => [
@@ -60,11 +59,9 @@ class CertificateController extends Controller
             ], 404);
         }
 
-        $safeCertId = preg_replace('/[^a-zA-Z0-9_\-]/', '', $certId);
-
-        return response($pdfContent, 200, [
-            'Content-Type'        => 'application/pdf',
-            'Content-Disposition' => "attachment; filename=\"certificate-{$safeCertId}.pdf\"",
+        return response()->json([
+            'success' => true,
+            'data'    => $result,
         ]);
     }
 }

--- a/config/mobile_payment.php
+++ b/config/mobile_payment.php
@@ -45,6 +45,17 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Idempotency Queue Window
+    |--------------------------------------------------------------------------
+    |
+    | Maximum age (in minutes) for accepting queued/retried submissions
+    | from mobile clients that were offline. Aligns with offline queue TTL.
+    |
+    */
+    'idempotency_queue_window_minutes' => (int) env('MOBILE_PAYMENT_IDEMPOTENCY_QUEUE_MINUTES', 30),
+
+    /*
+    |--------------------------------------------------------------------------
     | Demo Mode
     |--------------------------------------------------------------------------
     |

--- a/tests/Unit/Domain/TrustCert/Services/CertificateExportServiceTest.php
+++ b/tests/Unit/Domain/TrustCert/Services/CertificateExportServiceTest.php
@@ -32,7 +32,7 @@ describe('CertificateExportService', function (): void {
         expect($details)->toBeNull();
     });
 
-    it('returns formatted certificate details', function (): void {
+    it('returns formatted certificate details matching mobile spec', function (): void {
         $certificate = Certificate::fromArray([
             'certificate_id'        => 'cert_test123',
             'subject_id'            => 'user_456',
@@ -57,15 +57,14 @@ describe('CertificateExportService', function (): void {
         $details = $service->getCertificateDetails('cert_test123');
 
         expect($details)->not->toBeNull();
-        expect($details['certificateId'])->toBe('cert_test123');
-        expect($details['subjectId'])->toBe('user_456');
-        expect($details['status'])->toBe('active');
-        expect($details['isRoot'])->toBeTrue();
+        expect($details['certId'])->toBe('cert_test123');
+        expect($details['status'])->toBe('verified');
+        expect($details['verificationStatus'])->toBe('Fully Verified');
+        expect($details['scope'])->toBe('Individual Global Account');
         expect($details['disclaimer'])->toContain('FinAegis');
         expect($details)->toHaveKeys([
-            'certificateId', 'subjectId', 'subject', 'status',
-            'validFrom', 'validUntil', 'isValid', 'isExpired',
-            'isRevoked', 'isRoot', 'fingerprint', 'extensions', 'disclaimer',
+            'certId', 'status', 'verificationStatus', 'identityId',
+            'scope', 'validUntil', 'issuedAt', 'disclaimer', 'qrPayload',
         ]);
     });
 
@@ -109,5 +108,6 @@ describe('CertificateExportService', function (): void {
 
         expect($details['disclaimer'])->toContain('FinAegis ecosystem');
         expect($details['disclaimer'])->not->toContain('ShieldPay');
+        expect($details['qrPayload'])->toContain('cert_brand');
     });
 });


### PR DESCRIPTION
## Summary

- **Submit/cancel response shapes**: Return minimal JSON matching mobile spec instead of full `toApiResponse()`
- **Poll response always-present fields**: `tx`, `confirmations`, `requiredConfirmations`, `error` always included (null defaults)
- **Certificate API**: Returns mobile-spec fields (`certId`, `verificationStatus`, `identityId`, `scope`, `qrPayload`); PDF export returns `{pdfUrl, expiresAt}` JSON instead of raw binary
- **ExpireStalePaymentIntents resilience**: `chunkById(200)` + per-intent try/catch error isolation
- **State machine compliance**: Intent creates in `CREATED` then transitions to `AWAITING_AUTH`
- **Offline queue support**: Accept `X-Idempotency-Key` header + `idempotency_queue_window_minutes` config (30 min default)
- **Receipt/transaction details**: Share URL uses `public_id`; `privacyNote` always included (null when not protected)

## Files Changed (10)

| File | Change |
|------|--------|
| `PaymentIntentController.php` | Submit/cancel minimal responses, idempotency header support |
| `PaymentIntent.php` | `toApiResponse()` always includes tx/error/confirmations fields |
| `PaymentIntentService.php` | CREATED → AWAITING_AUTH state machine |
| `ExpireStalePaymentIntents.php` | chunkById + error isolation |
| `CertificateExportService.php` | Mobile-spec response shape, PDF stored to disk |
| `CertificateController.php` | PDF returns JSON instead of raw binary |
| `PaymentReceipt.php` | Share URL uses public_id |
| `TransactionDetailService.php` | privacyNote always included |
| `config/mobile_payment.php` | idempotency_queue_window_minutes |
| `CertificateExportServiceTest.php` | Updated for new response shape |

## Test plan

- [x] All 78 MobilePayment tests pass
- [x] All 5 CertificateExportService tests pass
- [x] Pre-commit checks pass (only pre-existing issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)