### PR TITLE
quality(fraud): Add strict_types, remove dead code, improve type safety

### DIFF
--- a/app/Domain/Fraud/Models/AnomalyDetection.php
+++ b/app/Domain/Fraud/Models/AnomalyDetection.php
@@ -116,4 +116,18 @@ class AnomalyDetection extends Model
             default      => 'low',
         };
     }
+
+    /**
+     * Record analyst feedback on this anomaly detection.
+     */
+    public function recordFeedback(string $outcome, ?string $notes = null): void
+    {
+        $this->update([
+            'feedback_outcome' => $outcome,
+            'feedback_notes'   => $notes,
+            'status'           => $outcome === 'false_positive'
+                ? AnomalyStatus::FalsePositive
+                : AnomalyStatus::Resolved,
+        ]);
+    }
 }

--- a/app/Domain/Fraud/Services/AnomalyDetectionOrchestrator.php
+++ b/app/Domain/Fraud/Services/AnomalyDetectionOrchestrator.php
@@ -170,7 +170,7 @@ class AnomalyDetectionOrchestrator
                 ? $this->behavioralService->detectDrift($profile, $recentTransactions)
                 : ['drifted' => false, 'drift_score' => 0.0, 'details' => []];
 
-            $driftScore = ($driftResult['drift_score'] ?? 0) * 100;
+            $driftScore = (float) ($driftResult['drift_score'] ?? 0) * 100;
             $highestScore = max($adaptiveScore, $driftScore);
 
             if ($highestScore <= 0) {
@@ -210,10 +210,10 @@ class AnomalyDetectionOrchestrator
 
             $windowScore = 0.0;
             foreach ($slidingWindows['breaches'] ?? [] as $breach) {
-                $windowScore = max($windowScore, ($breach['ratio'] ?? 1.0) * 40);
+                $windowScore = max($windowScore, (float) ($breach['ratio'] ?? 1.0) * 40);
             }
 
-            $burstScore = ($burstResult['is_burst'] ?? false) ? min(($burstResult['burst_ratio'] ?? 1.0) * 30, 80.0) : 0.0;
+            $burstScore = ($burstResult['is_burst'] ?? false) ? min((float) ($burstResult['burst_ratio'] ?? 1.0) * 30, 80.0) : 0.0;
             $highestScore = max($windowScore, $burstScore);
 
             if ($highestScore <= 0) {
@@ -275,8 +275,8 @@ class AnomalyDetectionOrchestrator
                 $ipResult = $this->deviceService->assessIpReputation($context['ip']);
                 $details['ip_reputation'] = $ipResult;
 
-                if ($ipResult['risk_score'] > $highestScore) {
-                    $highestScore = $ipResult['risk_score'];
+                if ((float) $ipResult['risk_score'] > $highestScore) {
+                    $highestScore = (float) $ipResult['risk_score'];
                     $highestMethod = DetectionMethod::IpReputation;
                 }
             }

--- a/app/Domain/Fraud/Services/BehavioralAnalysisService.php
+++ b/app/Domain/Fraud/Services/BehavioralAnalysisService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Domain\Fraud\Services;
 
 use App\Domain\Account\Models\Transaction;

--- a/app/Domain/Fraud/Services/DeviceFingerprintService.php
+++ b/app/Domain/Fraud/Services/DeviceFingerprintService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Domain\Fraud\Services;
 
 use App\Domain\Fraud\Models\DeviceFingerprint;
@@ -411,18 +413,6 @@ class DeviceFingerprintService
             }
         }
 
-        // Analyze mouse patterns
-        if (isset($newBiometrics['mouse_patterns'])) {
-            $mouseAnomaly = $this->analyzeMousePattern(
-                $device->mouse_patterns ?? [],
-                $newBiometrics['mouse_patterns']
-            );
-
-            if ($mouseAnomaly) {
-                $anomalies[] = 'mouse_pattern_anomaly';
-            }
-        }
-
         return $anomalies;
     }
 
@@ -443,21 +433,6 @@ class DeviceFingerprintService
         $deviation = abs($historicalAvg - $currentAvg) / $historicalAvg;
 
         return $deviation > 0.5; // 50% deviation threshold
-    }
-
-    /**
-     * Analyze mouse pattern for anomalies.
-     */
-    protected function analyzeMousePattern(array $historical, array $current): bool
-    {
-        if (empty($historical) || empty($current)) {
-            return false;
-        }
-
-        // Analyze movement speed and acceleration patterns
-        // In production, use more sophisticated analysis
-
-        return false;
     }
 
     /**

--- a/app/Domain/Fraud/Services/MachineLearningService.php
+++ b/app/Domain/Fraud/Services/MachineLearningService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Domain\Fraud\Services;
 
 use App\Domain\Account\Models\Transaction;

--- a/app/Domain/Fraud/Services/RuleEngineService.php
+++ b/app/Domain/Fraud/Services/RuleEngineService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Domain\Fraud\Services;
 
 use App\Domain\Fraud\Models\FraudRule;


### PR DESCRIPTION
## Summary
- Add `declare(strict_types=1)` to 4 fraud services (BehavioralAnalysis, RuleEngine, DeviceFingerprint, MachineLearning)
- Remove dead `analyzeMousePattern()` method that always returned false plus its unused call path
- Add `recordFeedback()` method to AnomalyDetection model for analyst workflow
- Add explicit `(float)` casts to orchestrator sub-service score handling (drift, velocity, IP reputation)

## Test plan
- [x] All 94 fraud domain tests pass
- [x] No PHPStan regressions (only pre-existing iterableValue warnings)
- [x] php-cs-fixer clean