### PR TITLE
feat(mobile-api): Auth fixes, CORS, route aliases (v2.10.0 PR 1/4)

### DIFF
--- a/app/Http/Controllers/Api/Auth/AccountDeletionController.php
+++ b/app/Http/Controllers/Api/Auth/AccountDeletionController.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class AccountDeletionController extends Controller
+{
+    /**
+     * Soft-delete the authenticated user's account and revoke all tokens.
+     *
+     * POST /auth/delete-account
+     */
+    public function __invoke(Request $request): JsonResponse
+    {
+        $request->validate([
+            'confirmation' => ['required', 'string', 'in:DELETE'],
+        ]);
+
+        $user = $request->user();
+
+        if (! $user) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'UNAUTHENTICATED',
+                    'message' => 'No authenticated user.',
+                ],
+            ], 401);
+        }
+
+        Log::warning('Account deletion requested', [
+            'user_id' => $user->id,
+            'email'   => $user->email,
+            'ip'      => $request->ip(),
+        ]);
+
+        // Revoke all tokens
+        $user->tokens()->delete();
+
+        // Soft-delete the user
+        $user->delete();
+
+        return response()->json([
+            'success' => true,
+            'data'    => [
+                'message'    => 'Account has been scheduled for deletion.',
+                'deleted_at' => now()->toIso8601String(),
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/Auth/LoginController.php
+++ b/app/Http/Controllers/Api/Auth/LoginController.php
@@ -48,17 +48,22 @@ class LoginController extends Controller
      *
      * @OA\JsonContent(
      *
+     * @OA\Property(property="success",           type="boolean", example=true),
      * @OA\Property(
-     *                 property="user",
+     *                 property="data",
      *                 type="object",
+     * @OA\Property(
+     *                     property="user",
+     *                     type="object",
      * @OA\Property(property="id",                type="integer", example=1),
      * @OA\Property(property="name",              type="string", example="John Doe"),
      * @OA\Property(property="email",             type="string", example="john@example.com"),
      * @OA\Property(property="email_verified_at", type="string", nullable=true)
-     *             ),
+     *                 ),
      * @OA\Property(property="access_token",      type="string", example="2|VVGVrIVokPBXkWLOi2yK13eHlQwQtQQONX5GCngZ..."),
      * @OA\Property(property="token_type",        type="string", example="Bearer"),
      * @OA\Property(property="expires_in",        type="integer", nullable=true, example=null, description="Token expiration time in seconds")
+     *             )
      *         )
      *     ),
      *
@@ -124,10 +129,13 @@ class LoginController extends Controller
 
         return response()->json(
             [
-                'user'         => $user,
-                'access_token' => $plainToken,
-                'token_type'   => 'Bearer',
-                'expires_in'   => config('sanctum.expiration') ? config('sanctum.expiration') * 60 : null,
+                'success' => true,
+                'data'    => [
+                    'user'         => $user,
+                    'access_token' => $plainToken,
+                    'token_type'   => 'Bearer',
+                    'expires_in'   => config('sanctum.expiration') ? config('sanctum.expiration') * 60 : null,
+                ],
             ]
         );
     }
@@ -193,8 +201,9 @@ class LoginController extends Controller
      *
      * @OA\JsonContent(
      *
+     * @OA\Property(property="success",           type="boolean", example=true),
      * @OA\Property(
-     *                 property="user",
+     *                 property="data",
      *                 type="object",
      * @OA\Property(property="id",                type="integer", example=1),
      * @OA\Property(property="name",              type="string", example="John Doe"),
@@ -220,7 +229,8 @@ class LoginController extends Controller
     {
         return response()->json(
             [
-                'user' => $request->user(),
+                'success' => true,
+                'data'    => $request->user(),
             ]
         );
     }

--- a/config/cors.php
+++ b/config/cors.php
@@ -35,7 +35,7 @@ return [
 
     'allowed_origins_patterns' => [],
 
-    'allowed_headers' => ['Content-Type', 'Authorization', 'X-Requested-With', 'X-CSRF-TOKEN', 'Accept', 'Origin'],
+    'allowed_headers' => ['Content-Type', 'Authorization', 'X-Requested-With', 'X-CSRF-TOKEN', 'Accept', 'Origin', 'X-Client-Platform', 'X-Client-Version'],
 
     'exposed_headers' => [],
 

--- a/tests/Feature/Api/Auth/RegisterControllerTest.php
+++ b/tests/Feature/Api/Auth/RegisterControllerTest.php
@@ -106,6 +106,6 @@ class RegisterControllerTest extends ControllerTestCase
         // Test that the token works
         $authResponse = $this->withToken($token)->getJson('/api/auth/user');
         $authResponse->assertOk()
-            ->assertJsonPath('user.email', 'john@example.com');
+            ->assertJsonPath('data.email', 'john@example.com');
     }
 }

--- a/tests/Feature/Security/ConcurrentSessionTest.php
+++ b/tests/Feature/Security/ConcurrentSessionTest.php
@@ -36,7 +36,7 @@ class ConcurrentSessionTest extends TestCase
             ]);
 
             $response->assertOk();
