### PR TITLE
fix: Resolve fatal Class 'config' error preventing HTTP boot

### DIFF
--- a/app/Domain/Treasury/Activities/Portfolio/DistributeReportActivity.php
+++ b/app/Domain/Treasury/Activities/Portfolio/DistributeReportActivity.php
@@ -389,7 +389,7 @@ class DistributeReportActivity extends Activity
             'compliance_officer'   => ['compliance@example.com'],
             'operations_team'      => ['ops@example.com'],
             'investment_committee' => ['committee@example.com'],
-            default                => ["${recipient}@example.com"],
+            default                => ["{$recipient}@example.com"],
         };
     }
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -97,8 +97,8 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
 
         // Apply demo middleware to web routes in demo environment
-        // Check if we're in demo environment (APP_ENV=demo)
-        if (config('app.env') === 'demo') {
+        // Note: env() is used here because config() is not available during middleware registration
+        if (env('APP_ENV') === 'demo') {
             $middleware->appendToGroup('web', App\Http\Middleware\DemoMode::class);
         }
     })

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Api\AIAgentController;
 use App\Http\Controllers\Api\AssetController;
 use App\Http\Controllers\Api\Auth\EmailVerificationController;
 use App\Http\Controllers\Api\Auth\LoginController;
+use App\Http\Controllers\Api\Auth\PasskeyController;
 use App\Http\Controllers\Api\Auth\PasswordResetController;
 use App\Http\Controllers\Api\Auth\RegisterController;
 use App\Http\Controllers\Api\Auth\SocialAuthController;
@@ -1364,6 +1365,6 @@ Route::prefix('v1/auth/passkey')
     ->middleware('throttle:5,1')
     ->name('mobile.auth.passkey.')
     ->group(function () {
-        Route::post('/challenge', [Auth\PasskeyController::class, 'challenge'])->name('challenge');
-        Route::post('/authenticate', [Auth\PasskeyController::class, 'authenticate'])->name('authenticate');
+        Route::post('/challenge', [PasskeyController::class, 'challenge'])->name('challenge');
+        Route::post('/authenticate', [PasskeyController::class, 'authenticate'])->name('authenticate');
     });


### PR DESCRIPTION
## Summary
- **Critical fix**: `bootstrap/app.php` used `config('app.env')` inside `withMiddleware()` callback, which executes before the config repository is bound to the service container. This caused `Class "config" does not exist` fatal error on every HTTP request via nginx/PHP-FPM, while artisan CLI worked fine (different bootstrap path).
- **Route fix**: Added missing `use` import for `PasskeyController` in `routes/api.php` — the class reference `Auth\PasskeyController` resolved to non-existent `\Auth\PasskeyController` instead of the correct `App\Http\Controllers\Api\Auth\PasskeyController`.
- **PHP 8.4 compat**: Fixed `${var}` deprecated string interpolation syntax in `DistributeReportActivity.php`.

## Root Cause
The `withMiddleware()` callback in Laravel's `ApplicationBuilder` runs during HTTP kernel resolution, before service providers have registered the `config` repository. Using `config()` helper at that point triggers a container resolve for the string `"config"`, which gets treated as a class name — hence `Class "config" does not exist`. The fix uses `env('APP_ENV')` which reads directly from environment variables without the container.

## Test plan
- [x] `php artisan` works (was already working)
- [x] HTTP kernel boots: `php -r "...->make('Illuminate\Contracts\Http\Kernel')"` returns OK
- [x] `curl http://127.0.0.1/api/v1/health -H "Host: finaegis.local"` returns proper JSON 404 (app running, no such route)
- [x] Tests: 301 passed (1 pre-existing RegTech test failure)
- [x] Code style clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)