### PR TITLE
feat(trustcert): Mobile TrustCert API endpoints

### DIFF
--- a/app/Http/Controllers/Api/TrustCert/CertificateApplicationController.php
+++ b/app/Http/Controllers/Api/TrustCert/CertificateApplicationController.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\TrustCert;
+
+use App\Domain\TrustCert\Enums\TrustLevel;
+use App\Domain\TrustCert\Services\CertificateAuthorityService;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+
+class CertificateApplicationController extends Controller
+{
+    public function __construct(
+        private readonly CertificateAuthorityService $certificateAuthority,
+    ) {
+    }
+
+    /**
+     * Create a new certificate application.
+     *
+     * POST /api/v1/trustcert/applications
+     */
+    public function create(Request $request): JsonResponse
+    {
+        $request->validate([
+            'target_level' => ['required', 'string', 'in:basic,verified,high,ultimate'],
+        ]);
+
+        $user = $request->user();
+        $targetLevel = TrustLevel::from($request->input('target_level'));
+
+        // Check for existing active application
+        $existing = $this->getActiveApplication($user->id);
+        if ($existing) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'APPLICATION_EXISTS',
+                    'message' => 'An active application already exists.',
+                ],
+            ], 409);
+        }
+
+        $application = [
+            'id'           => 'app_' . Str::random(20),
+            'user_id'      => $user->id,
+            'target_level' => $targetLevel->value,
+            'status'       => 'draft',
+            'requirements' => $targetLevel->requirements(),
+            'documents'    => [],
+            'created_at'   => now()->toIso8601String(),
+            'updated_at'   => now()->toIso8601String(),
+            'submitted_at' => null,
+        ];
+
+        $this->storeApplication($user->id, $application);
+
+        return response()->json([
+            'success' => true,
+            'data'    => $application,
+        ], 201);
+    }
+
+    /**
+     * Get a specific application by ID.
+     *
+     * GET /api/v1/trustcert/applications/{id}
+     */
+    public function show(string $id, Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $application = $this->findApplication($user->id, $id);
+
+        if (! $application) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'APPLICATION_NOT_FOUND',
+                    'message' => 'Application not found.',
+                ],
+            ], 404);
+        }
+
+        return response()->json([
+            'success' => true,
+            'data'    => $application,
+        ]);
+    }
+
+    /**
+     * Get the user's current active application.
+     *
+     * GET /api/v1/trustcert/applications/current
+     */
+    public function currentApplication(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $application = $this->getActiveApplication($user->id);
+
+        return response()->json([
+            'success' => true,
+            'data'    => $application,
+        ]);
+    }
+
+    /**
+     * Upload documents for a certificate application.
+     *
+     * POST /api/v1/trustcert/applications/{id}/documents
+     */
+    public function uploadDocuments(string $id, Request $request): JsonResponse
+    {
+        $request->validate([
+            'document_type' => ['required', 'string', 'in:identity,address,kyc,audit'],
+            'file_name'     => ['required', 'string'],
+        ]);
+
+        $user = $request->user();
+        $application = $this->findApplication($user->id, $id);
+
+        if (! $application) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'APPLICATION_NOT_FOUND',
+                    'message' => 'Application not found.',
+                ],
+            ], 404);
+        }
+
+        if ($application['status'] !== 'draft') {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'APPLICATION_NOT_EDITABLE',
+                    'message' => 'Application is not in a draft state.',
+                ],
+            ], 422);
+        }
+
+        $document = [
+            'id'            => 'doc_' . Str::random(16),
+            'document_type' => $request->input('document_type'),
+            'file_name'     => $request->input('file_name'),
+            'uploaded_at'   => now()->toIso8601String(),
+        ];
+
+        $application['documents'][] = $document;
+        $application['updated_at'] = now()->toIso8601String();
+        $this->storeApplication($user->id, $application);
+
+        return response()->json([
+            'success' => true,
+            'data'    => $document,
+        ], 201);
+    }
+
+    /**
+     * Submit an application for review.
+     *
+     * POST /api/v1/trustcert/applications/{id}/submit
+     */
+    public function submit(string $id, Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $application = $this->findApplication($user->id, $id);
+
+        if (! $application) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'APPLICATION_NOT_FOUND',
+                    'message' => 'Application not found.',
+                ],
+            ], 404);
+        }
+
+        if ($application['status'] !== 'draft') {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'APPLICATION_NOT_SUBMITTABLE',
+                    'message' => 'Only draft applications can be submitted.',
+                ],
+            ], 422);
+        }
+
+        $application['status'] = 'submitted';
+        $application['submitted_at'] = now()->toIso8601String();
+        $application['updated_at'] = now()->toIso8601String();
+        $this->storeApplication($user->id, $application);
+
+        return response()->json([
+            'success' => true,
+            'data'    => $application,
+        ]);
+    }
+
+    /**
+     * Cancel a pending application.
+     *
+     * POST /api/v1/trustcert/applications/{id}/cancel
+     */
+    public function cancel(string $id, Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $application = $this->findApplication($user->id, $id);
+
+        if (! $application) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'APPLICATION_NOT_FOUND',
+                    'message' => 'Application not found.',
+                ],
+            ], 404);
+        }
+
+        if (in_array($application['status'], ['approved', 'cancelled'], true)) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'APPLICATION_NOT_CANCELLABLE',
+                    'message' => 'This application cannot be cancelled.',
+                ],
+            ], 422);
+        }
+
+        $application['status'] = 'cancelled';
+        $application['updated_at'] = now()->toIso8601String();
+        $this->storeApplication($user->id, $application);
+
+        return response()->json([
+            'success' => true,
+            'data'    => $application,
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function getActiveApplication(int $userId): ?array
+    {
+        $application = Cache::get("trustcert_application:{$userId}");
+
+        if (! $application || in_array($application['status'], ['approved', 'cancelled'], true)) {
+            return null;
+        }
+
+        return $application;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function findApplication(int $userId, string $id): ?array
+    {
+        $application = Cache::get("trustcert_application:{$userId}");
+
+        if (! $application || $application['id'] !== $id) {
+            return null;
+        }
+
+        return $application;
+    }
+
+    /**
+     * @param array<string, mixed> $application
+     */
+    private function storeApplication(int $userId, array $application): void
+    {
+        Cache::put("trustcert_application:{$userId}", $application, now()->addDays(30));
+    }
+}

--- a/app/Http/Controllers/Api/TrustCert/MobileTrustCertController.php
+++ b/app/Http/Controllers/Api/TrustCert/MobileTrustCertController.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\TrustCert;
+
+use App\Domain\TrustCert\Enums\TrustLevel;
+use App\Domain\TrustCert\Services\CertificateAuthorityService;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class MobileTrustCertController extends Controller
+{
+    public function __construct(
+        private readonly CertificateAuthorityService $certificateAuthority,
+    ) {
+    }
+
+    /**
+     * Get user's current trust certificate and trust level.
+     *
+     * GET /api/v1/trustcert/current
+     */
+    public function current(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $subjectId = 'user:' . $user->id;
+
+        $certificate = $this->certificateAuthority->getCertificateBySubject($subjectId);
+
+        if (! $certificate) {
+            return response()->json([
+                'success' => true,
+                'data'    => [
+                    'trust_level' => TrustLevel::UNKNOWN->value,
+                    'label'       => TrustLevel::UNKNOWN->label(),
+                    'certificate' => null,
+                ],
+            ]);
+        }
+
+        $trustLevel = TrustLevel::tryFrom($certificate->extensions['trust_level'] ?? 'unknown')
+            ?? TrustLevel::UNKNOWN;
+
+        return response()->json([
+            'success' => true,
+            'data'    => [
+                'trust_level'   => $trustLevel->value,
+                'label'         => $trustLevel->label(),
+                'numeric_value' => $trustLevel->numericValue(),
+                'certificate'   => $certificate->toArray(),
+                'is_valid'      => $certificate->isValid(),
+                'expires_at'    => $certificate->validUntil->format('c'),
+            ],
+        ]);
+    }
+
+    /**
+     * Get all trust levels and their requirements.
+     *
+     * GET /api/v1/trustcert/requirements
+     */
+    public function requirements(): JsonResponse
+    {
+        $levels = [];
+        foreach (TrustLevel::cases() as $level) {
+            $levels[] = [
+                'level'         => $level->value,
+                'label'         => $level->label(),
+                'numeric_value' => $level->numericValue(),
+                'requirements'  => $level->requirements(),
+                'limits'        => $this->getLimitsForLevel($level),
+            ];
+        }
+
+        return response()->json([
+            'success' => true,
+            'data'    => $levels,
+        ]);
+    }
+
+    /**
+     * Get requirements for a specific trust level.
+     *
+     * GET /api/v1/trustcert/requirements/{level}
+     */
+    public function requirementsByLevel(string $level): JsonResponse
+    {
+        $trustLevel = TrustLevel::tryFrom($level);
+
+        if (! $trustLevel) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'INVALID_TRUST_LEVEL',
+                    'message' => 'Trust level not found.',
+                ],
+            ], 404);
+        }
+
+        return response()->json([
+            'success' => true,
+            'data'    => [
+                'level'         => $trustLevel->value,
+                'label'         => $trustLevel->label(),
+                'numeric_value' => $trustLevel->numericValue(),
+                'requirements'  => $trustLevel->requirements(),
+                'limits'        => $this->getLimitsForLevel($trustLevel),
+            ],
+        ]);
+    }
+
+    /**
+     * Get transaction limits for all trust levels.
+     *
+     * GET /api/v1/trustcert/limits
+     */
+    public function limits(): JsonResponse
+    {
+        $limits = [];
+        foreach (TrustLevel::cases() as $level) {
+            $limits[] = [
+                'level'  => $level->value,
+                'label'  => $level->label(),
+                'limits' => $this->getLimitsForLevel($level),
+            ];
+        }
+
+        return response()->json([
+            'success' => true,
+            'data'    => $limits,
+        ]);
+    }
+
+    /**
+     * Check if a transaction amount is within the user's trust level limits.
+     *
+     * POST /api/v1/trustcert/check-limit
+     */
+    public function checkLimit(Request $request): JsonResponse
+    {
+        $request->validate([
+            'amount'           => ['required', 'numeric', 'min:0'],
+            'transaction_type' => ['required', 'string', 'in:daily,monthly,single'],
+        ]);
+
+        $user = $request->user();
+        $subjectId = 'user:' . $user->id;
+
+        $certificate = $this->certificateAuthority->getCertificateBySubject($subjectId);
+        $trustLevel = TrustLevel::UNKNOWN;
+
+        if ($certificate && $certificate->isValid()) {
+            $trustLevel = TrustLevel::tryFrom($certificate->extensions['trust_level'] ?? 'unknown')
+                ?? TrustLevel::UNKNOWN;
+        }
+
+        $limits = $this->getLimitsForLevel($trustLevel);
+        $type = $request->input('transaction_type');
+        $amount = (float) $request->input('amount');
+        $limit = $limits[$type] ?? 0;
+
+        return response()->json([
+            'success' => true,
+            'data'    => [
+                'allowed'     => $amount <= $limit,
+                'trust_level' => $trustLevel->value,
+                'limit'       => $limit,
+                'amount'      => $amount,
+                'type'        => $type,
+                'remaining'   => max(0, $limit - $amount),
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<string, float>
+     */
+    private function getLimitsForLevel(TrustLevel $level): array
+    {
+        return match ($level) {
+            TrustLevel::UNKNOWN  => ['daily' => 0, 'monthly' => 0, 'single' => 0],
+            TrustLevel::BASIC    => ['daily' => 500, 'monthly' => 5000, 'single' => 200],
+            TrustLevel::VERIFIED => ['daily' => 5000, 'monthly' => 50000, 'single' => 2000],
+            TrustLevel::HIGH     => ['daily' => 50000, 'monthly' => 500000, 'single' => 25000],
+            TrustLevel::ULTIMATE => ['daily' => 500000, 'monthly' => 5000000, 'single' => 250000],
+        };
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -48,6 +48,8 @@ use App\Http\Controllers\Api\TransactionMonitoringController;
 use App\Http\Controllers\Api\TransactionReversalController;
 use App\Http\Controllers\Api\TransferController;
 use App\Http\Controllers\Api\Treasury\PortfolioController;
+use App\Http\Controllers\Api\TrustCert\CertificateApplicationController;
+use App\Http\Controllers\Api\TrustCert\MobileTrustCertController;
 use App\Http\Controllers\Api\UserVotingController;
 use App\Http\Controllers\Api\VoteController;
 use App\Http\Controllers\Api\Wallet\MobileWalletController;
@@ -1408,6 +1410,55 @@ Route::prefix('v1/wallet')->name('mobile.wallet.')
         Route::post('/transactions/send', [MobileWalletController::class, 'send'])
             ->middleware('transaction.rate_limit:payment_intent')
             ->name('transactions.send');
+    });
+
+/*
+|--------------------------------------------------------------------------
+| Mobile TrustCert API (v2.10.0)
+|--------------------------------------------------------------------------
+|
+| Trust certificate endpoints for mobile: current trust level, requirements,
+| transaction limits, and certificate application CRUD.
+|
+*/
+Route::prefix('v1/trustcert')->name('mobile.trustcert.')
+    ->middleware(['auth:sanctum', 'check.token.expiration'])
+    ->group(function () {
+        Route::get('/current', [MobileTrustCertController::class, 'current'])
+            ->middleware('api.rate_limit:query')
+            ->name('current');
+        Route::get('/requirements', [MobileTrustCertController::class, 'requirements'])
+            ->middleware('api.rate_limit:query')
+            ->name('requirements');
+        Route::get('/requirements/{level}', [MobileTrustCertController::class, 'requirementsByLevel'])
+            ->middleware('api.rate_limit:query')
+            ->name('requirements.level');
+        Route::get('/limits', [MobileTrustCertController::class, 'limits'])
+            ->middleware('api.rate_limit:query')
+            ->name('limits');
+        Route::post('/check-limit', [MobileTrustCertController::class, 'checkLimit'])
+            ->middleware('api.rate_limit:query')
+            ->name('check-limit');
+
+        // Certificate applications
+        Route::post('/applications', [CertificateApplicationController::class, 'create'])
+            ->middleware('api.rate_limit:mutation')
+            ->name('applications.create');
+        Route::get('/applications/current', [CertificateApplicationController::class, 'currentApplication'])
+            ->middleware('api.rate_limit:query')
+            ->name('applications.current');
+        Route::get('/applications/{id}', [CertificateApplicationController::class, 'show'])
+            ->middleware('api.rate_limit:query')
+            ->name('applications.show');
+        Route::post('/applications/{id}/documents', [CertificateApplicationController::class, 'uploadDocuments'])
+            ->middleware('api.rate_limit:mutation')
+            ->name('applications.documents');
+        Route::post('/applications/{id}/submit', [CertificateApplicationController::class, 'submit'])
+            ->middleware('api.rate_limit:mutation')
+            ->name('applications.submit');
+        Route::post('/applications/{id}/cancel', [CertificateApplicationController::class, 'cancel'])
+            ->middleware('api.rate_limit:mutation')
+            ->name('applications.cancel');
     });
 
 /*

--- a/tests/Unit/Http/Controllers/Api/TrustCert/CertificateApplicationControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/TrustCert/CertificateApplicationControllerTest.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\TrustCert\Services\CertificateAuthorityService;
+use App\Http\Controllers\Api\TrustCert\CertificateApplicationController;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Tests\UnitTestCase;
+
+uses(UnitTestCase::class);
+
+beforeEach(function (): void {
+    $this->certificateAuthority = Mockery::mock(CertificateAuthorityService::class);
+    Cache::flush();
+});
+
+function makeCertAppController($test): CertificateApplicationController
+{
+    return new CertificateApplicationController(
+        $test->certificateAuthority,
+    );
+}
+
+function certAppUserRequest(string $uri, string $method = 'GET', array $data = []): Request
+{
+    if ($method === 'POST') {
+        $request = Request::create($uri, $method, $data, [], [], ['CONTENT_TYPE' => 'application/json'], json_encode($data));
+    } else {
+        $request = Request::create($uri, $method, $data);
+    }
+    $user = Mockery::mock(User::class)->makePartial();
+    $user->id = 1;
+    $request->setUserResolver(fn () => $user);
+
+    return $request;
+}
+
+describe('CertificateApplicationController create', function (): void {
+    it('creates a new certificate application', function (): void {
+        $controller = makeCertAppController($this);
+
+        $request = certAppUserRequest('/api/v1/trustcert/applications', 'POST', [
+            'target_level' => 'verified',
+        ]);
+
+        $response = $controller->create($request);
+        $data = $response->getData(true);
+
+        expect($response->getStatusCode())->toBe(201)
+            ->and($data['success'])->toBeTrue()
+            ->and($data['data']['target_level'])->toBe('verified')
+            ->and($data['data']['status'])->toBe('draft')
+            ->and($data['data']['id'])->toStartWith('app_');
+    });
+
+    it('prevents duplicate active applications', function (): void {
+        $controller = makeCertAppController($this);
+
+        // Create first application
+        $request1 = certAppUserRequest('/api/v1/trustcert/applications', 'POST', [
+            'target_level' => 'verified',
+        ]);
+        $controller->create($request1);
+
+        // Try to create second
+        $request2 = certAppUserRequest('/api/v1/trustcert/applications', 'POST', [
+            'target_level' => 'high',
+        ]);
+        $response = $controller->create($request2);
+
+        expect($response->getStatusCode())->toBe(409);
+    });
+});
+
+describe('CertificateApplicationController show', function (): void {
+    it('returns application by ID', function (): void {
+        $controller = makeCertAppController($this);
+
+        // Create application first
+        $createRequest = certAppUserRequest('/api/v1/trustcert/applications', 'POST', [
+            'target_level' => 'verified',
+        ]);
+        $createResponse = $controller->create($createRequest);
+        $appId = $createResponse->getData(true)['data']['id'];
+
+        // Show it
+        $response = $controller->show($appId, certAppUserRequest("/api/v1/trustcert/applications/{$appId}"));
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue()
+            ->and($data['data']['id'])->toBe($appId);
+    });
+
+    it('returns 404 for non-existent application', function (): void {
+        $controller = makeCertAppController($this);
+
+        $response = $controller->show('nonexistent', certAppUserRequest('/api/v1/trustcert/applications/nonexistent'));
+
+        expect($response->getStatusCode())->toBe(404);
+    });
+});
+
+describe('CertificateApplicationController currentApplication', function (): void {
+    it('returns null when no active application', function (): void {
+        $controller = makeCertAppController($this);
+
+        $response = $controller->currentApplication(certAppUserRequest('/api/v1/trustcert/applications/current'));
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue()
+            ->and($data['data'])->toBeNull();
+    });
+
+    it('returns active application', function (): void {
+        $controller = makeCertAppController($this);
+
+        // Create one
+        $controller->create(certAppUserRequest('/api/v1/trustcert/applications', 'POST', [
+            'target_level' => 'basic',
+        ]));
+
+        // Check current
+        $response = $controller->currentApplication(certAppUserRequest('/api/v1/trustcert/applications/current'));
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue()
+            ->and($data['data'])->not->toBeNull()
+            ->and($data['data']['target_level'])->toBe('basic');
+    });
+});
+
+describe('CertificateApplicationController submit', function (): void {
+    it('submits a draft application', function (): void {
+        $controller = makeCertAppController($this);
+
+        // Create
+        $createResponse = $controller->create(certAppUserRequest('/api/v1/trustcert/applications', 'POST', [
+            'target_level' => 'verified',
+        ]));
+        $appId = $createResponse->getData(true)['data']['id'];
+
+        // Submit
+        $response = $controller->submit($appId, certAppUserRequest("/api/v1/trustcert/applications/{$appId}/submit", 'POST'));
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue()
+            ->and($data['data']['status'])->toBe('submitted')
+            ->and($data['data']['submitted_at'])->not->toBeNull();
+    });
+
+    it('rejects submitting non-draft application', function (): void {
+        $controller = makeCertAppController($this);
+
+        // Create and submit
+        $createResponse = $controller->create(certAppUserRequest('/api/v1/trustcert/applications', 'POST', [
+            'target_level' => 'verified',
+        ]));
+        $appId = $createResponse->getData(true)['data']['id'];
+        $controller->submit($appId, certAppUserRequest("/api/v1/trustcert/applications/{$appId}/submit", 'POST'));
+
+        // Try to submit again
+        $response = $controller->submit($appId, certAppUserRequest("/api/v1/trustcert/applications/{$appId}/submit", 'POST'));
+
+        expect($response->getStatusCode())->toBe(422);
+    });
+});
+
+describe('CertificateApplicationController cancel', function (): void {
+    it('cancels a draft application', function (): void {
+        $controller = makeCertAppController($this);
+
+        // Create
+        $createResponse = $controller->create(certAppUserRequest('/api/v1/trustcert/applications', 'POST', [
+            'target_level' => 'verified',
+        ]));
+        $appId = $createResponse->getData(true)['data']['id'];
+
+        // Cancel
+        $response = $controller->cancel($appId, certAppUserRequest("/api/v1/trustcert/applications/{$appId}/cancel", 'POST'));
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue()
+            ->and($data['data']['status'])->toBe('cancelled');
+    });
+});
+
+describe('CertificateApplicationController uploadDocuments', function (): void {
+    it('uploads a document to a draft application', function (): void {
+        $controller = makeCertAppController($this);
+
+        // Create
+        $createResponse = $controller->create(certAppUserRequest('/api/v1/trustcert/applications', 'POST', [
+            'target_level' => 'verified',
+        ]));
+        $appId = $createResponse->getData(true)['data']['id'];
+
+        // Upload document
+        $response = $controller->uploadDocuments($appId, certAppUserRequest(
+            "/api/v1/trustcert/applications/{$appId}/documents",
+            'POST',
+            ['document_type' => 'identity', 'file_name' => 'passport.pdf'],
+        ));
+        $data = $response->getData(true);
+
+        expect($response->getStatusCode())->toBe(201)
+            ->and($data['success'])->toBeTrue()
+            ->and($data['data']['document_type'])->toBe('identity')
+            ->and($data['data']['id'])->toStartWith('doc_');
+    });
+});
+
+describe('TrustCert application routes', function (): void {
+    it('has applications create route defined', function (): void {
+        $route = app('router')->getRoutes()->getByName('mobile.trustcert.applications.create');
+        expect($route)->not->toBeNull();
+    });
+
+    it('has applications current route defined', function (): void {
+        $route = app('router')->getRoutes()->getByName('mobile.trustcert.applications.current');
+        expect($route)->not->toBeNull();
+    });
+});

--- a/tests/Unit/Http/Controllers/Api/TrustCert/MobileTrustCertControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/TrustCert/MobileTrustCertControllerTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\TrustCert\Enums\CertificateStatus;
+use App\Domain\TrustCert\Services\CertificateAuthorityService;
+use App\Domain\TrustCert\ValueObjects\Certificate;
+use App\Http\Controllers\Api\TrustCert\MobileTrustCertController;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Tests\UnitTestCase;
+
+uses(UnitTestCase::class);
+
+beforeEach(function (): void {
+    $this->certificateAuthority = Mockery::mock(CertificateAuthorityService::class);
+});
+
+function makeTrustCertController($test): MobileTrustCertController
+{
+    return new MobileTrustCertController(
+        $test->certificateAuthority,
+    );
+}
+
+function trustCertUserRequest(string $uri, string $method = 'GET', array $data = []): Request
+{
+    if ($method === 'POST') {
+        $request = Request::create($uri, $method, $data, [], [], ['CONTENT_TYPE' => 'application/json'], json_encode($data));
+    } else {
+        $request = Request::create($uri, $method, $data);
+    }
+    $user = Mockery::mock(User::class)->makePartial();
+    $user->id = 1;
+    $request->setUserResolver(fn () => $user);
+
+    return $request;
+}
+
+describe('MobileTrustCertController current', function (): void {
+    it('returns unknown trust level when no certificate exists', function (): void {
+        $this->certificateAuthority->shouldReceive('getCertificateBySubject')
+            ->with('user:1')
+            ->andReturn(null);
+
+        $controller = makeTrustCertController($this);
+
+        $response = $controller->current(trustCertUserRequest('/api/v1/trustcert/current'));
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue()
+            ->and($data['data']['trust_level'])->toBe('unknown')
+            ->and($data['data']['certificate'])->toBeNull();
+    });
+
+    it('returns certificate info when user has certificate', function (): void {
+        $cert = new Certificate(
+            certificateId: 'cert-123',
+            subjectId: 'user:1',
+            subject: ['name' => 'Test User'],
+            publicKey: 'pk-test',
+            signature: 'sig-test',
+            validFrom: new DateTimeImmutable('-1 day'),
+            validUntil: new DateTimeImmutable('+365 days'),
+            status: CertificateStatus::ACTIVE,
+            extensions: ['trust_level' => 'verified'],
+        );
+
+        $this->certificateAuthority->shouldReceive('getCertificateBySubject')
+            ->with('user:1')
+            ->andReturn($cert);
+
+        $controller = makeTrustCertController($this);
+
+        $response = $controller->current(trustCertUserRequest('/api/v1/trustcert/current'));
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue()
+            ->and($data['data']['trust_level'])->toBe('verified')
+            ->and($data['data']['is_valid'])->toBeTrue()
+            ->and($data['data']['certificate'])->toBeArray()
+            ->and($data['data']['certificate']['certificate_id'])->toBe('cert-123');
+    });
+});
+
+describe('MobileTrustCertController requirements', function (): void {
+    it('returns all trust levels with requirements', function (): void {
+        $controller = makeTrustCertController($this);
+
+        $response = $controller->requirements();
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue()
+            ->and($data['data'])->toBeArray()
+            ->and(count($data['data']))->toBe(5);
+
+        $levels = array_column($data['data'], 'level');
+        expect($levels)->toContain('unknown')
+            ->and($levels)->toContain('basic')
+            ->and($levels)->toContain('verified')
+            ->and($levels)->toContain('high')
+            ->and($levels)->toContain('ultimate');
+    });
+
+    it('includes limits for each trust level', function (): void {
+        $controller = makeTrustCertController($this);
+
+        $response = $controller->requirements();
+        $data = $response->getData(true);
+
+        $verified = collect($data['data'])->firstWhere('level', 'verified');
+        expect($verified['limits'])->toHaveKeys(['daily', 'monthly', 'single'])
+            ->and($verified['requirements'])->toHaveKeys(['email_verified', 'identity_verified']);
+    });
+});
+
+describe('MobileTrustCertController requirementsByLevel', function (): void {
+    it('returns specific level requirements', function (): void {
+        $controller = makeTrustCertController($this);
+
+        $response = $controller->requirementsByLevel('high');
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue()
+            ->and($data['data']['level'])->toBe('high')
+            ->and($data['data']['requirements'])->toHaveKey('kyc_completed');
+    });
+
+    it('returns 404 for invalid trust level', function (): void {
+        $controller = makeTrustCertController($this);
+
+        $response = $controller->requirementsByLevel('nonexistent');
+
+        expect($response->getStatusCode())->toBe(404);
+    });
+});
+
+describe('MobileTrustCertController limits', function (): void {
+    it('returns transaction limits for all trust levels', function (): void {
+        $controller = makeTrustCertController($this);
+
+        $response = $controller->limits();
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue()
+            ->and($data['data'])->toBeArray()
+            ->and(count($data['data']))->toBe(5);
+
+        $basic = collect($data['data'])->firstWhere('level', 'basic');
+        expect($basic['limits']['daily'])->toBe(500)
+            ->and($basic['limits']['monthly'])->toBe(5000);
+    });
+});
+
+describe('MobileTrustCertController checkLimit', function (): void {
+    it('allows transaction within limits', function (): void {
+        $cert = new Certificate(
+            certificateId: 'cert-123',
+            subjectId: 'user:1',
+            subject: ['name' => 'Test User'],
+            publicKey: 'pk-test',
+            signature: 'sig-test',
+            validFrom: new DateTimeImmutable('-1 day'),
+            validUntil: new DateTimeImmutable('+365 days'),
+            status: CertificateStatus::ACTIVE,
+            extensions: ['trust_level' => 'verified'],
+        );
+
+        $this->certificateAuthority->shouldReceive('getCertificateBySubject')
+            ->with('user:1')
+            ->andReturn($cert);
+
+        $controller = makeTrustCertController($this);
+
+        $response = $controller->checkLimit(trustCertUserRequest(
+            '/api/v1/trustcert/check-limit',
+            'POST',
+            ['amount' => 1000, 'transaction_type' => 'daily'],
+        ));
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue()
+            ->and($data['data']['allowed'])->toBeTrue()
+            ->and($data['data']['trust_level'])->toBe('verified');
+    });
+
+    it('rejects transaction exceeding limits', function (): void {
+        $this->certificateAuthority->shouldReceive('getCertificateBySubject')
+            ->with('user:1')
+            ->andReturn(null);
+
+        $controller = makeTrustCertController($this);
+
+        $response = $controller->checkLimit(trustCertUserRequest(
+            '/api/v1/trustcert/check-limit',
+            'POST',
+            ['amount' => 100, 'transaction_type' => 'daily'],
+        ));
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue()
+            ->and($data['data']['allowed'])->toBeFalse()
+            ->and($data['data']['trust_level'])->toBe('unknown')
+            ->and($data['data']['limit'])->toBe(0);
+    });
+});
+
+describe('TrustCert routes', function (): void {
+    it('has trustcert current route defined', function (): void {
+        $route = app('router')->getRoutes()->getByName('mobile.trustcert.current');
+        expect($route)->not->toBeNull();
+    });
+
+    it('has trustcert requirements route defined', function (): void {
+        $route = app('router')->getRoutes()->getByName('mobile.trustcert.requirements');
+        expect($route)->not->toBeNull();
+    });
+
+    it('has trustcert limits route defined', function (): void {
+        $route = app('router')->getRoutes()->getByName('mobile.trustcert.limits');
+        expect($route)->not->toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
- Adds `MobileTrustCertController` with 5 endpoints: current trust level, requirements (all + by level), transaction limits, and limit checking
- Adds `CertificateApplicationController` with 6 endpoints: CRUD for certificate applications with document upload, submit, and cancel flows
- Reuses existing `CertificateAuthorityService` and `TrustLevel` enum
- Cache-based application storage for lightweight prototype
- 24 unit tests covering all endpoints + route existence checks

## Test plan
- [x] All 24 new unit tests pass
- [x] Full test suite passes (6900 passed, 0 failures)
- [x] Security checks pass (no binding resolution errors)
- [x] Code style verified with php-cs-fixer

🤖 Generated with [Claude Code](https://claude.com/claude-code)