### PR TITLE
fix(regtech): Security hardening, logic fixes, and boundary tests

### DIFF
--- a/app/Domain/RegTech/Services/MicaComplianceService.php
+++ b/app/Domain/RegTech/Services/MicaComplianceService.php
@@ -175,15 +175,17 @@ class MicaComplianceService
         if ($required) {
             $requiredOriginator = $travelRule['required_originator_info'] ?? [];
             $requiredBeneficiary = $travelRule['required_beneficiary_info'] ?? [];
+            $originator = $transaction['originator'] ?? [];
+            $beneficiary = $transaction['beneficiary'] ?? [];
 
             foreach ($requiredOriginator as $field) {
-                if (empty($transaction['originator'][$field])) {
+                if (empty($originator[$field])) {
                     $missingFields[] = "originator.{$field}";
                 }
             }
 
             foreach ($requiredBeneficiary as $field) {
-                if (empty($transaction['beneficiary'][$field])) {
+                if (empty($beneficiary[$field])) {
                     $missingFields[] = "beneficiary.{$field}";
                 }
             }

--- a/app/Domain/RegTech/Services/MifidReportingService.php
+++ b/app/Domain/RegTech/Services/MifidReportingService.php
@@ -86,7 +86,7 @@ class MifidReportingService
             'buyer_decision_maker'   => $transaction['buyer_decision_maker'] ?? null,
             'seller_decision_maker'  => $transaction['seller_decision_maker'] ?? null,
             'transmission_indicator' => $transaction['transmission_indicator'] ?? false,
-            'jurisdiction'           => $jurisdiction->value ?? 'EU',
+            'jurisdiction'           => $jurisdiction !== null ? $jurisdiction->value : 'EU',
             'reporting_deadline'     => $this->calculateReportingDeadline($transaction),
             'generated_at'           => now()->toIso8601String(),
         ];
@@ -205,11 +205,11 @@ class MifidReportingService
             $errors[] = 'executing_entity_id (LEI) is required.';
         }
 
-        if (empty($transaction['quantity']) || (float) $transaction['quantity'] <= 0) {
+        if (! isset($transaction['quantity']) || (float) $transaction['quantity'] <= 0) {
             $errors[] = 'quantity must be a positive number.';
         }
 
-        if (empty($transaction['price']) || (float) $transaction['price'] <= 0) {
+        if (! isset($transaction['price']) || (float) $transaction['price'] <= 0) {
             $errors[] = 'price must be a positive number.';
         }
 

--- a/app/Domain/RegTech/Services/RegTechOrchestrationService.php
+++ b/app/Domain/RegTech/Services/RegTechOrchestrationService.php
@@ -154,14 +154,16 @@ class RegTechOrchestrationService
             ];
         } catch (Throwable $e) {
             Log::error('RegTech: Report submission failed', [
-                'error' => $e->getMessage(),
+                'error'     => $e->getMessage(),
+                'exception' => $e::class,
+                'trace'     => $e->getTraceAsString(),
             ]);
 
             return [
                 'success'   => false,
                 'reference' => null,
-                'errors'    => [$e->getMessage()],
-                'details'   => ['exception' => true],
+                'errors'    => ['Report submission failed. Please try again or contact support.'],
+                'details'   => [],
             ];
         }
     }
@@ -235,10 +237,15 @@ class RegTechOrchestrationService
         try {
             return $adapter->checkStatus($reference);
         } catch (Throwable $e) {
+            Log::error('RegTech: Status check failed', [
+                'reference' => $reference,
+                'error'     => $e->getMessage(),
+            ]);
+
             return [
                 'status'  => 'error',
-                'message' => $e->getMessage(),
-                'details' => ['exception' => true],
+                'message' => 'Unable to check report status. Please try again later.',
+                'details' => [],
             ];
         }
     }

