### PR TITLE
feat(baas): Add marketplace service with integrations

### DIFF
--- a/app/Domain/FinancialInstitution/Models/FinancialInstitutionPartner.php
+++ b/app/Domain/FinancialInstitution/Models/FinancialInstitutionPartner.php
@@ -475,6 +475,16 @@ class FinancialInstitutionPartner extends Model
     }
 
     /**
+     * Get the marketplace integrations for this partner.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany<PartnerIntegration, $this>
+     */
+    public function integrations(): \Illuminate\Database\Eloquent\Relations\HasMany
+    {
+        return $this->hasMany(PartnerIntegration::class, 'partner_id');
+    }
+
+    /**
      * Get usage records for this partner.
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasMany

--- a/app/Domain/FinancialInstitution/Models/PartnerIntegration.php
+++ b/app/Domain/FinancialInstitution/Models/PartnerIntegration.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\FinancialInstitution\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * @property int $id
+ * @property string $uuid
+ * @property int $partner_id
+ * @property string $category
+ * @property string $provider
+ * @property string $status
+ * @property array<string, mixed>|null $config
+ * @property string|null $webhook_url
+ * @property \Illuminate\Support\Carbon|null $last_synced_at
+ * @property int $error_count
+ * @property string|null $last_error
+ * @property array<string, mixed>|null $metadata
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Illuminate\Support\Carbon|null $deleted_at
+ * @property-read FinancialInstitutionPartner $partner
+ *
+ * @method static Builder<static> active()
+ * @method static Builder<static> forCategory(string $category)
+ */
+/** @use HasFactory<\Database\Factories\PartnerIntegrationFactory> */
+class PartnerIntegration extends Model
+{
+    /** @use HasFactory<\Database\Factories\PartnerIntegrationFactory> */
+    use HasFactory;
+
+    use HasUuids;
+    use SoftDeletes;
+
+    protected $table = 'partner_integrations';
+
+    protected $fillable = [
+        'uuid',
+        'partner_id',
+        'category',
+        'provider',
+        'status',
+        'config',
+        'webhook_url',
+        'last_synced_at',
+        'error_count',
+        'last_error',
+        'metadata',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'config'         => 'encrypted:array',
+            'metadata'       => 'array',
+            'last_synced_at' => 'datetime',
+            'error_count'    => 'integer',
+        ];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function uniqueIds(): array
+    {
+        return ['uuid'];
+    }
+
+    /**
+     * @return BelongsTo<FinancialInstitutionPartner, $this>
+     */
+    public function partner(): BelongsTo
+    {
+        return $this->belongsTo(FinancialInstitutionPartner::class, 'partner_id');
+    }
+
+    /**
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('status', 'active');
+    }
+
+    /**
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeForCategory(Builder $query, string $category): Builder
+    {
+        return $query->where('category', $category);
+    }
+
+    public function isActive(): bool
+    {
+        return $this->status === 'active';
+    }
+
+    public function recordError(string $error): void
+    {
+        $this->update([
+            'error_count' => $this->error_count + 1,
+            'last_error'  => $error,
+        ]);
+    }
+
+    public function markSynced(): void
+    {
+        $this->update([
+            'last_synced_at' => now(),
+            'error_count'    => 0,
+            'last_error'     => null,
+        ]);
+    }
+}

--- a/app/Domain/FinancialInstitution/Services/PartnerMarketplaceService.php
+++ b/app/Domain/FinancialInstitution/Services/PartnerMarketplaceService.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\FinancialInstitution\Services;
+
+use App\Domain\FinancialInstitution\Models\FinancialInstitutionPartner;
+use App\Domain\FinancialInstitution\Models\PartnerIntegration;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+/**
+ * Manages partner marketplace integrations (connectors to third-party providers).
+ */
+class PartnerMarketplaceService
+{
+    /**
+     * List available integration categories and providers from config.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public function listAvailableIntegrations(): array
+    {
+        return config('baas.marketplace.integration_categories', []);
+    }
+
+    /**
+     * Enable an integration for a partner.
+     *
+     * @param  array<string, mixed>  $integrationConfig
+     * @return array{success: bool, message: string, integration: PartnerIntegration|null}
+     */
+    public function enableIntegration(
+        FinancialInstitutionPartner $partner,
+        string $category,
+        string $provider,
+        array $integrationConfig = [],
+    ): array {
+        if (! config('baas.marketplace.enabled', true)) {
+            return [
+                'success'     => false,
+                'message'     => 'Marketplace integrations are currently disabled',
+                'integration' => null,
+            ];
+        }
+
+        $categories = $this->listAvailableIntegrations();
+
+        if (! isset($categories[$category])) {
+            return [
+                'success'     => false,
+                'message'     => "Unknown integration category: {$category}",
+                'integration' => null,
+            ];
+        }
+
+        if (! in_array($provider, $categories[$category]['providers'] ?? [], true)) {
+            return [
+                'success'     => false,
+                'message'     => "Provider '{$provider}' is not available in category '{$category}'",
+                'integration' => null,
+            ];
+        }
+
+        // Check for existing active integration
+        $existing = PartnerIntegration::where('partner_id', $partner->id)
+            ->where('category', $category)
+            ->where('provider', $provider)
+            ->whereNull('deleted_at')
+            ->first();
+
+        if ($existing && $existing->isActive()) {
+            return [
+                'success'     => false,
+                'message'     => "Integration for {$provider} in {$category} is already active",
+                'integration' => $existing,
+            ];
+        }
+
+        if ($existing) {
+            $existing->update([
+                'status' => 'active',
+                'config' => $integrationConfig ?: $existing->config,
+            ]);
+            $integration = $existing->fresh();
+        } else {
+            $integration = PartnerIntegration::create([
+                'uuid'       => (string) Str::uuid(),
+                'partner_id' => $partner->id,
+                'category'   => $category,
+                'provider'   => $provider,
+                'status'     => 'active',
+                'config'     => $integrationConfig,
+                'metadata'   => [],
+            ]);
+        }
+
+        Log::info('Partner integration enabled', [
+            'partner_id' => $partner->id,
+            'category'   => $category,
+            'provider'   => $provider,
+        ]);
+
+        return [
+            'success'     => true,
+            'message'     => "Integration for {$provider} enabled successfully",
+            'integration' => $integration,
+        ];
+    }
+
+    /**
+     * Disable an integration for a partner.
+     *
+     * @return array{success: bool, message: string}
+     */
+    public function disableIntegration(
+        FinancialInstitutionPartner $partner,
+        int $integrationId,
+    ): array {
+        $integration = PartnerIntegration::where('partner_id', $partner->id)
+            ->where('id', $integrationId)
+            ->first();
+
+        if (! $integration) {
+            return [
+                'success' => false,
+                'message' => 'Integration not found',
+            ];
+        }
+
+        $integration->update(['status' => 'disabled']);
+
+        Log::info('Partner integration disabled', [
+            'partner_id'     => $partner->id,
+            'integration_id' => $integrationId,
+        ]);
+
+        return [
+            'success' => true,
+            'message' => "Integration for {$integration->provider} disabled",
+        ];
+    }
+
+    /**
+     * Get a partner's active integrations.
+     *
+     * @return Collection<int, PartnerIntegration>
+     */
+    public function getPartnerIntegrations(FinancialInstitutionPartner $partner): Collection
+    {
+        return PartnerIntegration::where('partner_id', $partner->id)
+            ->active()
+            ->get();
+    }
+
+    /**
+     * Test an integration connection (demo: always succeeds).
+     *
+     * @return array{success: bool, message: string, latency_ms: int}
+     */
+    public function testConnection(
+        FinancialInstitutionPartner $partner,
+        int $integrationId,
+    ): array {
+        $integration = PartnerIntegration::where('partner_id', $partner->id)
+            ->where('id', $integrationId)
+            ->first();
+
+        if (! $integration) {
+            return [
+                'success'    => false,
+                'message'    => 'Integration not found',
+                'latency_ms' => 0,
+            ];
+        }
+
+        // Demo mode: simulate a connection test
+        $latency = random_int(50, 200);
+
+        $integration->markSynced();
+
+        return [
+            'success'    => true,
+            'message'    => "Connection to {$integration->provider} successful",
+            'latency_ms' => $latency,
+        ];
+    }
+
+    /**
+     * Get integration health overview for a partner.
+     *
+     * @return array{total: int, active: int, errored: int, health_score: float}
+     */
+    public function getIntegrationHealth(FinancialInstitutionPartner $partner): array
+    {
+        $integrations = PartnerIntegration::where('partner_id', $partner->id)
+            ->whereNull('deleted_at')
+            ->get();
+
+        $total = $integrations->count();
+        $active = $integrations->where('status', 'active')->count();
+        $errored = $integrations->where('error_count', '>', 0)->count();
+
+        $healthScore = $total > 0
+            ? round((($active - $errored) / $total) * 100, 1)
+            : 100.0;
+
+        return [
+            'total'        => $total,
+            'active'       => $active,
+            'errored'      => $errored,
+            'health_score' => max(0.0, $healthScore),
+        ];
+    }
+}

--- a/database/factories/PartnerIntegrationFactory.php
+++ b/database/factories/PartnerIntegrationFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Domain\FinancialInstitution\Models\FinancialInstitutionPartner;
+use App\Domain\FinancialInstitution\Models\PartnerIntegration;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PartnerIntegration>
+ */
+class PartnerIntegrationFactory extends Factory
+{
+    protected $model = PartnerIntegration::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'uuid'        => fake()->uuid(),
+            'partner_id'  => FinancialInstitutionPartner::factory(),
+            'category'    => fake()->randomElement(['payment_processors', 'identity_providers', 'kyc_providers', 'accounting', 'analytics']),
+            'provider'    => fake()->randomElement(['stripe', 'okta', 'jumio', 'xero', 'mixpanel']),
+            'status'      => 'pending',
+            'config'      => ['api_key' => 'test_key_123'],
+            'webhook_url' => fake()->url(),
+            'error_count' => 0,
+            'metadata'    => [],
+        ];
+    }
+
+    public function active(): static
+    {
+        return $this->state(fn () => ['status' => 'active']);
+    }
+
+    public function disabled(): static
+    {
+        return $this->state(fn () => ['status' => 'disabled']);
+    }
+}

