### PR TITLE
feat(baas): Add partner usage metering service and auth middleware

### DIFF
--- a/app/Domain/FinancialInstitution/Services/PartnerUsageMeteringService.php
+++ b/app/Domain/FinancialInstitution/Services/PartnerUsageMeteringService.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\FinancialInstitution\Services;
+
+use App\Domain\FinancialInstitution\Models\FinancialInstitutionPartner;
+use App\Domain\FinancialInstitution\Models\PartnerUsageRecord;
+use Carbon\Carbon;
+
+/**
+ * Tracks and manages partner API usage metering for billing and analytics.
+ */
+class PartnerUsageMeteringService
+{
+    public function __construct(
+        private readonly PartnerTierService $tierService,
+    ) {
+    }
+
+    /**
+     * Record an API call for a partner.
+     */
+    public function recordApiCall(
+        FinancialInstitutionPartner $partner,
+        string $endpoint,
+        bool $success = true,
+        ?int $responseTimeMs = null,
+    ): void {
+        $record = $this->getOrCreateTodayRecord($partner);
+
+        $record->incrementApiCalls(1, $success, $endpoint);
+
+        if ($responseTimeMs !== null) {
+            $this->updateResponseTime($record, $responseTimeMs);
+        }
+    }
+
+    /**
+     * Record a widget load event.
+     */
+    public function recordWidgetLoad(
+        FinancialInstitutionPartner $partner,
+        string $widgetType,
+        bool $converted = false,
+    ): void {
+        $record = $this->getOrCreateTodayRecord($partner);
+
+        $record->increment('widget_loads');
+
+        if ($converted) {
+            $record->increment('widget_conversions');
+        }
+    }
+
+    /**
+     * Record an SDK download event.
+     */
+    public function recordSdkDownload(
+        FinancialInstitutionPartner $partner,
+        string $language,
+    ): void {
+        $record = $this->getOrCreateTodayRecord($partner);
+
+        $record->increment('sdk_downloads');
+    }
+
+    /**
+     * Get or create the daily usage record for today.
+     */
+    public function getOrCreateTodayRecord(FinancialInstitutionPartner $partner): PartnerUsageRecord
+    {
+        $today = now()->startOfDay();
+
+        $record = PartnerUsageRecord::where('partner_id', $partner->id)
+            ->whereDate('usage_date', $today)
+            ->where('period_type', 'daily')
+            ->first();
+
+        if ($record) {
+            return $record;
+        }
+
+        return PartnerUsageRecord::create([
+            'uuid'               => (string) \Illuminate\Support\Str::uuid(),
+            'partner_id'         => $partner->id,
+            'usage_date'         => $today->toDateString(),
+            'period_type'        => 'daily',
+            'api_calls'          => 0,
+            'api_calls_success'  => 0,
+            'api_calls_failed'   => 0,
+            'widget_loads'       => 0,
+            'widget_conversions' => 0,
+            'sdk_downloads'      => 0,
+            'is_billable'        => true,
+        ]);
+    }
+
+    /**
+     * Get aggregated usage summary for a date range.
+     *
+     * @return array<string, mixed>
+     */
+    public function getUsageSummary(
+        FinancialInstitutionPartner $partner,
+        Carbon $startDate,
+        Carbon $endDate,
+    ): array {
+        $records = PartnerUsageRecord::where('partner_id', $partner->id)
+            ->whereBetween('usage_date', [$startDate->toDateString(), $endDate->toDateString()])
+            ->get();
+
+        $tier = $this->tierService->getPartnerTier($partner);
+
+        $totalCalls = (int) $records->sum('api_calls');
+        $totalSuccess = (int) $records->sum('api_calls_success');
+        $totalFailed = (int) $records->sum('api_calls_failed');
+
+        return [
+            'partner_id'   => $partner->id,
+            'period_start' => $startDate->toDateString(),
+            'period_end'   => $endDate->toDateString(),
+            'tier'         => $tier->value,
+            'api_calls'    => [
+                'total'        => $totalCalls,
+                'successful'   => $totalSuccess,
+                'failed'       => $totalFailed,
+                'success_rate' => $totalCalls > 0
+                    ? round(($totalSuccess / $totalCalls) * 100, 2)
+                    : 0.0,
+            ],
+            'widget_loads'       => (int) $records->sum('widget_loads'),
+            'widget_conversions' => (int) $records->sum('widget_conversions'),
+            'sdk_downloads'      => (int) $records->sum('sdk_downloads'),
+            'daily_records'      => $records->count(),
+        ];
+    }
+
+    /**
+     * Check whether the partner has exceeded their monthly usage limit.
+     *
+     * @return array{exceeded: bool, current: int, limit: int, percentage: float}
+     */
+    public function checkUsageLimit(FinancialInstitutionPartner $partner): array
+    {
+        $tier = $this->tierService->getPartnerTier($partner);
+        $limit = $tier->apiCallLimit();
+
+        $currentUsage = (int) PartnerUsageRecord::where('partner_id', $partner->id)
+            ->whereYear('usage_date', now()->year)
+            ->whereMonth('usage_date', now()->month)
+            ->sum('api_calls');
+
+        return [
+            'exceeded'   => $currentUsage >= $limit,
+            'current'    => $currentUsage,
+            'limit'      => $limit,
+            'percentage' => $limit > 0
+                ? round(($currentUsage / $limit) * 100, 2)
+                : 0.0,
+        ];
+    }
+
+    /**
+     * Update rolling average and p99 response times.
+     */
+    private function updateResponseTime(PartnerUsageRecord $record, int $responseTimeMs): void
+    {
+        $currentAvg = (float) ($record->avg_response_time_ms ?? 0);
+        $currentP99 = (int) ($record->p99_response_time_ms ?? 0);
+        $totalCalls = (int) $record->api_calls;
+
+        // Simple rolling average
+        $newAvg = $totalCalls > 1
+            ? (($currentAvg * ($totalCalls - 1)) + $responseTimeMs) / $totalCalls
+            : (float) $responseTimeMs;
+
+        $updates = ['avg_response_time_ms' => round($newAvg, 2)];
+
+        if ($responseTimeMs > $currentP99) {
+            $updates['p99_response_time_ms'] = $responseTimeMs;
+        }
+
+        $record->update($updates);
+    }
+}