--- a/app/Domain/RegTech/Services/TravelRuleService.php
+++ b/app/Domain/RegTech/Services/TravelRuleService.php
@@ -34,11 +34,11 @@ class TravelRuleService
 
         if (! $jurisdiction) {
             return [
-                'compliant'     => true,
+                'compliant'     => false,
                 'jurisdiction'  => 'unknown',
                 'threshold'     => 0,
                 'amount'        => $amount,
-                'errors'        => [],
+                'errors'        => ['Unable to determine jurisdiction for currency: ' . $currency],
                 'required_data' => [],
             ];
         }
@@ -59,17 +59,19 @@ class TravelRuleService
 
         $errors = [];
         $requiredData = $this->getRequiredData($jurisdiction);
+        $originator = $transfer['originator'] ?? [];
+        $beneficiary = $transfer['beneficiary'] ?? [];
 
         // Validate originator data
         foreach ($requiredData['originator'] as $field) {
-            if (empty($transfer['originator'][$field])) {
+            if (empty($originator[$field])) {
                 $errors[] = "Missing originator field: {$field}";
             }
         }
 
         // Validate beneficiary data
         foreach ($requiredData['beneficiary'] as $field) {
-            if (empty($transfer['beneficiary'][$field])) {
+            if (empty($beneficiary[$field])) {
                 $errors[] = "Missing beneficiary field: {$field}";
             }
         }

--- a/app/Http/Requests/RegTech/ApplicableRegulationsRequest.php
+++ b/app/Http/Requests/RegTech/ApplicableRegulationsRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\RegTech;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ApplicableRegulationsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'amount'           => ['required', 'numeric', 'min:0', 'max:999999999999.99'],
+            'currency'         => ['required', 'string', 'regex:/^[A-Z]{3}$/'],
+            'transaction_type' => ['required', 'string', 'max:50'],
+            'is_crypto'        => ['nullable', 'boolean'],
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        // Merge query parameters into the request for validation
+        $this->merge($this->query());
+    }
+}

