### PR TITLE
feat(fraud): Batch anomaly scan command and job

### DIFF
--- a/app/Console/Commands/ScanAnomaliesCommand.php
+++ b/app/Console/Commands/ScanAnomaliesCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Account\Models\Transaction;
+use App\Domain\Fraud\Jobs\ProcessAnomalyBatchJob;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+class ScanAnomaliesCommand extends Command
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'fraud:scan-anomalies
+                            {--hours=24 : How many hours back to scan}
+                            {--chunk=100 : Number of transactions per batch job}
+                            {--sync : Run synchronously instead of dispatching jobs}';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Batch scan recent transactions for anomaly detection';
+
+    public function handle(): int
+    {
+        $hours = (int) $this->option('hours');
+        $chunkSize = (int) $this->option('chunk');
+        $sync = $this->option('sync');
+        $pipelineRunId = Str::uuid()->toString();
+
+        $this->info("Anomaly Detection Batch Scan (pipeline: {$pipelineRunId})");
+        $this->info("Scanning transactions from the last {$hours} hours in chunks of {$chunkSize}");
+
+        $query = Transaction::where('created_at', '>=', now()->subHours($hours))
+            ->orderBy('created_at', 'desc');
+
+        $total = $query->count();
+
+        if ($total === 0) {
+            $this->info('No transactions found in the specified time range.');
+
+            return Command::SUCCESS;
+        }
+
+        $this->info("Found {$total} transactions to scan.");
+
+        $dispatched = 0;
+
+        $query->select('id')->chunkById($chunkSize, function ($transactions) use ($pipelineRunId, $sync, &$dispatched) {
+            $ids = $transactions->pluck('id')->all();
+
+            if ($sync) {
+                ProcessAnomalyBatchJob::dispatchSync($ids, $pipelineRunId);
+            } else {
+                ProcessAnomalyBatchJob::dispatch($ids, $pipelineRunId);
+            }
+
+            $dispatched++;
+        });
+
+        $this->info("Dispatched {$dispatched} batch jobs covering {$total} transactions.");
+        $this->info('Pipeline run ID: ' . $pipelineRunId);
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Domain/Fraud/Jobs/ProcessAnomalyBatchJob.php
+++ b/app/Domain/Fraud/Jobs/ProcessAnomalyBatchJob.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Fraud\Jobs;
+
+use App\Domain\Account\Models\Transaction;
+use App\Domain\Fraud\Services\AnomalyDetectionOrchestrator;
+use Exception;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class ProcessAnomalyBatchJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public int $timeout = 600;
+
+    /**
+     * @param  array<int>  $transactionIds  The transaction IDs to scan
+     */
+    public function __construct(
+        private readonly array $transactionIds,
+        private readonly string $pipelineRunId,
+    ) {
+        $this->onQueue('fraud-batch');
+    }
+
+    public function handle(AnomalyDetectionOrchestrator $orchestrator): void
+    {
+        $transactions = Transaction::with('account.user')
+            ->whereIn('id', $this->transactionIds)
+            ->get();
+
+        $processed = 0;
+        $anomaliesFound = 0;
+
+        foreach ($transactions as $transaction) {
+            try {
+                $account = $transaction->account;
+                $user = $account?->user;
+
+                $context = [
+                    'amount' => (float) $transaction->amount,
+                    'type'   => $transaction->type ?? 'unknown',
+                    'user'   => $user ? [
+                        'id'      => $user->id,
+                        'country' => $user->country ?? null,
+                    ] : [],
+                    'daily_transaction_count'  => 0,
+                    'daily_transaction_volume' => 0,
+                    'pipeline_run_id'          => $this->pipelineRunId,
+                ];
+
+                $result = $orchestrator->detectAnomalies(
+                    $context,
+                    (string) $transaction->id,
+                    Transaction::class,
+                    $user?->id,
+                );
+
+                $processed++;
+
+                if ($result['highest_score'] > 0) {
+                    $anomaliesFound++;
+                }
+            } catch (Exception $e) {
+                Log::warning('Batch anomaly scan failed for transaction', [
+                    'transaction_id'  => $transaction->id,
+                    'pipeline_run_id' => $this->pipelineRunId,
+                    'error'           => $e->getMessage(),
+                ]);
+            }
+        }
+
+        Log::info('Anomaly batch chunk completed', [
+            'pipeline_run_id' => $this->pipelineRunId,
+            'processed'       => $processed,
+            'anomalies_found' => $anomaliesFound,
+            'total_in_chunk'  => count($this->transactionIds),
+        ]);
+    }
+
+    public function failed(Throwable $exception): void
+    {
+        Log::error('Anomaly batch job failed', [
+            'pipeline_run_id'   => $this->pipelineRunId,
+            'transaction_count' => count($this->transactionIds),
+            'error'             => $exception->getMessage(),
+        ]);
+    }
+}

--- a/routes/console.php
+++ b/routes/console.php
@@ -194,6 +194,16 @@ Schedule::job(new App\Domain\MobilePayment\Jobs\ExpireStalePaymentIntents())
     ->description('Expire stale payment intents past their TTL')
     ->withoutOverlapping();
 
+// Fraud Anomaly Detection Batch Scan
+Schedule::command('fraud:scan-anomalies --hours=' . config('fraud.batch.lookback_hours', 24) . ' --chunk=' . config('fraud.batch.chunk_size', 100))
+    ->cron(config('fraud.batch.schedule', '0 */6 * * *'))
+    ->description('Batch scan recent transactions for anomaly detection')
+    ->appendOutputTo(storage_path('logs/fraud-anomaly-scan.log'))
+    ->withoutOverlapping()
+    ->onFailure(function () {
+        Log::warning('Fraud anomaly batch scan failed to run');
+    });
+
 // TrustCert Certificate Management
 // Check for expired certificates and send renewal reminders daily at 6 AM
 Schedule::command('trustcert:check-expired')

