### PR TITLE
feat(baas): Add embeddable widget service

### DIFF
--- a/app/Domain/FinancialInstitution/Services/EmbeddableWidgetService.php
+++ b/app/Domain/FinancialInstitution/Services/EmbeddableWidgetService.php
@@ -1,0 +1,300 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\FinancialInstitution\Services;
+
+use App\Domain\FinancialInstitution\Models\FinancialInstitutionPartner;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Manages embeddable widget generation with partner branding.
+ */
+class EmbeddableWidgetService
+{
+    public function __construct(
+        private readonly PartnerTierService $tierService,
+    ) {
+    }
+
+    /**
+     * Generate embed code snippet for a widget type.
+     *
+     * @param  array<string, mixed>  $options
+     * @return array{success: bool, message: string, html: string|null, widget_type: string}
+     */
+    public function generateEmbedCode(
+        FinancialInstitutionPartner $partner,
+        string $widgetType,
+        array $options = [],
+    ): array {
+        $validation = $this->validateWidgetAccess($partner, $widgetType);
+
+        if (! $validation['allowed']) {
+            return [
+                'success'     => false,
+                'message'     => (string) $validation['reason'],
+                'html'        => null,
+                'widget_type' => $widgetType,
+            ];
+        }
+
+        $widgetConfig = $this->getWidgetTypeConfig($widgetType);
+        $branding = $partner->branding;
+        $brandingConfig = $branding ? $branding->getWidgetConfig() : $this->getDefaultBrandingConfig();
+        $cssVars = $branding ? $branding->getCssVariablesString() : '';
+
+        $domain = $partner->sandbox_enabled
+            ? config('baas.widgets.sandbox_domain', 'sandbox.finaegis.com')
+            : config('baas.widgets.production_domain', 'api.finaegis.com');
+
+        $containerId = $options['container_id'] ?? 'finaegis-widget';
+        $width = $options['width'] ?? '100%';
+        $height = $options['height'] ?? '400px';
+
+        $configJson = json_encode([
+            'partnerId'  => $partner->api_client_id,
+            'widgetType' => $widgetType,
+            'branding'   => $brandingConfig,
+            'options'    => $options,
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+
+        $jsFile = $widgetConfig['js_file'];
+
+        $html = <<<HTML
+<!-- FinAegis {$widgetConfig['name']} Widget -->
+<div id="{$containerId}" style="width: {$width}; height: {$height}; {$cssVars}"></div>
+<script src="https://{$domain}/widgets/{$jsFile}"></script>
+<script>
+  FinAegis.init({$configJson});
+  FinAegis.render('{$containerId}');
+</script>
+HTML;
+
+        Log::info('Widget embed code generated', [
+            'partner_id'  => $partner->id,
+            'widget_type' => $widgetType,
+        ]);
+
+        return [
+            'success'     => true,
+            'message'     => "Embed code generated for {$widgetConfig['name']}",
+            'html'        => $html,
+            'widget_type' => $widgetType,
+        ];
+    }
+
+    /**
+     * Get available widget types from config.
+     *
+     * @return array<string, array<string, string>>
+     */
+    public function getAvailableWidgets(): array
+    {
+        return config('baas.widgets.types', []);
+    }
+
+    /**
+     * Generate the JavaScript content for a widget.
+     *
+     * @return array{success: bool, message: string, content: string|null, widget_type: string}
+     */
+    public function generateWidgetScript(
+        FinancialInstitutionPartner $partner,
+        string $widgetType,
+    ): array {
+        $validation = $this->validateWidgetAccess($partner, $widgetType);
+
+        if (! $validation['allowed']) {
+            return [
+                'success'     => false,
+                'message'     => (string) $validation['reason'],
+                'content'     => null,
+                'widget_type' => $widgetType,
+            ];
+        }
+
+        $widgetConfig = $this->getWidgetTypeConfig($widgetType);
+        $branding = $partner->branding;
+        $brandingConfig = $branding ? $branding->getWidgetConfig() : $this->getDefaultBrandingConfig();
+
+        $brandingJson = (string) json_encode($brandingConfig, JSON_UNESCAPED_SLASHES);
+
+        $content = <<<JS
+/**
+ * FinAegis {$widgetConfig['name']} Widget
+ * Auto-generated for {$partner->institution_name}
+ */
+(function() {
+  'use strict';
+
+  var FinAegis = window.FinAegis || {};
+  var defaultBranding = {$brandingJson};
+
+  FinAegis.init = function(config) {
+    this.config = Object.assign({ branding: defaultBranding }, config);
+  };
+
+  FinAegis.render = function(containerId) {
+    var container = document.getElementById(containerId);
+    if (!container) { console.error('FinAegis: Container not found:', containerId); return; }
+    container.innerHTML = '<div class="finaegis-widget finaegis-{$widgetType}">' +
+      '<div class="finaegis-header">' + (this.config.branding.company_name || 'FinAegis') + '</div>' +
+      '<div class="finaegis-body">Widget loading...</div>' +
+      '</div>';
+  };
+
+  window.FinAegis = FinAegis;
+})();
+JS;
+
+        return [
+            'success'     => true,
+            'message'     => "Widget script generated for {$widgetConfig['name']}",
+            'content'     => $content,
+            'widget_type' => $widgetType,
+        ];
+    }
+
+    /**
+     * Generate a full HTML preview page for a widget.
+     *
+     * @return array{success: bool, message: string, html: string|null, widget_type: string}
+     */
+    public function previewWidget(
+        FinancialInstitutionPartner $partner,
+        string $widgetType,
+    ): array {
+        $validation = $this->validateWidgetAccess($partner, $widgetType);
+
+        if (! $validation['allowed']) {
+            return [
+                'success'     => false,
+                'message'     => (string) $validation['reason'],
+                'html'        => null,
+                'widget_type' => $widgetType,
+            ];
+        }
+
+        $widgetConfig = $this->getWidgetTypeConfig($widgetType);
+        $branding = $partner->branding;
+        $cssVars = $branding ? $branding->getCssVariablesString() : '';
+        $companyName = $branding->company_name ?? $partner->institution_name;
+        $logoUrl = $branding->logo_url ?? '';
+
+        $embedResult = $this->generateEmbedCode($partner, $widgetType);
+        $embedHtml = $embedResult['html'] ?? '';
+
+        $html = <<<HTML
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{$companyName} - {$widgetConfig['name']} Preview</title>
+  <style>
+    :root { {$cssVars} }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 0; padding: 20px; background: #f5f5f5; }
+    .preview-container { max-width: 800px; margin: 0 auto; background: white; border-radius: 8px; padding: 24px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); }
+    .preview-header { display: flex; align-items: center; gap: 12px; margin-bottom: 24px; padding-bottom: 16px; border-bottom: 1px solid #eee; }
+    .preview-header img { height: 32px; }
+    .preview-header h1 { font-size: 18px; margin: 0; }
+    .preview-badge { display: inline-block; background: #e3f2fd; color: #1565c0; padding: 2px 8px; border-radius: 4px; font-size: 12px; }
+  </style>
+</head>
+<body>
+  <div class="preview-container">
+    <div class="preview-header">
+      <img src="{$logoUrl}" alt="{$companyName}" onerror="this.style.display='none'">
+      <h1>{$companyName}</h1>
+      <span class="preview-badge">Preview</span>
+    </div>
+    {$embedHtml}
+  </div>
+</body>
+</html>
+HTML;
+
+        return [
+            'success'     => true,
+            'message'     => "Preview generated for {$widgetConfig['name']}",
+            'html'        => $html,
+            'widget_type' => $widgetType,
+        ];
+    }
+
+    /**
+     * Validate that a partner can access a widget type.
+     *
+     * @return array{allowed: bool, reason: string|null}
+     */
+    public function validateWidgetAccess(FinancialInstitutionPartner $partner, string $widgetType): array
+    {
+        $tier = $this->tierService->getPartnerTier($partner);
+
+        if (! $tier->hasWidgets()) {
+            return [
+                'allowed' => false,
+                'reason'  => "Widget access requires Growth or Enterprise tier. Current tier: {$tier->label()}",
+            ];
+        }
+
+        $availableWidgets = $this->getAvailableWidgets();
+
+        if (! isset($availableWidgets[$widgetType])) {
+            return [
+                'allowed' => false,
+                'reason'  => "Unknown widget type: {$widgetType}",
+            ];
+        }
+
+        if (! config('baas.widgets.enabled', true)) {
+            return [
+                'allowed' => false,
+                'reason'  => 'Widgets are currently disabled',
+            ];
+        }
+
+        return [
+            'allowed' => true,
+            'reason'  => null,
+        ];
+    }
+
+    /**
+     * Get configuration for a specific widget type.
+     *
+     * @return array<string, string>
+     */
+    private function getWidgetTypeConfig(string $widgetType): array
+    {
+        return config("baas.widgets.types.{$widgetType}", [
+            'name'        => ucfirst($widgetType),
+            'description' => "{$widgetType} widget",
+            'js_file'     => "finaegis-{$widgetType}.js",
+        ]);
+    }
+
+    /**
+     * Get default branding config when partner has no branding set.
+     *
+     * @return array<string, mixed>
+     */
+    private function getDefaultBrandingConfig(): array
+    {
+        return [
+            'colors' => [
+                '--fa-primary-color'    => '#1a73e8',
+                '--fa-secondary-color'  => '#5f6368',
+                '--fa-accent-color'     => '#1a73e8',
+                '--fa-text-color'       => '#202124',
+                '--fa-background-color' => '#ffffff',
+            ],
+            'logo'          => null,
+            'logo_dark'     => null,
+            'company_name'  => 'FinAegis',
+            'tagline'       => null,
+            'support_email' => 'support@finaegis.com',
+        ];
+    }
+}

--- a/tests/Unit/Domain/FinancialInstitution/Services/EmbeddableWidgetServiceTest.php
+++ b/tests/Unit/Domain/FinancialInstitution/Services/EmbeddableWidgetServiceTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\FinancialInstitution\Services;
+
+use App\Domain\FinancialInstitution\Models\FinancialInstitutionPartner;
+use App\Domain\FinancialInstitution\Models\PartnerBranding;
+use App\Domain\FinancialInstitution\Services\EmbeddableWidgetService;
+use App\Domain\FinancialInstitution\Services\PartnerTierService;
+use Mockery;
+use Tests\TestCase;
+
+class EmbeddableWidgetServiceTest extends TestCase
+{
+    private EmbeddableWidgetService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new EmbeddableWidgetService(new PartnerTierService());
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function createMockPartner(array $attributes = []): FinancialInstitutionPartner
+    {
+        $mock = Mockery::mock(FinancialInstitutionPartner::class)->makePartial();
+
+        $defaults = [
+            'id'               => fake()->uuid(),
+            'partner_code'     => 'TST-12345',
+            'institution_name' => 'Test Partner',
+            'tier'             => 'growth',
+            'api_client_id'    => 'test_client_abc',
+            'sandbox_enabled'  => true,
+        ];
+
+        foreach (array_merge($defaults, $attributes) as $key => $value) {
+            $mock->{$key} = $value;
+        }
+
+        return $mock;
+    }
+
+    private function createMockBranding(): PartnerBranding
+    {
+        $branding = Mockery::mock(PartnerBranding::class)->makePartial();
+        $branding->primary_color = '#1a73e8';
+        $branding->secondary_color = '#5f6368';
+        $branding->accent_color = '#1a73e8';
+        $branding->text_color = '#202124';
+        $branding->background_color = '#ffffff';
+        $branding->company_name = 'Test Partner Co';
+        $branding->tagline = 'Testing made easy';
+        $branding->logo_url = 'https://example.com/logo.png';
+        $branding->logo_dark_url = 'https://example.com/logo-dark.png';
+        $branding->support_email = 'support@test.com';
+        $branding->widget_config = null;
+
+        return $branding;
+    }
+
+    public function test_generate_embed_code_for_growth_tier(): void
+    {
+        $partner = $this->createMockPartner(['tier' => 'growth', 'branding' => $this->createMockBranding()]);
+
+        $result = $this->service->generateEmbedCode($partner, 'payment');
+
+        $this->assertTrue($result['success']);
+        $this->assertEquals('payment', $result['widget_type']);
+        $this->assertNotNull($result['html']);
+        $this->assertStringContainsString('finaegis-payment.js', $result['html']);
+        $this->assertStringContainsString('test_client_abc', $result['html']);
+    }
+
+    public function test_generate_embed_code_denied_for_starter_tier(): void
+    {
+        $partner = $this->createMockPartner(['tier' => 'starter']);
+
+        $result = $this->service->generateEmbedCode($partner, 'payment');
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('Growth or Enterprise', $result['message']);
+        $this->assertNull($result['html']);
+    }
+
+    public function test_generate_embed_code_invalid_widget_type(): void
+    {
+        $partner = $this->createMockPartner(['tier' => 'growth']);
+
+        $result = $this->service->generateEmbedCode($partner, 'nonexistent');
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('Unknown widget type', $result['message']);
+    }
+
+    public function test_generate_embed_code_with_custom_options(): void
+    {
+        $partner = $this->createMockPartner(['tier' => 'growth', 'branding' => $this->createMockBranding()]);
+
+        $result = $this->service->generateEmbedCode($partner, 'checkout', [
+            'container_id' => 'my-checkout',
+            'width'        => '500px',
+            'height'       => '600px',
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertStringContainsString('my-checkout', $result['html']);
+        $this->assertStringContainsString('500px', $result['html']);
+        $this->assertStringContainsString('600px', $result['html']);
+    }
+
+    public function test_generate_embed_code_uses_sandbox_domain(): void
+    {
+        $partner = $this->createMockPartner([
+            'tier'            => 'growth',
+            'sandbox_enabled' => true,
+            'branding'        => $this->createMockBranding(),
+        ]);
+
+        $result = $this->service->generateEmbedCode($partner, 'payment');
+
+        $this->assertTrue($result['success']);
+        $this->assertStringContainsString('sandbox.finaegis.com', $result['html']);
+    }
+
+    public function test_get_available_widgets(): void
+    {
+        $widgets = $this->service->getAvailableWidgets();
+
+        $this->assertIsArray($widgets);
+        $this->assertArrayHasKey('payment', $widgets);
+        $this->assertArrayHasKey('checkout', $widgets);
+        $this->assertArrayHasKey('balance', $widgets);
+        $this->assertArrayHasKey('transfer', $widgets);
+        $this->assertArrayHasKey('account', $widgets);
+    }
+
+    public function test_generate_widget_script(): void
+    {
+        $partner = $this->createMockPartner(['tier' => 'growth', 'branding' => $this->createMockBranding()]);
+
+        $result = $this->service->generateWidgetScript($partner, 'payment');
+
+        $this->assertTrue($result['success']);
+        $this->assertNotNull($result['content']);
+        $this->assertStringContainsString('FinAegis', $result['content']);
+        $this->assertStringContainsString('Payment Form', $result['content']);
+        $this->assertStringContainsString('Test Partner', $result['content']);
+    }
+
+    public function test_generate_widget_script_denied_for_starter(): void
+    {
+        $partner = $this->createMockPartner(['tier' => 'starter']);
+
+        $result = $this->service->generateWidgetScript($partner, 'payment');
+
+        $this->assertFalse($result['success']);
+        $this->assertNull($result['content']);
+    }
+
+    public function test_preview_widget(): void
+    {
+        $partner = $this->createMockPartner(['tier' => 'enterprise', 'branding' => $this->createMockBranding()]);
+
+        $result = $this->service->previewWidget($partner, 'balance');
+
+        $this->assertTrue($result['success']);
+        $this->assertNotNull($result['html']);
+        $this->assertStringContainsString('<!DOCTYPE html>', $result['html']);
+        $this->assertStringContainsString('Test Partner Co', $result['html']);
+        $this->assertStringContainsString('Preview', $result['html']);
+        $this->assertStringContainsString('finaegis-balance.js', $result['html']);
+    }
+
+    public function test_validate_widget_access_growth_allowed(): void
+    {
+        $partner = $this->createMockPartner(['tier' => 'growth']);
+
+        $result = $this->service->validateWidgetAccess($partner, 'payment');
+
+        $this->assertTrue($result['allowed']);
+        $this->assertNull($result['reason']);
+    }
+
+    public function test_validate_widget_access_starter_denied(): void
+    {
+        $partner = $this->createMockPartner(['tier' => 'starter']);
+
+        $result = $this->service->validateWidgetAccess($partner, 'payment');
+
+        $this->assertFalse($result['allowed']);
+        $this->assertStringContainsString('Growth or Enterprise', $result['reason']);
+    }
+
+    public function test_generate_embed_code_without_branding(): void
+    {
+        $partner = $this->createMockPartner(['tier' => 'growth', 'branding' => null]);
+
+        $result = $this->service->generateEmbedCode($partner, 'payment');
+
+        $this->assertTrue($result['success']);
+        $this->assertNotNull($result['html']);
+        $this->assertStringContainsString('finaegis-payment.js', $result['html']);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `EmbeddableWidgetService` for generating branded embed codes, widget scripts, and HTML preview pages
- Supports 5 widget types: payment, checkout, balance, transfer, account
- Tier-gated access: only Growth and Enterprise partners can use widgets
- Uses partner branding (colors, logo, company name) from `PartnerBranding` model
- 12 unit tests covering generation, tier gating, custom options, and branding fallbacks

## Test plan
- [x] All 12 widget service tests pass
- [x] PHPStan passes with 0 errors
- [x] PHP-CS-Fixer applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)