### PR TITLE
feat(defi): Add DeFi domain foundation

### DIFF
--- a/app/Domain/DeFi/Contracts/LendingProtocolInterface.php
+++ b/app/Domain/DeFi/Contracts/LendingProtocolInterface.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\DeFi\Contracts;
+
+use App\Domain\CrossChain\Enums\CrossChainNetwork;
+use App\Domain\DeFi\Enums\DeFiProtocol;
+
+interface LendingProtocolInterface
+{
+    public function getProtocol(): DeFiProtocol;
+
+    /**
+     * Supply (deposit) an asset to earn interest.
+     *
+     * @return array{tx_hash: string, supplied_amount: string, atoken_received: string}
+     */
+    public function supply(
+        CrossChainNetwork $chain,
+        string $token,
+        string $amount,
+        string $walletAddress,
+    ): array;
+
+    /**
+     * Borrow an asset against collateral.
+     *
+     * @return array{tx_hash: string, borrowed_amount: string, health_factor: string}
+     */
+    public function borrow(
+        CrossChainNetwork $chain,
+        string $token,
+        string $amount,
+        string $walletAddress,
+    ): array;
+
+    /**
+     * Repay a borrowed asset.
+     *
+     * @return array{tx_hash: string, repaid_amount: string, remaining_debt: string}
+     */
+    public function repay(
+        CrossChainNetwork $chain,
+        string $token,
+        string $amount,
+        string $walletAddress,
+    ): array;
+
+    /**
+     * Withdraw a supplied asset.
+     *
+     * @return array{tx_hash: string, withdrawn_amount: string}
+     */
+    public function withdraw(
+        CrossChainNetwork $chain,
+        string $token,
+        string $amount,
+        string $walletAddress,
+    ): array;
+
+    /**
+     * Get available lending markets.
+     *
+     * @return array<array{token: string, supply_apy: string, borrow_apy: string, total_supplied: string, total_borrowed: string, ltv: string}>
+     */
+    public function getMarkets(CrossChainNetwork $chain): array;
+
+    /**
+     * Get user positions in lending markets.
+     *
+     * @return array{supplies: array<array<string, mixed>>, borrows: array<array<string, mixed>>, health_factor: string, net_apy: string}
+     */
+    public function getUserPositions(CrossChainNetwork $chain, string $walletAddress): array;
+}

--- a/app/Domain/DeFi/Contracts/LiquidStakingInterface.php
+++ b/app/Domain/DeFi/Contracts/LiquidStakingInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\DeFi\Contracts;
+
+use App\Domain\CrossChain\Enums\CrossChainNetwork;
+use App\Domain\DeFi\Enums\DeFiProtocol;
+
+interface LiquidStakingInterface
+{
+    public function getProtocol(): DeFiProtocol;
+
+    /**
+     * Stake native tokens and receive liquid staking derivatives.
+     *
+     * @return array{tx_hash: string, staked_amount: string, derivative_received: string, derivative_token: string}
+     */
+    public function stake(
+        CrossChainNetwork $chain,
+        string $amount,
+        string $walletAddress,
+    ): array;
+
+    /**
+     * Unstake liquid staking derivatives.
+     *
+     * @return array{tx_hash: string, unstaked_amount: string, estimated_completion: string}
+     */
+    public function unstake(
+        CrossChainNetwork $chain,
+        string $amount,
+        string $walletAddress,
+    ): array;
+
+    /**
+     * Get current staking APY.
+     */
+    public function getStakingAPY(CrossChainNetwork $chain): string;
+
+    /**
+     * Get user's staked balance.
+     *
+     * @return array{staked: string, derivative_balance: string, derivative_token: string, value_usd: string}
+     */
+    public function getStakedBalance(CrossChainNetwork $chain, string $walletAddress): array;
+}

--- a/app/Domain/DeFi/Contracts/SwapProtocolInterface.php
+++ b/app/Domain/DeFi/Contracts/SwapProtocolInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\DeFi\Contracts;
+
+use App\Domain\CrossChain\Enums\CrossChainNetwork;
+use App\Domain\DeFi\Enums\DeFiProtocol;
+use App\Domain\DeFi\ValueObjects\SwapQuote;
+
+interface SwapProtocolInterface
+{
+    public function getProtocol(): DeFiProtocol;
+
+    /**
+     * Get a quote for a token swap.
+     */
+    public function getQuote(
+        CrossChainNetwork $chain,
+        string $fromToken,
+        string $toToken,
+        string $amount,
+        float $slippageTolerance = 0.5,
+    ): SwapQuote;
+
+    /**
+     * Execute a swap based on a quote.
+     *
+     * @return array{tx_hash: string, input_amount: string, output_amount: string, price_impact: string}
+     */
+    public function executeSwap(SwapQuote $quote, string $walletAddress): array;
+
+    /**
+     * Get supported trading pairs on a given chain.
+     *
+     * @return array<array{from: string, to: string, fee_tier: ?int}>
+     */
+    public function getSupportedPairs(CrossChainNetwork $chain): array;
+}

--- a/app/Domain/DeFi/Contracts/YieldVaultInterface.php
+++ b/app/Domain/DeFi/Contracts/YieldVaultInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\DeFi\Contracts;
+
+use App\Domain\CrossChain\Enums\CrossChainNetwork;
+
+interface YieldVaultInterface
+{
+    /**
+     * Deposit assets into a yield vault.
+     *
+     * @return array{tx_hash: string, deposited_amount: string, shares_received: string}
+     */
+    public function deposit(
+        CrossChainNetwork $chain,
+        string $vaultId,
+        string $amount,
+        string $walletAddress,
+    ): array;
+
+    /**
+     * Withdraw assets from a yield vault.
+     *
+     * @return array{tx_hash: string, withdrawn_amount: string, shares_burned: string}
+     */
+    public function withdraw(
+        CrossChainNetwork $chain,
+        string $vaultId,
+        string $amount,
+        string $walletAddress,
+    ): array;
+
+    /**
+     * Get current APY for a vault.
+     */
+    public function getAPY(CrossChainNetwork $chain, string $vaultId): string;
+
+    /**
+     * Get vault information.
+     *
+     * @return array{vault_id: string, token: string, tvl: string, apy: string, strategy: string}
+     */
+    public function getVaultInfo(CrossChainNetwork $chain, string $vaultId): array;
+}

