### PR TITLE
fix(custodian): Allow bank connectors to boot in demo environment

### DIFF
--- a/app/Domain/Custodian/Connectors/PayseraConnector.php
+++ b/app/Domain/Custodian/Connectors/PayseraConnector.php
@@ -41,8 +41,8 @@ class PayseraConnector extends BaseCustodianConnector
         $this->clientId = $config['client_id'] ?? '';
         $this->clientSecret = $config['client_secret'] ?? '';
 
-        // Allow empty credentials in testing/development environments
-        if ((empty($this->clientId) || empty($this->clientSecret)) && ! app()->environment(['local', 'testing'])) {
+        // Allow empty credentials in non-production environments
+        if ((empty($this->clientId) || empty($this->clientSecret)) && app()->environment('production')) {
             throw new InvalidArgumentException('Paysera client_id and client_secret are required');
         }
     }

--- a/config/services.php
+++ b/config/services.php
@@ -110,7 +110,7 @@ return [
 
     'banks' => [
         'paysera' => [
-            'enabled'       => env('BANK_PAYSERA_ENABLED', true),
+            'enabled'       => env('BANK_PAYSERA_ENABLED', false),
             'client_id'     => env('BANK_PAYSERA_CLIENT_ID'),
             'client_secret' => env('BANK_PAYSERA_CLIENT_SECRET'),
             'base_url'      => env('BANK_PAYSERA_BASE_URL', 'https://bank.paysera.com/rest/v1'),
@@ -118,14 +118,14 @@ return [
         ],
 
         'deutsche' => [
-            'enabled'       => env('BANK_DEUTSCHE_ENABLED', true),
+            'enabled'       => env('BANK_DEUTSCHE_ENABLED', false),
             'client_id'     => env('BANK_DEUTSCHE_CLIENT_ID'),
             'client_secret' => env('BANK_DEUTSCHE_CLIENT_SECRET'),
             'base_url'      => env('BANK_DEUTSCHE_BASE_URL', 'https://api.db.com/v2'),
         ],
 
         'santander' => [
-            'enabled'       => env('BANK_SANTANDER_ENABLED', true),
+            'enabled'       => env('BANK_SANTANDER_ENABLED', false),
             'client_id'     => env('BANK_SANTANDER_CLIENT_ID'),
             'client_secret' => env('BANK_SANTANDER_CLIENT_SECRET'),
             'base_url'      => env('BANK_SANTANDER_BASE_URL', 'https://api.santander.com/v2'),


### PR DESCRIPTION
## Summary

- **Root cause of production 404**: `PayseraConnector` constructor threw `InvalidArgumentException` when `client_id`/`client_secret` were empty in `APP_ENV=demo`. This crashed the entire app boot via `BankIntegrationServiceProvider`, preventing any route from resolving.
- `PayseraConnector`: Changed credential enforcement to only apply in `production` environment (matching `DeutscheBankConnector` and `SantanderConnector` which already use `app()->environment('production')`)
- `config/services.php`: Changed bank connector defaults from `true` to `false` so they aren't eagerly instantiated without explicit opt-in via env vars

## Test plan

- [x] All 2075 tests pass (`./vendor/bin/pest --parallel`)
- [ ] Deploy to production: `git pull && php artisan optimize:clear`
- [ ] Verify https://finaegis.org/ no longer returns 404
- [ ] Verify `php artisan route:list` no longer crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)