### PR TITLE
feat(wallet): Add P2P transfer helper endpoints for mobile send flow

### DIFF
--- a/app/Domain/Wallet/Services/WalletTransferService.php
+++ b/app/Domain/Wallet/Services/WalletTransferService.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Wallet\Services;
+
+use App\Domain\MobilePayment\Enums\PaymentAsset;
+use App\Domain\MobilePayment\Enums\PaymentNetwork;
+
+class WalletTransferService
+{
+    /**
+     * Validate a blockchain address for a specific network.
+     *
+     * @return array{valid: bool, network: string, address: string, address_type: string|null, error: string|null}
+     */
+    public function validateAddress(string $address, string $network): array
+    {
+        $paymentNetwork = PaymentNetwork::tryFrom($network);
+
+        if (! $paymentNetwork) {
+            return [
+                'valid'        => false,
+                'network'      => $network,
+                'address'      => $address,
+                'address_type' => null,
+                'error'        => 'Unsupported network. Supported: ' . implode(', ', PaymentNetwork::values()),
+            ];
+        }
+
+        $pattern = $paymentNetwork->addressPattern();
+        $isValid = (bool) preg_match($pattern, $address);
+
+        return [
+            'valid'        => $isValid,
+            'network'      => $paymentNetwork->value,
+            'address'      => $address,
+            'address_type' => $isValid ? $this->detectAddressType($address, $paymentNetwork) : null,
+            'error'        => $isValid ? null : "Invalid {$paymentNetwork->label()} address format.",
+        ];
+    }
+
+    /**
+     * Resolve an ENS/SNS name to a blockchain address.
+     *
+     * @return array{resolved: bool, name: string, address: string|null, network: string, error: string|null}
+     */
+    public function resolveName(string $name, string $network): array
+    {
+        $paymentNetwork = PaymentNetwork::tryFrom($network);
+
+        if (! $paymentNetwork) {
+            return [
+                'resolved' => false,
+                'name'     => $name,
+                'address'  => null,
+                'network'  => $network,
+                'error'    => 'Unsupported network. Supported: ' . implode(', ', PaymentNetwork::values()),
+            ];
+        }
+
+        return $this->performNameResolution($name, $paymentNetwork);
+    }
+
+    /**
+     * Get a fee quote for a wallet-to-wallet transfer.
+     *
+     * @return array{network: string, asset: string, estimated_fee: string, fee_currency: string, estimated_time_seconds: int, exchange_rate_usd: string}
+     */
+    public function getTransferQuote(string $network, string $asset, string $amount): array
+    {
+        $paymentNetwork = PaymentNetwork::from($network);
+        $paymentAsset = PaymentAsset::from($asset);
+
+        $gasCostUsd = $paymentNetwork->averageGasCostUsd();
+
+        return [
+            'network'                => $paymentNetwork->value,
+            'asset'                  => $paymentAsset->value,
+            'amount'                 => $amount,
+            'estimated_fee'          => number_format($gasCostUsd, 6),
+            'fee_currency'           => 'USD',
+            'estimated_time_seconds' => $this->estimateTransferTime($paymentNetwork),
+            'exchange_rate_usd'      => '1.000000',
+        ];
+    }
+
+    /**
+     * Detect address type based on format heuristics.
+     */
+    private function detectAddressType(string $address, PaymentNetwork $network): string
+    {
+        return match ($network) {
+            PaymentNetwork::SOLANA => strlen($address) >= 40 ? 'program' : 'wallet',
+            PaymentNetwork::TRON   => str_starts_with($address, 'T') ? 'base58' : 'hex',
+        };
+    }
+
+    /**
+     * Perform name resolution for the given name and network.
+     *
+     * In production, this would call external resolvers (SNS for Solana, etc.).
+     * Currently returns a stub response indicating resolution is not yet available.
+     *
+     * @return array{resolved: bool, name: string, address: string|null, network: string, error: string|null}
+     */
+    private function performNameResolution(string $name, PaymentNetwork $network): array
+    {
+        // SNS (.sol) resolution for Solana
+        if ($network === PaymentNetwork::SOLANA && str_ends_with($name, '.sol')) {
+            return [
+                'resolved' => false,
+                'name'     => $name,
+                'address'  => null,
+                'network'  => $network->value,
+                'error'    => 'SNS resolution requires external resolver integration. Please use a wallet address directly.',
+            ];
+        }
+
+        // ENS (.eth) - not natively supported on Solana/Tron
+        if (str_ends_with($name, '.eth')) {
+            return [
+                'resolved' => false,
+                'name'     => $name,
+                'address'  => null,
+                'network'  => $network->value,
+                'error'    => 'ENS names (.eth) are not supported on ' . $network->label() . '. Please use a wallet address directly.',
+            ];
+        }
+
+        return [
+            'resolved' => false,
+            'name'     => $name,
+            'address'  => null,
+            'network'  => $network->value,
+            'error'    => 'Name resolution is not available for this format. Please use a wallet address directly.',
+        ];
+    }
+
+    /**
+     * Estimate transfer confirmation time in seconds.
+     */
+    private function estimateTransferTime(PaymentNetwork $network): int
+    {
+        return match ($network) {
+            PaymentNetwork::SOLANA => 5,
+            PaymentNetwork::TRON   => 30,
+        };
+    }
+}