--- a/app/Domain/DeFi/Enums/DeFiPositionStatus.php
+++ b/app/Domain/DeFi/Enums/DeFiPositionStatus.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\DeFi\Enums;
+
+enum DeFiPositionStatus: string
+{
+    case ACTIVE = 'active';
+    case CLOSED = 'closed';
+    case LIQUIDATED = 'liquidated';
+
+    public function isOpen(): bool
+    {
+        return $this === self::ACTIVE;
+    }
+}

--- a/app/Domain/DeFi/Enums/DeFiPositionType.php
+++ b/app/Domain/DeFi/Enums/DeFiPositionType.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\DeFi\Enums;
+
+enum DeFiPositionType: string
+{
+    case SWAP = 'swap';
+    case SUPPLY = 'supply';
+    case BORROW = 'borrow';
+    case LP = 'lp';
+    case STAKE = 'stake';
+    case YIELD_VAULT = 'yield_vault';
+}

--- a/app/Domain/DeFi/Enums/DeFiProtocol.php
+++ b/app/Domain/DeFi/Enums/DeFiProtocol.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\DeFi\Enums;
+
+enum DeFiProtocol: string
+{
+    case UNISWAP_V3 = 'uniswap_v3';
+    case AAVE_V3 = 'aave_v3';
+    case CURVE = 'curve';
+    case LIDO = 'lido';
+    case DEMO = 'demo';
+
+    public function getDisplayName(): string
+    {
+        return match ($this) {
+            self::UNISWAP_V3 => 'Uniswap V3',
+            self::AAVE_V3    => 'Aave V3',
+            self::CURVE      => 'Curve Finance',
+            self::LIDO       => 'Lido',
+            self::DEMO       => 'Demo Protocol',
+        };
+    }
+
+    public function getCategory(): string
+    {
+        return match ($this) {
+            self::UNISWAP_V3, self::CURVE => 'dex',
+            self::AAVE_V3 => 'lending',
+            self::LIDO    => 'liquid_staking',
+            self::DEMO    => 'demo',
+        };
+    }
+
+    public function isProduction(): bool
+    {
+        return $this !== self::DEMO;
+    }
+}

--- a/app/Domain/DeFi/Events/PositionClosed.php
+++ b/app/Domain/DeFi/Events/PositionClosed.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\DeFi\Events;
+
+use App\Domain\DeFi\Enums\DeFiPositionType;
+use App\Domain\DeFi\Enums\DeFiProtocol;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class PositionClosed
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly string $positionId,
+        public readonly DeFiProtocol $protocol,
+        public readonly DeFiPositionType $type,
+        public readonly string $reason,
+    ) {
+    }
+}

--- a/app/Domain/DeFi/Events/PositionOpened.php
+++ b/app/Domain/DeFi/Events/PositionOpened.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\DeFi\Events;
+
+use App\Domain\CrossChain\Enums\CrossChainNetwork;
+use App\Domain\DeFi\Enums\DeFiPositionType;
+use App\Domain\DeFi\Enums\DeFiProtocol;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class PositionOpened
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly string $positionId,
+        public readonly DeFiProtocol $protocol,
+        public readonly DeFiPositionType $type,
+        public readonly CrossChainNetwork $chain,
+        public readonly string $asset,
+        public readonly string $amount,
+        public readonly string $walletAddress,
+    ) {
+    }
+}

--- a/app/Domain/DeFi/Events/SwapExecuted.php
+++ b/app/Domain/DeFi/Events/SwapExecuted.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\DeFi\Events;
+
+use App\Domain\CrossChain\Enums\CrossChainNetwork;
+use App\Domain\DeFi\Enums\DeFiProtocol;
+use Illuminate\Foundation\Events\Dispatchable;
+
+class SwapExecuted
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly CrossChainNetwork $chain,
+        public readonly DeFiProtocol $protocol,
+        public readonly string $fromToken,
+        public readonly string $toToken,
+        public readonly string $inputAmount,
+        public readonly string $outputAmount,
+        public readonly string $walletAddress,
+        public readonly string $txHash,
+    ) {
+    }
+}

--- a/app/Domain/DeFi/Exceptions/HealthFactorTooLowException.php
+++ b/app/Domain/DeFi/Exceptions/HealthFactorTooLowException.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\DeFi\Exceptions;
+
+use Exception;
+
+class HealthFactorTooLowException extends Exception
+{
+    public const CODE = 'ERR_DEFI_003';
+
+    public function __construct(
+        string $message,
+        public readonly string $errorCode = self::CODE,
+        public readonly int $httpStatusCode = 422,
+    ) {
+        parent::__construct($message);
+    }
+
+    public static function belowThreshold(string $healthFactor, string $threshold = '1.0'): self
+    {
+        return new self(
+            "Health factor {$healthFactor} is below minimum threshold {$threshold}",
+        );
+    }
+}

--- a/app/Domain/DeFi/Exceptions/InsufficientLiquidityException.php
+++ b/app/Domain/DeFi/Exceptions/InsufficientLiquidityException.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\DeFi\Exceptions;
+
+use Exception;
+
+class InsufficientLiquidityException extends Exception
+{
+    public const CODE = 'ERR_DEFI_001';
+
+    public function __construct(
+        string $message,
+        public readonly string $errorCode = self::CODE,
+        public readonly int $httpStatusCode = 422,
+    ) {
+        parent::__construct($message);
+    }
+
+    public static function forPair(string $fromToken, string $toToken, string $amount): self
+    {
+        return new self(
+            "Insufficient liquidity to swap {$amount} {$fromToken} to {$toToken}",
+        );
+    }
+}

--- a/app/Domain/DeFi/Exceptions/SlippageExceededException.php
+++ b/app/Domain/DeFi/Exceptions/SlippageExceededException.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\DeFi\Exceptions;
+
+use Exception;
+
+class SlippageExceededException extends Exception
+{
+    public const CODE = 'ERR_DEFI_002';
+
+    public function __construct(
+        string $message,
+        public readonly string $errorCode = self::CODE,
+        public readonly int $httpStatusCode = 422,
+    ) {
+        parent::__construct($message);
+    }
+
+    public static function exceeded(string $expected, string $actual, float $tolerance): self
+    {
+        return new self(
+            "Slippage exceeded: expected {$expected}, got {$actual} (tolerance: {$tolerance}%)",
+        );
+    }
+}

