### PR TITLE
feat(fraud): Add ML anomaly detection foundation

### DIFF
--- a/app/Domain/Fraud/Enums/AnomalyStatus.php
+++ b/app/Domain/Fraud/Enums/AnomalyStatus.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Fraud\Enums;
+
+enum AnomalyStatus: string
+{
+    case Detected = 'detected';
+    case Investigating = 'investigating';
+    case Confirmed = 'confirmed';
+    case FalsePositive = 'false_positive';
+    case Resolved = 'resolved';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Detected      => 'Detected',
+            self::Investigating => 'Under Investigation',
+            self::Confirmed     => 'Confirmed',
+            self::FalsePositive => 'False Positive',
+            self::Resolved      => 'Resolved',
+        };
+    }
+
+    public function isTerminal(): bool
+    {
+        return in_array($this, [self::FalsePositive, self::Resolved]);
+    }
+}

--- a/app/Domain/Fraud/Enums/AnomalyType.php
+++ b/app/Domain/Fraud/Enums/AnomalyType.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Fraud\Enums;
+
+enum AnomalyType: string
+{
+    case Statistical = 'statistical';
+    case Behavioral = 'behavioral';
+    case Velocity = 'velocity';
+    case Geolocation = 'geolocation';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Statistical => 'Statistical Anomaly',
+            self::Behavioral  => 'Behavioral Anomaly',
+            self::Velocity    => 'Velocity Anomaly',
+            self::Geolocation => 'Geolocation Anomaly',
+        };
+    }
+}

--- a/app/Domain/Fraud/Enums/DetectionMethod.php
+++ b/app/Domain/Fraud/Enums/DetectionMethod.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Fraud\Enums;
+
+enum DetectionMethod: string
+{
+    // Statistical methods
+    case ZScore = 'z_score';
+    case IQR = 'iqr';
+    case IsolationForest = 'isolation_forest';
+    case LOF = 'lof';
+
+    // Behavioral methods
+    case AdaptiveThreshold = 'adaptive_threshold';
+    case DriftDetection = 'drift_detection';
+
+    // Velocity methods
+    case SlidingWindow = 'sliding_window';
+    case BurstDetection = 'burst';
+
+    // Geolocation methods
+    case ImpossibleTravel = 'impossible_travel';
+    case IpReputation = 'ip_reputation';
+    case GeoClustering = 'geo_clustering';
+
+    public function anomalyType(): AnomalyType
+    {
+        return match ($this) {
+            self::ZScore, self::IQR, self::IsolationForest, self::LOF => AnomalyType::Statistical,
+            self::AdaptiveThreshold, self::DriftDetection => AnomalyType::Behavioral,
+            self::SlidingWindow, self::BurstDetection => AnomalyType::Velocity,
+            self::ImpossibleTravel, self::IpReputation, self::GeoClustering => AnomalyType::Geolocation,
+        };
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::ZScore            => 'Z-Score Analysis',
+            self::IQR               => 'Interquartile Range',
+            self::IsolationForest   => 'Isolation Forest',
+            self::LOF               => 'Local Outlier Factor',
+            self::AdaptiveThreshold => 'Adaptive Threshold',
+            self::DriftDetection    => 'Drift Detection',
+            self::SlidingWindow     => 'Sliding Window',
+            self::BurstDetection    => 'Burst Detection',
+            self::ImpossibleTravel  => 'Impossible Travel',
+            self::IpReputation      => 'IP Reputation',
+            self::GeoClustering     => 'Geo-Clustering',
+        };
+    }
+}

