### PR TITLE
fix(test): Boot app in ActivityFeedServiceTest and remove broken alias mock

### DIFF
--- a/tests/Unit/Domain/MobilePayment/Services/ActivityFeedServiceTest.php
+++ b/tests/Unit/Domain/MobilePayment/Services/ActivityFeedServiceTest.php
@@ -5,15 +5,19 @@ declare(strict_types=1);
 use App\Domain\MobilePayment\Enums\ActivityItemType;
 use App\Domain\MobilePayment\Models\ActivityFeedItem;
 use App\Domain\MobilePayment\Services\ActivityFeedService;
+use Tests\UnitTestCase;
+
+uses(UnitTestCase::class);
+
+beforeEach(function (): void {
+    Illuminate\Support\Facades\Event::fake();
+});
 
 describe('ActivityFeedService', function (): void {
-    it('returns empty feed for user with no activity', function (): void {
+    it('can be instantiated', function (): void {
         $service = new ActivityFeedService();
 
-        // Mock the query to return empty collection
-        $mock = Mockery::mock('alias:' . ActivityFeedItem::class);
-        // We'll just test the decode logic directly instead
-        expect(true)->toBeTrue();
+        expect($service)->toBeInstanceOf(ActivityFeedService::class);
     });
 
     it('decodes invalid cursor gracefully', function (): void {


### PR DESCRIPTION
## Summary

- Fixed `ActivityFeedServiceTest` failing in CI with `RuntimeException` (broken alias mock) and `BindingResolutionException` (config class not available)
- Added `uses(UnitTestCase::class)` + `Event::fake()` to properly boot the app
- Replaced broken `Mockery::mock('alias:')` test (class already loaded at runtime) with a proper instantiation test

Follow-up to PR #409.

## Test plan

- [x] All 78 MobilePayment unit tests pass locally
- [ ] CI Unit Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)