-            $tokens[] = $response->json('access_token');
+            $tokens[] = $response->json('data.access_token');
         }
 
         // Verify 5 tokens exist
@@ -50,7 +50,7 @@ class ConcurrentSessionTest extends TestCase
         ]);
 
         $response->assertOk();
-        $tokens[] = $response->json('access_token');
+        $tokens[] = $response->json('data.access_token');
 
         // Still only 5 tokens
         $this->assertEquals(5, $this->user->tokens()->count());

--- a/tests/Feature/Security/TokenExpirationTest.php
+++ b/tests/Feature/Security/TokenExpirationTest.php
@@ -31,12 +31,15 @@ class TokenExpirationTest extends TestCase
 
         $response->assertOk();
         $response->assertJsonStructure([
-            'access_token',
-            'expires_in',
+            'success',
+            'data' => [
+                'access_token',
+                'expires_in',
+            ],
         ]);
 
         // Check that expires_in is set correctly (60 minutes = 3600 seconds)
-        $this->assertEquals(3600, $response->json('expires_in'));
+        $this->assertEquals(3600, $response->json('data.expires_in'));
 
         // Check database for token expiration
         $token = $this->user->tokens()->first();
@@ -156,7 +159,7 @@ class TokenExpirationTest extends TestCase
         ]);
 
         $response->assertOk();
-        $this->assertNull($response->json('expires_in'));
+        $this->assertNull($response->json('data.expires_in'));
 
         // Token should not have expires_at set
         $token = $this->user->tokens()->first();
@@ -174,7 +177,7 @@ class TokenExpirationTest extends TestCase
         ]);
 
         $response->assertOk();
-        $this->assertEquals(7200, $response->json('expires_in')); // 120 minutes = 7200 seconds
+        $this->assertEquals(7200, $response->json('data.expires_in')); // 120 minutes = 7200 seconds
 
         // Check database
         $token = $this->user->tokens()->first();

--- a/tests/Integration/Domain/KeyManagement/HsmProviderSwitchingTest.php
+++ b/tests/Integration/Domain/KeyManagement/HsmProviderSwitchingTest.php
@@ -2,9 +2,6 @@
 
 declare(strict_types=1);
 
-use App\Domain\KeyManagement\HSM\AwsKmsHsmProvider;
-use App\Domain\KeyManagement\HSM\AzureKeyVaultHsmProvider;
-use App\Domain\KeyManagement\HSM\DemoHsmProvider;
 use App\Domain\KeyManagement\HSM\HsmIntegrationService;
 use Illuminate\Support\Facades\Cache;
 
@@ -24,7 +21,7 @@ describe('HSM Provider Switching', function (): void {
     });
 
     it('supports injecting a custom provider', function (): void {
-        $mockProvider = Mockery::mock(\App\Domain\KeyManagement\Contracts\HsmProviderInterface::class);
+        $mockProvider = Mockery::mock(App\Domain\KeyManagement\Contracts\HsmProviderInterface::class);
         $mockProvider->shouldReceive('isAvailable')->andReturn(true);
         $mockProvider->shouldReceive('getProviderName')->andReturn('custom');
 

--- a/tests/Security/Authentication/AuthenticationSecurityTest.php
+++ b/tests/Security/Authentication/AuthenticationSecurityTest.php
@@ -162,7 +162,7 @@ class AuthenticationSecurityTest extends TestCase
             'email'    => $user->email,
             'password' => 'password',
         ]);
-        $token1 = $response1->json('access_token');
+        $token1 = $response1->json('data.access_token');
 
         // Create second session
         $response2 = $this->postJson('/api/auth/login', [
@@ -170,7 +170,7 @@ class AuthenticationSecurityTest extends TestCase
             'password'    => 'password',
             'device_name' => 'second-device',
         ]);
-        $token2 = $response2->json('access_token');
+        $token2 = $response2->json('data.access_token');
 
         // Create third session
         $response3 = $this->postJson('/api/auth/login', [
@@ -178,7 +178,7 @@ class AuthenticationSecurityTest extends TestCase
             'password'    => 'password',
             'device_name' => 'third-device',
         ]);
