### PR TITLE
fix(payment): Return flat arrays from DemoPaymentGatewayService

### DIFF
--- a/app/Domain/Payment/Services/DemoPaymentGatewayService.php
+++ b/app/Domain/Payment/Services/DemoPaymentGatewayService.php
@@ -135,28 +135,23 @@ class DemoPaymentGatewayService extends PaymentGatewayService
             'user_id' => $user->id,
         ]);
 
-        // Return demo payment methods
+        // Return demo payment methods matching the real PaymentGatewayService format
         return [
-            (object) [
-                'id'   => 'demo_pm_card',
-                'type' => 'card',
-                'card' => (object) [
-                    'brand'     => 'visa',
-                    'last4'     => '4242',
-                    'exp_month' => 12,
-                    'exp_year'  => date('Y') + 1,
-                ],
-                'created' => time(),
+            [
+                'id'         => 'demo_pm_card',
+                'brand'      => 'visa',
+                'last4'      => '4242',
+                'exp_month'  => 12,
+                'exp_year'   => date('Y') + 1,
+                'is_default' => true,
             ],
-            (object) [
-                'id'           => 'demo_pm_bank',
-                'type'         => 'bank_account',
-                'bank_account' => (object) [
-                    'bank_name'           => 'Demo Bank',
-                    'last4'               => '1234',
-                    'account_holder_name' => $user->name,
-                ],
-                'created' => time(),
+            [
+                'id'         => 'demo_pm_card_2',
+                'brand'      => 'mastercard',
+                'last4'      => '5555',
+                'exp_month'  => 6,
+                'exp_year'   => date('Y') + 2,
+                'is_default' => false,
             ],
         ];
     }

--- a/tests/Unit/Domain/Payment/Services/DemoPaymentGatewayServiceTest.php
+++ b/tests/Unit/Domain/Payment/Services/DemoPaymentGatewayServiceTest.php
@@ -108,20 +108,19 @@ class DemoPaymentGatewayServiceTest extends TestCase
 
         $this->assertCount(2, $methods);
 
-        // Check card method
+        // Check card method (flat array matching real PaymentGatewayService format)
         $cardMethod = $methods[0];
-        $this->assertEquals('demo_pm_card', $cardMethod->id);
-        $this->assertEquals('card', $cardMethod->type);
-        $this->assertEquals('visa', $cardMethod->card->brand);
-        $this->assertEquals('4242', $cardMethod->card->last4);
+        $this->assertEquals('demo_pm_card', $cardMethod['id']);
+        $this->assertEquals('visa', $cardMethod['brand']);
+        $this->assertEquals('4242', $cardMethod['last4']);
+        $this->assertTrue($cardMethod['is_default']);
 
-        // Check bank method
-        $bankMethod = $methods[1];
-        $this->assertEquals('demo_pm_bank', $bankMethod->id);
-        $this->assertEquals('bank_account', $bankMethod->type);
-        $this->assertEquals('Demo Bank', $bankMethod->bank_account->bank_name);
-        $this->assertEquals('1234', $bankMethod->bank_account->last4);
-        $this->assertEquals($this->user->name, $bankMethod->bank_account->account_holder_name);
+        // Check second card method
+        $cardMethod2 = $methods[1];
+        $this->assertEquals('demo_pm_card_2', $cardMethod2['id']);
+        $this->assertEquals('mastercard', $cardMethod2['brand']);
+        $this->assertEquals('5555', $cardMethod2['last4']);
+        $this->assertFalse($cardMethod2['is_default']);
     }
 
     public function test_add_payment_method_returns_mock_cashier_method(): void


### PR DESCRIPTION
## Summary
- Fix production crash: `Cannot use object of type stdClass as array` in `deposit-card.blade.php`
- `DemoPaymentGatewayService::getSavedPaymentMethods()` returned `stdClass` objects with nested `->card->brand` structure
- Blade template expects flat arrays (`$method['brand']`, `$method['last4']`) matching the real `PaymentGatewayService` format
- Updated test assertions to match the new flat array format

## Test plan
- [x] `DemoPaymentGatewayServiceTest` passes (14/14, 65 assertions)
- [x] Full test suite unaffected (only pre-existing SQLite/MariaDB incompatibilities in HardwareWallet/TenantIsolation tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)