### PR TITLE
feat(regtech): Add jurisdiction-specific regulatory filing adapters

### DIFF
--- a/app/Domain/RegTech/Adapters/AbstractRegulatoryAdapter.php
+++ b/app/Domain/RegTech/Adapters/AbstractRegulatoryAdapter.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\RegTech\Adapters;
+
+use App\Domain\RegTech\Contracts\RegulatoryFilingAdapterInterface;
+use App\Domain\RegTech\Enums\Jurisdiction;
+use Illuminate\Support\Str;
+use Throwable;
+
+/**
+ * Base adapter with shared demo/sandbox behaviour.
+ * Concrete adapters override jurisdiction-specific details.
+ */
+abstract class AbstractRegulatoryAdapter implements RegulatoryFilingAdapterInterface
+{
+    protected bool $sandboxMode;
+
+    protected string $apiEndpoint;
+
+    public function __construct()
+    {
+        $regulator = strtolower($this->getRegulatorKey());
+
+        $this->sandboxMode = true;
+        $this->apiEndpoint = "https://sandbox.{$regulator}.demo/api/v1";
+
+        try {
+            $this->sandboxMode = (bool) config('regtech.demo_mode', true);
+            $this->apiEndpoint = (string) config(
+                "regtech.api_endpoints.{$regulator}.sandbox",
+                $this->apiEndpoint
+            );
+        } catch (Throwable) {
+            // Config not available outside Laravel context (e.g. unit tests)
+        }
+    }
+
+    abstract protected function getRegulatorKey(): string;
+
+    /**
+     * @return array{success: bool, reference: string|null, errors: array<string>, response: array<string, mixed>}
+     */
+    public function submitReport(string $reportType, array $reportData, array $metadata = []): array
+    {
+        if (! in_array($reportType, $this->getSupportedReportTypes(), true)) {
+            return [
+                'success'   => false,
+                'reference' => null,
+                'errors'    => ["Unsupported report type: {$reportType}"],
+                'response'  => [],
+            ];
+        }
+
+        $validation = $this->validateReport($reportType, $reportData);
+        if (! $validation['valid']) {
+            return [
+                'success'   => false,
+                'reference' => null,
+                'errors'    => $validation['errors'],
+                'response'  => [],
+            ];
+        }
+
+        // Demo/sandbox: generate a simulated reference
+        $reference = strtoupper($this->getRegulatorKey()) . '-' . now()->format('Ymd') . '-' . Str::random(8);
+
+        return [
+            'success'   => true,
+            'reference' => $reference,
+            'errors'    => [],
+            'response'  => [
+                'submission_id'    => $reference,
+                'submitted_at'     => now()->toIso8601String(),
+                'jurisdiction'     => $this->getJurisdiction()->value,
+                'report_type'      => $reportType,
+                'sandbox'          => $this->sandboxMode,
+                'estimated_review' => '24-48 hours',
+            ],
+        ];
+    }
+
+    /**
+     * @return array{status: string, message: string, details: array<string, mixed>}
+     */
+    public function checkStatus(string $reference): array
+    {
+        // Demo mode: simulate processing status
+        return [
+            'status'  => 'accepted',
+            'message' => "Report {$reference} has been accepted for processing.",
+            'details' => [
+                'reference'    => $reference,
+                'jurisdiction' => $this->getJurisdiction()->value,
+                'adapter'      => $this->getName(),
+                'checked_at'   => now()->toIso8601String(),
+                'sandbox'      => $this->sandboxMode,
+            ],
+        ];
+    }
+
+    public function getApiEndpoint(): string
+    {
+        return $this->apiEndpoint;
+    }
+
+    public function isAvailable(): bool
+    {
+        return true; // Demo adapters are always available
+    }
+
+    public function isSandboxMode(): bool
+    {
+        return $this->sandboxMode;
+    }
+
+    /**
+     * Validate common report fields shared across jurisdictions.
+     *
+     * @param  array<string, mixed>  $data
+     * @return array<string>
+     */
+    protected function validateCommonFields(array $data): array
+    {
+        $errors = [];
+
+        if (empty($data['entity_name'])) {
+            $errors[] = 'entity_name is required.';
+        }
+
+        if (empty($data['reporting_date'])) {
+            $errors[] = 'reporting_date is required.';
+        }
+
+        return $errors;
+    }
+}