--- a/app/Domain/DeFi/Services/DeFiPortfolioService.php
+++ b/app/Domain/DeFi/Services/DeFiPortfolioService.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\DeFi\Services;
+
+use App\Domain\DeFi\ValueObjects\DeFiPosition;
+
+/**
+ * Aggregated DeFi portfolio view: total value, protocol breakdown, yield earned, health factors.
+ */
+class DeFiPortfolioService
+{
+    public function __construct(
+        private readonly DeFiPositionTrackerService $positionTracker,
+    ) {
+    }
+
+    /**
+     * Get full portfolio summary for a wallet.
+     *
+     * @return array<string, mixed>
+     */
+    public function getPortfolioSummary(string $walletAddress): array
+    {
+        $positions = $this->positionTracker->getActivePositions($walletAddress);
+
+        return [
+            'total_value_usd'    => $this->calculateTotalValue($positions),
+            'positions_count'    => count($positions),
+            'protocol_breakdown' => $this->getProtocolBreakdown($positions),
+            'chain_breakdown'    => $this->getChainBreakdown($positions),
+            'type_breakdown'     => $this->getTypeBreakdown($positions),
+            'weighted_avg_apy'   => $this->calculateWeightedApy($positions),
+            'at_risk_positions'  => count($this->positionTracker->getAtRiskPositions($walletAddress)),
+        ];
+    }
+
+    /**
+     * Get portfolio by chain.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public function getByChain(string $walletAddress): array
+    {
+        $positions = $this->positionTracker->getActivePositions($walletAddress);
+        $byChain = [];
+
+        foreach ($positions as $position) {
+            $chain = $position->chain->value;
+            if (! isset($byChain[$chain])) {
+                $byChain[$chain] = [
+                    'chain'     => $chain,
+                    'value_usd' => '0',
+                    'positions' => 0,
+                    'avg_apy'   => '0',
+                ];
+            }
+
+            $byChain[$chain]['value_usd'] = bcadd($byChain[$chain]['value_usd'], $position->valueUsd, 2);
+            $byChain[$chain]['positions']++;
+        }
+
+        return $byChain;
+    }
+
+    /**
+     * Get yield opportunities (positions sorted by APY).
+     *
+     * @return array<array<string, mixed>>
+     */
+    public function getYieldOpportunities(string $walletAddress): array
+    {
+        $positions = $this->positionTracker->getActivePositions($walletAddress);
+
+        usort($positions, fn (DeFiPosition $a, DeFiPosition $b) => bccomp($b->apy, $a->apy, 4));
+
+        return array_map(fn (DeFiPosition $pos) => $pos->toArray(), $positions);
+    }
+
+    /**
+     * @param array<DeFiPosition> $positions
+     */
+    private function calculateTotalValue(array $positions): string
+    {
+        $total = '0';
+        foreach ($positions as $position) {
+            $total = bcadd($total, $position->valueUsd, 2);
+        }
+
+        return $total;
+    }
+
+    /**
+     * @param array<DeFiPosition> $positions
+     * @return array<string, array{value_usd: string, positions: int}>
+     */
+    private function getProtocolBreakdown(array $positions): array
+    {
+        $breakdown = [];
+        foreach ($positions as $pos) {
+            $key = $pos->protocol->value;
+            if (! isset($breakdown[$key])) {
+                $breakdown[$key] = ['value_usd' => '0', 'positions' => 0];
+            }
+            $breakdown[$key]['value_usd'] = bcadd($breakdown[$key]['value_usd'], $pos->valueUsd, 2);
+            $breakdown[$key]['positions']++;
+        }
+
+        return $breakdown;
+    }
+
+    /**
+     * @param array<DeFiPosition> $positions
+     * @return array<string, array{value_usd: string, positions: int}>
+     */
+    private function getChainBreakdown(array $positions): array
+    {
+        $breakdown = [];
+        foreach ($positions as $pos) {
+            $key = $pos->chain->value;
+            if (! isset($breakdown[$key])) {
+                $breakdown[$key] = ['value_usd' => '0', 'positions' => 0];
+            }
+            $breakdown[$key]['value_usd'] = bcadd($breakdown[$key]['value_usd'], $pos->valueUsd, 2);
+            $breakdown[$key]['positions']++;
+        }
+
+        return $breakdown;
+    }
+
+    /**
+     * @param array<DeFiPosition> $positions
+     * @return array<string, array{value_usd: string, positions: int}>
+     */
+    private function getTypeBreakdown(array $positions): array
+    {
+        $breakdown = [];
+        foreach ($positions as $pos) {
+            $key = $pos->type->value;
+            if (! isset($breakdown[$key])) {
+                $breakdown[$key] = ['value_usd' => '0', 'positions' => 0];
+            }
+            $breakdown[$key]['value_usd'] = bcadd($breakdown[$key]['value_usd'], $pos->valueUsd, 2);
+            $breakdown[$key]['positions']++;
+        }
+
+        return $breakdown;
+    }
+
+    /**
+     * @param array<DeFiPosition> $positions
+     */
+    private function calculateWeightedApy(array $positions): string
+    {
+        $totalValue = $this->calculateTotalValue($positions);
+        if ($totalValue === '0' || empty($positions)) {
+            return '0';
+        }
+
+        $weightedSum = '0';
+        foreach ($positions as $pos) {
+            $weight = bcmul($pos->apy, $pos->valueUsd, 8);
+            $weightedSum = bcadd($weightedSum, $weight, 8);
+        }
+
+        return bcdiv($weightedSum, $totalValue, 4);
+    }
+}