--- a/tests/Unit/Domain/Fraud/Jobs/ProcessAnomalyBatchJobTest.php
+++ b/tests/Unit/Domain/Fraud/Jobs/ProcessAnomalyBatchJobTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Fraud\Jobs;
+
+use App\Domain\Account\Models\Account;
+use App\Domain\Account\Models\Transaction;
+use App\Domain\Fraud\Jobs\ProcessAnomalyBatchJob;
+use App\Domain\Fraud\Services\AnomalyDetectionOrchestrator;
+use App\Models\User;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Queue;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use Tests\TestCase;
+
+class ProcessAnomalyBatchJobTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Config::set('fraud.anomaly_detection.enabled', true);
+    }
+
+    #[Test]
+    public function job_dispatches_to_correct_queue(): void
+    {
+        Queue::fake();
+
+        ProcessAnomalyBatchJob::dispatch([1, 2, 3], 'test-pipeline');
+
+        Queue::assertPushedOn('fraud-batch', ProcessAnomalyBatchJob::class);
+    }
+
+    #[Test]
+    public function job_processes_transactions_through_orchestrator(): void
+    {
+        $user = User::factory()->create();
+        $account = Account::factory()->create(['user_id' => $user->id]);
+        $transaction = Transaction::factory()->create([
+            'account_id' => $account->id,
+            'amount'     => 5000,
+        ]);
+
+        $orchestrator = Mockery::mock(AnomalyDetectionOrchestrator::class);
+        $orchestrator->shouldReceive('detectAnomalies')
+            ->once()
+            ->andReturn([
+                'anomalies'     => [],
+                'highest_score' => 0.0,
+                'has_critical'  => false,
+                'persisted'     => 0,
+            ]);
+
+        $job = new ProcessAnomalyBatchJob([$transaction->id], 'test-pipeline-123');
+        $job->handle($orchestrator);
+
+        // No assertion needed beyond the mock expectation
+        $this->assertTrue(true);
+    }
+
+    #[Test]
+    public function job_handles_missing_transactions_gracefully(): void
+    {
+        $orchestrator = Mockery::mock(AnomalyDetectionOrchestrator::class);
+        // Should not be called since no transactions found
+        $orchestrator->shouldNotReceive('detectAnomalies');
+
+        $job = new ProcessAnomalyBatchJob([999999], 'test-pipeline-missing');
+        $job->handle($orchestrator);
+
+        $this->assertTrue(true);
+    }
+
+    #[Test]
+    public function job_continues_after_individual_transaction_failure(): void
+    {
+        $user = User::factory()->create();
+        $account = Account::factory()->create(['user_id' => $user->id]);
+        $tx1 = Transaction::factory()->create(['account_id' => $account->id, 'amount' => 100]);
+        $tx2 = Transaction::factory()->create(['account_id' => $account->id, 'amount' => 200]);
+
+        $orchestrator = Mockery::mock(AnomalyDetectionOrchestrator::class);
+        $orchestrator->shouldReceive('detectAnomalies')
+            ->twice()
+            ->andReturnUsing(function ($context) {
+                if (($context['amount'] ?? 0) === 100.0) {
+                    throw new RuntimeException('Test failure');
+                }
+
+                return [
+                    'anomalies'     => [],
+                    'highest_score' => 0.0,
+                    'has_critical'  => false,
+                    'persisted'     => 0,
+                ];
+            });
+
+        $job = new ProcessAnomalyBatchJob([$tx1->id, $tx2->id], 'test-pipeline-fail');
+        $job->handle($orchestrator);
+
+        // Should not throw - graceful handling of individual failures
+        $this->assertTrue(true);
+    }
+
+    #[Test]
+    public function command_dispatches_batch_jobs(): void
+    {
+        Queue::fake();
+
+        $user = User::factory()->create();
+        $account = Account::factory()->create(['user_id' => $user->id]);
+        Transaction::factory()->count(3)->create([
+            'account_id' => $account->id,
+            'created_at' => now()->subHours(1),
+        ]);
+
+        $this->artisan('fraud:scan-anomalies', ['--hours' => 24, '--chunk' => 2])
+            ->assertExitCode(0);
+
+        Queue::assertPushed(ProcessAnomalyBatchJob::class);
+    }
+
+    #[Test]
+    public function command_reports_zero_transactions(): void
+    {
+        // No transactions in DB within range
+        $this->artisan('fraud:scan-anomalies', ['--hours' => 1])
+            ->expectsOutput('No transactions found in the specified time range.')
+            ->assertExitCode(0);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ProcessAnomalyBatchJob` for chunk-based transaction scanning via the orchestrator (queue: `fraud-batch`, 3 retries, 10min timeout)
- Add `fraud:scan-anomalies` artisan command with `--hours`, `--chunk`, `--sync` options for on-demand or scheduled batch scanning
- Schedule batch scan every 6 hours in `routes/console.php` (configurable via `fraud.batch.schedule`)

## Test plan
- [x] Job dispatches to correct queue
- [x] Job processes transactions through orchestrator
- [x] Job handles missing transactions gracefully
- [x] Job continues after individual transaction failure
- [x] Command dispatches batch jobs with chunking
- [x] Command reports zero transactions gracefully
- [x] All 6 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)