--- a/app/Domain/Fraud/Models/AnomalyDetection.php
+++ b/app/Domain/Fraud/Models/AnomalyDetection.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Fraud\Models;
+
+use App\Domain\Fraud\Enums\AnomalyStatus;
+use App\Domain\Fraud\Enums\AnomalyType;
+use App\Domain\Fraud\Enums\DetectionMethod;
+use App\Domain\Shared\Traits\UsesTenantConnection;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class AnomalyDetection extends Model
+{
+    use HasFactory;
+    use HasUuids;
+    use SoftDeletes;
+    use UsesTenantConnection;
+
+    protected $fillable = [
+        'entity_id',
+        'entity_type',
+        'user_id',
+        'anomaly_type',
+        'detection_method',
+        'status',
+        'anomaly_score',
+        'confidence',
+        'severity',
+        'features',
+        'thresholds',
+        'explanation',
+        'raw_scores',
+        'context_snapshot',
+        'baseline_snapshot',
+        'model_version',
+        'pipeline_run_id',
+        'is_real_time',
+        'fraud_score_id',
+        'fraud_case_id',
+        'feedback_outcome',
+        'feedback_notes',
+    ];
+
+    protected $casts = [
+        'anomaly_type'      => AnomalyType::class,
+        'detection_method'  => DetectionMethod::class,
+        'status'            => AnomalyStatus::class,
+        'anomaly_score'     => 'decimal:2',
+        'confidence'        => 'decimal:4',
+        'features'          => 'array',
+        'thresholds'        => 'array',
+        'explanation'       => 'array',
+        'raw_scores'        => 'array',
+        'context_snapshot'  => 'array',
+        'baseline_snapshot' => 'array',
+        'is_real_time'      => 'boolean',
+    ];
+
+    // Relationships
+
+    public function entity(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function fraudScore(): BelongsTo
+    {
+        return $this->belongsTo(FraudScore::class, 'fraud_score_id');
+    }
+
+    public function fraudCase(): BelongsTo
+    {
+        return $this->belongsTo(FraudCase::class, 'fraud_case_id');
+    }
+
+    protected static function newFactory(): \Database\Factories\AnomalyDetectionFactory
+    {
+        return \Database\Factories\AnomalyDetectionFactory::new();
+    }
+
+    // Helpers
+
+    public function isCritical(): bool
+    {
+        return $this->severity === 'critical';
+    }
+
+    public function isHighSeverity(): bool
+    {
+        return in_array($this->severity, ['high', 'critical']);
+    }
+
+    public function isActive(): bool
+    {
+        return ! $this->status->isTerminal();
+    }
+
+    public static function calculateSeverity(float $score): string
+    {
+        return match (true) {
+            $score >= 80 => 'critical',
+            $score >= 60 => 'high',
+            $score >= 40 => 'medium',
+            default      => 'low',
+        };
+    }
+}

--- a/app/Domain/Fraud/Models/BehavioralProfile.php
+++ b/app/Domain/Fraud/Models/BehavioralProfile.php
@@ -95,6 +95,15 @@ class BehavioralProfile extends Model
         'is_established',
         'ml_feature_vector',
         'ml_features_updated_at',
+        // v2.9.0 Anomaly Detection columns
+        'adaptive_thresholds',
+        'segment_tags',
+        'drift_metrics',
+        'seasonal_patterns',
+        'sliding_window_stats',
+        'user_segment',
+        'drift_score',
+        'last_drift_check_at',
     ];
 
     protected $casts = [
@@ -129,6 +138,14 @@ class BehavioralProfile extends Model
         'last_suspicious_activity'   => 'datetime',
         'profile_established_at'     => 'datetime',
         'ml_features_updated_at'     => 'datetime',
+        // v2.9.0 Anomaly Detection casts
+        'adaptive_thresholds'  => 'array',
+        'segment_tags'         => 'array',
+        'drift_metrics'        => 'array',
+        'seasonal_patterns'    => 'array',
+        'sliding_window_stats' => 'array',
+        'drift_score'          => 'decimal:2',
+        'last_drift_check_at'  => 'datetime',
     ];
 
     // Relationships