--- a/app/Http/Controllers/Api/Wallet/WalletTransferController.php
+++ b/app/Http/Controllers/Api/Wallet/WalletTransferController.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Wallet;
+
+use App\Domain\Wallet\Services\WalletTransferService;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Wallet\ResolveNameRequest;
+use App\Http\Requests\Wallet\ValidateAddressRequest;
+use App\Http\Requests\Wallet\WalletQuoteRequest;
+use Illuminate\Http\JsonResponse;
+use Throwable;
+
+class WalletTransferController extends Controller
+{
+    public function __construct(
+        private readonly WalletTransferService $transferService,
+    ) {
+    }
+
+    /**
+     * Validate a blockchain address.
+     *
+     * GET /v1/wallet/validate-address?address=...&network=SOLANA
+     */
+    public function validateAddress(ValidateAddressRequest $request): JsonResponse
+    {
+        $validated = $request->validated();
+
+        $result = $this->transferService->validateAddress(
+            $validated['address'],
+            $validated['network'],
+        );
+
+        return response()->json([
+            'success' => true,
+            'data'    => $result,
+        ]);
+    }
+
+    /**
+     * Resolve an ENS/SNS name to a blockchain address.
+     *
+     * POST /v1/wallet/resolve-name
+     */
+    public function resolveName(ResolveNameRequest $request): JsonResponse
+    {
+        $validated = $request->validated();
+
+        $result = $this->transferService->resolveName(
+            $validated['name'],
+            $validated['network'],
+        );
+
+        $statusCode = $result['resolved'] ? 200 : 422;
+
+        return response()->json([
+            'success' => $result['resolved'],
+            'data'    => $result,
+        ], $statusCode);
+    }
+
+    /**
+     * Get a fee quote for a wallet-to-wallet transfer.
+     *
+     * POST /v1/wallet/quote
+     */
+    public function quote(WalletQuoteRequest $request): JsonResponse
+    {
+        $validated = $request->validated();
+
+        try {
+            $result = $this->transferService->getTransferQuote(
+                $validated['network'],
+                $validated['asset'],
+                $validated['amount'],
+            );
+
+            return response()->json([
+                'success' => true,
+                'data'    => $result,
+            ]);
+        } catch (Throwable $e) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'QUOTE_FAILED',
+                    'message' => $e->getMessage(),
+                ],
+            ], 400);
+        }
+    }
+}