--- a/app/Domain/DeFi/Services/DeFiPositionTrackerService.php
+++ b/app/Domain/DeFi/Services/DeFiPositionTrackerService.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\DeFi\Services;
+
+use App\Domain\CrossChain\Enums\CrossChainNetwork;
+use App\Domain\DeFi\Enums\DeFiPositionStatus;
+use App\Domain\DeFi\Enums\DeFiPositionType;
+use App\Domain\DeFi\Enums\DeFiProtocol;
+use App\Domain\DeFi\ValueObjects\DeFiPosition;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+
+/**
+ * Tracks user DeFi positions across protocols.
+ */
+class DeFiPositionTrackerService
+{
+    private const CACHE_PREFIX = 'defi_pos:';
+
+    private const CACHE_TTL = 86400;
+
+    /**
+     * Record a new DeFi position.
+     */
+    public function openPosition(
+        DeFiProtocol $protocol,
+        DeFiPositionType $type,
+        CrossChainNetwork $chain,
+        string $asset,
+        string $amount,
+        string $valueUsd,
+        string $apy,
+        string $walletAddress,
+        ?string $healthFactor = null,
+    ): DeFiPosition {
+        $positionId = 'pos-' . Str::uuid()->toString();
+
+        $position = new DeFiPosition(
+            positionId: $positionId,
+            protocol: $protocol,
+            type: $type,
+            status: DeFiPositionStatus::ACTIVE,
+            chain: $chain,
+            asset: $asset,
+            amount: $amount,
+            valueUsd: $valueUsd,
+            apy: $apy,
+            healthFactor: $healthFactor,
+        );
+
+        $this->storePosition($walletAddress, $position);
+
+        return $position;
+    }
+
+    /**
+     * Close a position.
+     */
+    public function closePosition(string $walletAddress, string $positionId): void
+    {
+        $positions = $this->getPositionsFromCache($walletAddress);
+
+        foreach ($positions as $i => $data) {
+            if ($data['position_id'] === $positionId) {
+                $positions[$i]['status'] = DeFiPositionStatus::CLOSED->value;
+                break;
+            }
+        }
+
+        Cache::put(self::CACHE_PREFIX . $walletAddress, $positions, self::CACHE_TTL);
+    }
+
+    /**
+     * Get all active positions for a wallet.
+     *
+     * @return array<DeFiPosition>
+     */
+    public function getActivePositions(
+        string $walletAddress,
+        ?CrossChainNetwork $chain = null,
+        ?DeFiProtocol $protocol = null,
+        ?DeFiPositionType $type = null,
+    ): array {
+        $positions = $this->getPositionsFromCache($walletAddress);
+
+        return array_values(array_filter(
+            array_map(fn (array $data) => $this->hydratePosition($data), $positions),
+            function (DeFiPosition $pos) use ($chain, $protocol, $type) {
+                if ($pos->status !== DeFiPositionStatus::ACTIVE) {
+                    return false;
+                }
+                if ($chain !== null && $pos->chain !== $chain) {
+                    return false;
+                }
+                if ($protocol !== null && $pos->protocol !== $protocol) {
+                    return false;
+                }
+                if ($type !== null && $pos->type !== $type) {
+                    return false;
+                }
+
+                return true;
+            },
+        ));
+    }
+
+    /**
+     * Get positions at risk (health factor < 1.5).
+     *
+     * @return array<DeFiPosition>
+     */
+    public function getAtRiskPositions(string $walletAddress): array
+    {
+        return array_filter(
+            $this->getActivePositions($walletAddress),
+            fn (DeFiPosition $pos) => $pos->isAtRisk(),
+        );
+    }
+
+    /**
+     * Get total value of all active positions.
+     */
+    public function getTotalValue(string $walletAddress): string
+    {
+        $total = '0';
+
+        foreach ($this->getActivePositions($walletAddress) as $position) {
+            $total = bcadd($total, $position->valueUsd, 2);
+        }
+
+        return $total;
+    }
+
+    private function storePosition(string $walletAddress, DeFiPosition $position): void
+    {
+        $positions = $this->getPositionsFromCache($walletAddress);
+        $positions[] = $position->toArray();
+
+        Cache::put(self::CACHE_PREFIX . $walletAddress, $positions, self::CACHE_TTL);
+    }
+
+    /**
+     * @return array<array<string, mixed>>
+     */
+    private function getPositionsFromCache(string $walletAddress): array
+    {
+        return Cache::get(self::CACHE_PREFIX . $walletAddress, []);
+    }
+
+    private function hydratePosition(array $data): DeFiPosition
+    {
+        return new DeFiPosition(
+            positionId: $data['position_id'],
+            protocol: DeFiProtocol::from($data['protocol']),
+            type: DeFiPositionType::from($data['type']),
+            status: DeFiPositionStatus::from($data['status']),
+            chain: CrossChainNetwork::from($data['chain']),
+            asset: $data['asset'],
+            amount: $data['amount'],
+            valueUsd: $data['value_usd'],
+            apy: $data['apy'],
+            healthFactor: $data['health_factor'] ?? null,
+        );
+    }
+}

--- a/app/Domain/DeFi/Services/SwapAggregatorService.php
+++ b/app/Domain/DeFi/Services/SwapAggregatorService.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\DeFi\Services;
+
+use App\Domain\CrossChain\Enums\CrossChainNetwork;
+use App\Domain\DeFi\Contracts\SwapProtocolInterface;
+use App\Domain\DeFi\Exceptions\InsufficientLiquidityException;
+use App\Domain\DeFi\ValueObjects\SwapQuote;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Aggregates quotes from multiple DEXs and finds the best route.
+ */
+class SwapAggregatorService
+{
+    /** @var array<string, SwapProtocolInterface> */
+    private array $connectors = [];
+
+    public function registerConnector(SwapProtocolInterface $connector): void
+    {
+        $this->connectors[$connector->getProtocol()->value] = $connector;
+    }
+
+    /**
+     * @return array<string, SwapProtocolInterface>
+     */
+    public function getConnectors(): array
+    {
+        return $this->connectors;
+    }
+
+    /**
+     * Get quotes from all available DEXs for a swap.
+     *
+     * @return array<SwapQuote>
+     * @throws InsufficientLiquidityException
+     */
+    public function getQuotes(
+        CrossChainNetwork $chain,
+        string $fromToken,
+        string $toToken,
+        string $amount,
+        float $slippage = 0.5,
+    ): array {
+        $quotes = [];
+
+        foreach ($this->connectors as $connector) {
+            try {
+                $quotes[] = $connector->getQuote($chain, $fromToken, $toToken, $amount, $slippage);
+            } catch (Throwable $e) {
+                Log::warning('DeFi connector quote failed', [
+                    'protocol' => $connector->getProtocol()->value,
+                    'chain'    => $chain->value,
+                    'pair'     => "{$fromToken}/{$toToken}",
+                    'error'    => $e->getMessage(),
+                ]);
+            }
+        }
+
+        if (empty($quotes)) {
+            throw InsufficientLiquidityException::forPair($fromToken, $toToken, $amount);
+        }
+
+        return $quotes;
+    }
+
+    /**
+     * Get the best swap quote (highest output amount).
+     *
+     * @throws InsufficientLiquidityException
+     */
+    public function getBestQuote(
+        CrossChainNetwork $chain,
+        string $fromToken,
+        string $toToken,
+        string $amount,
+        float $slippage = 0.5,
+    ): SwapQuote {
+        $quotes = $this->getQuotes($chain, $fromToken, $toToken, $amount, $slippage);
+
+        usort($quotes, fn (SwapQuote $a, SwapQuote $b) => bccomp($b->outputAmount, $a->outputAmount, 18));
+
+        return $quotes[0];
+    }
+
+    /**
+     * Get the cheapest swap quote (lowest gas cost).
+     *
+     * @throws InsufficientLiquidityException
+     */
+    public function getCheapestGasQuote(
+        CrossChainNetwork $chain,
+        string $fromToken,
+        string $toToken,
+        string $amount,
+        float $slippage = 0.5,
+    ): SwapQuote {
+        $quotes = $this->getQuotes($chain, $fromToken, $toToken, $amount, $slippage);
+
+        usort($quotes, fn (SwapQuote $a, SwapQuote $b) => bccomp($a->gasEstimate, $b->gasEstimate, 18));
+
+        return $quotes[0];
+    }
+}