--- a/app/Domain/Fraud/module.json
+++ b/app/Domain/Fraud/module.json
@@ -1,8 +1,8 @@
 {
     "$schema": "https://finaegis.io/schemas/module.json",
     "name": "finaegis/fraud",
-    "version": "1.3.0",
-    "description": "Fraud detection with ML-based analysis and behavioral patterns",
+    "version": "2.0.0",
+    "description": "Fraud detection with ML anomaly detection, behavioral profiling, and pattern analysis",
     "type": "optional",
     "dependencies": {
         "required": {

--- a/config/fraud.php
+++ b/config/fraud.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | ML Anomaly Detection Settings
+    |--------------------------------------------------------------------------
+    */
+    'anomaly_detection' => [
+        'enabled'   => env('FRAUD_ANOMALY_DETECTION_ENABLED', true),
+        'demo_mode' => env('FRAUD_ANOMALY_DEMO_MODE', true),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Statistical Analysis
+    |--------------------------------------------------------------------------
+    */
+    'statistical' => [
+        'z_score_threshold'              => (float) env('FRAUD_Z_SCORE_THRESHOLD', 3.0),
+        'iqr_multiplier'                 => (float) env('FRAUD_IQR_MULTIPLIER', 1.5),
+        'isolation_forest_contamination' => (float) env('FRAUD_IF_CONTAMINATION', 0.1),
+        'lof_neighbors'                  => (int) env('FRAUD_LOF_NEIGHBORS', 20),
+        'history_days'                   => 90,
+        'min_samples'                    => 10,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Behavioral Analysis
+    |--------------------------------------------------------------------------
+    */
+    'behavioral' => [
+        'adaptive_sensitivity' => (float) env('FRAUD_ADAPTIVE_SENSITIVITY', 1.5),
+        'drift_window_days'    => 7,
+        'drift_baseline_days'  => 90,
+        'drift_threshold'      => (float) env('FRAUD_DRIFT_THRESHOLD', 0.3),
+        'segments'             => [
+            'high_value_trader',
+            'retail_consumer',
+            'occasional_user',
+            'new_account',
+            'dormant_reactivated',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Velocity Analysis
+    |--------------------------------------------------------------------------
+    */
+    'velocity' => [
+        'sliding_windows' => [
+            '5m'  => ['minutes' => 5, 'max_count' => 5, 'max_volume' => 10000],
+            '15m' => ['minutes' => 15, 'max_count' => 10, 'max_volume' => 25000],
+            '1h'  => ['minutes' => 60, 'max_count' => 20, 'max_volume' => 50000],
+            '6h'  => ['minutes' => 360, 'max_count' => 50, 'max_volume' => 100000],
+            '24h' => ['minutes' => 1440, 'max_count' => 100, 'max_volume' => 250000],
+            '7d'  => ['minutes' => 10080, 'max_count' => 500, 'max_volume' => 1000000],
+        ],
+        'burst_ratio_threshold' => (float) env('FRAUD_BURST_RATIO_THRESHOLD', 3.0),
+        'cross_account'         => [
+            'enabled'                 => true,
+            'shared_device_threshold' => 3,
+            'shared_ip_threshold'     => 5,
+            'time_window_minutes'     => 60,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Geolocation Analysis
+    |--------------------------------------------------------------------------
+    */
+    'geolocation' => [
+        'impossible_travel_max_speed_kmh' => (float) env('FRAUD_MAX_TRAVEL_SPEED', 900.0),
+        'ip_reputation_threshold'         => (float) env('FRAUD_IP_REPUTATION_THRESHOLD', 0.6),
+        'geo_cluster'                     => [
+            'eps_km'                       => 50.0,
+            'min_points'                   => 3,
+            'max_distance_from_cluster_km' => 500.0,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Batch Processing
+    |--------------------------------------------------------------------------
+    */
+    'batch' => [
+        'schedule'       => env('FRAUD_BATCH_SCHEDULE', 'hourly'),
+        'chunk_size'     => (int) env('FRAUD_BATCH_CHUNK_SIZE', 100),
+        'lookback_hours' => (int) env('FRAUD_BATCH_LOOKBACK_HOURS', 24),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | ML Service
+    |--------------------------------------------------------------------------
+    */
+    'ml' => [
+        'enabled'       => env('FRAUD_ML_ENABLED', false),
+        'api_endpoint'  => env('FRAUD_ML_API_ENDPOINT', ''),
+        'model_version' => env('FRAUD_ML_MODEL_VERSION', 'v1.0'),
+    ],
+];

--- a/database/factories/AnomalyDetectionFactory.php
+++ b/database/factories/AnomalyDetectionFactory.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Domain\Account\Models\Transaction;
+use App\Domain\Fraud\Enums\AnomalyStatus;
+use App\Domain\Fraud\Enums\AnomalyType;
+use App\Domain\Fraud\Enums\DetectionMethod;
+use App\Domain\Fraud\Models\AnomalyDetection;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Domain\Fraud\Models\AnomalyDetection>
+ */
+class AnomalyDetectionFactory extends Factory
+{
+    protected $model = AnomalyDetection::class;
+
+    public function definition(): array
+    {
+        $anomalyType = $this->faker->randomElement(AnomalyType::cases());
+        $detectionMethod = $this->getMethodForType($anomalyType);
+        $score = $this->faker->randomFloat(2, 10, 95);
+
+        return [
+            'entity_id'         => $this->faker->uuid(),
+            'entity_type'       => Transaction::class,
+            'user_id'           => User::factory(),
+            'anomaly_type'      => $anomalyType,
+            'detection_method'  => $detectionMethod,
+            'status'            => AnomalyStatus::Detected,
+            'anomaly_score'     => $score,
+            'confidence'        => $this->faker->randomFloat(4, 0.5, 0.99),
+            'severity'          => AnomalyDetection::calculateSeverity($score),
+            'features'          => ['amount' => $this->faker->randomFloat(2, 100, 50000)],
+            'thresholds'        => ['z_score' => 3.0, 'iqr_multiplier' => 1.5],
+            'explanation'       => ['reason' => 'Test anomaly detection'],
+            'raw_scores'        => ['z_score' => $this->faker->randomFloat(4, 2.0, 5.0)],
+            'context_snapshot'  => ['ip' => $this->faker->ipv4()],
+            'baseline_snapshot' => ['avg_amount' => $this->faker->randomFloat(2, 500, 5000)],
+            'model_version'     => 'v1.0',
+            'pipeline_run_id'   => $this->faker->uuid(),
+            'is_real_time'      => true,
+            'fraud_score_id'    => null,
+            'fraud_case_id'     => null,
+            'feedback_outcome'  => null,
+            'feedback_notes'    => null,
+        ];
+    }
+
+    private function getMethodForType(AnomalyType $type): DetectionMethod
+    {
+        return match ($type) {
+            AnomalyType::Statistical => $this->faker->randomElement([
+                DetectionMethod::ZScore, DetectionMethod::IQR,
+                DetectionMethod::IsolationForest, DetectionMethod::LOF,
+            ]),
+            AnomalyType::Behavioral => $this->faker->randomElement([
+                DetectionMethod::AdaptiveThreshold, DetectionMethod::DriftDetection,
+            ]),
+            AnomalyType::Velocity => $this->faker->randomElement([
+                DetectionMethod::SlidingWindow, DetectionMethod::BurstDetection,
+            ]),
+            AnomalyType::Geolocation => $this->faker->randomElement([
+                DetectionMethod::ImpossibleTravel, DetectionMethod::IpReputation,
+                DetectionMethod::GeoClustering,
+            ]),
+        };
+    }
+
+    public function statistical(): static
+    {
+        return $this->state(fn () => [
+            'anomaly_type'     => AnomalyType::Statistical,
+            'detection_method' => DetectionMethod::ZScore,
+        ]);
+    }
+
+    public function behavioral(): static
+    {
+        return $this->state(fn () => [
+            'anomaly_type'     => AnomalyType::Behavioral,
+            'detection_method' => DetectionMethod::AdaptiveThreshold,
+        ]);
+    }
+
+    public function velocity(): static
+    {
+        return $this->state(fn () => [
+            'anomaly_type'     => AnomalyType::Velocity,
+            'detection_method' => DetectionMethod::SlidingWindow,
+        ]);
+    }
+
+    public function geolocation(): static
+    {
+        return $this->state(fn () => [
+            'anomaly_type'     => AnomalyType::Geolocation,
+            'detection_method' => DetectionMethod::ImpossibleTravel,
+        ]);
+    }
+
+    public function critical(): static
+    {
+        return $this->state(fn () => [
+            'anomaly_score' => $this->faker->randomFloat(2, 80, 100),
+            'severity'      => 'critical',
+            'confidence'    => $this->faker->randomFloat(4, 0.9, 0.99),
+        ]);
+    }
+
+    public function falsePositive(): static
+    {
+        return $this->state(fn () => [
+            'status'           => AnomalyStatus::FalsePositive,
+            'feedback_outcome' => 'false_positive',
+            'feedback_notes'   => 'Confirmed as false positive during review.',
+        ]);
+    }
+}

--- a/database/migrations/2026_02_09_000001_create_anomaly_detections_table.php
+++ b/database/migrations/2026_02_09_000001_create_anomaly_detections_table.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('anomaly_detections', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+
+            // Polymorphic entity reference
+            $table->uuid('entity_id');
+            $table->string('entity_type');
+            $table->foreignId('user_id')->nullable()->constrained();
+
+            // Classification
+            $table->string('anomaly_type'); // statistical|behavioral|velocity|geolocation
+            $table->string('detection_method'); // z_score|iqr|isolation_forest|lof|adaptive_threshold|drift_detection|sliding_window|burst|impossible_travel|ip_reputation|geo_clustering
+            $table->string('status')->default('detected'); // detected|investigating|confirmed|false_positive|resolved
+
+            // Scores
+            $table->decimal('anomaly_score', 5, 2)->default(0); // 0-100
+            $table->decimal('confidence', 5, 4)->default(0); // 0-1
+            $table->string('severity')->default('low'); // low|medium|high|critical
+
+            // Detail payloads
+            $table->json('features')->nullable();
+            $table->json('thresholds')->nullable();
+            $table->json('explanation')->nullable();
+            $table->json('raw_scores')->nullable();
+            $table->json('context_snapshot')->nullable();
+            $table->json('baseline_snapshot')->nullable();
+
+            // ML metadata
+            $table->string('model_version')->nullable();
+            $table->string('pipeline_run_id')->nullable();
+            $table->boolean('is_real_time')->default(true);
+
+            // Links to existing fraud domain
+            $table->uuid('fraud_score_id')->nullable();
+            $table->uuid('fraud_case_id')->nullable();
+
+            // Feedback loop
+            $table->string('feedback_outcome')->nullable();
+            $table->text('feedback_notes')->nullable();
+
+            $table->timestamps();
+            $table->softDeletes();
+
+            // Indexes
+            $table->index(['entity_id', 'entity_type']);
+            $table->index(['anomaly_type', 'created_at']);
+            $table->index(['user_id', 'anomaly_type', 'created_at']);
+            $table->index(['severity', 'status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('anomaly_detections');
+    }
+};

--- a/database/migrations/2026_02_09_000002_add_anomaly_columns_to_behavioral_profiles_table.php
+++ b/database/migrations/2026_02_09_000002_add_anomaly_columns_to_behavioral_profiles_table.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('behavioral_profiles', function (Blueprint $table) {
+            // Adaptive thresholds per user
+            $table->json('adaptive_thresholds')->nullable()->after('ml_features_updated_at');
+            $table->json('segment_tags')->nullable()->after('adaptive_thresholds');
+            $table->json('drift_metrics')->nullable()->after('segment_tags');
+            $table->json('seasonal_patterns')->nullable()->after('drift_metrics');
+            $table->json('sliding_window_stats')->nullable()->after('seasonal_patterns');
+
+            // Segmentation
+            $table->string('user_segment')->nullable()->after('sliding_window_stats');
+
+            // Drift tracking
+            $table->decimal('drift_score', 5, 2)->nullable()->after('user_segment');
+            $table->dateTime('last_drift_check_at')->nullable()->after('drift_score');
+
+            $table->index('user_segment');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('behavioral_profiles', function (Blueprint $table) {
+            $table->dropIndex(['user_segment']);
+            $table->dropColumn([
+                'adaptive_thresholds',
+                'segment_tags',
+                'drift_metrics',
+                'seasonal_patterns',
+                'sliding_window_stats',
+                'user_segment',
+                'drift_score',
+                'last_drift_check_at',
+            ]);
+        });
+    }
+};

--- a/tests/Unit/Domain/Fraud/Enums/AnomalyEnumsTest.php
+++ b/tests/Unit/Domain/Fraud/Enums/AnomalyEnumsTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Fraud\Enums;
+
+use App\Domain\Fraud\Enums\AnomalyStatus;
+use App\Domain\Fraud\Enums\AnomalyType;
+use App\Domain\Fraud\Enums\DetectionMethod;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class AnomalyEnumsTest extends TestCase
+{
+    #[Test]
+    public function test_anomaly_type_has_all_expected_cases(): void
+    {
+        $cases = AnomalyType::cases();
+
+        $this->assertCount(4, $cases);
+        $this->assertEquals('statistical', AnomalyType::Statistical->value);
+        $this->assertEquals('behavioral', AnomalyType::Behavioral->value);
+        $this->assertEquals('velocity', AnomalyType::Velocity->value);
+        $this->assertEquals('geolocation', AnomalyType::Geolocation->value);
+    }
+
+    #[Test]
+    public function test_anomaly_type_labels(): void
+    {
+        $this->assertEquals('Statistical Anomaly', AnomalyType::Statistical->label());
+        $this->assertEquals('Behavioral Anomaly', AnomalyType::Behavioral->label());
+        $this->assertEquals('Velocity Anomaly', AnomalyType::Velocity->label());
+        $this->assertEquals('Geolocation Anomaly', AnomalyType::Geolocation->label());
+    }
+
+    #[Test]
+    public function test_anomaly_status_has_all_expected_cases(): void
+    {
+        $cases = AnomalyStatus::cases();
+
+        $this->assertCount(5, $cases);
+        $this->assertEquals('detected', AnomalyStatus::Detected->value);
+        $this->assertEquals('investigating', AnomalyStatus::Investigating->value);
+        $this->assertEquals('confirmed', AnomalyStatus::Confirmed->value);
+        $this->assertEquals('false_positive', AnomalyStatus::FalsePositive->value);
+        $this->assertEquals('resolved', AnomalyStatus::Resolved->value);
+    }
+
+    #[Test]
+    public function test_anomaly_status_terminal_states(): void
+    {
+        $this->assertFalse(AnomalyStatus::Detected->isTerminal());
+        $this->assertFalse(AnomalyStatus::Investigating->isTerminal());
+        $this->assertFalse(AnomalyStatus::Confirmed->isTerminal());
+        $this->assertTrue(AnomalyStatus::FalsePositive->isTerminal());
+        $this->assertTrue(AnomalyStatus::Resolved->isTerminal());
+    }
+
+    #[Test]
+    public function test_detection_method_has_all_expected_cases(): void
+    {
+        $cases = DetectionMethod::cases();
+
+        $this->assertCount(11, $cases);
+    }
+
+    #[Test]
+    public function test_detection_method_maps_to_correct_anomaly_type(): void
+    {
+        $this->assertEquals(AnomalyType::Statistical, DetectionMethod::ZScore->anomalyType());
+        $this->assertEquals(AnomalyType::Statistical, DetectionMethod::IQR->anomalyType());
+        $this->assertEquals(AnomalyType::Statistical, DetectionMethod::IsolationForest->anomalyType());
+        $this->assertEquals(AnomalyType::Statistical, DetectionMethod::LOF->anomalyType());
+
+        $this->assertEquals(AnomalyType::Behavioral, DetectionMethod::AdaptiveThreshold->anomalyType());
+        $this->assertEquals(AnomalyType::Behavioral, DetectionMethod::DriftDetection->anomalyType());
+
+        $this->assertEquals(AnomalyType::Velocity, DetectionMethod::SlidingWindow->anomalyType());
+        $this->assertEquals(AnomalyType::Velocity, DetectionMethod::BurstDetection->anomalyType());
+
+        $this->assertEquals(AnomalyType::Geolocation, DetectionMethod::ImpossibleTravel->anomalyType());
+        $this->assertEquals(AnomalyType::Geolocation, DetectionMethod::IpReputation->anomalyType());
+        $this->assertEquals(AnomalyType::Geolocation, DetectionMethod::GeoClustering->anomalyType());
+    }
+
+    #[Test]
+    public function test_detection_method_labels(): void
+    {
+        $this->assertEquals('Z-Score Analysis', DetectionMethod::ZScore->label());
+        $this->assertEquals('Interquartile Range', DetectionMethod::IQR->label());
+        $this->assertEquals('Impossible Travel', DetectionMethod::ImpossibleTravel->label());
+    }
+}

--- a/tests/Unit/Domain/Fraud/Models/AnomalyDetectionTest.php
+++ b/tests/Unit/Domain/Fraud/Models/AnomalyDetectionTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Fraud\Models;
+
+use App\Domain\Fraud\Enums\AnomalyStatus;
+use App\Domain\Fraud\Enums\AnomalyType;
+use App\Domain\Fraud\Enums\DetectionMethod;
+use App\Domain\Fraud\Models\AnomalyDetection;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class AnomalyDetectionTest extends TestCase
+{
+    #[Test]
+    public function test_can_create_anomaly_detection_via_factory(): void
+    {
+        $anomaly = AnomalyDetection::factory()->create();
+
+        $this->assertNotNull($anomaly->id);
+        $this->assertInstanceOf(AnomalyType::class, $anomaly->anomaly_type);
+        $this->assertInstanceOf(DetectionMethod::class, $anomaly->detection_method);
+        $this->assertInstanceOf(AnomalyStatus::class, $anomaly->status);
+    }
+
+    #[Test]
+    public function test_statistical_factory_state(): void
+    {
+        $anomaly = AnomalyDetection::factory()->statistical()->create();
+
+        $this->assertEquals(AnomalyType::Statistical, $anomaly->anomaly_type);
+        $this->assertEquals(DetectionMethod::ZScore, $anomaly->detection_method);
+    }
+
+    #[Test]
+    public function test_critical_factory_state(): void
+    {
+        $anomaly = AnomalyDetection::factory()->critical()->create();
+
+        $this->assertEquals('critical', $anomaly->severity);
+        $this->assertGreaterThanOrEqual(80, (float) $anomaly->anomaly_score);
+    }
+
+    #[Test]
+    public function test_calculate_severity(): void
+    {
+        $this->assertEquals('low', AnomalyDetection::calculateSeverity(20.0));
+        $this->assertEquals('medium', AnomalyDetection::calculateSeverity(45.0));
+        $this->assertEquals('high', AnomalyDetection::calculateSeverity(65.0));
+        $this->assertEquals('critical', AnomalyDetection::calculateSeverity(90.0));
+    }
+
+    #[Test]
+    public function test_is_critical(): void
+    {
+        $anomaly = AnomalyDetection::factory()->create(['severity' => 'critical']);
+        $this->assertTrue($anomaly->isCritical());
+
+        $anomaly = AnomalyDetection::factory()->create(['severity' => 'high']);
+        $this->assertFalse($anomaly->isCritical());
+    }
+
+    #[Test]
+    public function test_is_high_severity(): void
+    {
+        $this->assertTrue(AnomalyDetection::factory()->create(['severity' => 'critical'])->isHighSeverity());
+        $this->assertTrue(AnomalyDetection::factory()->create(['severity' => 'high'])->isHighSeverity());
+        $this->assertFalse(AnomalyDetection::factory()->create(['severity' => 'medium'])->isHighSeverity());
+        $this->assertFalse(AnomalyDetection::factory()->create(['severity' => 'low'])->isHighSeverity());
+    }
+
+    #[Test]
+    public function test_is_active(): void
+    {
+        $detected = AnomalyDetection::factory()->create(['status' => AnomalyStatus::Detected]);
+        $this->assertTrue($detected->isActive());
+
+        $investigating = AnomalyDetection::factory()->create(['status' => AnomalyStatus::Investigating]);
+        $this->assertTrue($investigating->isActive());
+
+        $resolved = AnomalyDetection::factory()->create(['status' => AnomalyStatus::Resolved]);
+        $this->assertFalse($resolved->isActive());
+
+        $falsePositive = AnomalyDetection::factory()->create(['status' => AnomalyStatus::FalsePositive]);
+        $this->assertFalse($falsePositive->isActive());
+    }
+
+    #[Test]
+    public function test_false_positive_factory_state(): void
+    {
+        $anomaly = AnomalyDetection::factory()->falsePositive()->create();
+
+        $this->assertEquals(AnomalyStatus::FalsePositive, $anomaly->status);
+        $this->assertEquals('false_positive', $anomaly->feedback_outcome);
+        $this->assertNotNull($anomaly->feedback_notes);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `AnomalyType`, `AnomalyStatus`, `DetectionMethod` enums covering 4 anomaly types and 11 detection methods
- Creates `anomaly_detections` table with polymorphic entity references, scoring, ML metadata, and feedback loop columns
- Adds adaptive threshold, drift detection, and segmentation columns to `behavioral_profiles`
- Creates `AnomalyDetection` model with factory and severity calculation helpers
- Consolidates fraud ML config in `config/fraud.php` (statistical, behavioral, velocity, geolocation, batch settings)
- Bumps Fraud module to v2.0.0

## Test plan
- [x] 7 enum tests (cases, labels, type mapping, terminal states)
- [x] 8 model tests (factory creation, severity, active state, factory states)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.ai/code)