--- a/app/Http/Requests/Wallet/ResolveNameRequest.php
+++ b/app/Http/Requests/Wallet/ResolveNameRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Wallet;
+
+use App\Domain\MobilePayment\Enums\PaymentNetwork;
+use Illuminate\Foundation\Http\FormRequest;
+
+class ResolveNameRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'name'    => ['required', 'string', 'min:3', 'max:253', 'regex:/^[a-zA-Z0-9][a-zA-Z0-9.-]+\.[a-z]{2,}$/'],
+            'network' => ['required', 'string', 'in:' . implode(',', PaymentNetwork::values())],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'name.required' => 'A domain name is required (e.g. alice.sol, vitalik.eth).',
+            'name.regex'    => 'Invalid name format. Expected format: name.tld (e.g. alice.sol).',
+            'network.in'    => 'Supported networks: ' . implode(', ', PaymentNetwork::values()),
+        ];
+    }
+}

--- a/app/Http/Requests/Wallet/ValidateAddressRequest.php
+++ b/app/Http/Requests/Wallet/ValidateAddressRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Wallet;
+
+use App\Domain\MobilePayment\Enums\PaymentNetwork;
+use Illuminate\Foundation\Http\FormRequest;
+
+class ValidateAddressRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'address' => ['required', 'string', 'min:20', 'max:128'],
+            'network' => ['required', 'string', 'in:' . implode(',', PaymentNetwork::values())],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'address.required' => 'A wallet address is required.',
+            'network.required' => 'A network is required.',
+            'network.in'       => 'Supported networks: ' . implode(', ', PaymentNetwork::values()),
+        ];
+    }
+}