--- a/app/Http/Middleware/PartnerAuthMiddleware.php
+++ b/app/Http/Middleware/PartnerAuthMiddleware.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Domain\FinancialInstitution\Models\FinancialInstitutionPartner;
+use Closure;
+use Exception;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Authenticates BaaS partner API requests via client credentials.
+ *
+ * Validates X-Partner-Client-Id and X-Partner-Client-Secret headers,
+ * checks partner status/IP allowlist, and binds the partner to the request.
+ */
+class PartnerAuthMiddleware
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $clientId = $request->header(
+            config('baas.partner_api.authentication.header_client_id', 'X-Partner-Client-Id'),
+        );
+        $clientSecret = $request->header(
+            config('baas.partner_api.authentication.header_client_secret', 'X-Partner-Client-Secret'),
+        );
+
+        if (empty($clientId) || empty($clientSecret)) {
+            return $this->unauthorizedResponse('Missing partner credentials.');
+        }
+
+        $partner = FinancialInstitutionPartner::where('api_client_id', $clientId)->first();
+
+        if (! $partner) {
+            Log::warning('Partner auth failed: invalid client ID', [
+                'client_id' => $clientId,
+                'ip'        => $request->ip(),
+            ]);
+
+            return $this->unauthorizedResponse('Invalid partner credentials.');
+        }
+
+        // Verify the client secret
+        try {
+            if ($clientSecret !== $partner->getApiClientSecret()) {
+                Log::warning('Partner auth failed: invalid client secret', [
+                    'partner_id' => $partner->id,
+                    'ip'         => $request->ip(),
+                ]);
+
+                return $this->unauthorizedResponse('Invalid partner credentials.');
+            }
+        } catch (Exception $e) {
+            Log::error('Partner auth failed: decryption error', [
+                'partner_id' => $partner->id,
+                'error'      => $e->getMessage(),
+            ]);
+
+            return $this->unauthorizedResponse('Invalid partner credentials.');
+        }
+
+        // Check partner status
+        if (! $partner->isActive()) {
+            Log::warning('Partner auth failed: partner not active', [
+                'partner_id' => $partner->id,
+                'status'     => $partner->status,
+            ]);
+
+            return $this->forbiddenResponse('Partner account is not active.');
+        }
+
+        // Check IP allowlist
+        if (! $partner->isIpAllowed($request->ip())) {
+            Log::warning('Partner auth failed: IP not allowed', [
+                'partner_id' => $partner->id,
+                'ip'         => $request->ip(),
+            ]);
+
+            return $this->forbiddenResponse('IP address not allowed.');
+        }
+
+        // Bind the partner to the request for downstream use
+        $request->attributes->set('partner', $partner);
+
+        return $next($request);
+    }
+
+    private function unauthorizedResponse(string $message): JsonResponse
+    {
+        return response()->json([
+            'error'   => 'Unauthorized',
+            'message' => $message,
+        ], 401);
+    }
+
+    private function forbiddenResponse(string $message): JsonResponse
+    {
+        return response()->json([
+            'error'   => 'Forbidden',
+            'message' => $message,
+        ], 403);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -67,6 +67,8 @@ return Application::configure(basePath: dirname(__DIR__))
             'auth.agent'       => App\Http\Middleware\AuthenticateAgentDID::class,
             'agent.scope'      => App\Http\Middleware\CheckAgentScope::class,
             'agent.capability' => App\Http\Middleware\CheckAgentCapability::class,
+            // BaaS partner authentication middleware
+            'partner.auth' => App\Http\Middleware\PartnerAuthMiddleware::class,
             // Multi-tenancy middleware
             'tenant' => App\Http\Middleware\InitializeTenancyByTeam::class,
         ]);