--- a/app/Domain/RegTech/Adapters/ESMAAdapter.php
+++ b/app/Domain/RegTech/Adapters/ESMAAdapter.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\RegTech\Adapters;
+
+use App\Domain\RegTech\Enums\Jurisdiction;
+
+/**
+ * ESMA (European Securities and Markets Authority) adapter for EU regulatory filings.
+ * Handles FIRDS/TREM: MiFID_Transaction, EMIR, SFTR.
+ */
+class ESMAAdapter extends AbstractRegulatoryAdapter
+{
+    protected function getRegulatorKey(): string
+    {
+        return 'esma';
+    }
+
+    public function getName(): string
+    {
+        return 'ESMA FIRDS/TREM';
+    }
+
+    public function getJurisdiction(): Jurisdiction
+    {
+        return Jurisdiction::EU;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getSupportedReportTypes(): array
+    {
+        return ['MiFID_Transaction', 'EMIR', 'SFTR'];
+    }
+
+    /**
+     * @param  array<string, mixed>  $reportData
+     * @return array{valid: bool, errors: array<string>}
+     */
+    public function validateReport(string $reportType, array $reportData): array
+    {
+        $errors = $this->validateCommonFields($reportData);
+
+        return match ($reportType) {
+            'MiFID_Transaction' => $this->validateMifidTransaction($reportData, $errors),
+            'EMIR'              => $this->validateEmir($reportData, $errors),
+            'SFTR'              => $this->validateSftr($reportData, $errors),
+            default             => ['valid' => false, 'errors' => ["Unsupported ESMA report type: {$reportType}"]],
+        };
+    }
+
+    /**
+     * Validate MiFID II Transaction Report (RTS 25 format, T+1 deadline).
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<string>  $errors
+     * @return array{valid: bool, errors: array<string>}
+     */
+    private function validateMifidTransaction(array $data, array $errors): array
+    {
+        if (empty($data['instrument_id'])) {
+            $errors[] = 'instrument_id (ISIN) is required for MiFID Transaction Report.';
+        }
+
+        if (empty($data['transaction_reference'])) {
+            $errors[] = 'transaction_reference is required for MiFID Transaction Report.';
+        }
+
+        if (empty($data['executing_entity_id'])) {
+            $errors[] = 'executing_entity_id (LEI) is required for MiFID Transaction Report.';
+        }
+
+        if (empty($data['buyer_id']) && empty($data['seller_id'])) {
+            $errors[] = 'buyer_id or seller_id is required for MiFID Transaction Report.';
+        }
+
+        if (empty($data['quantity'])) {
+            $errors[] = 'quantity is required for MiFID Transaction Report.';
+        }
+
+        if (empty($data['price'])) {
+            $errors[] = 'price is required for MiFID Transaction Report.';
+        }
+
+        if (empty($data['venue'])) {
+            $errors[] = 'venue (MIC code) is required for MiFID Transaction Report.';
+        }
+
+        return ['valid' => $errors === [], 'errors' => $errors];
+    }
+
+    /**
+     * Validate EMIR (European Market Infrastructure Regulation) derivative trade report.
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<string>  $errors
+     * @return array{valid: bool, errors: array<string>}
+     */
+    private function validateEmir(array $data, array $errors): array
+    {
+        if (empty($data['counterparty_id'])) {
+            $errors[] = 'counterparty_id (LEI) is required for EMIR.';
+        }
+
+        if (empty($data['trade_id'])) {
+            $errors[] = 'trade_id (UTI) is required for EMIR.';
+        }
+
+        if (empty($data['derivative_type'])) {
+            $errors[] = 'derivative_type is required for EMIR.';
+        }
+
+        if (empty($data['notional_amount'])) {
+            $errors[] = 'notional_amount is required for EMIR.';
+        }
+
+        if (empty($data['maturity_date'])) {
+            $errors[] = 'maturity_date is required for EMIR.';
+        }
+
+        if (empty($data['action_type'])) {
+            $errors[] = 'action_type (new, modify, cancel) is required for EMIR.';
+        }
+
+        return ['valid' => $errors === [], 'errors' => $errors];
+    }
+
+    /**
+     * Validate SFTR (Securities Financing Transactions Regulation) report.
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<string>  $errors
+     * @return array{valid: bool, errors: array<string>}
+     */
+    private function validateSftr(array $data, array $errors): array
+    {
+        if (empty($data['counterparty_id'])) {
+            $errors[] = 'counterparty_id (LEI) is required for SFTR.';
+        }
+
+        if (empty($data['sft_type'])) {
+            $errors[] = 'sft_type (repo, securities_lending, margin_lending, buy_sell_back) is required for SFTR.';
+        }
+
+        if (empty($data['collateral_info'])) {
+            $errors[] = 'collateral_info is required for SFTR.';
+        }
+
+        if (empty($data['principal_amount'])) {
+            $errors[] = 'principal_amount is required for SFTR.';
+        }
+
+        return ['valid' => $errors === [], 'errors' => $errors];
+    }
+}

--- a/app/Domain/RegTech/Adapters/FCAAdapter.php
+++ b/app/Domain/RegTech/Adapters/FCAAdapter.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\RegTech\Adapters;
+
+use App\Domain\RegTech\Enums\Jurisdiction;
+
+/**
+ * FCA (Financial Conduct Authority) adapter for UK regulatory filings.
+ * Handles Gabriel reporting: MiFID_Transaction, REP-CRIM, SUP16.
+ */
+class FCAAdapter extends AbstractRegulatoryAdapter
+{
+    protected function getRegulatorKey(): string
+    {
+        return 'fca';
+    }
+
+    public function getName(): string
+    {
+        return 'FCA Gabriel';
+    }
+
+    public function getJurisdiction(): Jurisdiction
+    {
+        return Jurisdiction::UK;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getSupportedReportTypes(): array
+    {
+        return ['MiFID_Transaction', 'REP-CRIM', 'SUP16'];
+    }
+
+    /**
+     * @param  array<string, mixed>  $reportData
+     * @return array{valid: bool, errors: array<string>}
+     */
+    public function validateReport(string $reportType, array $reportData): array
+    {
+        $errors = $this->validateCommonFields($reportData);
+
+        return match ($reportType) {
+            'MiFID_Transaction' => $this->validateMifidTransaction($reportData, $errors),
+            'REP-CRIM'          => $this->validateRepCrim($reportData, $errors),
+            'SUP16'             => $this->validateSup16($reportData, $errors),
+            default             => ['valid' => false, 'errors' => ["Unsupported FCA report type: {$reportType}"]],
+        };
+    }
+
+    /**
+     * Validate MiFID II Transaction Report (UK variant via FCA's Market Data Processor).
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<string>  $errors
+     * @return array{valid: bool, errors: array<string>}
+     */
+    private function validateMifidTransaction(array $data, array $errors): array
+    {
+        if (empty($data['instrument_id'])) {
+            $errors[] = 'instrument_id (ISIN) is required for MiFID Transaction Report.';
+        }
+
+        if (empty($data['transaction_reference'])) {
+            $errors[] = 'transaction_reference is required for MiFID Transaction Report.';
+        }
+
+        if (empty($data['executing_entity_id'])) {
+            $errors[] = 'executing_entity_id (LEI) is required for MiFID Transaction Report.';
+        }
+
+        if (empty($data['quantity'])) {
+            $errors[] = 'quantity is required for MiFID Transaction Report.';
+        }
+
+        if (empty($data['price'])) {
+            $errors[] = 'price is required for MiFID Transaction Report.';
+        }
+
+        if (empty($data['firm_reference'])) {
+            $errors[] = 'firm_reference (FCA FRN) is required for UK MiFID Transaction Report.';
+        }
+
+        return ['valid' => $errors === [], 'errors' => $errors];
+    }
+
+    /**
+     * Validate REP-CRIM (Annual Financial Crime Report).
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<string>  $errors
+     * @return array{valid: bool, errors: array<string>}
+     */
+    private function validateRepCrim(array $data, array $errors): array
+    {
+        if (empty($data['reporting_period'])) {
+            $errors[] = 'reporting_period is required for REP-CRIM.';
+        }
+
+        if (! isset($data['total_sars_submitted'])) {
+            $errors[] = 'total_sars_submitted count is required for REP-CRIM.';
+        }
+
+        if (! isset($data['aml_budget'])) {
+            $errors[] = 'aml_budget is required for REP-CRIM.';
+        }
+
+        if (! isset($data['compliance_staff_count'])) {
+            $errors[] = 'compliance_staff_count is required for REP-CRIM.';
+        }
+
+        if (empty($data['risk_assessment_date'])) {
+            $errors[] = 'risk_assessment_date is required for REP-CRIM.';
+        }
+
+        return ['valid' => $errors === [], 'errors' => $errors];
+    }
+
+    /**
+     * Validate SUP16 (Regulatory Transaction Reporting).
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<string>  $errors
+     * @return array{valid: bool, errors: array<string>}
+     */
+    private function validateSup16(array $data, array $errors): array
+    {
+        if (empty($data['firm_reference'])) {
+            $errors[] = 'firm_reference (FCA FRN) is required for SUP16.';
+        }
+
+        if (empty($data['reporting_period'])) {
+            $errors[] = 'reporting_period is required for SUP16.';
+        }
+
+        if (empty($data['transaction_data'])) {
+            $errors[] = 'transaction_data is required for SUP16.';
+        }
+
+        if (empty($data['product_type'])) {
+            $errors[] = 'product_type is required for SUP16.';
+        }
+
+        return ['valid' => $errors === [], 'errors' => $errors];
+    }
+}

--- a/app/Domain/RegTech/Adapters/FinCENAdapter.php
+++ b/app/Domain/RegTech/Adapters/FinCENAdapter.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\RegTech\Adapters;
+
+use App\Domain\RegTech\Enums\Jurisdiction;
+
+/**
+ * FinCEN (Financial Crimes Enforcement Network) adapter for US regulatory filings.
+ * Handles BSA E-Filing: CTR, SAR, CMIR, FBAR.
+ */
+class FinCENAdapter extends AbstractRegulatoryAdapter
+{
+    protected function getRegulatorKey(): string
+    {
+        return 'fincen';
+    }
+
+    public function getName(): string
+    {
+        return 'FinCEN BSA E-Filing';
+    }
+
+    public function getJurisdiction(): Jurisdiction
+    {
+        return Jurisdiction::US;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getSupportedReportTypes(): array
+    {
+        return ['CTR', 'SAR', 'CMIR', 'FBAR'];
+    }
+
+    /**
+     * @param  array<string, mixed>  $reportData
+     * @return array{valid: bool, errors: array<string>}
+     */
+    public function validateReport(string $reportType, array $reportData): array
+    {
+        $errors = $this->validateCommonFields($reportData);
+
+        return match ($reportType) {
+            'CTR'   => $this->validateCtr($reportData, $errors),
+            'SAR'   => $this->validateSar($reportData, $errors),
+            'CMIR'  => $this->validateCmir($reportData, $errors),
+            'FBAR'  => $this->validateFbar($reportData, $errors),
+            default => ['valid' => false, 'errors' => ["Unsupported FinCEN report type: {$reportType}"]],
+        };
+    }
+
+    /**
+     * Validate Currency Transaction Report (transactions >= $10,000).
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<string>  $errors
+     * @return array{valid: bool, errors: array<string>}
+     */
+    private function validateCtr(array $data, array $errors): array
+    {
+        if (empty($data['transaction_amount'])) {
+            $errors[] = 'transaction_amount is required for CTR.';
+        } elseif ((float) $data['transaction_amount'] < 10000) {
+            $errors[] = 'CTR is required only for transactions of $10,000 or more.';
+        }
+
+        if (empty($data['transaction_type'])) {
+            $errors[] = 'transaction_type is required for CTR (deposit, withdrawal, exchange, transfer).';
+        }
+
+        if (empty($data['financial_institution'])) {
+            $errors[] = 'financial_institution name is required for CTR.';
+        }
+
+        if (empty($data['conductor_info'])) {
+            $errors[] = 'conductor_info (person conducting transaction) is required for CTR.';
+        }
+
+        return ['valid' => $errors === [], 'errors' => $errors];
+    }
+
+    /**
+     * Validate Suspicious Activity Report.
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<string>  $errors
+     * @return array{valid: bool, errors: array<string>}
+     */
+    private function validateSar(array $data, array $errors): array
+    {
+        if (empty($data['suspicious_activity_type'])) {
+            $errors[] = 'suspicious_activity_type is required for SAR.';
+        }
+
+        if (empty($data['narrative'])) {
+            $errors[] = 'narrative description is required for SAR.';
+        }
+
+        if (empty($data['activity_date_range'])) {
+            $errors[] = 'activity_date_range is required for SAR.';
+        }
+
+        if (empty($data['subject_info'])) {
+            $errors[] = 'subject_info is required for SAR.';
+        }
+
+        return ['valid' => $errors === [], 'errors' => $errors];
+    }
+
+    /**
+     * Validate Report of International Transportation of Currency or Monetary Instruments.
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<string>  $errors
+     * @return array{valid: bool, errors: array<string>}
+     */
+    private function validateCmir(array $data, array $errors): array
+    {
+        if (empty($data['transport_amount'])) {
+            $errors[] = 'transport_amount is required for CMIR.';
+        } elseif ((float) $data['transport_amount'] < 10000) {
+            $errors[] = 'CMIR is required only for amounts of $10,000 or more.';
+        }
+
+        if (empty($data['transport_direction'])) {
+            $errors[] = 'transport_direction (inbound/outbound) is required for CMIR.';
+        }
+
+        if (empty($data['country_of_origin']) && empty($data['country_of_destination'])) {
+            $errors[] = 'country_of_origin or country_of_destination is required for CMIR.';
+        }
+
+        return ['valid' => $errors === [], 'errors' => $errors];
+    }
+
+    /**
+     * Validate Report of Foreign Bank and Financial Accounts.
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<string>  $errors
+     * @return array{valid: bool, errors: array<string>}
+     */
+    private function validateFbar(array $data, array $errors): array
+    {
+        if (empty($data['foreign_accounts'])) {
+            $errors[] = 'foreign_accounts list is required for FBAR.';
+        }
+
+        if (empty($data['max_account_value'])) {
+            $errors[] = 'max_account_value is required for FBAR.';
+        } elseif ((float) $data['max_account_value'] < 10000) {
+            $errors[] = 'FBAR is required only when aggregate value exceeds $10,000.';
+        }
+
+        if (empty($data['tax_year'])) {
+            $errors[] = 'tax_year is required for FBAR.';
+        }
+
+        return ['valid' => $errors === [], 'errors' => $errors];
+    }
+}

--- a/app/Domain/RegTech/Adapters/MASAdapter.php
+++ b/app/Domain/RegTech/Adapters/MASAdapter.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\RegTech\Adapters;
+
+use App\Domain\RegTech\Enums\Jurisdiction;
+
+/**
+ * MAS (Monetary Authority of Singapore) adapter for SG regulatory filings.
+ * Handles eServices Gateway: MAS_Returns, STR.
+ */
+class MASAdapter extends AbstractRegulatoryAdapter
+{
+    protected function getRegulatorKey(): string
+    {
+        return 'mas';
+    }
+
+    public function getName(): string
+    {
+        return 'MAS eServices Gateway';
+    }
+
+    public function getJurisdiction(): Jurisdiction
+    {
+        return Jurisdiction::SG;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getSupportedReportTypes(): array
+    {
+        return ['MAS_Returns', 'STR'];
+    }
+
+    /**
+     * @param  array<string, mixed>  $reportData
+     * @return array{valid: bool, errors: array<string>}
+     */
+    public function validateReport(string $reportType, array $reportData): array
+    {
+        $errors = $this->validateCommonFields($reportData);
+
+        return match ($reportType) {
+            'MAS_Returns' => $this->validateMasReturns($reportData, $errors),
+            'STR'         => $this->validateStr($reportData, $errors),
+            default       => ['valid' => false, 'errors' => ["Unsupported MAS report type: {$reportType}"]],
+        };
+    }
+
+    /**
+     * Validate MAS Returns (periodic regulatory returns).
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<string>  $errors
+     * @return array{valid: bool, errors: array<string>}
+     */
+    private function validateMasReturns(array $data, array $errors): array
+    {
+        if (empty($data['return_type'])) {
+            $errors[] = 'return_type is required for MAS Returns.';
+        }
+
+        if (empty($data['reporting_period'])) {
+            $errors[] = 'reporting_period is required for MAS Returns.';
+        }
+
+        if (empty($data['institution_code'])) {
+            $errors[] = 'institution_code is required for MAS Returns.';
+        }
+
+        if (empty($data['financial_data'])) {
+            $errors[] = 'financial_data is required for MAS Returns.';
+        }
+
+        return ['valid' => $errors === [], 'errors' => $errors];
+    }
+
+    /**
+     * Validate Suspicious Transaction Report (threshold: SGD 20,000).
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<string>  $errors
+     * @return array{valid: bool, errors: array<string>}
+     */
+    private function validateStr(array $data, array $errors): array
+    {
+        if (empty($data['suspicious_activity_type'])) {
+            $errors[] = 'suspicious_activity_type is required for STR.';
+        }
+
+        if (empty($data['narrative'])) {
+            $errors[] = 'narrative description is required for STR.';
+        }
+
+        if (empty($data['subject_info'])) {
+            $errors[] = 'subject_info is required for STR.';
+        }
+
+        if (empty($data['transaction_details'])) {
+            $errors[] = 'transaction_details is required for STR.';
+        }
+
+        if (empty($data['reporting_institution'])) {
+            $errors[] = 'reporting_institution is required for STR.';
+        }
+
+        if (empty($data['grounds_for_suspicion'])) {
+            $errors[] = 'grounds_for_suspicion is required for STR.';
+        }
+
+        return ['valid' => $errors === [], 'errors' => $errors];
+    }
+}

--- a/app/Providers/RegTechServiceProvider.php
+++ b/app/Providers/RegTechServiceProvider.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use App\Domain\RegTech\Adapters\ESMAAdapter;
+use App\Domain\RegTech\Adapters\FCAAdapter;
+use App\Domain\RegTech\Adapters\FinCENAdapter;
+use App\Domain\RegTech\Adapters\MASAdapter;
+use App\Domain\RegTech\Services\RegTechOrchestrationService;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Registers jurisdiction-specific regulatory filing adapters.
+ */
+class RegTechServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        //
+    }
+
+    public function boot(): void
+    {
+        if (! config('regtech.enabled', true)) {
+            return;
+        }
+
+        $this->registerAdapters();
+    }
+
+    private function registerAdapters(): void
+    {
+        $orchestration = $this->app->make(RegTechOrchestrationService::class);
+
+        $orchestration->registerAdapter('us', new FinCENAdapter());
+        $orchestration->registerAdapter('eu', new ESMAAdapter());
+        $orchestration->registerAdapter('uk', new FCAAdapter());
+        $orchestration->registerAdapter('sg', new MASAdapter());
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -26,6 +26,7 @@ return [
     App\Providers\LendingServiceProvider::class,
     App\Providers\MobilePaymentServiceProvider::class,
     App\Providers\PrivacyServiceProvider::class,
+    App\Providers\RegTechServiceProvider::class,
     App\Providers\RelayerServiceProvider::class,
     App\Providers\StablecoinServiceProvider::class,
     App\Providers\TelescopeServiceProvider::class,

--- a/tests/Unit/Domain/RegTech/Adapters/ESMAAdapterTest.php
+++ b/tests/Unit/Domain/RegTech/Adapters/ESMAAdapterTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\RegTech\Adapters\ESMAAdapter;
+use App\Domain\RegTech\Enums\Jurisdiction;
+
+describe('ESMAAdapter', function (): void {
+    beforeEach(function (): void {
+        $this->adapter = new ESMAAdapter();
+    });
+
+    describe('metadata', function (): void {
+        it('has correct name', function (): void {
+            expect($this->adapter->getName())->toBe('ESMA FIRDS/TREM');
+        });
+
+        it('handles EU jurisdiction', function (): void {
+            expect($this->adapter->getJurisdiction())->toBe(Jurisdiction::EU);
+        });
+
+        it('supports MiFID_Transaction, EMIR, SFTR', function (): void {
+            expect($this->adapter->getSupportedReportTypes())
+                ->toBe(['MiFID_Transaction', 'EMIR', 'SFTR']);
+        });
+    });
+
+    describe('validateReport', function (): void {
+        it('validates MiFID Transaction Report', function (): void {
+            $result = $this->adapter->validateReport('MiFID_Transaction', [
+                'entity_name'           => 'Test Firm',
+                'reporting_date'        => '2026-01-15',
+                'instrument_id'         => 'US0378331005',
+                'transaction_reference' => 'TXN-001',
+                'executing_entity_id'   => '529900T8BM49AURSDO55',
+                'buyer_id'              => 'CLIENT-001',
+                'quantity'              => 100,
+                'price'                 => 150.50,
+                'venue'                 => 'XNAS',
+            ]);
+
+            expect($result['valid'])->toBeTrue();
+        });
+
+        it('rejects MiFID without instrument_id', function (): void {
+            $result = $this->adapter->validateReport('MiFID_Transaction', [
+                'entity_name'    => 'Test Firm',
+                'reporting_date' => '2026-01-15',
+            ]);
+
+            expect($result['valid'])->toBeFalse()
+                ->and($result['errors'])->toContain('instrument_id (ISIN) is required for MiFID Transaction Report.');
+        });
+
+        it('validates EMIR derivative trade report', function (): void {
+            $result = $this->adapter->validateReport('EMIR', [
+                'entity_name'     => 'Test Firm',
+                'reporting_date'  => '2026-01-15',
+                'counterparty_id' => '529900T8BM49AURSDO55',
+                'trade_id'        => 'UTI-001',
+                'derivative_type' => 'interest_rate_swap',
+                'notional_amount' => 1000000,
+                'maturity_date'   => '2027-01-15',
+                'action_type'     => 'new',
+            ]);
+
+            expect($result['valid'])->toBeTrue();
+        });
+
+        it('rejects EMIR without counterparty_id', function (): void {
+            $result = $this->adapter->validateReport('EMIR', [
+                'entity_name'    => 'Test Firm',
+                'reporting_date' => '2026-01-15',
+            ]);
+
+            expect($result['valid'])->toBeFalse()
+                ->and($result['errors'])->toContain('counterparty_id (LEI) is required for EMIR.');
+        });
+
+        it('validates SFTR report', function (): void {
+            $result = $this->adapter->validateReport('SFTR', [
+                'entity_name'      => 'Test Firm',
+                'reporting_date'   => '2026-01-15',
+                'counterparty_id'  => '529900T8BM49AURSDO55',
+                'sft_type'         => 'repo',
+                'collateral_info'  => ['type' => 'government_bonds'],
+                'principal_amount' => 500000,
+            ]);
+
+            expect($result['valid'])->toBeTrue();
+        });
+
+        it('rejects unsupported report type', function (): void {
+            $result = $this->adapter->validateReport('INVALID', []);
+
+            expect($result['valid'])->toBeFalse()
+                ->and($result['errors'])->toContain('Unsupported ESMA report type: INVALID');
+        });
+    });
+
+    describe('submitReport', function (): void {
+        it('submits valid MiFID report', function (): void {
+            $result = $this->adapter->submitReport('MiFID_Transaction', [
+                'entity_name'           => 'Test Firm',
+                'reporting_date'        => '2026-01-15',
+                'instrument_id'         => 'US0378331005',
+                'transaction_reference' => 'TXN-001',
+                'executing_entity_id'   => '529900T8BM49AURSDO55',
+                'buyer_id'              => 'CLIENT-001',
+                'quantity'              => 100,
+                'price'                 => 150.50,
+                'venue'                 => 'XNAS',
+            ]);
+
+            expect($result['success'])->toBeTrue()
+                ->and($result['reference'])->toStartWith('ESMA-')
+                ->and($result['response']['jurisdiction'])->toBe('EU');
+        });
+    });
+});

--- a/tests/Unit/Domain/RegTech/Adapters/FCAAdapterTest.php
+++ b/tests/Unit/Domain/RegTech/Adapters/FCAAdapterTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\RegTech\Adapters\FCAAdapter;
+use App\Domain\RegTech\Enums\Jurisdiction;
+
+describe('FCAAdapter', function (): void {
+    beforeEach(function (): void {
+        $this->adapter = new FCAAdapter();
+    });
+
+    describe('metadata', function (): void {
+        it('has correct name', function (): void {
+            expect($this->adapter->getName())->toBe('FCA Gabriel');
+        });
+
+        it('handles UK jurisdiction', function (): void {
+            expect($this->adapter->getJurisdiction())->toBe(Jurisdiction::UK);
+        });
+
+        it('supports MiFID_Transaction, REP-CRIM, SUP16', function (): void {
+            expect($this->adapter->getSupportedReportTypes())
+                ->toBe(['MiFID_Transaction', 'REP-CRIM', 'SUP16']);
+        });
+    });
+
+    describe('validateReport', function (): void {
+        it('validates UK MiFID Transaction Report with firm_reference', function (): void {
+            $result = $this->adapter->validateReport('MiFID_Transaction', [
+                'entity_name'           => 'Test UK Firm',
+                'reporting_date'        => '2026-01-15',
+                'instrument_id'         => 'GB0002634946',
+                'transaction_reference' => 'TXN-UK-001',
+                'executing_entity_id'   => '213800MBWEIJDM5CU638',
+                'quantity'              => 500,
+                'price'                 => 12.50,
+                'firm_reference'        => '123456',
+            ]);
+
+            expect($result['valid'])->toBeTrue();
+        });
+
+        it('rejects UK MiFID without firm_reference', function (): void {
+            $result = $this->adapter->validateReport('MiFID_Transaction', [
+                'entity_name'           => 'Test UK Firm',
+                'reporting_date'        => '2026-01-15',
+                'instrument_id'         => 'GB0002634946',
+                'transaction_reference' => 'TXN-UK-001',
+                'executing_entity_id'   => '213800MBWEIJDM5CU638',
+                'quantity'              => 500,
+                'price'                 => 12.50,
+            ]);
+
+            expect($result['valid'])->toBeFalse()
+                ->and($result['errors'])->toContain('firm_reference (FCA FRN) is required for UK MiFID Transaction Report.');
+        });
+
+        it('validates REP-CRIM annual financial crime report', function (): void {
+            $result = $this->adapter->validateReport('REP-CRIM', [
+                'entity_name'            => 'Test UK Firm',
+                'reporting_date'         => '2026-01-15',
+                'reporting_period'       => '2025',
+                'total_sars_submitted'   => 42,
+                'aml_budget'             => 250000,
+                'compliance_staff_count' => 15,
+                'risk_assessment_date'   => '2025-06-15',
+            ]);
+
+            expect($result['valid'])->toBeTrue();
+        });
+
+        it('rejects REP-CRIM without compliance data', function (): void {
+            $result = $this->adapter->validateReport('REP-CRIM', [
+                'entity_name'    => 'Test UK Firm',
+                'reporting_date' => '2026-01-15',
+            ]);
+
+            expect($result['valid'])->toBeFalse()
+                ->and($result['errors'])->toContain('reporting_period is required for REP-CRIM.')
+                ->and($result['errors'])->toContain('total_sars_submitted count is required for REP-CRIM.');
+        });
+
+        it('validates SUP16 regulatory transaction reporting', function (): void {
+            $result = $this->adapter->validateReport('SUP16', [
+                'entity_name'      => 'Test UK Firm',
+                'reporting_date'   => '2026-01-15',
+                'firm_reference'   => '123456',
+                'reporting_period' => 'Q4-2025',
+                'transaction_data' => [['id' => 'TX1', 'amount' => 1000]],
+                'product_type'     => 'derivatives',
+            ]);
+
+            expect($result['valid'])->toBeTrue();
+        });
+
+        it('rejects unsupported report type', function (): void {
+            $result = $this->adapter->validateReport('INVALID', []);
+
+            expect($result['valid'])->toBeFalse()
+                ->and($result['errors'])->toContain('Unsupported FCA report type: INVALID');
+        });
+    });
+
+    describe('submitReport', function (): void {
+        it('submits valid UK MiFID report', function (): void {
+            $result = $this->adapter->submitReport('MiFID_Transaction', [
+                'entity_name'           => 'Test UK Firm',
+                'reporting_date'        => '2026-01-15',
+                'instrument_id'         => 'GB0002634946',
+                'transaction_reference' => 'TXN-UK-001',
+                'executing_entity_id'   => '213800MBWEIJDM5CU638',
+                'quantity'              => 500,
+                'price'                 => 12.50,
+                'firm_reference'        => '123456',
+            ]);
+
+            expect($result['success'])->toBeTrue()
+                ->and($result['reference'])->toStartWith('FCA-')
+                ->and($result['response']['jurisdiction'])->toBe('UK');
+        });
+    });
+});

--- a/tests/Unit/Domain/RegTech/Adapters/FinCENAdapterTest.php
+++ b/tests/Unit/Domain/RegTech/Adapters/FinCENAdapterTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\RegTech\Adapters\FinCENAdapter;
+use App\Domain\RegTech\Enums\Jurisdiction;
+
+describe('FinCENAdapter', function (): void {
+    beforeEach(function (): void {
+        $this->adapter = new FinCENAdapter();
+    });
+
+    describe('metadata', function (): void {
+        it('has correct name', function (): void {
+            expect($this->adapter->getName())->toBe('FinCEN BSA E-Filing');
+        });
+
+        it('handles US jurisdiction', function (): void {
+            expect($this->adapter->getJurisdiction())->toBe(Jurisdiction::US);
+        });
+
+        it('supports CTR, SAR, CMIR, FBAR', function (): void {
+            expect($this->adapter->getSupportedReportTypes())
+                ->toBe(['CTR', 'SAR', 'CMIR', 'FBAR']);
+        });
+
+        it('is available', function (): void {
+            expect($this->adapter->isAvailable())->toBeTrue();
+        });
+
+        it('runs in sandbox mode', function (): void {
+            expect($this->adapter->isSandboxMode())->toBeTrue();
+        });
+    });
+
+    describe('validateReport', function (): void {
+        it('validates CTR requires transaction amount >= 10000', function (): void {
+            $result = $this->adapter->validateReport('CTR', [
+                'entity_name'           => 'Test Corp',
+                'reporting_date'        => '2026-01-15',
+                'transaction_amount'    => 15000,
+                'transaction_type'      => 'deposit',
+                'financial_institution' => 'Test Bank',
+                'conductor_info'        => ['name' => 'John Doe'],
+            ]);
+
+            expect($result['valid'])->toBeTrue()
+                ->and($result['errors'])->toBeEmpty();
+        });
+
+        it('rejects CTR below threshold', function (): void {
+            $result = $this->adapter->validateReport('CTR', [
+                'entity_name'           => 'Test Corp',
+                'reporting_date'        => '2026-01-15',
+                'transaction_amount'    => 5000,
+                'transaction_type'      => 'deposit',
+                'financial_institution' => 'Test Bank',
+                'conductor_info'        => ['name' => 'John Doe'],
+            ]);
+
+            expect($result['valid'])->toBeFalse()
+                ->and($result['errors'])->toContain('CTR is required only for transactions of $10,000 or more.');
+        });
+
+        it('validates SAR requires narrative and subject info', function (): void {
+            $result = $this->adapter->validateReport('SAR', [
+                'entity_name'              => 'Test Corp',
+                'reporting_date'           => '2026-01-15',
+                'suspicious_activity_type' => 'structuring',
+                'narrative'                => 'Suspected structuring activity.',
+                'activity_date_range'      => ['start' => '2026-01-01', 'end' => '2026-01-15'],
+                'subject_info'             => ['name' => 'Jane Doe'],
+            ]);
+
+            expect($result['valid'])->toBeTrue();
+        });
+
+        it('rejects SAR without narrative', function (): void {
+            $result = $this->adapter->validateReport('SAR', [
+                'entity_name'    => 'Test Corp',
+                'reporting_date' => '2026-01-15',
+            ]);
+
+            expect($result['valid'])->toBeFalse()
+                ->and($result['errors'])->toContain('narrative description is required for SAR.');
+        });
+
+        it('validates CMIR requires transport details', function (): void {
+            $result = $this->adapter->validateReport('CMIR', [
+                'entity_name'            => 'Test Corp',
+                'reporting_date'         => '2026-01-15',
+                'transport_amount'       => 50000,
+                'transport_direction'    => 'outbound',
+                'country_of_destination' => 'CH',
+            ]);
+
+            expect($result['valid'])->toBeTrue();
+        });
+
+        it('validates FBAR requires foreign accounts', function (): void {
+            $result = $this->adapter->validateReport('FBAR', [
+                'entity_name'       => 'Test Corp',
+                'reporting_date'    => '2026-01-15',
+                'foreign_accounts'  => [['bank' => 'Swiss Bank', 'country' => 'CH']],
+                'max_account_value' => 25000,
+                'tax_year'          => '2025',
+            ]);
+
+            expect($result['valid'])->toBeTrue();
+        });
+
+        it('rejects common fields when missing', function (): void {
+            $result = $this->adapter->validateReport('CTR', []);
+
+            expect($result['valid'])->toBeFalse()
+                ->and($result['errors'])->toContain('entity_name is required.')
+                ->and($result['errors'])->toContain('reporting_date is required.');
+        });
+
+        it('rejects unsupported report type', function (): void {
+            $result = $this->adapter->validateReport('INVALID', ['entity_name' => 'Test']);
+
+            expect($result['valid'])->toBeFalse()
+                ->and($result['errors'])->toContain('Unsupported FinCEN report type: INVALID');
+        });
+    });
+
+    describe('submitReport', function (): void {
+        it('submits valid report successfully', function (): void {
+            $result = $this->adapter->submitReport('CTR', [
+                'entity_name'           => 'Test Corp',
+                'reporting_date'        => '2026-01-15',
+                'transaction_amount'    => 15000,
+                'transaction_type'      => 'deposit',
+                'financial_institution' => 'Test Bank',
+                'conductor_info'        => ['name' => 'John Doe'],
+            ]);
+
+            expect($result['success'])->toBeTrue()
+                ->and($result['reference'])->toStartWith('FINCEN-')
+                ->and($result['errors'])->toBeEmpty()
+                ->and($result['response']['jurisdiction'])->toBe('US')
+                ->and($result['response']['sandbox'])->toBeTrue();
+        });
+
+        it('rejects unsupported report type on submit', function (): void {
+            $result = $this->adapter->submitReport('INVALID', []);
+
+            expect($result['success'])->toBeFalse()
+                ->and($result['errors'])->toContain('Unsupported report type: INVALID');
+        });
+
+        it('rejects invalid report data on submit', function (): void {
+            $result = $this->adapter->submitReport('CTR', []);
+
+            expect($result['success'])->toBeFalse()
+                ->and($result['errors'])->not->toBeEmpty();
+        });
+    });
+
+    describe('checkStatus', function (): void {
+        it('returns accepted status', function (): void {
+            $result = $this->adapter->checkStatus('FINCEN-20260115-ABCD1234');
+
+            expect($result['status'])->toBe('accepted')
+                ->and($result['details']['adapter'])->toBe('FinCEN BSA E-Filing')
+                ->and($result['details']['jurisdiction'])->toBe('US');
+        });
+    });
+});

--- a/tests/Unit/Domain/RegTech/Adapters/MASAdapterTest.php
+++ b/tests/Unit/Domain/RegTech/Adapters/MASAdapterTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\RegTech\Adapters\MASAdapter;
+use App\Domain\RegTech\Enums\Jurisdiction;
+
+describe('MASAdapter', function (): void {
+    beforeEach(function (): void {
+        $this->adapter = new MASAdapter();
+    });
+
+    describe('metadata', function (): void {
+        it('has correct name', function (): void {
+            expect($this->adapter->getName())->toBe('MAS eServices Gateway');
+        });
+
+        it('handles SG jurisdiction', function (): void {
+            expect($this->adapter->getJurisdiction())->toBe(Jurisdiction::SG);
+        });
+
+        it('supports MAS_Returns, STR', function (): void {
+            expect($this->adapter->getSupportedReportTypes())
+                ->toBe(['MAS_Returns', 'STR']);
+        });
+    });
+
+    describe('validateReport', function (): void {
+        it('validates MAS Returns', function (): void {
+            $result = $this->adapter->validateReport('MAS_Returns', [
+                'entity_name'      => 'Test SG Firm',
+                'reporting_date'   => '2026-01-15',
+                'return_type'      => 'capital_adequacy',
+                'reporting_period' => 'Q4-2025',
+                'institution_code' => 'MAS-001',
+                'financial_data'   => ['total_assets' => 1000000],
+            ]);
+
+            expect($result['valid'])->toBeTrue();
+        });
+
+        it('rejects MAS Returns without institution code', function (): void {
+            $result = $this->adapter->validateReport('MAS_Returns', [
+                'entity_name'    => 'Test SG Firm',
+                'reporting_date' => '2026-01-15',
+            ]);
+
+            expect($result['valid'])->toBeFalse()
+                ->and($result['errors'])->toContain('institution_code is required for MAS Returns.');
+        });
+
+        it('validates STR (Suspicious Transaction Report)', function (): void {
+            $result = $this->adapter->validateReport('STR', [
+                'entity_name'              => 'Test SG Firm',
+                'reporting_date'           => '2026-01-15',
+                'suspicious_activity_type' => 'money_laundering',
+                'narrative'                => 'Multiple large cash deposits.',
+                'subject_info'             => ['name' => 'Suspect Doe'],
+                'transaction_details'      => [['amount' => 25000, 'date' => '2026-01-10']],
+                'reporting_institution'    => 'Test SG Bank',
+                'grounds_for_suspicion'    => 'Unusual cash deposit pattern.',
+            ]);
+
+            expect($result['valid'])->toBeTrue();
+        });
+
+        it('rejects STR without grounds for suspicion', function (): void {
+            $result = $this->adapter->validateReport('STR', [
+                'entity_name'    => 'Test SG Firm',
+                'reporting_date' => '2026-01-15',
+            ]);
+
+            expect($result['valid'])->toBeFalse()
+                ->and($result['errors'])->toContain('grounds_for_suspicion is required for STR.');
+        });
+
+        it('rejects unsupported report type', function (): void {
+            $result = $this->adapter->validateReport('INVALID', []);
+
+            expect($result['valid'])->toBeFalse()
+                ->and($result['errors'])->toContain('Unsupported MAS report type: INVALID');
+        });
+    });
+
+    describe('submitReport', function (): void {
+        it('submits valid MAS Returns', function (): void {
+            $result = $this->adapter->submitReport('MAS_Returns', [
+                'entity_name'      => 'Test SG Firm',
+                'reporting_date'   => '2026-01-15',
+                'return_type'      => 'capital_adequacy',
+                'reporting_period' => 'Q4-2025',
+                'institution_code' => 'MAS-001',
+                'financial_data'   => ['total_assets' => 1000000],
+            ]);
+
+            expect($result['success'])->toBeTrue()
+                ->and($result['reference'])->toStartWith('MAS-')
+                ->and($result['response']['jurisdiction'])->toBe('SG');
+        });
+    });
+
+    describe('checkStatus', function (): void {
+        it('returns accepted status', function (): void {
+            $result = $this->adapter->checkStatus('MAS-20260115-ABCD1234');
+
+            expect($result['status'])->toBe('accepted')
+                ->and($result['details']['adapter'])->toBe('MAS eServices Gateway')
+                ->and($result['details']['jurisdiction'])->toBe('SG');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Add `AbstractRegulatoryAdapter` base class with shared demo/sandbox behavior (submit, status check, validation)
- Implement 4 jurisdiction-specific adapters: **FinCEN** (US: CTR, SAR, CMIR, FBAR), **ESMA** (EU: MiFID_Transaction, EMIR, SFTR), **FCA** (UK: MiFID_Transaction, REP-CRIM, SUP16), **MAS** (SG: MAS_Returns, STR)
- Register adapters via `RegTechServiceProvider` with the `RegTechOrchestrationService`
- 47 unit tests covering metadata, validation, submission, and status checks

## Test plan
- [x] All 47 adapter unit tests pass (`pest tests/Unit/Domain/RegTech/Adapters/`)
- [x] PHPStan Level 8 clean on all new files
- [x] Code style (php-cs-fixer) applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)