### PR TITLE
fix(test): Seed random in flaky DemoLendingService risk test

### DIFF
--- a/tests/Unit/Domain/Lending/Services/DemoLendingServiceTest.php
+++ b/tests/Unit/Domain/Lending/Services/DemoLendingServiceTest.php
@@ -342,6 +342,8 @@ class DemoLendingServiceTest extends TestCase
     #[Test]
     public function it_assesses_risk_factors_correctly()
     {
+        srand(1); // Seed random for consistent test results
+
         $application = LoanApplication::create([
             'id'               => 'demo_app_risk_test',
             'borrower_id'      => 1,
@@ -353,7 +355,7 @@ class DemoLendingServiceTest extends TestCase
             'submitted_at'     => now(),
         ]);
 
-        Config::set('demo.domains.lending.default_credit_score', 600); // Fair credit
+        Config::set('demo.domains.lending.default_credit_score', 500); // Low credit ensures high risk even with rand variation
 
         $this->service->processApplication($application);
         $application->refresh();


### PR DESCRIPTION
## Summary

- `it_assesses_risk_factors_correctly` was flaky because `simulateCreditScore()` adds `rand(-100, 100)` variation to the base score
- With base 600, the score could go above 700 (no credit risk factor), dropping risk rating to 'medium' instead of expected 'high'
- Fixed by seeding random with `srand(1)` and using base 500 (guarantees 'high' risk even with max +100 variation)

## Test plan

- [x] Test passes locally consistently
- [ ] CI Unit Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)