-        $token3 = $response3->json('access_token');
+        $token3 = $response3->json('data.access_token');
 
         // Create fourth session
         $response4 = $this->postJson('/api/auth/login', [
@@ -186,7 +186,7 @@ class AuthenticationSecurityTest extends TestCase
             'password'    => 'password',
             'device_name' => 'fourth-device',
         ]);
-        $token4 = $response4->json('access_token');
+        $token4 = $response4->json('data.access_token');
 
         // Check that we have tokens
         $this->assertNotNull($token4);
@@ -209,7 +209,7 @@ class AuthenticationSecurityTest extends TestCase
             'password' => 'password',
         ]);
 
-        $token = $response->json('access_token');
+        $token = $response->json('data.access_token');
 
         // Check the token works
         $this->withHeader('Authorization', 'Bearer ' . $token)
@@ -353,7 +353,7 @@ class AuthenticationSecurityTest extends TestCase
             'password' => 'password',
         ]);
 
-        $token = $response->json('access_token');
+        $token = $response->json('data.access_token');
 
         // Verify token works
         $this->withHeader('Authorization', 'Bearer ' . $token)

--- a/tests/Security/ComprehensiveSecurityTest.php
+++ b/tests/Security/ComprehensiveSecurityTest.php
@@ -368,7 +368,7 @@ class ComprehensiveSecurityTest extends TestCase
         ]);
 
         $response->assertSuccessful();
-        $token = $response->json('access_token');
+        $token = $response->json('data.access_token');
         $this->assertNotNull($token, 'Login should return an access token');
 
         // Test session timeout (configured to 60 minutes in sanctum config)
@@ -389,7 +389,7 @@ class ComprehensiveSecurityTest extends TestCase
             ]);
 
             $response->assertSuccessful();
-            $token = $response->json('access_token');
+            $token = $response->json('data.access_token');
             $this->assertNotNull($token, "Token should not be null for iteration $i");
             $tokens[] = $token;
         }
@@ -445,8 +445,8 @@ class ComprehensiveSecurityTest extends TestCase
 
         $response->assertOk();
 
-        // The response structure is { "user": {...} }
-        $userData = $response->json('user');
+        // The response structure is { "success": true, "data": {...} }
+        $userData = $response->json('data');
 
         // Password should never be in response
         $this->assertArrayNotHasKey('password', $userData);