--- a/app/Http/Requests/Wallet/WalletQuoteRequest.php
+++ b/app/Http/Requests/Wallet/WalletQuoteRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Wallet;
+
+use App\Domain\MobilePayment\Enums\PaymentAsset;
+use App\Domain\MobilePayment\Enums\PaymentNetwork;
+use Illuminate\Foundation\Http\FormRequest;
+
+class WalletQuoteRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'network' => ['required', 'string', 'in:' . implode(',', PaymentNetwork::values())],
+            'asset'   => ['required', 'string', 'in:' . implode(',', PaymentAsset::values())],
+            'amount'  => ['required', 'numeric', 'gt:0', 'max:1000000'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'network.in' => 'Supported networks: ' . implode(', ', PaymentNetwork::values()),
+            'asset.in'   => 'Supported assets: ' . implode(', ', PaymentAsset::values()),
+            'amount.gt'  => 'Amount must be greater than zero.',
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -46,6 +46,7 @@ use App\Http\Controllers\Api\TransferController;
 use App\Http\Controllers\Api\Treasury\PortfolioController;
 use App\Http\Controllers\Api\UserVotingController;
 use App\Http\Controllers\Api\VoteController;
+use App\Http\Controllers\Api\Wallet\WalletTransferController;
 use App\Http\Controllers\Api\WorkflowMonitoringController;
 use App\Http\Controllers\StatusController;
 use Illuminate\Http\Request;
@@ -1306,6 +1307,17 @@ Route::prefix('v1')->middleware(['auth:sanctum', 'check.token.expiration'])->gro
     Route::get('/networks/status', NetworkStatusController::class)
         ->middleware('api.rate_limit:query')
         ->name('mobile.networks.status');
+
+    // Wallet Transfer Helpers (P2P send flow)
+    Route::get('/wallet/validate-address', [WalletTransferController::class, 'validateAddress'])
+        ->middleware('api.rate_limit:query')
+        ->name('mobile.wallet.validate-address');
+    Route::post('/wallet/resolve-name', [WalletTransferController::class, 'resolveName'])
+        ->middleware('api.rate_limit:query')
+        ->name('mobile.wallet.resolve-name');
+    Route::post('/wallet/quote', [WalletTransferController::class, 'quote'])
+        ->middleware('api.rate_limit:query')
+        ->name('mobile.wallet.quote');
 });
 
 /*

--- a/tests/Unit/Domain/Wallet/Services/WalletTransferServiceTest.php
+++ b/tests/Unit/Domain/Wallet/Services/WalletTransferServiceTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Wallet\Services\WalletTransferService;
+
+describe('WalletTransferService', function (): void {
+    beforeEach(function (): void {
+        $this->service = new WalletTransferService();
+    });
+
+    // ── Address Validation ──────────────────────────────────────
+
+    describe('validateAddress', function (): void {
+        it('validates a valid Solana address', function (): void {
+            $result = $this->service->validateAddress(
+                '7xR9Hk3JpZ1mNvLqQ8nWX5vY2bF4cD6eA9tGTsP4f2Z',
+                'SOLANA',
+            );
+
+            expect($result['valid'])->toBeTrue();
+            expect($result['network'])->toBe('SOLANA');
+            expect($result['address_type'])->not->toBeNull();
+            expect($result['error'])->toBeNull();
+        });
+
+        it('rejects an invalid Solana address', function (): void {
+            $result = $this->service->validateAddress(
+                'invalid-address!',
+                'SOLANA',
+            );
+
+            expect($result['valid'])->toBeFalse();
+            expect($result['network'])->toBe('SOLANA');
+            expect($result['address_type'])->toBeNull();
+            expect($result['error'])->toContain('Invalid Solana address format');
+        });
+
+        it('validates a valid Tron address', function (): void {
+            $result = $this->service->validateAddress(
+                'TJYbqJPyFqFNeAXUGNsmbmh7ya2Bji3XDQ',
+                'TRON',
+            );
+
+            expect($result['valid'])->toBeTrue();
+            expect($result['network'])->toBe('TRON');
+            expect($result['address_type'])->toBe('base58');
+            expect($result['error'])->toBeNull();
+        });
+
+        it('rejects an invalid Tron address', function (): void {
+            $result = $this->service->validateAddress(
+                'notATronAddress',
+                'TRON',
+            );
+
+            expect($result['valid'])->toBeFalse();
+            expect($result['error'])->toContain('Invalid Tron address format');
+        });
+
+        it('rejects unsupported networks', function (): void {
+            $result = $this->service->validateAddress(
+                '0x742d35Cc6634C0532925a3b844Bc9e7595f2bD08',
+                'ETHEREUM',
+            );
+
+            expect($result['valid'])->toBeFalse();
+            expect($result['error'])->toContain('Unsupported network');
+        });
+
+        it('detects short Solana addresses as wallet type', function (): void {
+            // 32-char base58 address (wallet)
+            $result = $this->service->validateAddress(
+                '7xR9Hk3JpZ1mNvLqQ8nWX5vY2bF4cDaK',
+                'SOLANA',
+            );
+
+            expect($result['valid'])->toBeTrue();
+            expect($result['address_type'])->toBe('wallet');
+        });
+
+        it('validates address with exact 44 base58 characters', function (): void {
+            $result = $this->service->validateAddress(
+                'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+                'SOLANA',
+            );
+
+            expect($result['valid'])->toBeTrue();
+            expect($result['address_type'])->toBe('program');
+        });
+    });
+
+    // ── Name Resolution ─────────────────────────────────────────
+
+    describe('resolveName', function (): void {
+        it('returns stub for .sol names on Solana', function (): void {
+            $result = $this->service->resolveName('alice.sol', 'SOLANA');
+
+            expect($result['resolved'])->toBeFalse();
+            expect($result['name'])->toBe('alice.sol');
+            expect($result['address'])->toBeNull();
+            expect($result['network'])->toBe('SOLANA');
+            expect($result['error'])->toContain('SNS resolution');
+        });
+
+        it('rejects .eth names on Solana', function (): void {
+            $result = $this->service->resolveName('vitalik.eth', 'SOLANA');
+
+            expect($result['resolved'])->toBeFalse();
+            expect($result['error'])->toContain('not supported');
+        });
+
+        it('rejects .eth names on Tron', function (): void {
+            $result = $this->service->resolveName('vitalik.eth', 'TRON');
+
+            expect($result['resolved'])->toBeFalse();
+            expect($result['error'])->toContain('not supported on Tron');
+        });
+
+        it('rejects unsupported networks', function (): void {
+            $result = $this->service->resolveName('alice.sol', 'ETHEREUM');
+
+            expect($result['resolved'])->toBeFalse();
+            expect($result['error'])->toContain('Unsupported network');
+        });
+
+        it('returns error for unknown name formats', function (): void {
+            $result = $this->service->resolveName('alice.xyz', 'SOLANA');
+
+            expect($result['resolved'])->toBeFalse();
+            expect($result['error'])->toContain('not available');
+        });
+
+        it('returns correct network in result', function (): void {
+            $result = $this->service->resolveName('alice.sol', 'SOLANA');
+
+            expect($result['network'])->toBe('SOLANA');
+            expect($result['name'])->toBe('alice.sol');
+        });
+    });
+
+    // ── Transfer Quotes ─────────────────────────────────────────
+
+    describe('getTransferQuote', function (): void {
+        it('returns a quote for Solana USDC transfer', function (): void {
+            $result = $this->service->getTransferQuote('SOLANA', 'USDC', '100.00');
+
+            expect($result['network'])->toBe('SOLANA');
+            expect($result['asset'])->toBe('USDC');
+            expect($result['amount'])->toBe('100.00');
+            expect($result['fee_currency'])->toBe('USD');
+            expect($result['estimated_time_seconds'])->toBe(5);
+            expect($result['estimated_fee'])->toBe('0.001000');
+        });
+
+        it('returns a quote for Tron USDC transfer', function (): void {
+            $result = $this->service->getTransferQuote('TRON', 'USDC', '50.00');
+
+            expect($result['network'])->toBe('TRON');
+            expect($result['asset'])->toBe('USDC');
+            expect($result['estimated_time_seconds'])->toBe(30);
+            expect($result['estimated_fee'])->toBe('0.500000');
+        });
+
+        it('throws for invalid network', function (): void {
+            expect(fn () => $this->service->getTransferQuote('ETHEREUM', 'USDC', '100.00'))
+                ->toThrow(ValueError::class);
+        });
+
+        it('throws for invalid asset', function (): void {
+            expect(fn () => $this->service->getTransferQuote('SOLANA', 'USDT', '100.00'))
+                ->toThrow(ValueError::class);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- **GET /v1/wallet/validate-address**: Validates blockchain address format for Solana (base58, 32-44 chars) and Tron (T-prefixed, 34 chars)
- **POST /v1/wallet/resolve-name**: ENS/SNS name resolution endpoint (stub implementation - returns informative error messages for .sol, .eth, and unsupported formats)
- **POST /v1/wallet/quote**: Fee quote for wallet-to-wallet transfers with estimated time and gas costs

These endpoints support the mobile app's send-stablecoins flow (4 screens: recipient selection, amount entry, review & confirm, QR scan).

## New Files
- `app/Domain/Wallet/Services/WalletTransferService.php` - Core service with address validation, name resolution, and fee quoting
- `app/Http/Controllers/Api/Wallet/WalletTransferController.php` - Controller with 3 endpoints
- `app/Http/Requests/Wallet/` - 3 form request validators
- `tests/Unit/Domain/Wallet/Services/WalletTransferServiceTest.php` - 17 tests covering all service methods

## Test plan
- [x] 17 unit tests pass (address validation, name resolution, fee quotes)
- [x] 78 existing MobilePayment tests still pass
- [x] PHPStan clean (0 errors)
- [x] PHP CS Fixer formatting applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)