### PR TITLE
fix(test): Boot app in MobilePayment unit tests to fix CI failures

### DIFF
--- a/tests/Unit/Domain/MobilePayment/Events/PaymentStatusChangedTest.php
+++ b/tests/Unit/Domain/MobilePayment/Events/PaymentStatusChangedTest.php
@@ -5,6 +5,14 @@ declare(strict_types=1);
 use App\Domain\MobilePayment\Enums\PaymentIntentStatus;
 use App\Domain\MobilePayment\Events\Broadcast\PaymentStatusChanged;
 use App\Domain\MobilePayment\Models\PaymentIntent;
+use Tests\UnitTestCase;
+
+uses(UnitTestCase::class);
+
+beforeEach(function (): void {
+    // Prevent Spatie EventSourcing EventSubscriber from being resolved
+    Illuminate\Support\Facades\Event::fake();
+});
 
 describe('PaymentStatusChanged Broadcast Event', function (): void {
     it('broadcasts on private payments channel', function (): void {

--- a/tests/Unit/Domain/MobilePayment/Models/PaymentIntentTest.php
+++ b/tests/Unit/Domain/MobilePayment/Models/PaymentIntentTest.php
@@ -7,6 +7,14 @@ use App\Domain\MobilePayment\Enums\PaymentIntentStatus;
 use App\Domain\MobilePayment\Enums\PaymentNetwork;
 use App\Domain\MobilePayment\Exceptions\InvalidStateTransitionException;
 use App\Domain\MobilePayment\Models\PaymentIntent;
+use Tests\UnitTestCase;
+
+uses(UnitTestCase::class);
+
+beforeEach(function (): void {
+    // Prevent Spatie EventSourcing EventSubscriber from being resolved
+    Illuminate\Support\Facades\Event::fake();
+});
 
 describe('PaymentIntent Model', function (): void {
     it('casts status to enum', function (): void {


### PR DESCRIPTION
## Summary

- Fixed `PaymentStatusChangedTest` and `PaymentIntentTest` failing in CI with `BindingResolutionException: Unresolvable dependency resolving $storedEventRepository in Spatie\EventSourcing\StoredEvents\EventSubscriber`
- Root cause: Tests instantiate Eloquent models (`PaymentIntent`) without the Laravel app booted, causing Spatie's globally-registered `EventSubscriber` to fail resolution
- Fix: Added `uses(UnitTestCase::class)` to properly boot the app, plus `Event::fake()` in `beforeEach` to prevent the subscriber from resolving

## Test plan

- [x] Both test files pass locally (20 tests, 48 assertions)
- [ ] CI Unit Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)