### PR TITLE
fix(migration): Fix foreign key type mismatch on tenant data tables

### DIFF
--- a/database/migrations/2026_01_28_172217_create_tenant_data_migration_tables.php
+++ b/database/migrations/2026_01_28_172217_create_tenant_data_migration_tables.php
@@ -18,7 +18,7 @@ return new class () extends Migration {
         // Track data migrations from central to tenant databases
         Schema::create('tenant_data_migrations', function (Blueprint $table) {
             $table->id();
-            $table->uuid('tenant_id');
+            $table->string('tenant_id');
             $table->integer('migrated_count')->default(0);
             $table->integer('skipped_count')->default(0);
             $table->integer('error_count')->default(0);
@@ -41,7 +41,7 @@ return new class () extends Migration {
         // Track data imports from backup files to tenant databases
         Schema::create('tenant_data_imports', function (Blueprint $table) {
             $table->id();
-            $table->uuid('tenant_id');
+            $table->string('tenant_id');
             $table->string('source_file', 500);
             $table->string('format', 20)->default('json');
             $table->integer('imported_count')->default(0);
@@ -66,7 +66,7 @@ return new class () extends Migration {
         // Track data exports for audit purposes
         Schema::create('tenant_data_exports', function (Blueprint $table) {
             $table->id();
-            $table->uuid('tenant_id');
+            $table->string('tenant_id');
             $table->string('output_file', 500);
             $table->string('format', 20)->default('json');
             $table->integer('record_count')->default(0);


### PR DESCRIPTION
## Summary

- Fix `SQLSTATE[HY000]: General error: 1005` when running `php artisan migrate` on MariaDB
- The `tenants` table uses `string('id')->primary()` (VARCHAR), but `tenant_data_migrations`, `tenant_data_imports`, and `tenant_data_exports` used `uuid('tenant_id')` (CHAR(36))
- MariaDB rejects FK constraints when column types don't match exactly
- Changed all three `tenant_id` columns from `uuid()` to `string()` to match the parent table

## Test plan

- [x] Verified column type mismatch is the root cause
- [ ] Run `php artisan migrate` — should complete without FK errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)