--- a/tests/Unit/Domain/Security/Services/SecurityAuditServiceTest.php
+++ b/tests/Unit/Domain/Security/Services/SecurityAuditServiceTest.php
@@ -103,15 +103,15 @@ describe('SecurityAuditService', function (): void {
 
 describe('SecurityAuditReport', function (): void {
     it('calculates grade from score', function (): void {
-        expect(\App\Domain\Security\ValueObjects\SecurityAuditReport::gradeFromScore(95))->toBe('A');
-        expect(\App\Domain\Security\ValueObjects\SecurityAuditReport::gradeFromScore(85))->toBe('B');
-        expect(\App\Domain\Security\ValueObjects\SecurityAuditReport::gradeFromScore(75))->toBe('C');
-        expect(\App\Domain\Security\ValueObjects\SecurityAuditReport::gradeFromScore(65))->toBe('D');
-        expect(\App\Domain\Security\ValueObjects\SecurityAuditReport::gradeFromScore(50))->toBe('F');
+        expect(App\Domain\Security\ValueObjects\SecurityAuditReport::gradeFromScore(95))->toBe('A');
+        expect(App\Domain\Security\ValueObjects\SecurityAuditReport::gradeFromScore(85))->toBe('B');
+        expect(App\Domain\Security\ValueObjects\SecurityAuditReport::gradeFromScore(75))->toBe('C');
+        expect(App\Domain\Security\ValueObjects\SecurityAuditReport::gradeFromScore(65))->toBe('D');
+        expect(App\Domain\Security\ValueObjects\SecurityAuditReport::gradeFromScore(50))->toBe('F');
     });
 
     it('reports isPassing correctly', function (): void {
-        $report = new \App\Domain\Security\ValueObjects\SecurityAuditReport(
+        $report = new App\Domain\Security\ValueObjects\SecurityAuditReport(
             checks: [],
             overallScore: 80,
             grade: 'B',
@@ -123,7 +123,7 @@ describe('SecurityAuditReport', function (): void {
     });
 
     it('serializes to array', function (): void {
-        $report = new \App\Domain\Security\ValueObjects\SecurityAuditReport(
+        $report = new App\Domain\Security\ValueObjects\SecurityAuditReport(
             checks: [
                 new SecurityCheckResult(
                     name: 'test',

--- a/tests/Unit/Http/Controllers/Api/Auth/MobileAuthCompatTest.php
+++ b/tests/Unit/Http/Controllers/Api/Auth/MobileAuthCompatTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Mobile\Services\MobileDeviceService;
+use App\Domain\Mobile\Services\PasskeyAuthenticationService;
+use App\Http\Controllers\Api\Auth\AccountDeletionController;
+use App\Http\Controllers\Api\Auth\LoginController;
+use App\Http\Controllers\Api\Auth\PasskeyController;
+use App\Models\User;
+use App\Services\IpBlockingService;
+use Illuminate\Http\Request;
+use Tests\UnitTestCase;
+
+uses(UnitTestCase::class);
+
+describe('LoginController response envelope', function (): void {
+    it('wraps user/me response in { success, data } envelope', function (): void {
+        $ipBlockingService = Mockery::mock(IpBlockingService::class);
+        $controller = new LoginController($ipBlockingService);
+
+        $user = Mockery::mock(User::class)->makePartial();
+        $user->id = 1;
+        $user->name = 'Test User';
+        $user->email = 'test@example.com';
+
+        $request = Request::create('/api/auth/user', 'GET');
+        $request->setUserResolver(fn () => $user);
+
+        $response = $controller->user($request);
+        $data = $response->getData(true);
+
+        expect($data)->toHaveKey('success')
+            ->and($data['success'])->toBeTrue()
+            ->and($data)->toHaveKey('data');
+    });
+
+    it('login method returns success and data keys in response', function (): void {
+        // Verify the login method source code returns the { success, data } envelope
+        $reflection = new ReflectionMethod(LoginController::class, 'login');
+        $source = file_get_contents($reflection->getFileName());
+
+        expect($source)->toContain("'success' => true")
+            ->and($source)->toContain("'data'    => [")
+            ->and($source)->toContain("'access_token' => \$plainToken");
+    });
+});
+
+describe('AccountDeletionController', function (): void {
+    it('requires confirmation string DELETE', function (): void {
+        $controller = new AccountDeletionController();
+
+        $request = Request::create('/api/auth/delete-account', 'POST', [
+            'confirmation' => 'DELETE',
+        ]);
+
+        $user = Mockery::mock(User::class)->makePartial();
+        $user->id = 1;
+        $user->email = 'test@example.com';
+        $user->shouldReceive('tokens->delete')->once();
+        $user->shouldReceive('delete')->once();
+        $request->setUserResolver(fn () => $user);
+
+        $response = $controller($request);
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue()
+            ->and($data['data'])->toHaveKey('message')
+            ->and($data['data']['message'])->toContain('deletion');
+    });
+
+    it('rejects request without proper confirmation', function (): void {
+        $controller = new AccountDeletionController();
+
+        $request = Request::create('/api/auth/delete-account', 'POST', [
+            'confirmation' => 'wrong',
+        ]);
+
+        $user = Mockery::mock(User::class)->makePartial();
+        $request->setUserResolver(fn () => $user);
+
+        $controller($request);
+    })->throws(Illuminate\Validation\ValidationException::class);
+});
+
+describe('PasskeyController register', function (): void {
+    it('registers a passkey for the authenticated user device', function (): void {
+        $passkeyService = Mockery::mock(PasskeyAuthenticationService::class);
+        $deviceService = Mockery::mock(MobileDeviceService::class);
+
+        $device = Mockery::mock(App\Domain\Mobile\Models\MobileDevice::class)->makePartial();
+        $device->user_id = 1;
+
+        $deviceService->shouldReceive('findByDeviceId')
+            ->with('device-123')
+            ->andReturn($device);
+
+        $passkeyService->shouldReceive('registerPasskey')
+            ->with($device, 'cred-id-abc', 'pub-key-xyz')
+            ->andReturn([
+                'credential_id' => 'cred-id-abc',
+                'registered_at' => now()->toIso8601String(),
+            ]);
+
+        $controller = new PasskeyController($passkeyService, $deviceService);
+
+        $user = Mockery::mock(User::class)->makePartial();
+        $user->id = 1;
+
+        $request = Request::create('/api/auth/passkey/register', 'POST', [
+            'device_id'     => 'device-123',
+            'credential_id' => 'cred-id-abc',
+            'public_key'    => 'pub-key-xyz',
+        ]);
+        $request->setUserResolver(fn () => $user);
+
+        $response = $controller->register($request);
+        $data = $response->getData(true);
+
+        expect($response->getStatusCode())->toBe(201)
+            ->and($data['success'])->toBeTrue()
+            ->and($data['data'])->toHaveKey('credential_id');
+    });
+
+    it('rejects register for device not belonging to user', function (): void {
+        $passkeyService = Mockery::mock(PasskeyAuthenticationService::class);
+        $deviceService = Mockery::mock(MobileDeviceService::class);
+
+        $device = Mockery::mock(App\Domain\Mobile\Models\MobileDevice::class)->makePartial();
+        $device->user_id = 999; // Different user
+
+        $deviceService->shouldReceive('findByDeviceId')
+            ->with('device-123')
+            ->andReturn($device);
+
+        $controller = new PasskeyController($passkeyService, $deviceService);
+
+        $user = Mockery::mock(User::class)->makePartial();
+        $user->id = 1;
+
+        $request = Request::create('/api/auth/passkey/register', 'POST', [
+            'device_id'     => 'device-123',
+            'credential_id' => 'cred-id-abc',
+            'public_key'    => 'pub-key-xyz',
+        ]);
+        $request->setUserResolver(fn () => $user);
+
+        $response = $controller->register($request);
+
+        expect($response->getStatusCode())->toBe(403);
+    });
+
+    it('returns 404 for non-existent device', function (): void {
+        $passkeyService = Mockery::mock(PasskeyAuthenticationService::class);
+        $deviceService = Mockery::mock(MobileDeviceService::class);
+
+        $deviceService->shouldReceive('findByDeviceId')
+            ->with('nonexistent')
+            ->andReturn(null);
+
+        $controller = new PasskeyController($passkeyService, $deviceService);
+
+        $user = Mockery::mock(User::class)->makePartial();
+        $user->id = 1;
+
+        $request = Request::create('/api/auth/passkey/register', 'POST', [
+            'device_id'     => 'nonexistent',
+            'credential_id' => 'cred-id-abc',
+            'public_key'    => 'pub-key-xyz',
+        ]);
+        $request->setUserResolver(fn () => $user);
+
+        $response = $controller->register($request);
+
+        expect($response->getStatusCode())->toBe(404);
+    });
+});
+
+describe('CORS configuration', function (): void {
+    it('includes mobile client headers in allowed headers', function (): void {
+        $corsConfig = config('cors.allowed_headers');
+
+        expect($corsConfig)->toContain('X-Client-Platform')
+            ->and($corsConfig)->toContain('X-Client-Version');
+    });
+});
+
+describe('Route aliases', function (): void {
+    it('has auth/me route defined', function (): void {
+        $route = app('router')->getRoutes()->getByName('api.auth.me');
+        expect($route)->not->toBeNull();
+    });
+
+    it('has auth/delete-account route defined', function (): void {
+        $route = app('router')->getRoutes()->getByName('api.auth.delete-account');
+        expect($route)->not->toBeNull();
+    });
+
+    it('has passkey challenge GET alias defined', function (): void {
+        $route = app('router')->getRoutes()->getByName('api.auth.passkey.challenge.get');
+        expect($route)->not->toBeNull();
+    });
+
+    it('has passkey verify alias defined', function (): void {
+        $route = app('router')->getRoutes()->getByName('api.auth.passkey.verify');
+        expect($route)->not->toBeNull();
+    });
+
+    it('has passkey register route defined', function (): void {
+        $route = app('router')->getRoutes()->getByName('api.auth.passkey.register');
+        expect($route)->not->toBeNull();
+    });
+
+    it('has receipt GET alias defined', function (): void {
+        $route = app('router')->getRoutes()->getByName('mobile.transactions.receipt.get');
+        expect($route)->not->toBeNull();
+    });
+
+    it('has parameterized network status route defined', function (): void {
+        $route = app('router')->getRoutes()->getByName('mobile.networks.status.parameterized');
+        expect($route)->not->toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
- Wrap `LoginController` login/user responses in `{ success, data }` envelope for mobile client consistency
- Add route aliases for mobile path mismatches: `/auth/me`, `/auth/passkey/*`, receipt GET, parameterized network status
- Add `AccountDeletionController` for `POST /auth/delete-account` soft-delete flow
- Add passkey `register()` method to `PasskeyController`
- Add `X-Client-Platform`, `X-Client-Version` to CORS allowed headers

## Test plan
- [x] 15 new unit tests for auth envelope, account deletion, passkey register, route aliases, CORS
- [x] Updated 6 existing test files for new response envelope format
- [x] Full test suite passes: 6861 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)