--- a/routes/api.php
+++ b/routes/api.php
@@ -1368,3 +1368,16 @@ Route::prefix('v1/auth/passkey')
         Route::post('/challenge', [PasskeyController::class, 'challenge'])->name('challenge');
         Route::post('/authenticate', [PasskeyController::class, 'authenticate'])->name('authenticate');
     });
+
+/*
+|--------------------------------------------------------------------------
+| BaaS Partner API Routes (v2.9.0)
+|--------------------------------------------------------------------------
+|
+| Partner-facing API endpoints for the Banking-as-a-Service platform.
+| Authenticated via X-Partner-Client-Id / X-Partner-Client-Secret headers.
+|
+*/
+Route::prefix('partner/v1')->name('api.partner.')->middleware('partner.auth')->group(function () {
+    // Partner API routes will be added in feature/baas-api-routes
+});

--- a/tests/Unit/Domain/FinancialInstitution/Middleware/PartnerAuthMiddlewareTest.php
+++ b/tests/Unit/Domain/FinancialInstitution/Middleware/PartnerAuthMiddlewareTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\FinancialInstitution\Middleware;
+
+use App\Domain\FinancialInstitution\Models\FinancialInstitutionApplication;
+use App\Domain\FinancialInstitution\Models\FinancialInstitutionPartner;
+use App\Http\Middleware\PartnerAuthMiddleware;
+use Closure;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class PartnerAuthMiddlewareTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private PartnerAuthMiddleware $middleware;
+
+    private string $clientSecret = 'test_secret_abc123';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->middleware = new PartnerAuthMiddleware();
+    }
+
+    private function createPartnerApplication(): FinancialInstitutionApplication
+    {
+        return FinancialInstitutionApplication::create([
+            'application_number'       => 'FIA-2026-' . fake()->unique()->numerify('#####'),
+            'institution_name'         => 'Test Partner',
+            'legal_name'               => 'Test Partner Ltd',
+            'registration_number'      => 'REG-123456',
+            'tax_id'                   => 'TAX-123456',
+            'country'                  => 'US',
+            'institution_type'         => 'fintech',
+            'years_in_operation'       => 5,
+            'contact_name'             => 'John Doe',
+            'contact_email'            => 'john@test.com',
+            'contact_phone'            => '+1234567890',
+            'contact_position'         => 'CTO',
+            'headquarters_address'     => '123 Test St',
+            'headquarters_city'        => 'New York',
+            'headquarters_postal_code' => '10001',
+            'headquarters_country'     => 'US',
+            'business_description'     => 'Test fintech partner',
+            'target_markets'           => ['US', 'EU'],
+            'product_offerings'        => ['payments'],
+            'required_currencies'      => ['USD'],
+            'integration_requirements' => ['api'],
+            'status'                   => 'approved',
+        ]);
+    }
+
+    private function createPartner(array $attributes = []): FinancialInstitutionPartner
+    {
+        $application = $this->createPartnerApplication();
+
+        return FinancialInstitutionPartner::create(array_merge([
+            'application_id'        => $application->id,
+            'partner_code'          => 'TST-' . fake()->unique()->numerify('####'),
+            'institution_name'      => 'Test Partner',
+            'legal_name'            => 'Test Partner Ltd',
+            'institution_type'      => 'fintech',
+            'country'               => 'US',
+            'status'                => 'active',
+            'tier'                  => 'growth',
+            'api_client_id'         => 'test_client_' . fake()->unique()->numerify('####'),
+            'api_client_secret'     => encrypt($this->clientSecret),
+            'webhook_secret'        => encrypt('webhook_secret_123'),
+            'sandbox_enabled'       => true,
+            'production_enabled'    => false,
+            'rate_limit_per_minute' => 300,
+            'fee_structure'         => ['base' => 0],
+            'risk_rating'           => 'low',
+            'risk_score'            => 10.00,
+            'primary_contact'       => ['name' => 'Test', 'email' => 'test@example.com'],
+        ], $attributes));
+    }
+
+    private function createRequest(array $headers = []): Request
+    {
+        $request = Request::create('/api/partner/v1/profile', 'GET');
+
+        foreach ($headers as $key => $value) {
+            $request->headers->set($key, $value);
+        }
+
+        return $request;
+    }
+
+    private function passThrough(): Closure
+    {
+        return fn (Request $request) => new JsonResponse(['status' => 'ok']);
+    }
+
+    public function test_missing_credentials_returns_401(): void
+    {
+        $request = $this->createRequest();
+        $response = $this->middleware->handle($request, $this->passThrough());
+
+        $this->assertEquals(401, $response->getStatusCode());
+        $data = json_decode($response->getContent(), true);
+        $this->assertEquals('Unauthorized', $data['error']);
+    }
+
+    public function test_missing_client_secret_returns_401(): void
+    {
+        $request = $this->createRequest([
+            'X-Partner-Client-Id' => 'some_id',
+        ]);
+        $response = $this->middleware->handle($request, $this->passThrough());
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    public function test_invalid_client_id_returns_401(): void
+    {
+        $request = $this->createRequest([
+            'X-Partner-Client-Id'     => 'nonexistent_id',
+            'X-Partner-Client-Secret' => 'some_secret',
+        ]);
+        $response = $this->middleware->handle($request, $this->passThrough());
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    public function test_invalid_client_secret_returns_401(): void
+    {
+        $partner = $this->createPartner();
+
+        $request = $this->createRequest([
+            'X-Partner-Client-Id'     => $partner->api_client_id,
+            'X-Partner-Client-Secret' => 'wrong_secret',
+        ]);
+
+        $response = $this->middleware->handle($request, $this->passThrough());
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    public function test_inactive_partner_returns_403(): void
+    {
+        $partner = $this->createPartner(['status' => 'suspended']);
+
+        $request = $this->createRequest([
+            'X-Partner-Client-Id'     => $partner->api_client_id,
+            'X-Partner-Client-Secret' => $this->clientSecret,
+        ]);
+
+        $response = $this->middleware->handle($request, $this->passThrough());
+
+        $this->assertEquals(403, $response->getStatusCode());
+        $data = json_decode($response->getContent(), true);
+        $this->assertStringContainsString('not active', $data['message']);
+    }
+
+    public function test_ip_not_allowed_returns_403(): void
+    {
+        $partner = $this->createPartner([
+            'allowed_ip_addresses' => ['10.0.0.1', '10.0.0.2'],
+        ]);
+
+        $request = $this->createRequest([
+            'X-Partner-Client-Id'     => $partner->api_client_id,
+            'X-Partner-Client-Secret' => $this->clientSecret,
+        ]);
+
+        $response = $this->middleware->handle($request, $this->passThrough());
+
+        $this->assertEquals(403, $response->getStatusCode());
+        $data = json_decode($response->getContent(), true);
+        $this->assertStringContainsString('IP address', $data['message']);
+    }
+
+    public function test_valid_credentials_passes_through(): void
+    {
+        $partner = $this->createPartner();
+
+        $request = $this->createRequest([
+            'X-Partner-Client-Id'     => $partner->api_client_id,
+            'X-Partner-Client-Secret' => $this->clientSecret,
+        ]);
+
+        $response = $this->middleware->handle($request, $this->passThrough());
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function test_valid_credentials_binds_partner_to_request(): void
+    {
+        $partner = $this->createPartner();
+
+        $request = $this->createRequest([
+            'X-Partner-Client-Id'     => $partner->api_client_id,
+            'X-Partner-Client-Secret' => $this->clientSecret,
+        ]);
+
+        $this->middleware->handle($request, function (Request $req) use ($partner) {
+            $boundPartner = $req->attributes->get('partner');
+            $this->assertInstanceOf(FinancialInstitutionPartner::class, $boundPartner);
+            $this->assertEquals($partner->id, $boundPartner->id);
+
+            return new JsonResponse(['status' => 'ok']);
+        });
+    }
+
+    public function test_empty_ip_allowlist_allows_all_ips(): void
+    {
+        $partner = $this->createPartner([
+            'allowed_ip_addresses' => [],
+        ]);
+
+        $request = $this->createRequest([
+            'X-Partner-Client-Id'     => $partner->api_client_id,
+            'X-Partner-Client-Secret' => $this->clientSecret,
+        ]);
+
+        $response = $this->middleware->handle($request, $this->passThrough());
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+}

--- a/tests/Unit/Domain/FinancialInstitution/Services/PartnerUsageMeteringServiceTest.php
+++ b/tests/Unit/Domain/FinancialInstitution/Services/PartnerUsageMeteringServiceTest.php
@@ -1,0 +1,294 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\FinancialInstitution\Services;
+
+use App\Domain\FinancialInstitution\Models\FinancialInstitutionApplication;
+use App\Domain\FinancialInstitution\Models\FinancialInstitutionPartner;
+use App\Domain\FinancialInstitution\Models\PartnerUsageRecord;
+use App\Domain\FinancialInstitution\Services\PartnerTierService;
+use App\Domain\FinancialInstitution\Services\PartnerUsageMeteringService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+class PartnerUsageMeteringServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private PartnerUsageMeteringService $service;
+
+    private PartnerTierService $tierService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->tierService = new PartnerTierService();
+        $this->service = new PartnerUsageMeteringService($this->tierService);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function createPartnerApplication(): FinancialInstitutionApplication
+    {
+        return FinancialInstitutionApplication::create([
+            'application_number'       => 'FIA-2026-' . fake()->unique()->numerify('#####'),
+            'institution_name'         => 'Test Partner',
+            'legal_name'               => 'Test Partner Ltd',
+            'registration_number'      => 'REG-123456',
+            'tax_id'                   => 'TAX-123456',
+            'country'                  => 'US',
+            'institution_type'         => 'fintech',
+            'years_in_operation'       => 5,
+            'contact_name'             => 'John Doe',
+            'contact_email'            => 'john@test.com',
+            'contact_phone'            => '+1234567890',
+            'contact_position'         => 'CTO',
+            'headquarters_address'     => '123 Test St',
+            'headquarters_city'        => 'New York',
+            'headquarters_postal_code' => '10001',
+            'headquarters_country'     => 'US',
+            'business_description'     => 'Test fintech partner',
+            'target_markets'           => ['US', 'EU'],
+            'product_offerings'        => ['payments'],
+            'required_currencies'      => ['USD'],
+            'integration_requirements' => ['api'],
+            'status'                   => 'approved',
+        ]);
+    }
+
+    private function createPartner(array $attributes = []): FinancialInstitutionPartner
+    {
+        $application = $this->createPartnerApplication();
+
+        return FinancialInstitutionPartner::create(array_merge([
+            'application_id'        => $application->id,
+            'partner_code'          => 'TST-' . fake()->unique()->numerify('####'),
+            'institution_name'      => 'Test Partner',
+            'legal_name'            => 'Test Partner Ltd',
+            'institution_type'      => 'fintech',
+            'country'               => 'US',
+            'status'                => 'active',
+            'tier'                  => 'growth',
+            'api_client_id'         => 'test_client_' . fake()->unique()->numerify('####'),
+            'api_client_secret'     => encrypt('test_secret_123'),
+            'webhook_secret'        => encrypt('webhook_secret_123'),
+            'sandbox_enabled'       => true,
+            'production_enabled'    => false,
+            'rate_limit_per_minute' => 300,
+            'fee_structure'         => ['base' => 0],
+            'risk_rating'           => 'low',
+            'risk_score'            => 10.00,
+            'primary_contact'       => ['name' => 'Test', 'email' => 'test@example.com'],
+        ], $attributes));
+    }
+
+    public function test_record_api_call_creates_daily_record(): void
+    {
+        $partner = $this->createPartner();
+
+        $this->service->recordApiCall($partner, '/api/accounts', true, 150);
+
+        $record = PartnerUsageRecord::where('partner_id', $partner->id)->first();
+        $this->assertNotNull($record);
+        $this->assertEquals(now()->toDateString(), $record->usage_date->toDateString());
+        $this->assertEquals(1, $record->api_calls);
+        $this->assertEquals(1, $record->api_calls_success);
+        $this->assertEquals(0, $record->api_calls_failed);
+    }
+
+    public function test_record_api_call_increments_existing_record(): void
+    {
+        $partner = $this->createPartner();
+
+        $this->service->recordApiCall($partner, '/api/accounts', true, 100);
+        $this->service->recordApiCall($partner, '/api/accounts', true, 200);
+
+        $record = PartnerUsageRecord::where('partner_id', $partner->id)->first();
+        $this->assertEquals(2, $record->api_calls);
+        $this->assertEquals(2, $record->api_calls_success);
+    }
+
+    public function test_record_failed_api_call(): void
+    {
+        $partner = $this->createPartner();
+
+        $this->service->recordApiCall($partner, '/api/transfers', false);
+
+        $record = PartnerUsageRecord::where('partner_id', $partner->id)->first();
+        $this->assertEquals(1, $record->api_calls);
+        $this->assertEquals(0, $record->api_calls_success);
+        $this->assertEquals(1, $record->api_calls_failed);
+    }
+
+    public function test_record_api_call_tracks_endpoint_breakdown(): void
+    {
+        $partner = $this->createPartner();
+
+        $this->service->recordApiCall($partner, '/api/accounts', true);
+        $this->service->recordApiCall($partner, '/api/accounts', true);
+        $this->service->recordApiCall($partner, '/api/transfers', true);
+
+        $record = PartnerUsageRecord::where('partner_id', $partner->id)->first();
+        $breakdown = $record->endpoint_breakdown;
+        $this->assertEquals(2, $breakdown['/api/accounts']);
+        $this->assertEquals(1, $breakdown['/api/transfers']);
+    }
+
+    public function test_record_api_call_updates_response_time(): void
+    {
+        $partner = $this->createPartner();
+
+        $this->service->recordApiCall($partner, '/api/accounts', true, 100);
+
+        $record = PartnerUsageRecord::where('partner_id', $partner->id)->first();
+        $this->assertEquals(100.0, (float) $record->avg_response_time_ms);
+        $this->assertEquals(100, $record->p99_response_time_ms);
+    }
+
+    public function test_record_widget_load(): void
+    {
+        $partner = $this->createPartner();
+
+        $this->service->recordWidgetLoad($partner, 'payment', false);
+
+        $record = PartnerUsageRecord::where('partner_id', $partner->id)->first();
+        $this->assertEquals(1, $record->widget_loads);
+        $this->assertEquals(0, $record->widget_conversions);
+    }
+
+    public function test_record_widget_load_with_conversion(): void
+    {
+        $partner = $this->createPartner();
+
+        $this->service->recordWidgetLoad($partner, 'checkout', true);
+
+        $record = PartnerUsageRecord::where('partner_id', $partner->id)->first();
+        $this->assertEquals(1, $record->widget_loads);
+        $this->assertEquals(1, $record->widget_conversions);
+    }
+
+    public function test_record_sdk_download(): void
+    {
+        $partner = $this->createPartner();
+
+        $this->service->recordSdkDownload($partner, 'typescript');
+        $this->service->recordSdkDownload($partner, 'python');
+
+        $record = PartnerUsageRecord::where('partner_id', $partner->id)->first();
+        $this->assertEquals(2, $record->sdk_downloads);
+    }
+
+    public function test_get_or_create_today_record(): void
+    {
+        $partner = $this->createPartner();
+
+        $record1 = $this->service->getOrCreateTodayRecord($partner);
+        $record2 = $this->service->getOrCreateTodayRecord($partner);
+
+        $this->assertEquals($record1->id, $record2->id);
+        $this->assertEquals('daily', $record1->period_type);
+        $this->assertTrue($record1->is_billable);
+    }
+
+    public function test_get_usage_summary(): void
+    {
+        $partner = $this->createPartner();
+
+        // Create some usage records
+        PartnerUsageRecord::create([
+            'uuid'               => fake()->uuid(),
+            'partner_id'         => $partner->id,
+            'usage_date'         => now()->subDays(2)->toDateString(),
+            'period_type'        => 'daily',
+            'api_calls'          => 500,
+            'api_calls_success'  => 480,
+            'api_calls_failed'   => 20,
+            'widget_loads'       => 10,
+            'widget_conversions' => 3,
+            'sdk_downloads'      => 1,
+            'is_billable'        => true,
+        ]);
+
+        PartnerUsageRecord::create([
+            'uuid'               => fake()->uuid(),
+            'partner_id'         => $partner->id,
+            'usage_date'         => now()->subDays(1)->toDateString(),
+            'period_type'        => 'daily',
+            'api_calls'          => 300,
+            'api_calls_success'  => 290,
+            'api_calls_failed'   => 10,
+            'widget_loads'       => 5,
+            'widget_conversions' => 2,
+            'sdk_downloads'      => 0,
+            'is_billable'        => true,
+        ]);
+
+        $summary = $this->service->getUsageSummary(
+            $partner,
+            now()->subDays(7),
+            now(),
+        );
+
+        $this->assertEquals($partner->id, $summary['partner_id']);
+        $this->assertEquals(800, $summary['api_calls']['total']);
+        $this->assertEquals(770, $summary['api_calls']['successful']);
+        $this->assertEquals(30, $summary['api_calls']['failed']);
+        $this->assertEquals(96.25, $summary['api_calls']['success_rate']);
+        $this->assertEquals(15, $summary['widget_loads']);
+        $this->assertEquals(5, $summary['widget_conversions']);
+        $this->assertEquals(1, $summary['sdk_downloads']);
+        $this->assertEquals(2, $summary['daily_records']);
+    }
+
+    public function test_check_usage_limit_not_exceeded(): void
+    {
+        $partner = $this->createPartner(['tier' => 'growth']); // 100K limit
+
+        PartnerUsageRecord::create([
+            'uuid'              => fake()->uuid(),
+            'partner_id'        => $partner->id,
+            'usage_date'        => now()->toDateString(),
+            'period_type'       => 'daily',
+            'api_calls'         => 5000,
+            'api_calls_success' => 5000,
+            'api_calls_failed'  => 0,
+            'is_billable'       => true,
+        ]);
+
+        $result = $this->service->checkUsageLimit($partner);
+
+        $this->assertFalse($result['exceeded']);
+        $this->assertEquals(5000, $result['current']);
+        $this->assertEquals(100000, $result['limit']);
+        $this->assertEquals(5.0, $result['percentage']);
+    }
+
+    public function test_check_usage_limit_exceeded(): void
+    {
+        $partner = $this->createPartner(['tier' => 'starter']); // 10K limit
+
+        PartnerUsageRecord::create([
+            'uuid'              => fake()->uuid(),
+            'partner_id'        => $partner->id,
+            'usage_date'        => now()->toDateString(),
+            'period_type'       => 'daily',
+            'api_calls'         => 15000,
+            'api_calls_success' => 14000,
+            'api_calls_failed'  => 1000,
+            'is_billable'       => true,
+        ]);
+
+        $result = $this->service->checkUsageLimit($partner);
+
+        $this->assertTrue($result['exceeded']);
+        $this->assertEquals(15000, $result['current']);
+        $this->assertEquals(10000, $result['limit']);
+        $this->assertEquals(150.0, $result['percentage']);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `PartnerUsageMeteringService` for tracking API calls, widget loads, and SDK downloads with daily aggregation and response time tracking
- Add `PartnerAuthMiddleware` for authenticating partner API requests via `X-Partner-Client-Id`/`X-Partner-Client-Secret` headers with IP allowlist validation
- Register `partner.auth` middleware alias and add partner route group placeholder in `routes/api.php`

## Test plan
- [x] 12 metering service tests (API call recording, widget loads, SDK downloads, usage summary, limit checks)
- [x] 9 middleware tests (missing credentials, invalid credentials, inactive partner, IP blocking, successful auth)
- [x] All 21 tests passing
- [x] Code style fixed with php-cs-fixer

🤖 Generated with [Claude Code](https://claude.ai/code)