--- a/app/Domain/DeFi/ValueObjects/DeFiPosition.php
+++ b/app/Domain/DeFi/ValueObjects/DeFiPosition.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\DeFi\ValueObjects;
+
+use App\Domain\CrossChain\Enums\CrossChainNetwork;
+use App\Domain\DeFi\Enums\DeFiPositionStatus;
+use App\Domain\DeFi\Enums\DeFiPositionType;
+use App\Domain\DeFi\Enums\DeFiProtocol;
+
+final readonly class DeFiPosition
+{
+    public function __construct(
+        public string $positionId,
+        public DeFiProtocol $protocol,
+        public DeFiPositionType $type,
+        public DeFiPositionStatus $status,
+        public CrossChainNetwork $chain,
+        public string $asset,
+        public string $amount,
+        public string $valueUsd,
+        public string $apy,
+        public ?string $healthFactor = null,
+    ) {
+    }
+
+    public function isAtRisk(): bool
+    {
+        if ($this->healthFactor === null) {
+            return false;
+        }
+
+        return bccomp($this->healthFactor, '1.5', 2) < 0;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'position_id'   => $this->positionId,
+            'protocol'      => $this->protocol->value,
+            'type'          => $this->type->value,
+            'status'        => $this->status->value,
+            'chain'         => $this->chain->value,
+            'asset'         => $this->asset,
+            'amount'        => $this->amount,
+            'value_usd'     => $this->valueUsd,
+            'apy'           => $this->apy,
+            'health_factor' => $this->healthFactor,
+        ];
+    }
+}

--- a/app/Domain/DeFi/ValueObjects/SwapQuote.php
+++ b/app/Domain/DeFi/ValueObjects/SwapQuote.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\DeFi\ValueObjects;
+
+use App\Domain\CrossChain\Enums\CrossChainNetwork;
+use App\Domain\DeFi\Enums\DeFiProtocol;
+use Carbon\CarbonImmutable;
+
+final readonly class SwapQuote
+{
+    public function __construct(
+        public string $quoteId,
+        public CrossChainNetwork $chain,
+        public string $inputToken,
+        public string $outputToken,
+        public string $inputAmount,
+        public string $outputAmount,
+        public string $priceImpact,
+        public DeFiProtocol $protocol,
+        public string $gasEstimate,
+        public ?int $feeTier,
+        public CarbonImmutable $expiresAt,
+    ) {
+    }
+
+    public function isExpired(): bool
+    {
+        return CarbonImmutable::now()->greaterThan($this->expiresAt);
+    }
+
+    public function getEffectiveRate(): string
+    {
+        if ($this->inputAmount === '0') {
+            return '0';
+        }
+
+        return bcdiv($this->outputAmount, $this->inputAmount, 18);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'quote_id'      => $this->quoteId,
+            'chain'         => $this->chain->value,
+            'input_token'   => $this->inputToken,
+            'output_token'  => $this->outputToken,
+            'input_amount'  => $this->inputAmount,
+            'output_amount' => $this->outputAmount,
+            'price_impact'  => $this->priceImpact,
+            'protocol'      => $this->protocol->value,
+            'gas_estimate'  => $this->gasEstimate,
+            'fee_tier'      => $this->feeTier,
+            'expires_at'    => $this->expiresAt->toIso8601String(),
+        ];
+    }
+}

