### PR TITLE
feat(wallet): Mobile wallet API endpoints

### DIFF
--- a/app/Http/Controllers/Api/Wallet/MobileWalletController.php
+++ b/app/Http/Controllers/Api/Wallet/MobileWalletController.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Wallet;
+
+use App\Domain\MobilePayment\Services\ActivityFeedService;
+use App\Domain\MobilePayment\Services\PaymentIntentService;
+use App\Domain\MobilePayment\Services\TransactionDetailService;
+use App\Domain\Relayer\Enums\SupportedNetwork;
+use App\Domain\Relayer\Services\SmartAccountService;
+use App\Domain\Relayer\Services\WalletBalanceService;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Throwable;
+
+class MobileWalletController extends Controller
+{
+    public function __construct(
+        private readonly WalletBalanceService $balanceService,
+        private readonly SmartAccountService $smartAccountService,
+        private readonly ActivityFeedService $activityFeedService,
+        private readonly TransactionDetailService $transactionDetailService,
+        private readonly PaymentIntentService $paymentIntentService,
+    ) {
+    }
+
+    /**
+     * Get supported token list with network and decimals info.
+     *
+     * GET /api/v1/wallet/tokens
+     */
+    public function tokens(): JsonResponse
+    {
+        $tokens = [
+            [
+                'symbol'   => 'USDC',
+                'name'     => 'USD Coin',
+                'decimals' => 6,
+                'networks' => ['polygon', 'base', 'arbitrum', 'optimism', 'ethereum'],
+                'icon'     => 'usdc',
+            ],
+            [
+                'symbol'   => 'USDT',
+                'name'     => 'Tether USD',
+                'decimals' => 6,
+                'networks' => ['polygon', 'arbitrum', 'optimism', 'ethereum'],
+                'icon'     => 'usdt',
+            ],
+            [
+                'symbol'   => 'WETH',
+                'name'     => 'Wrapped Ether',
+                'decimals' => 18,
+                'networks' => ['polygon', 'base', 'arbitrum', 'optimism'],
+                'icon'     => 'weth',
+            ],
+            [
+                'symbol'   => 'WBTC',
+                'name'     => 'Wrapped Bitcoin',
+                'decimals' => 8,
+                'networks' => ['polygon', 'arbitrum', 'ethereum'],
+                'icon'     => 'wbtc',
+            ],
+        ];
+
+        return response()->json([
+            'success' => true,
+            'data'    => $tokens,
+        ]);
+    }
+
+    /**
+     * Get ERC-20 balances across user's smart accounts.
+     *
+     * GET /api/v1/wallet/balances
+     */
+    public function balances(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $accounts = $this->smartAccountService->getUserAccounts($user);
+
+        $balances = [];
+        $supportedTokens = ['USDC', 'USDT', 'WETH', 'WBTC'];
+
+        foreach ($accounts as $account) {
+            $networkStr = $account->network ?? 'polygon';
+            $network = SupportedNetwork::tryFrom($networkStr);
+            if (! $network) {
+                continue;
+            }
+            foreach ($supportedTokens as $token) {
+                if (! $this->balanceService->isTokenSupported($token, $network)) {
+                    continue;
+                }
+                try {
+                    $balance = $this->balanceService->getBalance(
+                        $account->account_address,
+                        $token,
+                        $network,
+                    );
+                    $balances[] = [
+                        'token'   => $token,
+                        'network' => $networkStr,
+                        'address' => $account->account_address,
+                        'balance' => $balance,
+                    ];
+                } catch (Throwable) {
+                    $balances[] = [
+                        'token'   => $token,
+                        'network' => $networkStr,
+                        'address' => $account->account_address,
+                        'balance' => '0',
+                        'error'   => 'Balance query failed',
+                    ];
+                }
+            }
+        }
+
+        return response()->json([
+            'success' => true,
+            'data'    => $balances,
+        ]);
+    }
+
+    /**
+     * Get aggregated wallet state (balances + addresses + sync info).
+     *
+     * GET /api/v1/wallet/state
+     */
+    public function state(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $accounts = $this->smartAccountService->getUserAccounts($user);
+
+        $addresses = [];
+        foreach ($accounts as $account) {
+            $addresses[] = [
+                'address'  => $account->account_address,
+                'network'  => $account->network ?? 'polygon',
+                'deployed' => $account->is_deployed ?? false,
+            ];
+        }
+
+        return response()->json([
+            'success' => true,
+            'data'    => [
+                'addresses'     => $addresses,
+                'networks'      => $this->smartAccountService->getSupportedNetworks(),
+                'synced_at'     => now()->toIso8601String(),
+                'account_count' => count($accounts),
+            ],
+        ]);
+    }
+
+    /**
+     * List user's addresses per network.
+     *
+     * GET /api/v1/wallet/addresses
+     */
+    public function addresses(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $accounts = $this->smartAccountService->getUserAccounts($user);
+
+        $addresses = [];
+        foreach ($accounts as $account) {
+            $addresses[] = [
+                'address'    => $account->account_address,
+                'network'    => $account->network ?? 'polygon',
+                'deployed'   => $account->is_deployed ?? false,
+                'created_at' => $account->created_at?->toIso8601String(),
+            ];
+        }
+
+        return response()->json([
+            'success' => true,
+            'data'    => $addresses,
+        ]);
+    }
+
+    /**
+     * Cursor-based transaction list from activity feed.
+     *
+     * GET /api/v1/wallet/transactions
+     */
+    public function transactions(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        $feed = $this->activityFeedService->getFeed(
+            userId: $user->id,
+            cursor: $request->query('cursor'),
+            limit: min((int) $request->query('limit', '20'), 100),
+        );
+
+        return response()->json([
+            'success' => true,
+            'data'    => $feed,
+        ]);
+    }
+
+    /**
+     * Get transaction detail.
+     *
+     * GET /api/v1/wallet/transactions/{id}
+     */
+    public function transactionDetail(string $id, Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $detail = $this->transactionDetailService->getDetails($id, $user->id);
+
+        if (! $detail) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'TRANSACTION_NOT_FOUND',
+                    'message' => 'Transaction not found.',
+                ],
+            ], 404);
+        }
+
+        return response()->json([
+            'success' => true,
+            'data'    => $detail,
+        ]);
+    }
+
+    /**
+     * Create and auto-submit a payment intent (send transaction).
+     *
+     * POST /api/v1/wallet/transactions/send
+     */
+    public function send(Request $request): JsonResponse
+    {
+        $request->validate([
+            'to'      => ['required', 'string'],
+            'token'   => ['required', 'string', 'in:USDC,USDT,WETH,WBTC'],
+            'amount'  => ['required', 'string'],
+            'network' => ['required', 'string'],
+        ]);
+
+        $user = $request->user();
+
+        try {
+            $intent = $this->paymentIntentService->create(
+                userId: $user->id,
+                data: [
+                    'recipient_address' => $request->input('to'),
+                    'token'             => $request->input('token'),
+                    'amount'            => $request->input('amount'),
+                    'network'           => $request->input('network'),
+                    'type'              => 'send',
+                ],
+            );
+
+            $intentId = $intent->public_id;
+
+            // Auto-submit the intent
+            $result = $this->paymentIntentService->submit($intentId, $user->id, 'wallet');
+
+            return response()->json([
+                'success' => true,
+                'data'    => $result->toApiResponse(),
+            ], 201);
+        } catch (Throwable $e) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'SEND_FAILED',
+                    'message' => $e->getMessage(),
+                ],
+            ], 422);
+        }
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -50,6 +50,7 @@ use App\Http\Controllers\Api\TransferController;
 use App\Http\Controllers\Api\Treasury\PortfolioController;
 use App\Http\Controllers\Api\UserVotingController;
 use App\Http\Controllers\Api\VoteController;