--- a/app/Providers/RegTechServiceProvider.php
+++ b/app/Providers/RegTechServiceProvider.php
@@ -16,6 +16,18 @@ use Illuminate\Support\ServiceProvider;
  */
 class RegTechServiceProvider extends ServiceProvider
 {
+    /**
+     * Adapter class map keyed by jurisdiction.
+     *
+     * @var array<string, class-string>
+     */
+    private const ADAPTER_MAP = [
+        'us' => FinCENAdapter::class,
+        'eu' => ESMAAdapter::class,
+        'uk' => FCAAdapter::class,
+        'sg' => MASAdapter::class,
+    ];
+
     public function register(): void
     {
         //
@@ -34,9 +46,8 @@ class RegTechServiceProvider extends ServiceProvider
     {
         $orchestration = $this->app->make(RegTechOrchestrationService::class);
 
-        $orchestration->registerAdapter('us', new FinCENAdapter());
-        $orchestration->registerAdapter('eu', new ESMAAdapter());
-        $orchestration->registerAdapter('uk', new FCAAdapter());
-        $orchestration->registerAdapter('sg', new MASAdapter());
+        foreach (self::ADAPTER_MAP as $key => $adapterClass) {
+            $orchestration->registerAdapter($key, new $adapterClass());
+        }
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -613,13 +613,13 @@ Route::middleware('auth:sanctum', 'check.token.expiration')->prefix('compliance'
 });
 
 // RegTech endpoints (regulatory compliance, MiFID II, MiCA, Travel Rule)
-Route::middleware('auth:sanctum', 'check.token.expiration')->prefix('regtech')->name('api.regtech.')->group(function () {
+Route::middleware('auth:sanctum', 'check.token.expiration', 'throttle:60,1')->prefix('regtech')->name('api.regtech.')->group(function () {
     Route::get('/compliance/summary', [RegTechController::class, 'complianceSummary'])->name('compliance.summary');
     Route::get('/adapters', [RegTechController::class, 'adapters'])->name('adapters');
     Route::get('/regulations/applicable', [RegTechController::class, 'applicableRegulations'])->name('regulations.applicable');
 
-    // Report submission & status
-    Route::post('/reports', [RegTechController::class, 'submitReport'])->name('reports.submit');
+    // Report submission & status (stricter rate limit on write operations)
+    Route::post('/reports', [RegTechController::class, 'submitReport'])->middleware('throttle:10,1')->name('reports.submit');
     Route::get('/reports/{reference}/status', [RegTechController::class, 'reportStatus'])->name('reports.status');
 
     // MiFID II
@@ -627,7 +627,7 @@ Route::middleware('auth:sanctum', 'check.token.expiration')->prefix('regtech')->
 
     // MiCA
     Route::get('/mica/status', [RegTechController::class, 'micaStatus'])->name('mica.status');
-    Route::post('/mica/whitepaper/validate', [RegTechController::class, 'validateWhitepaper'])->name('mica.whitepaper.validate');
+    Route::post('/mica/whitepaper/validate', [RegTechController::class, 'validateWhitepaper'])->middleware('throttle:10,1')->name('mica.whitepaper.validate');
     Route::get('/mica/reserves', [RegTechController::class, 'micaReserves'])->name('mica.reserves');
 
     // Travel Rule

--- a/tests/Unit/Domain/RegTech/Services/MicaComplianceServiceTest.php
+++ b/tests/Unit/Domain/RegTech/Services/MicaComplianceServiceTest.php
@@ -211,5 +211,34 @@ describe('MicaComplianceService', function (): void {
             expect($result['required'])->toBeTrue()
                 ->and($result['missing_fields'])->toBeEmpty();
         });
+
+        it('requires travel rule at exactly the threshold', function (): void {
+            $result = $this->service->checkTravelRuleRequirement([
+                'amount'   => 1000,
+                'currency' => 'EUR',
+            ]);
+
+            expect($result['required'])->toBeTrue()
+                ->and($result['threshold'])->toBe(1000.0);
+        });
+
+        it('does not require travel rule just below threshold', function (): void {
+            $result = $this->service->checkTravelRuleRequirement([
+                'amount'   => 999.99,
+                'currency' => 'EUR',
+            ]);
+
+            expect($result['required'])->toBeFalse();
+        });
+
+        it('handles missing originator key gracefully', function (): void {
+            $result = $this->service->checkTravelRuleRequirement([
+                'amount'   => 2000,
+                'currency' => 'EUR',
+            ]);
+
+            expect($result['required'])->toBeTrue()
+                ->and($result['missing_fields'])->not->toBeEmpty();
+        });
     });
 });


### PR DESCRIPTION
## Summary

Post-release v2.8.0 review and hardening of the RegTech domain based on a 4-dimensional professional review (security, architecture, test coverage, code quality).

### Security Fixes
- Rate limiting on RegTech API routes (60/min reads, 10/min POST writes)
- Removed `api_endpoint` exposure from adapters response
- Added `ApplicableRegulationsRequest` FormRequest for query parameter input validation
- Reference format validation (`^[A-Za-z0-9\-_]{1,100}$`) in `reportStatus`
- Defensive `Jurisdiction::tryFrom()` with 422 fallback in `submitReport`
- Audit logging with `user_id` and `ip_address` on report submissions
- Sanitized exception messages in API responses (generic user-facing, detailed server-side logs)

### Logic Bug Fixes
- **Critical**: `TravelRuleService` unknown jurisdiction now returns `compliant: false` (was incorrectly `true`)
- Fixed unsafe array access in `TravelRuleService::evaluate()` and `MicaComplianceService::checkTravelRuleRequirement()`
- Fixed `MifidReportingService` null safety with explicit null check for jurisdiction
- Fixed `empty()` vs `isset()` for numeric quantity/price validation (empty("0") is truthy in PHP)

### Architecture Improvements
- Config-driven adapter registration via `ADAPTER_MAP` constant in `RegTechServiceProvider`

### Test Coverage
- 13 new boundary/edge case tests across 3 service test files (49 total, 120 assertions)
- Tests for: threshold boundaries, negative values, missing fields, null jurisdictions, zero amounts

## Test plan
- [x] All 49 RegTech service tests pass (120 assertions)
- [x] PHPStan analysis passes with 0 errors
- [x] Code style check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)