--- a/database/migrations/2026_02_09_100000_create_partner_integrations_table.php
+++ b/database/migrations/2026_02_09_100000_create_partner_integrations_table.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('partner_integrations', function (Blueprint $table) {
+            $table->id();
+            $table->uuid('uuid')->unique();
+            $table->foreignId('partner_id')->constrained('financial_institution_partners')->cascadeOnDelete();
+            $table->string('category');
+            $table->string('provider');
+            $table->string('status')->default('pending'); // pending, active, disabled
+            $table->json('config')->nullable(); // encrypted at application level
+            $table->string('webhook_url')->nullable();
+            $table->timestamp('last_synced_at')->nullable();
+            $table->unsignedInteger('error_count')->default(0);
+            $table->text('last_error')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->unique(['partner_id', 'category', 'provider']);
+            $table->index(['partner_id', 'status']);
+            $table->index('category');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('partner_integrations');
+    }
+};

--- a/tests/Unit/Domain/FinancialInstitution/Services/PartnerMarketplaceServiceTest.php
+++ b/tests/Unit/Domain/FinancialInstitution/Services/PartnerMarketplaceServiceTest.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\FinancialInstitution\Services;
+
+use App\Domain\FinancialInstitution\Models\FinancialInstitutionApplication;
+use App\Domain\FinancialInstitution\Models\FinancialInstitutionPartner;
+use App\Domain\FinancialInstitution\Services\PartnerMarketplaceService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PartnerMarketplaceServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private PartnerMarketplaceService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new PartnerMarketplaceService();
+    }
+
+    private function createPartnerApplication(): FinancialInstitutionApplication
+    {
+        return FinancialInstitutionApplication::create([
+            'application_number'       => 'FIA-2026-' . fake()->unique()->numerify('#####'),
+            'institution_name'         => 'Test Partner',
+            'legal_name'               => 'Test Partner Ltd',
+            'registration_number'      => 'REG-123456',
+            'tax_id'                   => 'TAX-123456',
+            'country'                  => 'US',
+            'institution_type'         => 'fintech',
+            'years_in_operation'       => 5,
+            'contact_name'             => 'John Doe',
+            'contact_email'            => 'john@test.com',
+            'contact_phone'            => '+1234567890',
+            'contact_position'         => 'CTO',
+            'headquarters_address'     => '123 Test St',
+            'headquarters_city'        => 'New York',
+            'headquarters_postal_code' => '10001',
+            'headquarters_country'     => 'US',
+            'business_description'     => 'Test fintech partner',
+            'target_markets'           => ['US', 'EU'],
+            'product_offerings'        => ['payments'],
+            'required_currencies'      => ['USD'],
+            'integration_requirements' => ['api'],
+            'status'                   => 'approved',
+        ]);
+    }
+
+    private function createPartner(array $attributes = []): FinancialInstitutionPartner
+    {
+        $application = $this->createPartnerApplication();
+
+        return FinancialInstitutionPartner::create(array_merge([
+            'application_id'        => $application->id,
+            'partner_code'          => 'TST-' . fake()->unique()->numerify('####'),
+            'institution_name'      => 'Test Partner',
+            'legal_name'            => 'Test Partner Ltd',
+            'institution_type'      => 'fintech',
+            'country'               => 'US',
+            'status'                => 'active',
+            'tier'                  => 'growth',
+            'billing_cycle'         => 'monthly',
+            'api_client_id'         => 'test_client_' . fake()->unique()->numerify('####'),
+            'api_client_secret'     => encrypt('test_secret_123'),
+            'webhook_secret'        => encrypt('webhook_secret_123'),
+            'sandbox_enabled'       => true,
+            'production_enabled'    => false,
+            'rate_limit_per_minute' => 300,
+            'fee_structure'         => ['base' => 0],
+            'risk_rating'           => 'low',
+            'risk_score'            => 10.00,
+            'primary_contact'       => ['name' => 'Test', 'email' => 'test@example.com'],
+        ], $attributes));
+    }
+
+    public function test_list_available_integrations(): void
+    {
+        $integrations = $this->service->listAvailableIntegrations();
+
+        $this->assertIsArray($integrations);
+        $this->assertArrayHasKey('payment_processors', $integrations);
+        $this->assertArrayHasKey('identity_providers', $integrations);
+        $this->assertArrayHasKey('kyc_providers', $integrations);
+        $this->assertArrayHasKey('accounting', $integrations);
+        $this->assertArrayHasKey('analytics', $integrations);
+    }
+
+    public function test_enable_integration_success(): void
+    {
+        $partner = $this->createPartner();
+
+        $result = $this->service->enableIntegration($partner, 'payment_processors', 'stripe', [
+            'api_key' => 'sk_test_123',
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertNotNull($result['integration']);
+        $this->assertEquals('stripe', $result['integration']->provider);
+        $this->assertEquals('active', $result['integration']->status);
+    }
+
+    public function test_enable_integration_invalid_category(): void
+    {
+        $partner = $this->createPartner();
+
+        $result = $this->service->enableIntegration($partner, 'nonexistent_category', 'stripe');
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('Unknown integration category', $result['message']);
+    }
+
+    public function test_enable_integration_invalid_provider(): void
+    {
+        $partner = $this->createPartner();
+
+        $result = $this->service->enableIntegration($partner, 'payment_processors', 'nonexistent_provider');
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('not available', $result['message']);
+    }
+
+    public function test_enable_integration_already_active(): void
+    {
+        $partner = $this->createPartner();
+
+        $this->service->enableIntegration($partner, 'payment_processors', 'stripe');
+        $result = $this->service->enableIntegration($partner, 'payment_processors', 'stripe');
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('already active', $result['message']);
+    }
+
+    public function test_enable_integration_reactivates_disabled(): void
+    {
+        $partner = $this->createPartner();
+
+        $enableResult = $this->service->enableIntegration($partner, 'payment_processors', 'stripe');
+        $this->service->disableIntegration($partner, $enableResult['integration']->id);
+        $result = $this->service->enableIntegration($partner, 'payment_processors', 'stripe');
+
+        $this->assertTrue($result['success']);
+        $this->assertEquals('active', $result['integration']->status);
+    }
+
+    public function test_disable_integration(): void
+    {
+        $partner = $this->createPartner();
+
+        $enableResult = $this->service->enableIntegration($partner, 'payment_processors', 'stripe');
+        $result = $this->service->disableIntegration($partner, $enableResult['integration']->id);
+
+        $this->assertTrue($result['success']);
+        $this->assertStringContainsString('disabled', $result['message']);
+    }
+
+    public function test_disable_integration_not_found(): void
+    {
+        $partner = $this->createPartner();
+
+        $result = $this->service->disableIntegration($partner, 999999);
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('not found', $result['message']);
+    }
+
+    public function test_get_partner_integrations(): void
+    {
+        $partner = $this->createPartner();
+
+        $this->service->enableIntegration($partner, 'payment_processors', 'stripe');
+        $this->service->enableIntegration($partner, 'analytics', 'mixpanel');
+
+        $integrations = $this->service->getPartnerIntegrations($partner);
+
+        $this->assertCount(2, $integrations);
+    }
+
+    public function test_test_connection(): void
+    {
+        $partner = $this->createPartner();
+
+        $enableResult = $this->service->enableIntegration($partner, 'payment_processors', 'stripe');
+        $result = $this->service->testConnection($partner, $enableResult['integration']->id);
+
+        $this->assertTrue($result['success']);
+        $this->assertGreaterThan(0, $result['latency_ms']);
+        $this->assertStringContainsString('stripe', $result['message']);
+    }
+
+    public function test_test_connection_not_found(): void
+    {
+        $partner = $this->createPartner();
+
+        $result = $this->service->testConnection($partner, 999999);
+
+        $this->assertFalse($result['success']);
+        $this->assertEquals(0, $result['latency_ms']);
+    }
+
+    public function test_get_integration_health(): void
+    {
+        $partner = $this->createPartner();
+
+        $this->service->enableIntegration($partner, 'payment_processors', 'stripe');
+        $this->service->enableIntegration($partner, 'analytics', 'mixpanel');
+
+        $health = $this->service->getIntegrationHealth($partner);
+
+        $this->assertEquals(2, $health['total']);
+        $this->assertEquals(2, $health['active']);
+        $this->assertEquals(0, $health['errored']);
+        $this->assertEquals(100.0, $health['health_score']);
+    }
+
+    public function test_get_integration_health_with_errors(): void
+    {
+        $partner = $this->createPartner();
+
+        $enableResult = $this->service->enableIntegration($partner, 'payment_processors', 'stripe');
+        $enableResult['integration']->recordError('Connection timeout');
+
+        $this->service->enableIntegration($partner, 'analytics', 'mixpanel');
+
+        $health = $this->service->getIntegrationHealth($partner);
+
+        $this->assertEquals(2, $health['total']);
+        $this->assertEquals(2, $health['active']);
+        $this->assertEquals(1, $health['errored']);
+        $this->assertEquals(50.0, $health['health_score']);
+    }
+
+    public function test_get_integration_health_no_integrations(): void
+    {
+        $partner = $this->createPartner();
+
+        $health = $this->service->getIntegrationHealth($partner);
+
+        $this->assertEquals(0, $health['total']);
+        $this->assertEquals(100.0, $health['health_score']);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `PartnerMarketplaceService` for managing third-party integration connectors
- Adds `PartnerIntegration` model with migration, factory, and encrypted config
- 5 integration categories: payment processors, identity providers, KYC, accounting, analytics
- Adds `integrations()` HasMany relationship to `FinancialInstitutionPartner`
- 14 tests covering CRUD operations, validation, health scoring, and connection testing

## Test plan
- [x] All 14 marketplace service tests pass
- [x] PHPStan passes with 0 errors on all new/modified files
- [x] PHP-CS-Fixer applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)