+use App\Http\Controllers\Api\Wallet\MobileWalletController;
 use App\Http\Controllers\Api\Wallet\WalletTransferController;
 use App\Http\Controllers\Api\WorkflowMonitoringController;
 use App\Http\Controllers\StatusController;
@@ -1373,6 +1374,41 @@ Route::prefix('v1')->middleware(['auth:sanctum', 'check.token.expiration'])->gro
         ->middleware('api.rate_limit:query')
         ->name('mobile.wallet.quote');
 });
+
+/*
+|--------------------------------------------------------------------------
+| Mobile Wallet API (v2.10.0)
+|--------------------------------------------------------------------------
+|
+| Wallet endpoints for mobile home screen: tokens, balances, addresses,
+| transaction history, and send flow.
+|
+*/
+Route::prefix('v1/wallet')->name('mobile.wallet.')
+    ->middleware(['auth:sanctum', 'check.token.expiration'])
+    ->group(function () {
+        Route::get('/tokens', [MobileWalletController::class, 'tokens'])
+            ->middleware('api.rate_limit:query')
+            ->name('tokens');
+        Route::get('/balances', [MobileWalletController::class, 'balances'])
+            ->middleware('api.rate_limit:query')
+            ->name('balances');
+        Route::get('/state', [MobileWalletController::class, 'state'])
+            ->middleware('api.rate_limit:query')
+            ->name('state');
+        Route::get('/addresses', [MobileWalletController::class, 'addresses'])
+            ->middleware('api.rate_limit:query')
+            ->name('addresses');
+        Route::get('/transactions', [MobileWalletController::class, 'transactions'])
+            ->middleware('api.rate_limit:query')
+            ->name('transactions');
+        Route::get('/transactions/{id}', [MobileWalletController::class, 'transactionDetail'])
+            ->middleware('api.rate_limit:query')
+            ->name('transactions.detail');
+        Route::post('/transactions/send', [MobileWalletController::class, 'send'])
+            ->middleware('transaction.rate_limit:payment_intent')
+            ->name('transactions.send');
+    });
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Unit/Http/Controllers/Api/Wallet/MobileWalletControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/Wallet/MobileWalletControllerTest.php
@@ -1,0 +1,295 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\MobilePayment\Models\PaymentIntent;
+use App\Domain\MobilePayment\Services\ActivityFeedService;
+use App\Domain\MobilePayment\Services\PaymentIntentService;
+use App\Domain\MobilePayment\Services\TransactionDetailService;
+use App\Domain\Relayer\Services\SmartAccountService;
+use App\Domain\Relayer\Services\WalletBalanceService;
+use App\Http\Controllers\Api\Wallet\MobileWalletController;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\Request;
+use Tests\UnitTestCase;
+
+uses(UnitTestCase::class);
+
+beforeEach(function (): void {
+    $this->balanceService = Mockery::mock(WalletBalanceService::class);
+    $this->smartAccountService = Mockery::mock(SmartAccountService::class);
+    $this->activityFeedService = Mockery::mock(ActivityFeedService::class);
+    $this->transactionDetailService = Mockery::mock(TransactionDetailService::class);
+    $this->paymentIntentService = Mockery::mock(PaymentIntentService::class);
+});
+
+function makeWalletController($test): MobileWalletController
+{
+    return new MobileWalletController(
+        $test->balanceService,
+        $test->smartAccountService,
+        $test->activityFeedService,
+        $test->transactionDetailService,
+        $test->paymentIntentService,
+    );
+}
+
+function walletUserRequest(string $uri = '/api/v1/wallet/tokens', string $method = 'GET', array $data = []): Request
+{
+    if ($method === 'POST') {
+        $request = Request::create($uri, $method, $data, [], [], ['CONTENT_TYPE' => 'application/json'], json_encode($data));
+    } else {
+        $request = Request::create($uri, $method, $data);
+    }
+    $user = Mockery::mock(User::class)->makePartial();
+    $user->id = 1;
+    $request->setUserResolver(fn () => $user);
+
+    return $request;
+}
+
+describe('MobileWalletController tokens', function (): void {
+    it('returns supported token list', function (): void {
+        $controller = makeWalletController($this);
+
+        $response = $controller->tokens();
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue()
+            ->and($data['data'])->toBeArray()
+            ->and(count($data['data']))->toBe(4);
+
+        $symbols = array_column($data['data'], 'symbol');
+        expect($symbols)->toContain('USDC')
+            ->and($symbols)->toContain('USDT')
+            ->and($symbols)->toContain('WETH')
+            ->and($symbols)->toContain('WBTC');
+    });
+
+    it('includes network and decimals info per token', function (): void {
+        $controller = makeWalletController($this);
+
+        $response = $controller->tokens();
+        $data = $response->getData(true);
+
+        $usdc = collect($data['data'])->firstWhere('symbol', 'USDC');
+        expect($usdc)->toHaveKeys(['symbol', 'name', 'decimals', 'networks', 'icon'])
+            ->and($usdc['decimals'])->toBe(6)
+            ->and($usdc['networks'])->toContain('polygon');
+    });
+});
+
+describe('MobileWalletController balances', function (): void {
+    it('queries balances across smart accounts', function (): void {
+        $account = (object) [
+            'account_address' => '0xabc123',
+            'network'         => 'polygon',
+        ];
+        $this->smartAccountService->shouldReceive('getUserAccounts')->andReturn(new Collection([$account]));
+        $this->balanceService->shouldReceive('isTokenSupported')->andReturn(true);
+        $this->balanceService->shouldReceive('getBalance')->andReturn('100.50');
+
+        $controller = makeWalletController($this);
+
+        $response = $controller->balances(walletUserRequest('/api/v1/wallet/balances'));
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue()
+            ->and($data['data'])->toBeArray()
+            ->and(count($data['data']))->toBeGreaterThan(0)
+            ->and($data['data'][0])->toHaveKeys(['token', 'network', 'address', 'balance']);
+    });
+
+    it('handles balance query failure gracefully', function (): void {
+        $account = (object) [
+            'account_address' => '0xabc123',
+            'network'         => 'polygon',
+        ];
+        $this->smartAccountService->shouldReceive('getUserAccounts')->andReturn(new Collection([$account]));
+        $this->balanceService->shouldReceive('isTokenSupported')->andReturn(true);
+        $this->balanceService->shouldReceive('getBalance')->andThrow(new RuntimeException('RPC error'));
+
+        $controller = makeWalletController($this);
+
+        $response = $controller->balances(walletUserRequest('/api/v1/wallet/balances'));
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue()
+            ->and($data['data'][0]['balance'])->toBe('0')
+            ->and($data['data'][0])->toHaveKey('error');
+    });
+});
+
+describe('MobileWalletController state', function (): void {
+    it('returns aggregated wallet state', function (): void {
+        $account = (object) [
+            'account_address' => '0xabc123',
+            'network'         => 'polygon',
+            'is_deployed'     => true,
+        ];
+        $this->smartAccountService->shouldReceive('getUserAccounts')->andReturn(new Collection([$account]));
+        $this->smartAccountService->shouldReceive('getSupportedNetworks')->andReturn(['polygon', 'base']);
+
+        $controller = makeWalletController($this);
+
+        $response = $controller->state(walletUserRequest('/api/v1/wallet/state'));
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue()
+            ->and($data['data'])->toHaveKeys(['addresses', 'networks', 'synced_at', 'account_count'])
+            ->and($data['data']['account_count'])->toBe(1)
+            ->and($data['data']['addresses'][0]['deployed'])->toBeTrue();
+    });
+});
+
+describe('MobileWalletController addresses', function (): void {
+    it('lists user addresses per network', function (): void {
+        $account = (object) [
+            'account_address' => '0xdef456',
+            'network'         => 'base',
+            'is_deployed'     => false,
+            'created_at'      => now(),
+        ];
+        $this->smartAccountService->shouldReceive('getUserAccounts')->andReturn(new Collection([$account]));
+
+        $controller = makeWalletController($this);
+
+        $response = $controller->addresses(walletUserRequest('/api/v1/wallet/addresses'));
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue()
+            ->and($data['data'])->toBeArray()
+            ->and($data['data'][0])->toHaveKeys(['address', 'network', 'deployed', 'created_at'])
+            ->and($data['data'][0]['address'])->toBe('0xdef456');
+    });
+});
+
+describe('MobileWalletController transactions', function (): void {
+    it('returns cursor-based transaction list', function (): void {
+        $this->activityFeedService->shouldReceive('getFeed')
+            ->andReturn([
+                'items'       => [],
+                'next_cursor' => null,
+                'has_more'    => false,
+            ]);
+
+        $controller = makeWalletController($this);
+
+        $response = $controller->transactions(walletUserRequest('/api/v1/wallet/transactions'));
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue()
+            ->and($data['data'])->toHaveKeys(['items', 'next_cursor', 'has_more']);
+    });
+});
+
+describe('MobileWalletController transactionDetail', function (): void {
+    it('returns transaction detail for existing transaction', function (): void {
+        $this->transactionDetailService->shouldReceive('getDetails')
+            ->with('tx-123', 1)
+            ->andReturn([
+                'id'     => 'tx-123',
+                'status' => 'confirmed',
+                'amount' => '50.00',
+            ]);
+
+        $controller = makeWalletController($this);
+
+        $response = $controller->transactionDetail('tx-123', walletUserRequest('/api/v1/wallet/transactions/tx-123'));
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue()
+            ->and($data['data']['id'])->toBe('tx-123');
+    });
+
+    it('returns 404 for non-existent transaction', function (): void {
+        $this->transactionDetailService->shouldReceive('getDetails')
+            ->with('tx-999', 1)
+            ->andReturn(null);
+
+        $controller = makeWalletController($this);
+
+        $response = $controller->transactionDetail('tx-999', walletUserRequest('/api/v1/wallet/transactions/tx-999'));
+
+        expect($response->getStatusCode())->toBe(404);
+    });
+});
+
+describe('MobileWalletController send', function (): void {
+    it('creates and submits a payment intent', function (): void {
+        $intentMock = Mockery::mock(PaymentIntent::class)->makePartial();
+        $intentMock->public_id = 'pi-abc';
+
+        $resultMock = Mockery::mock(PaymentIntent::class)->makePartial();
+        $resultMock->shouldReceive('toApiResponse')->andReturn([
+            'intentId' => 'pi-abc',
+            'status'   => 'SUBMITTED',
+            'tx'       => ['hash' => '0xdeadbeef'],
+        ]);
+
+        $this->paymentIntentService->shouldReceive('create')
+            ->once()
+            ->andReturn($intentMock);
+        $this->paymentIntentService->shouldReceive('submit')
+            ->with('pi-abc', 1, 'wallet')
+            ->once()
+            ->andReturn($resultMock);
+
+        $controller = makeWalletController($this);
+
+        $request = walletUserRequest('/api/v1/wallet/transactions/send', 'POST', [
+            'to'      => '0xrecipient',
+            'token'   => 'USDC',
+            'amount'  => '25.00',
+            'network' => 'polygon',
+        ]);
+
+        $response = $controller->send($request);
+        $data = $response->getData(true);
+
+        expect($response->getStatusCode())->toBe(201)
+            ->and($data['success'])->toBeTrue()
+            ->and($data['data'])->toHaveKey('status');
+    });
+
+    it('returns 422 on send failure', function (): void {
+        $this->paymentIntentService->shouldReceive('create')
+            ->andThrow(new RuntimeException('Insufficient balance'));
+
+        $controller = makeWalletController($this);
+
+        $request = walletUserRequest('/api/v1/wallet/transactions/send', 'POST', [
+            'to'      => '0xrecipient',
+            'token'   => 'USDC',
+            'amount'  => '25.00',
+            'network' => 'polygon',
+        ]);
+
+        $response = $controller->send($request);
+
+        expect($response->getStatusCode())->toBe(422);
+    });
+});
+
+describe('Wallet routes', function (): void {
+    it('has wallet tokens route defined', function (): void {
+        $route = app('router')->getRoutes()->getByName('mobile.wallet.tokens');
+        expect($route)->not->toBeNull();
+    });
+
+    it('has wallet balances route defined', function (): void {
+        $route = app('router')->getRoutes()->getByName('mobile.wallet.balances');
+        expect($route)->not->toBeNull();
+    });
+
+    it('has wallet state route defined', function (): void {
+        $route = app('router')->getRoutes()->getByName('mobile.wallet.state');
+        expect($route)->not->toBeNull();
+    });
+
+    it('has wallet transactions send route defined', function (): void {
+        $route = app('router')->getRoutes()->getByName('mobile.wallet.transactions.send');
+        expect($route)->not->toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
- Adds `MobileWalletController` with 7 endpoints for the mobile home screen: tokens, balances, state, addresses, transactions, transaction detail, and send
- Reuses existing domain services (`WalletBalanceService`, `SmartAccountService`, `ActivityFeedService`, `TransactionDetailService`, `PaymentIntentService`)
- Properly converts network strings to `SupportedNetwork` enum for balance queries
- 15 unit tests covering all endpoints + route existence checks

## Test plan
- [x] All 15 new unit tests pass
- [x] Full test suite passes (3338 passed, 1 pre-existing failure in ExchangeRateControllerTest)
- [x] Code style verified with php-cs-fixer
- [ ] Manual verification of route registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)