--- a/app/Providers/DeFiServiceProvider.php
+++ b/app/Providers/DeFiServiceProvider.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use App\Domain\DeFi\Services\DeFiPortfolioService;
+use App\Domain\DeFi\Services\DeFiPositionTrackerService;
+use App\Domain\DeFi\Services\SwapAggregatorService;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Service provider for the DeFi domain (protocol connectors & position tracking).
+ */
+class DeFiServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->mergeConfigFrom(
+            __DIR__ . '/../../config/defi.php',
+            'defi',
+        );
+
+        $this->app->singleton(SwapAggregatorService::class, function () {
+            return new SwapAggregatorService();
+        });
+
+        $this->app->singleton(DeFiPositionTrackerService::class);
+
+        $this->app->singleton(DeFiPortfolioService::class, function ($app) {
+            return new DeFiPortfolioService(
+                $app->make(DeFiPositionTrackerService::class),
+            );
+        });
+    }
+
+    public function boot(): void
+    {
+        //
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -14,6 +14,7 @@ return [
     App\Providers\ConsoleServiceProvider::class,
     App\Providers\CrossChainServiceProvider::class,
     App\Providers\CustodianServiceProvider::class,
+    App\Providers\DeFiServiceProvider::class,
     App\Providers\DemoServiceProvider::class,
     App\Providers\EventServiceProvider::class,
     App\Providers\ExchangeRateProviderServiceProvider::class,

--- a/config/defi.php
+++ b/config/defi.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | DeFi Protocol Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Configuration for DeFi protocol integrations including Uniswap, Aave,
+    | Curve, and Lido connectors.
+    |
+    */
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Swap Provider
+    |--------------------------------------------------------------------------
+    */
+
+    'default_swap_provider' => env('DEFI_DEFAULT_SWAP', 'demo'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Swap Defaults
+    |--------------------------------------------------------------------------
+    */
+
+    'swap' => [
+        'default_slippage'  => env('DEFI_DEFAULT_SLIPPAGE', 0.5),
+        'max_slippage'      => env('DEFI_MAX_SLIPPAGE', 5.0),
+        'quote_ttl_seconds' => env('DEFI_QUOTE_TTL', 60),
+        'max_price_impact'  => env('DEFI_MAX_PRICE_IMPACT', 3.0),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Uniswap V3 Configuration
+    |--------------------------------------------------------------------------
+    */
+
+    'uniswap' => [
+        'enabled' => env('UNISWAP_ENABLED', false),
+        'routers' => [
+            'ethereum' => env('UNISWAP_ROUTER_ETH', '0xE592427A0AEce92De3Edee1F18E0157C05861564'),
+            'polygon'  => env('UNISWAP_ROUTER_POLYGON', '0xE592427A0AEce92De3Edee1F18E0157C05861564'),
+            'arbitrum' => env('UNISWAP_ROUTER_ARBITRUM', '0xE592427A0AEce92De3Edee1F18E0157C05861564'),
+            'optimism' => env('UNISWAP_ROUTER_OPTIMISM', '0xE592427A0AEce92De3Edee1F18E0157C05861564'),
+            'base'     => env('UNISWAP_ROUTER_BASE', '0x2626664c2603336E57B271c5C0b26F421741e481'),
+        ],
+        'quoters' => [
+            'ethereum' => env('UNISWAP_QUOTER_ETH', '0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6'),
+            'polygon'  => env('UNISWAP_QUOTER_POLYGON', '0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6'),
+            'arbitrum' => env('UNISWAP_QUOTER_ARBITRUM', '0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6'),
+            'optimism' => env('UNISWAP_QUOTER_OPTIMISM', '0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6'),
+            'base'     => env('UNISWAP_QUOTER_BASE', '0x3d4e44Eb1374240CE5F1B871ab261CD16335B76a'),
+        ],
+        'fee_tiers' => [100, 500, 3000, 10000],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Aave V3 Configuration
+    |--------------------------------------------------------------------------
+    */
+
+    'aave' => [
+        'enabled' => env('AAVE_ENABLED', false),
+        'pools'   => [
+            'ethereum' => env('AAVE_POOL_ETH', '0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2'),
+            'polygon'  => env('AAVE_POOL_POLYGON', '0x794a61358D6845594F94dc1DB02A252b5b4814aD'),
+            'arbitrum' => env('AAVE_POOL_ARBITRUM', '0x794a61358D6845594F94dc1DB02A252b5b4814aD'),
+            'optimism' => env('AAVE_POOL_OPTIMISM', '0x794a61358D6845594F94dc1DB02A252b5b4814aD'),
+            'base'     => env('AAVE_POOL_BASE', '0xA238Dd80C259a72e81d7e4664a9801593F98d1c5'),
+        ],
+        'flash_loan_fee' => env('AAVE_FLASH_LOAN_FEE', 0.0005),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Curve Finance Configuration
+    |--------------------------------------------------------------------------
+    */
+
+    'curve' => [
+        'enabled'  => env('CURVE_ENABLED', false),
+        'registry' => [
+            'ethereum' => env('CURVE_REGISTRY_ETH', '0x90E00ACe148ca3b23Ac1bC8C240C2a7Dd9c2d7f5'),
+            'polygon'  => env('CURVE_REGISTRY_POLYGON', '0x0000000022D53366457F9d5E68Ec105046FC4383'),
+            'arbitrum' => env('CURVE_REGISTRY_ARBITRUM', '0x0000000022D53366457F9d5E68Ec105046FC4383'),
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Lido Configuration
+    |--------------------------------------------------------------------------
+    */
+
+    'lido' => [
+        'enabled'          => env('LIDO_ENABLED', false),
+        'steth'            => env('LIDO_STETH', '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84'),
+        'wsteth'           => env('LIDO_WSTETH', '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0'),
+        'withdrawal_queue' => env('LIDO_WITHDRAWAL', '0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Demo Configuration
+    |--------------------------------------------------------------------------
+    */
+
+    'demo' => [
+        'simulated_swap_fee'    => env('DEFI_DEMO_SWAP_FEE', 0.003),
+        'simulated_supply_apy'  => env('DEFI_DEMO_SUPPLY_APY', 3.5),
+        'simulated_borrow_apy'  => env('DEFI_DEMO_BORROW_APY', 5.2),
+        'simulated_staking_apy' => env('DEFI_DEMO_STAKING_APY', 3.8),
+    ],
+];

--- a/tests/Unit/Domain/DeFi/Services/DeFiPortfolioServiceTest.php
+++ b/tests/Unit/Domain/DeFi/Services/DeFiPortfolioServiceTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\CrossChain\Enums\CrossChainNetwork;
+use App\Domain\DeFi\Enums\DeFiPositionType;
+use App\Domain\DeFi\Enums\DeFiProtocol;
+use App\Domain\DeFi\Services\DeFiPortfolioService;
+use App\Domain\DeFi\Services\DeFiPositionTrackerService;
+use Illuminate\Support\Facades\Cache;
+
+uses(Tests\TestCase::class);
+
+beforeEach(function () {
+    Cache::flush();
+    $this->tracker = new DeFiPositionTrackerService();
+    $this->portfolio = new DeFiPortfolioService($this->tracker);
+
+    // Set up common test positions
+    $this->tracker->openPosition(DeFiProtocol::AAVE_V3, DeFiPositionType::SUPPLY, CrossChainNetwork::ETHEREUM, 'USDC', '5000.00', '5000.00', '3.50', '0xTestWallet');
+    $this->tracker->openPosition(DeFiProtocol::LIDO, DeFiPositionType::STAKE, CrossChainNetwork::ETHEREUM, 'ETH', '4.00', '10000.00', '3.80', '0xTestWallet');
+    $this->tracker->openPosition(DeFiProtocol::UNISWAP_V3, DeFiPositionType::LP, CrossChainNetwork::POLYGON, 'USDC/WETH', '2000.00', '2000.00', '12.50', '0xTestWallet');
+});
+
+describe('DeFiPortfolioService', function () {
+    it('returns portfolio summary with total value', function () {
+        $summary = $this->portfolio->getPortfolioSummary('0xTestWallet');
+
+        expect($summary['total_value_usd'])->toBe('17000.00');
+        expect($summary['positions_count'])->toBe(3);
+    });
+
+    it('includes protocol breakdown', function () {
+        $summary = $this->portfolio->getPortfolioSummary('0xTestWallet');
+
+        expect($summary['protocol_breakdown'])->toHaveKey('aave_v3');
+        expect($summary['protocol_breakdown'])->toHaveKey('lido');
+        expect($summary['protocol_breakdown'])->toHaveKey('uniswap_v3');
+    });
+
+    it('includes chain breakdown', function () {
+        $summary = $this->portfolio->getPortfolioSummary('0xTestWallet');
+
+        expect($summary['chain_breakdown'])->toHaveKey('ethereum');
+        expect($summary['chain_breakdown'])->toHaveKey('polygon');
+        expect($summary['chain_breakdown']['ethereum']['positions'])->toBe(2);
+    });
+
+    it('calculates weighted average APY', function () {
+        $summary = $this->portfolio->getPortfolioSummary('0xTestWallet');
+
+        expect((float) $summary['weighted_avg_apy'])->toBeGreaterThan(0);
+    });
+
+    it('gets portfolio grouped by chain', function () {
+        $byChain = $this->portfolio->getByChain('0xTestWallet');
+
+        expect($byChain)->toHaveKey('ethereum');
+        expect($byChain['ethereum']['value_usd'])->toBe('15000.00');
+    });
+
+    it('returns empty summary for wallet with no positions', function () {
+        $summary = $this->portfolio->getPortfolioSummary('0xEmptyWallet');
+
+        expect($summary['total_value_usd'])->toBe('0');
+        expect($summary['positions_count'])->toBe(0);
+    });
+});

--- a/tests/Unit/Domain/DeFi/Services/DeFiPositionTrackerServiceTest.php
+++ b/tests/Unit/Domain/DeFi/Services/DeFiPositionTrackerServiceTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\CrossChain\Enums\CrossChainNetwork;
+use App\Domain\DeFi\Enums\DeFiPositionStatus;
+use App\Domain\DeFi\Enums\DeFiPositionType;
+use App\Domain\DeFi\Enums\DeFiProtocol;
+use App\Domain\DeFi\Services\DeFiPositionTrackerService;
+use Illuminate\Support\Facades\Cache;
+
+uses(Tests\TestCase::class);
+
+beforeEach(function () {
+    Cache::flush();
+    $this->tracker = new DeFiPositionTrackerService();
+});
+
+describe('DeFiPositionTrackerService', function () {
+    it('opens and retrieves a position', function () {
+        $position = $this->tracker->openPosition(
+            DeFiProtocol::AAVE_V3,
+            DeFiPositionType::SUPPLY,
+            CrossChainNetwork::ETHEREUM,
+            'USDC',
+            '1000.00',
+            '1000.00',
+            '3.50',
+            '0xWallet1',
+        );
+
+        expect($position->positionId)->toStartWith('pos-');
+        expect($position->protocol)->toBe(DeFiProtocol::AAVE_V3);
+        expect($position->status)->toBe(DeFiPositionStatus::ACTIVE);
+    });
+
+    it('closes a position', function () {
+        $position = $this->tracker->openPosition(
+            DeFiProtocol::LIDO,
+            DeFiPositionType::STAKE,
+            CrossChainNetwork::ETHEREUM,
+            'ETH',
+            '10.00',
+            '25000.00',
+            '3.80',
+            '0xWallet2',
+        );
+
+        $this->tracker->closePosition('0xWallet2', $position->positionId);
+
+        $active = $this->tracker->getActivePositions('0xWallet2');
+        expect($active)->toBeEmpty();
+    });
+
+    it('filters positions by chain', function () {
+        $this->tracker->openPosition(DeFiProtocol::AAVE_V3, DeFiPositionType::SUPPLY, CrossChainNetwork::ETHEREUM, 'USDC', '1000.00', '1000.00', '3.50', '0xWallet3');
+        $this->tracker->openPosition(DeFiProtocol::AAVE_V3, DeFiPositionType::SUPPLY, CrossChainNetwork::POLYGON, 'USDC', '500.00', '500.00', '4.00', '0xWallet3');
+
+        $ethPositions = $this->tracker->getActivePositions('0xWallet3', chain: CrossChainNetwork::ETHEREUM);
+        expect($ethPositions)->toHaveCount(1);
+    });
+
+    it('filters positions by protocol', function () {
+        $this->tracker->openPosition(DeFiProtocol::AAVE_V3, DeFiPositionType::SUPPLY, CrossChainNetwork::ETHEREUM, 'USDC', '1000.00', '1000.00', '3.50', '0xWallet4');
+        $this->tracker->openPosition(DeFiProtocol::LIDO, DeFiPositionType::STAKE, CrossChainNetwork::ETHEREUM, 'ETH', '5.00', '12500.00', '3.80', '0xWallet4');
+
+        $aavePositions = $this->tracker->getActivePositions('0xWallet4', protocol: DeFiProtocol::AAVE_V3);
+        expect($aavePositions)->toHaveCount(1);
+    });
+
+    it('detects at-risk positions', function () {
+        $this->tracker->openPosition(DeFiProtocol::AAVE_V3, DeFiPositionType::BORROW, CrossChainNetwork::ETHEREUM, 'USDC', '5000.00', '5000.00', '5.20', '0xWallet5', '1.2');
+        $this->tracker->openPosition(DeFiProtocol::AAVE_V3, DeFiPositionType::SUPPLY, CrossChainNetwork::ETHEREUM, 'ETH', '10.00', '25000.00', '2.00', '0xWallet5', '2.5');
+
+        $atRisk = $this->tracker->getAtRiskPositions('0xWallet5');
+        expect($atRisk)->toHaveCount(1);
+    });
+
+    it('calculates total portfolio value', function () {
+        $this->tracker->openPosition(DeFiProtocol::AAVE_V3, DeFiPositionType::SUPPLY, CrossChainNetwork::ETHEREUM, 'USDC', '1000.00', '1000.00', '3.50', '0xWallet6');
+        $this->tracker->openPosition(DeFiProtocol::LIDO, DeFiPositionType::STAKE, CrossChainNetwork::ETHEREUM, 'ETH', '2.00', '5000.00', '3.80', '0xWallet6');
+
+        $total = $this->tracker->getTotalValue('0xWallet6');
+        expect($total)->toBe('6000.00');
+    });
+});

--- a/tests/Unit/Domain/DeFi/Services/SwapAggregatorServiceTest.php
+++ b/tests/Unit/Domain/DeFi/Services/SwapAggregatorServiceTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\CrossChain\Enums\CrossChainNetwork;
+use App\Domain\DeFi\Contracts\SwapProtocolInterface;
+use App\Domain\DeFi\Enums\DeFiProtocol;
+use App\Domain\DeFi\Exceptions\InsufficientLiquidityException;
+use App\Domain\DeFi\Services\SwapAggregatorService;
+use App\Domain\DeFi\ValueObjects\SwapQuote;
+use Carbon\CarbonImmutable;
+
+uses(Tests\TestCase::class);
+
+beforeEach(function () {
+    $this->service = new SwapAggregatorService();
+});
+
+function createMockSwapConnector(
+    DeFiProtocol $protocol,
+    string $outputAmount = '990.00',
+    string $gasEstimate = '5.00',
+): SwapProtocolInterface&Mockery\MockInterface {
+    $mock = Mockery::mock(SwapProtocolInterface::class);
+    $mock->shouldReceive('getProtocol')->andReturn($protocol);
+    $mock->shouldReceive('getQuote')->andReturn(new SwapQuote(
+        quoteId: 'q-' . uniqid(),
+        chain: CrossChainNetwork::ETHEREUM,
+        inputToken: 'USDC',
+        outputToken: 'WETH',
+        inputAmount: '1000.00',
+        outputAmount: $outputAmount,
+        priceImpact: '0.1',
+        protocol: $protocol,
+        gasEstimate: $gasEstimate,
+        feeTier: 3000,
+        expiresAt: CarbonImmutable::now()->addMinutes(1),
+    ));
+
+    return $mock;
+}
+
+describe('SwapAggregatorService', function () {
+    it('registers and retrieves connectors', function () {
+        $connector = createMockSwapConnector(DeFiProtocol::DEMO);
+        $this->service->registerConnector($connector);
+
+        expect($this->service->getConnectors())->toHaveKey('demo');
+    });
+
+    it('gets quotes from all connectors', function () {
+        $this->service->registerConnector(createMockSwapConnector(DeFiProtocol::DEMO, '990.00'));
+        $this->service->registerConnector(createMockSwapConnector(DeFiProtocol::UNISWAP_V3, '995.00'));
+
+        $quotes = $this->service->getQuotes(
+            CrossChainNetwork::ETHEREUM,
+            'USDC',
+            'WETH',
+            '1000.00',
+        );
+
+        expect($quotes)->toHaveCount(2);
+    });
+
+    it('throws when no connectors provide quotes', function () {
+        $this->service->getQuotes(
+            CrossChainNetwork::ETHEREUM,
+            'UNKNOWN',
+            'WETH',
+            '1000.00',
+        );
+    })->throws(InsufficientLiquidityException::class);
+
+    it('gets best quote by highest output', function () {
+        $this->service->registerConnector(createMockSwapConnector(DeFiProtocol::DEMO, '990.00'));
+        $this->service->registerConnector(createMockSwapConnector(DeFiProtocol::UNISWAP_V3, '998.00'));
+
+        $best = $this->service->getBestQuote(
+            CrossChainNetwork::ETHEREUM,
+            'USDC',
+            'WETH',
+            '1000.00',
+        );
+
+        expect($best->outputAmount)->toBe('998.00');
+    });
+
+    it('gets cheapest gas quote', function () {
+        $this->service->registerConnector(createMockSwapConnector(DeFiProtocol::DEMO, '990.00', '10.00'));
+        $this->service->registerConnector(createMockSwapConnector(DeFiProtocol::CURVE, '988.00', '2.00'));
+
+        $cheapest = $this->service->getCheapestGasQuote(
+            CrossChainNetwork::ETHEREUM,
+            'USDC',
+            'WETH',
+            '1000.00',
+        );
+
+        expect($cheapest->gasEstimate)->toBe('2.00');
+    });
+
+    it('gracefully handles failing connectors', function () {
+        $failingConnector = Mockery::mock(SwapProtocolInterface::class);
+        $failingConnector->shouldReceive('getProtocol')->andReturn(DeFiProtocol::UNISWAP_V3);
+        $failingConnector->shouldReceive('getQuote')->andThrow(new RuntimeException('API error'));
+
+        $workingConnector = createMockSwapConnector(DeFiProtocol::DEMO);
+
+        $this->service->registerConnector($failingConnector);
+        $this->service->registerConnector($workingConnector);
+
+        $quotes = $this->service->getQuotes(
+            CrossChainNetwork::ETHEREUM,
+            'USDC',
+            'WETH',
+            '1000.00',
+        );
+
+        expect($quotes)->toHaveCount(1);
+    });
+
+    it('handles custom slippage tolerance', function () {
+        $this->service->registerConnector(createMockSwapConnector(DeFiProtocol::DEMO));
+
+        $quotes = $this->service->getQuotes(
+            CrossChainNetwork::ETHEREUM,
+            'USDC',
+            'WETH',
+            '1000.00',
+            1.0,
+        );
+
+        expect($quotes)->toHaveCount(1);
+    });
+
+    it('returns quotes from multiple protocols', function () {
+        $this->service->registerConnector(createMockSwapConnector(DeFiProtocol::DEMO));
+        $this->service->registerConnector(createMockSwapConnector(DeFiProtocol::UNISWAP_V3));
+        $this->service->registerConnector(createMockSwapConnector(DeFiProtocol::CURVE));
+
+        $quotes = $this->service->getQuotes(
+            CrossChainNetwork::ETHEREUM,
+            'USDC',
+            'WETH',
+            '1000.00',
+        );
+
+        expect($quotes)->toHaveCount(3);
+    });
+});


### PR DESCRIPTION
## Summary
- Create new `DeFi` bounded context with protocol adapter interfaces and position tracking
- Add `SwapProtocolInterface`, `LendingProtocolInterface`, `LiquidStakingInterface`, `YieldVaultInterface`
- Implement `SwapAggregatorService` for multi-DEX quote aggregation with best-price/cheapest-gas routing
- Implement `DeFiPositionTrackerService` for position lifecycle (open/close/filter/at-risk detection)
- Implement `DeFiPortfolioService` with protocol/chain/type breakdowns and weighted APY
- Add enums, value objects, domain events, and domain exceptions
- Register `DeFiServiceProvider` with protocol-specific configs

## Test plan
- [x] 20 unit tests passing (8 aggregator + 6 position tracker + 6 portfolio)
- [x] Code style fixed via php-cs-fixer
- [x] All existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)