### PR TITLE
feat(api): Add CrossChain & DeFi API endpoints + v3.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to the FinAegis Core Banking Platform will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v3.0.0] - 2026-02-10
+
+### Added
+
+#### CrossChain Domain
+- **CrossChain bounded context** with bridge protocol abstractions and chain registry
+- **BridgeOrchestratorService** - Multi-provider bridge orchestration (quote aggregation, route optimization)
+- **Wormhole, LayerZero, Axelar bridge adapters** - Protocol-specific implementations with demo mode
+- **BridgeFeeComparisonService** - Cross-provider fee/time comparison with weighted ranking
+- **CrossChainAssetRegistryService** - Token address mapping across 9 chains
+- **BridgeTransactionTracker** - Cache-based bridge transaction lifecycle tracking
+- **CrossChainSwapService** - Atomic cross-chain swaps (bridge + swap in optimal order)
+- **CrossChainSwapSaga** - Compensation-based saga for bridge+swap failure recovery
+- **CrossChainYieldService** - Best yield discovery across chains with bridge cost analysis
+- **MultiChainPortfolioService** - Aggregated portfolio across all chains with DeFi positions
+
+#### DeFi Domain
+- **DeFi bounded context** with protocol adapter interfaces and position tracking
+- **UniswapV3Connector** - Multi-fee-tier swaps, L2 gas optimization, price impact estimation
+- **AaveV3Connector** - Supply/borrow/repay/withdraw with market data and health factor
+- **CurveConnector** - Stablecoin-optimized swaps with lower fees (0.04%)
+- **LidoConnector** - ETH staking with stETH derivatives and withdrawal queue
+- **SwapAggregatorService** - Multi-DEX quote aggregation with best-price routing
+- **SwapRouterService** - Optimal route selection across DEXs with price impact validation
+- **FlashLoanService** - Aave V3 flash loan orchestration with 0.05% fee
+- **DeFiPortfolioService** - Aggregated portfolio with protocol/chain/type breakdowns
+- **DeFiPositionTrackerService** - DeFi position tracking with health factor monitoring
+
+#### API Endpoints
+- 6 CrossChain API endpoints (`/api/v1/crosschain/`) - chains, bridge quotes, bridge initiate, bridge status, cross-chain swap quote/execute
+- 8 DeFi API endpoints (`/api/v1/defi/`) - protocols, swap quote/execute, lending markets, portfolio, positions, staking, yield
+
+---
+
 ## [v2.10.0] - 2026-02-10
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ git status && git branch --show-current
 ### Version Status
 | Version | Status | Key Changes |
 |---------|--------|-------------|
+| v3.0.0 | ✅ Released | Cross-Chain & DeFi: Bridge protocols (Wormhole/LayerZero/Axelar), DeFi connectors (Uniswap/Aave/Curve/Lido), cross-chain swaps, multi-chain portfolio |
 | v2.10.0 | ✅ Released | Mobile API Compatibility: Wallet, TrustCert, Commerce, Relayer mobile endpoints |
 | v2.9.0 | ✅ Released | BaaS Implementation, SDK Generation, Production Hardening |
 | v2.8.0 | ✅ Released | AI Query Endpoints, RegTech Adapters, MiFID II/MiCA/Travel Rule Services |
@@ -101,6 +102,8 @@ app/
 │   ├── Relayer/      # ERC-4337 Gas Abstraction, Smart Accounts (v2.6.0)
 │   ├── MobilePayment/# Payment Intents, Receipts, Activity Feed (v2.7.0)
 │   ├── RegTech/      # MiFID II, MiCA, Travel Rule, Jurisdiction Adapters (v2.8.0)
+│   ├── CrossChain/   # Bridge protocols, cross-chain swaps, multi-chain portfolio (v3.0.0)
+│   ├── DeFi/         # DEX aggregation, lending, staking, yield optimization (v3.0.0)
 │   └── Shared/       # CQRS interfaces, events
 ├── Infrastructure/   # CQRS bus implementations
 ├── Http/Controllers/ # REST API
@@ -156,6 +159,16 @@ app/
 | Travel Rule | `TravelRuleService` (RegTech) |
 | RegTech Orchestration | `RegTechOrchestrationService` (RegTech) |
 | AI Transaction Query | `TransactionQueryTool` (AI) |
+| Bridge Orchestration | `BridgeOrchestratorService` (CrossChain) |
+| Bridge Fee Comparison | `BridgeFeeComparisonService` (CrossChain) |
+| Cross-Chain Swap | `CrossChainSwapService` (CrossChain) |
+| Multi-Chain Portfolio | `MultiChainPortfolioService` (CrossChain) |
+| Cross-Chain Yield | `CrossChainYieldService` (CrossChain) |
+| Swap Aggregation | `SwapAggregatorService` (DeFi) |
+| Swap Routing | `SwapRouterService` (DeFi) |
+| DeFi Portfolio | `DeFiPortfolioService` (DeFi) |
+| DeFi Positions | `DeFiPositionTrackerService` (DeFi) |
+| Flash Loans | `FlashLoanService` (DeFi) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FinAegis Core Banking Platform
 
 [![CI Pipeline](https://github.com/finaegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml/badge.svg)](https://github.com/finaegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml)
-[![Version](https://img.shields.io/badge/version-2.10.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-3.0.0-blue.svg)](CHANGELOG.md)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![PHP Version](https://img.shields.io/badge/php-%3E%3D8.3-8892BF.svg)](https://php.net/)
 [![Laravel Version](https://img.shields.io/badge/Laravel-12.x-FF2D20.svg)](https://laravel.com/)

--- a/app/Http/Controllers/Api/CrossChain/CrossChainController.php
+++ b/app/Http/Controllers/Api/CrossChain/CrossChainController.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\CrossChain;
+
+use App\Domain\CrossChain\Enums\CrossChainNetwork;
+use App\Domain\CrossChain\Services\BridgeOrchestratorService;
+use App\Domain\CrossChain\Services\BridgeTransactionTracker;
+use App\Domain\CrossChain\Services\CrossChainSwapService;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class CrossChainController extends Controller
+{
+    public function __construct(
+        private readonly BridgeOrchestratorService $bridgeOrchestrator,
+        private readonly BridgeTransactionTracker $bridgeTracker,
+        private readonly CrossChainSwapService $swapService,
+    ) {
+    }
+
+    /**
+     * List supported chains with bridge availability.
+     */
+    public function chains(): JsonResponse
+    {
+        $chains = $this->bridgeOrchestrator->getSupportedChains();
+
+        return response()->json([
+            'success' => true,
+            'data'    => $chains,
+        ]);
+    }
+
+    /**
+     * Get bridge quotes from all providers.
+     */
+    public function bridgeQuote(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'from_chain' => 'required|string',
+            'to_chain'   => 'required|string',
+            'token'      => 'required|string|max:20',
+            'amount'     => 'required|string|regex:/^\d+(\.\d+)?$/',
+        ]);
+
+        try {
+            $sourceChain = CrossChainNetwork::from($validated['from_chain']);
+            $destChain = CrossChainNetwork::from($validated['to_chain']);
+
+            $quotes = $this->bridgeOrchestrator->getQuotes(
+                $sourceChain,
+                $destChain,
+                $validated['token'],
+                $validated['amount'],
+            );
+
+            return response()->json([
+                'success' => true,
+                'data'    => array_map(fn ($q) => $q->toArray(), $quotes),
+            ]);
+        } catch (Throwable $e) {
+            Log::error('Bridge quote failed', ['error' => $e->getMessage()]);
+
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'ERR_CROSSCHAIN_001',
+                    'message' => $e->getMessage(),
+                ],
+            ], 400);
+        }
+    }
+
+    /**
+     * Initiate a bridge transfer.
+     */
+    public function bridgeInitiate(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'from_chain'        => 'required|string',
+            'to_chain'          => 'required|string',
+            'token'             => 'required|string|max:20',
+            'amount'            => 'required|string|regex:/^\d+(\.\d+)?$/',
+            'sender_address'    => 'required|string|max:100',
+            'recipient_address' => 'required|string|max:100',
+        ]);
+
+        try {
+            $sourceChain = CrossChainNetwork::from($validated['from_chain']);
+            $destChain = CrossChainNetwork::from($validated['to_chain']);
+
+            $quote = $this->bridgeOrchestrator->getBestQuote(
+                $sourceChain,
+                $destChain,
+                $validated['token'],
+                $validated['amount'],
+            );
+
+            $result = $this->bridgeOrchestrator->initiateBridge(
+                $quote,
+                $validated['sender_address'],
+                $validated['recipient_address'],
+            );
+
+            return response()->json([
+                'success' => true,
+                'data'    => [
+                    'transaction_id' => $result['transaction_id'],
+                    'status'         => $result['status']->value,
+                    'quote'          => $quote->toArray(),
+                ],
+            ]);
+        } catch (Throwable $e) {
+            Log::error('Bridge initiation failed', ['error' => $e->getMessage()]);
+
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'ERR_CROSSCHAIN_002',
+                    'message' => $e->getMessage(),
+                ],
+            ], 400);
+        }
+    }
+
+    /**
+     * Get bridge transaction status.
+     */
+    public function bridgeStatus(string $id): JsonResponse
+    {
+        $transaction = $this->bridgeTracker->getTransaction($id);
+
+        if ($transaction === null) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'ERR_CROSSCHAIN_003',
+                    'message' => 'Bridge transaction not found.',
+                ],
+            ], 404);
+        }
+
+        return response()->json([
+            'success' => true,
+            'data'    => $transaction,
+        ]);
+    }
+
+    /**
+     * Get a cross-chain swap quote (bridge + swap).
+     */
+    public function swapQuote(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'from_chain' => 'required|string',
+            'to_chain'   => 'required|string',
+            'from_token' => 'required|string|max:20',
+            'to_token'   => 'required|string|max:20',
+            'amount'     => 'required|string|regex:/^\d+(\.\d+)?$/',
+        ]);
+
+        try {
+            $sourceChain = CrossChainNetwork::from($validated['from_chain']);
+            $destChain = CrossChainNetwork::from($validated['to_chain']);
+
+            $quote = $this->swapService->getQuote(
+                $sourceChain,
+                $destChain,
+                $validated['from_token'],
+                $validated['to_token'],
+                $validated['amount'],
+            );
+
+            return response()->json([
+                'success' => true,
+                'data'    => $quote->toArray(),
+            ]);
+        } catch (Throwable $e) {
+            Log::error('Cross-chain swap quote failed', ['error' => $e->getMessage()]);
+
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'ERR_CROSSCHAIN_004',
+                    'message' => $e->getMessage(),
+                ],
+            ], 400);
+        }
+    }
+
+    /**
+     * Execute a cross-chain swap.
+     */
+    public function swapExecute(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'from_chain'     => 'required|string',
+            'to_chain'       => 'required|string',
+            'from_token'     => 'required|string|max:20',
+            'to_token'       => 'required|string|max:20',
+            'amount'         => 'required|string|regex:/^\d+(\.\d+)?$/',
+            'wallet_address' => 'required|string|max:100',
+        ]);
+
+        try {
+            $sourceChain = CrossChainNetwork::from($validated['from_chain']);
+            $destChain = CrossChainNetwork::from($validated['to_chain']);
+
+            $quote = $this->swapService->getQuote(
+                $sourceChain,
+                $destChain,
+                $validated['from_token'],
+                $validated['to_token'],
+                $validated['amount'],
+            );
+
+            $result = $this->swapService->executeSwap($quote, $validated['wallet_address']);
+
+            return response()->json([
+                'success' => true,
+                'data'    => $result,
+            ]);
+        } catch (Throwable $e) {
+            Log::error('Cross-chain swap execution failed', ['error' => $e->getMessage()]);
+
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'ERR_CROSSCHAIN_005',
+                    'message' => $e->getMessage(),
+                ],
+            ], 400);
+        }
+    }
+}

--- a/app/Http/Controllers/Api/DeFi/DeFiController.php
+++ b/app/Http/Controllers/Api/DeFi/DeFiController.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\DeFi;
+
+use App\Domain\CrossChain\Enums\CrossChainNetwork;
+use App\Domain\DeFi\Contracts\LendingProtocolInterface;
+use App\Domain\DeFi\Contracts\LiquidStakingInterface;
+use App\Domain\DeFi\Enums\DeFiProtocol;
+use App\Domain\DeFi\Services\DeFiPortfolioService;
+use App\Domain\DeFi\Services\DeFiPositionTrackerService;
+use App\Domain\DeFi\Services\SwapRouterService;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class DeFiController extends Controller
+{
+    public function __construct(
+        private readonly SwapRouterService $swapRouter,
+        private readonly DeFiPortfolioService $portfolioService,
+        private readonly DeFiPositionTrackerService $positionTracker,
+        private readonly LendingProtocolInterface $lendingProtocol,
+        private readonly LiquidStakingInterface $stakingProtocol,
+    ) {
+    }
+
+    /**
+     * List supported DeFi protocols with chain availability.
+     */
+    public function protocols(): JsonResponse
+    {
+        $protocols = array_map(fn (DeFiProtocol $p) => [
+            'name'     => $p->value,
+            'display'  => $p->getDisplayName(),
+            'category' => $p->getCategory(),
+        ], DeFiProtocol::cases());
+
+        return response()->json([
+            'success' => true,
+            'data'    => array_values($protocols),
+        ]);
+    }
+
+    /**
+     * Get multi-DEX swap quote.
+     */
+    public function swapQuote(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'chain'      => 'required|string',
+            'from_token' => 'required|string|max:20',
+            'to_token'   => 'required|string|max:20',
+            'amount'     => 'required|string|regex:/^\d+(\.\d+)?$/',
+            'slippage'   => 'nullable|numeric|min:0.01|max:50',
+        ]);
+
+        try {
+            $chain = CrossChainNetwork::from($validated['chain']);
+            $slippage = (float) ($validated['slippage'] ?? 0.5);
+
+            $quote = $this->swapRouter->findBestRoute(
+                $chain,
+                $validated['from_token'],
+                $validated['to_token'],
+                $validated['amount'],
+                $slippage,
+            );
+
+            return response()->json([
+                'success' => true,
+                'data'    => $quote->toArray(),
+            ]);
+        } catch (Throwable $e) {
+            Log::error('DeFi swap quote failed', ['error' => $e->getMessage()]);
+
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'ERR_DEFI_001',
+                    'message' => $e->getMessage(),
+                ],
+            ], 400);
+        }
+    }
+
+    /**
+     * Execute swap via best route.
+     */
+    public function swapExecute(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'chain'          => 'required|string',
+            'from_token'     => 'required|string|max:20',
+            'to_token'       => 'required|string|max:20',
+            'amount'         => 'required|string|regex:/^\d+(\.\d+)?$/',
+            'wallet_address' => 'required|string|max:100',
+            'slippage'       => 'nullable|numeric|min:0.01|max:50',
+        ]);
+
+        try {
+            $chain = CrossChainNetwork::from($validated['chain']);
+            $slippage = (float) ($validated['slippage'] ?? 0.5);
+
+            $quote = $this->swapRouter->findBestRoute(
+                $chain,
+                $validated['from_token'],
+                $validated['to_token'],
+                $validated['amount'],
+                $slippage,
+            );
+
+            $result = $this->swapRouter->executeSwap($quote, $validated['wallet_address']);
+
+            return response()->json([
+                'success' => true,
+                'data'    => $result,
+            ]);
+        } catch (Throwable $e) {
+            Log::error('DeFi swap execution failed', ['error' => $e->getMessage()]);
+
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'ERR_DEFI_002',
+                    'message' => $e->getMessage(),
+                ],
+            ], 400);
+        }
+    }
+
+    /**
+     * Get lending markets.
+     */
+    public function lendingMarkets(Request $request): JsonResponse
+    {
+        $chain = $request->query('chain', 'ethereum');
+
+        try {
+            $network = CrossChainNetwork::from((string) $chain);
+            $markets = $this->lendingProtocol->getMarkets($network);
+
+            return response()->json([
+                'success' => true,
+                'data'    => $markets,
+            ]);
+        } catch (Throwable $e) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'ERR_DEFI_003',
+                    'message' => $e->getMessage(),
+                ],
+            ], 400);
+        }
+    }
+
+    /**
+     * Get full DeFi portfolio across chains.
+     */
+    public function portfolio(Request $request): JsonResponse
+    {
+        $walletAddress = $request->query('wallet_address', '0xDefault');
+
+        $summary = $this->portfolioService->getPortfolioSummary((string) $walletAddress);
+
+        return response()->json([
+            'success' => true,
+            'data'    => $summary,
+        ]);
+    }
+
+    /**
+     * Get active DeFi positions with optional filters.
+     */
+    public function positions(Request $request): JsonResponse
+    {
+        $walletAddress = $request->query('wallet_address', '0xDefault');
+        $chain = $request->query('chain');
+        $protocol = $request->query('protocol');
+
+        $chainFilter = $chain ? CrossChainNetwork::tryFrom((string) $chain) : null;
+        $protocolFilter = $protocol ? DeFiProtocol::tryFrom((string) $protocol) : null;
+
+        $positions = $this->positionTracker->getActivePositions(
+            (string) $walletAddress,
+            $chainFilter,
+            $protocolFilter,
+        );
+
+        return response()->json([
+            'success' => true,
+            'data'    => array_map(fn ($p) => $p->toArray(), $positions),
+        ]);
+    }
+
+    /**
+     * Get liquid staking info and user positions.
+     */
+    public function staking(Request $request): JsonResponse
+    {
+        $chain = $request->query('chain', 'ethereum');
+        $walletAddress = $request->query('wallet_address', '0xDefault');
+
+        try {
+            $network = CrossChainNetwork::from((string) $chain);
+
+            $data = [
+                'protocol'       => 'lido',
+                'staking_apy'    => $this->stakingProtocol->getStakingAPY($network),
+                'staked_balance' => $this->stakingProtocol->getStakedBalance($network, (string) $walletAddress),
+            ];
+
+            return response()->json([
+                'success' => true,
+                'data'    => $data,
+            ]);
+        } catch (Throwable $e) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'ERR_DEFI_004',
+                    'message' => $e->getMessage(),
+                ],
+            ], 400);
+        }
+    }
+
+    /**
+     * Get yield opportunities across chains.
+     */
+    public function yield(Request $request): JsonResponse
+    {
+        $walletAddress = $request->query('wallet_address', '0xDefault');
+
+        $opportunities = $this->portfolioService->getYieldOpportunities((string) $walletAddress);
+
+        return response()->json([
+            'success' => true,
+            'data'    => $opportunities,
+        ]);
+    }
+}

--- a/docs/VERSION_ROADMAP.md
+++ b/docs/VERSION_ROADMAP.md
@@ -1105,6 +1105,7 @@ main ─────────●─────────●─────
 | **v2.9.0** | BaaS & Production Hardening | ML Anomaly Detection, BaaS Implementation, SDK Generation | ✅ Released 2026-02-10 |
 | **v2.9.1** | Production Hardening | On-Chain SBT, snarkjs, AWS KMS, Azure Key Vault, Security Audit | ✅ Released 2026-02-10 |
 | **v2.10.0** | Mobile API Compatibility | ~30 mobile-facing API endpoints, response envelope consistency, wallet/TrustCert/commerce/relayer mobile APIs | ✅ Released 2026-02-10 |
+| **v3.0.0** | Cross-Chain & DeFi | CrossChain bridges (Wormhole/LayerZero/Axelar), DeFi protocols (Uniswap/Aave/Curve/Lido), cross-chain swaps, multi-chain portfolio | ✅ Released 2026-02-10 |
 
 ---
 
@@ -1509,5 +1510,5 @@ Adds approximately 30 new mobile-facing API endpoints across wallet, TrustCert, 
 
 *Document Version: 2.10.0*
 *Created: January 11, 2026*
-*Updated: February 10, 2026 (v2.10.0 Released — Mobile API Compatibility)*
+*Updated: February 10, 2026 (v3.0.0 Released — Cross-Chain & DeFi)*
 *Next Review: v3.0.0 Planning*

--- a/routes/api.php
+++ b/routes/api.php
@@ -1591,6 +1591,60 @@ Route::prefix('partner/v1')->name('api.partner.')->middleware('partner.auth')->g
     Route::get('/marketplace/health', [App\Http\Controllers\Api\Partner\PartnerMarketplaceController::class, 'health'])->name('marketplace.health');
 });
 
+/*
+|--------------------------------------------------------------------------
+| CrossChain Bridge & Swap API Routes (v3.0.0)
+|--------------------------------------------------------------------------
+|
+| Cross-chain bridge transfers, multi-provider quotes, and cross-chain swaps.
+|
+*/
+
+use App\Http\Controllers\Api\CrossChain\CrossChainController;
+
+Route::prefix('v1/crosschain')->name('api.crosschain.')->group(function () {
+    Route::get('/chains', [CrossChainController::class, 'chains'])->name('chains');
+
+    Route::middleware(['auth:sanctum', 'check.token.expiration'])->group(function () {
+        Route::post('/bridge/quote', [CrossChainController::class, 'bridgeQuote'])->name('bridge.quote');
+        Route::post('/bridge/initiate', [CrossChainController::class, 'bridgeInitiate'])
+            ->middleware('transaction.rate_limit:crosschain')
+            ->name('bridge.initiate');
+        Route::get('/bridge/{id}/status', [CrossChainController::class, 'bridgeStatus'])->name('bridge.status');
+        Route::post('/swap/quote', [CrossChainController::class, 'swapQuote'])->name('swap.quote');
+        Route::post('/swap/execute', [CrossChainController::class, 'swapExecute'])
+            ->middleware('transaction.rate_limit:crosschain')
+            ->name('swap.execute');
+    });
+});
+
+/*
+|--------------------------------------------------------------------------
+| DeFi Protocol API Routes (v3.0.0)
+|--------------------------------------------------------------------------
+|
+| Multi-DEX swap aggregation, lending markets, staking, yield, and portfolio.
+|
+*/
+
+use App\Http\Controllers\Api\DeFi\DeFiController;
+
+Route::prefix('v1/defi')->name('api.defi.')->group(function () {
+    Route::get('/protocols', [DeFiController::class, 'protocols'])->name('protocols');
+
+    Route::middleware(['auth:sanctum', 'check.token.expiration'])->group(function () {
+        Route::post('/swap/quote', [DeFiController::class, 'swapQuote'])->name('swap.quote');
+        Route::post('/swap/execute', [DeFiController::class, 'swapExecute'])
+            ->middleware('transaction.rate_limit:defi')
+            ->name('swap.execute');
+        Route::get('/lending/markets', [DeFiController::class, 'lendingMarkets'])->name('lending.markets');
+        Route::get('/portfolio', [DeFiController::class, 'portfolio'])->name('portfolio');
+        Route::get('/positions', [DeFiController::class, 'positions'])->name('positions');
+        Route::get('/staking', [DeFiController::class, 'staking'])->name('staking');
+        Route::get('/yield', [DeFiController::class, 'yield'])->name('yield');
+    });
+});
+
 // TEMPORARY DEBUG ROUTE - remove after testing
 Route::post('/debug-json', function (Request $request) {
     return response()->json([

--- a/tests/Unit/Http/Controllers/Api/CrossChain/CrossChainControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/CrossChain/CrossChainControllerTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\CrossChain\Enums\BridgeProvider;
+use App\Domain\CrossChain\Enums\CrossChainNetwork;
+use App\Domain\CrossChain\Services\Adapters\DemoBridgeAdapter;
+use App\Domain\CrossChain\Services\BridgeOrchestratorService;
+use App\Domain\CrossChain\Services\BridgeTransactionTracker;
+use App\Domain\CrossChain\Services\CrossChainSwapSaga;
+use App\Domain\CrossChain\Services\CrossChainSwapService;
+use App\Domain\DeFi\Services\Connectors\DemoSwapConnector;
+use App\Domain\DeFi\Services\Connectors\UniswapV3Connector;
+use App\Domain\DeFi\Services\SwapAggregatorService;
+use App\Domain\DeFi\Services\SwapRouterService;
+use App\Http\Controllers\Api\CrossChain\CrossChainController;
+use Illuminate\Http\Request;
+
+uses(Tests\TestCase::class);
+
+function makePostRequest(string $uri, array $data): Request
+{
+    $json = json_encode($data);
+
+    return Request::create($uri, 'POST', [], [], [], [
+        'CONTENT_TYPE' => 'application/json',
+        'HTTP_ACCEPT'  => 'application/json',
+    ], $json);
+}
+
+beforeEach(function () {
+    $this->bridgeOrchestrator = new BridgeOrchestratorService();
+    $this->bridgeOrchestrator->registerAdapter(new DemoBridgeAdapter());
+
+    $this->bridgeTracker = new BridgeTransactionTracker();
+
+    $aggregator = new SwapAggregatorService();
+    $aggregator->registerConnector(new DemoSwapConnector());
+    $aggregator->registerConnector(new UniswapV3Connector());
+    $swapRouter = new SwapRouterService($aggregator);
+
+    $saga = new CrossChainSwapSaga($this->bridgeOrchestrator, $swapRouter, $this->bridgeTracker);
+    $this->swapService = new CrossChainSwapService($this->bridgeOrchestrator, $swapRouter, $saga);
+
+    $this->controller = new CrossChainController(
+        $this->bridgeOrchestrator,
+        $this->bridgeTracker,
+        $this->swapService,
+    );
+});
+
+describe('CrossChainController', function () {
+    it('returns supported chains', function () {
+        $response = $this->controller->chains();
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue();
+        expect($data['data'])->toBeArray();
+    });
+
+    it('returns bridge quotes', function () {
+        $request = makePostRequest('/api/v1/crosschain/bridge/quote', [
+            'from_chain' => 'ethereum',
+            'to_chain'   => 'polygon',
+            'token'      => 'USDC',
+            'amount'     => '1000.00',
+        ]);
+
+        $response = $this->controller->bridgeQuote($request);
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue();
+        expect($data['data'])->toBeArray();
+        expect($data['data'][0])->toHaveKeys(['quote_id', 'input_amount', 'output_amount', 'fee']);
+    });
+
+    it('initiates a bridge transfer', function () {
+        $request = makePostRequest('/api/v1/crosschain/bridge/initiate', [
+            'from_chain'        => 'ethereum',
+            'to_chain'          => 'polygon',
+            'token'             => 'USDC',
+            'amount'            => '500.00',
+            'sender_address'    => '0xSender',
+            'recipient_address' => '0xRecipient',
+        ]);
+
+        $response = $this->controller->bridgeInitiate($request);
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue();
+        expect($data['data'])->toHaveKeys(['transaction_id', 'status', 'quote']);
+    });
+
+    it('returns bridge transaction status', function () {
+        $this->bridgeTracker->recordTransaction(
+            'test_tx_123',
+            CrossChainNetwork::ETHEREUM,
+            CrossChainNetwork::POLYGON,
+            'USDC',
+            '500.00',
+            BridgeProvider::DEMO,
+            '0xSender',
+            '0xRecipient',
+        );
+
+        $response = $this->controller->bridgeStatus('test_tx_123');
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue();
+        expect($data['data'])->toHaveKey('transaction_id');
+    });
+
+    it('returns 404 for unknown bridge transaction', function () {
+        $response = $this->controller->bridgeStatus('nonexistent_tx');
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeFalse();
+        expect($response->getStatusCode())->toBe(404);
+    });
+
+    it('returns cross-chain swap quote', function () {
+        $request = makePostRequest('/api/v1/crosschain/swap/quote', [
+            'from_chain' => 'ethereum',
+            'to_chain'   => 'polygon',
+            'from_token' => 'USDC',
+            'to_token'   => 'WETH',
+            'amount'     => '1000.00',
+        ]);
+
+        $response = $this->controller->swapQuote($request);
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue();
+        expect($data['data'])->toHaveKeys([
+            'quote_id', 'source_chain', 'dest_chain', 'input_token',
+            'output_token', 'bridge_quote', 'total_fee',
+        ]);
+    });
+
+    it('executes cross-chain swap', function () {
+        $request = makePostRequest('/api/v1/crosschain/swap/execute', [
+            'from_chain'     => 'ethereum',
+            'to_chain'       => 'polygon',
+            'from_token'     => 'USDC',
+            'to_token'       => 'WETH',
+            'amount'         => '1000.00',
+            'wallet_address' => '0xTestWallet',
+        ]);
+
+        $response = $this->controller->swapExecute($request);
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue();
+        expect($data['data'])->toHaveKeys(['bridge_tx', 'swap_tx', 'output_amount', 'status']);
+        expect($data['data']['status'])->toBe('completed');
+    });
+
+    it('handles errors for invalid chain in bridge quote', function () {
+        $request = makePostRequest('/api/v1/crosschain/bridge/quote', [
+            'from_chain' => 'invalid_chain',
+            'to_chain'   => 'polygon',
+            'token'      => 'USDC',
+            'amount'     => '1000.00',
+        ]);
+
+        $response = $this->controller->bridgeQuote($request);
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeFalse();
+        expect($response->getStatusCode())->toBe(400);
+    });
+
+    it('returns bridge-only swap when tokens match', function () {
+        $request = makePostRequest('/api/v1/crosschain/swap/quote', [
+            'from_chain' => 'ethereum',
+            'to_chain'   => 'arbitrum',
+            'from_token' => 'USDC',
+            'to_token'   => 'USDC',
+            'amount'     => '2000.00',
+        ]);
+
+        $response = $this->controller->swapQuote($request);
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue();
+        expect($data['data']['swap_quote'])->toBeNull();
+    });
+
+    it('includes fee currency in swap quote', function () {
+        $request = makePostRequest('/api/v1/crosschain/swap/quote', [
+            'from_chain' => 'ethereum',
+            'to_chain'   => 'polygon',
+            'from_token' => 'USDC',
+            'to_token'   => 'WETH',
+            'amount'     => '1000.00',
+        ]);
+
+        $response = $this->controller->swapQuote($request);
+        $data = $response->getData(true);
+
+        expect($data['data'])->toHaveKey('fee_currency');
+    });
+
+    it('supports different chain combinations for bridge', function () {
+        $request = makePostRequest('/api/v1/crosschain/bridge/quote', [
+            'from_chain' => 'arbitrum',
+            'to_chain'   => 'optimism',
+            'token'      => 'USDC',
+            'amount'     => '500.00',
+        ]);
+
+        $response = $this->controller->bridgeQuote($request);
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue();
+    });
+});

--- a/tests/Unit/Http/Controllers/Api/DeFi/DeFiControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/DeFi/DeFiControllerTest.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\CrossChain\Enums\CrossChainNetwork;
+use App\Domain\DeFi\Enums\DeFiPositionType;
+use App\Domain\DeFi\Enums\DeFiProtocol;
+use App\Domain\DeFi\Services\Connectors\AaveV3Connector;
+use App\Domain\DeFi\Services\Connectors\DemoSwapConnector;
+use App\Domain\DeFi\Services\Connectors\LidoConnector;
+use App\Domain\DeFi\Services\Connectors\UniswapV3Connector;
+use App\Domain\DeFi\Services\DeFiPortfolioService;
+use App\Domain\DeFi\Services\DeFiPositionTrackerService;
+use App\Domain\DeFi\Services\SwapAggregatorService;
+use App\Domain\DeFi\Services\SwapRouterService;
+use App\Http\Controllers\Api\DeFi\DeFiController;
+use Illuminate\Http\Request;
+
+uses(Tests\TestCase::class);
+
+function makeDefiPostRequest(string $uri, array $data): Request
+{
+    $json = json_encode($data);
+
+    return Request::create($uri, 'POST', [], [], [], [
+        'CONTENT_TYPE' => 'application/json',
+        'HTTP_ACCEPT'  => 'application/json',
+    ], $json);
+}
+
+beforeEach(function () {
+    $aggregator = new SwapAggregatorService();
+    $aggregator->registerConnector(new DemoSwapConnector());
+    $aggregator->registerConnector(new UniswapV3Connector());
+    $this->swapRouter = new SwapRouterService($aggregator);
+
+    $this->positionTracker = new DeFiPositionTrackerService();
+    $this->portfolioService = new DeFiPortfolioService($this->positionTracker);
+
+    $this->controller = new DeFiController(
+        $this->swapRouter,
+        $this->portfolioService,
+        $this->positionTracker,
+        new AaveV3Connector(),
+        new LidoConnector(),
+    );
+});
+
+describe('DeFiController', function () {
+    it('returns list of supported protocols', function () {
+        $response = $this->controller->protocols();
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue();
+        expect($data['data'])->toBeArray();
+        expect(count($data['data']))->toBeGreaterThanOrEqual(4);
+
+        $names = array_column($data['data'], 'name');
+        expect($names)->toContain('uniswap_v3');
+        expect($names)->toContain('aave_v3');
+    });
+
+    it('returns swap quote', function () {
+        $request = makeDefiPostRequest('/api/v1/defi/swap/quote', [
+            'chain'      => 'ethereum',
+            'from_token' => 'USDC',
+            'to_token'   => 'WETH',
+            'amount'     => '1000.00',
+        ]);
+
+        $response = $this->controller->swapQuote($request);
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue();
+        expect($data['data'])->toHaveKeys([
+            'quote_id', 'chain', 'input_token', 'output_token',
+            'input_amount', 'output_amount', 'price_impact', 'protocol',
+        ]);
+    });
+
+    it('executes swap', function () {
+        $request = makeDefiPostRequest('/api/v1/defi/swap/execute', [
+            'chain'          => 'ethereum',
+            'from_token'     => 'USDC',
+            'to_token'       => 'WETH',
+            'amount'         => '500.00',
+            'wallet_address' => '0xTestWallet',
+        ]);
+
+        $response = $this->controller->swapExecute($request);
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue();
+        expect($data['data'])->toHaveKeys(['tx_hash', 'output_amount', 'protocol']);
+    });
+
+    it('returns lending markets', function () {
+        $request = Request::create('/api/v1/defi/lending/markets?chain=ethereum');
+
+        $response = $this->controller->lendingMarkets($request);
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue();
+        expect($data['data'])->toBeArray();
+        expect(count($data['data']))->toBeGreaterThan(0);
+        expect($data['data'][0])->toHaveKeys(['token', 'supply_apy', 'borrow_apy']);
+    });
+
+    it('returns empty markets for unsupported chain', function () {
+        $request = Request::create('/api/v1/defi/lending/markets?chain=bitcoin');
+
+        $response = $this->controller->lendingMarkets($request);
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue();
+        expect($data['data'])->toBeEmpty();
+    });
+
+    it('returns portfolio summary', function () {
+        $request = Request::create('/api/v1/defi/portfolio?wallet_address=0xPortfolioUser');
+
+        $response = $this->controller->portfolio($request);
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue();
+        expect($data['data'])->toHaveKeys(['total_value_usd', 'positions_count']);
+    });
+
+    it('returns active positions', function () {
+        $this->positionTracker->openPosition(
+            DeFiProtocol::AAVE_V3,
+            DeFiPositionType::SUPPLY,
+            CrossChainNetwork::ETHEREUM,
+            'USDC',
+            '5000.00',
+            '5000.00',
+            '3.50',
+            '0xPositionUser',
+        );
+
+        $request = Request::create('/api/v1/defi/positions?wallet_address=0xPositionUser');
+
+        $response = $this->controller->positions($request);
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue();
+        expect($data['data'])->toBeArray();
+        expect(count($data['data']))->toBe(1);
+    });
+
+    it('filters positions by chain', function () {
+        $this->positionTracker->openPosition(
+            DeFiProtocol::AAVE_V3,
+            DeFiPositionType::SUPPLY,
+            CrossChainNetwork::ETHEREUM,
+            'USDC',
+            '1000.00',
+            '1000.00',
+            '3.50',
+            '0xFilterUser',
+        );
+        $this->positionTracker->openPosition(
+            DeFiProtocol::AAVE_V3,
+            DeFiPositionType::SUPPLY,
+            CrossChainNetwork::POLYGON,
+            'USDC',
+            '2000.00',
+            '2000.00',
+            '3.50',
+            '0xFilterUser',
+        );
+
+        $request = Request::create('/api/v1/defi/positions?wallet_address=0xFilterUser&chain=ethereum');
+
+        $response = $this->controller->positions($request);
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue();
+        expect(count($data['data']))->toBe(1);
+    });
+
+    it('returns staking info', function () {
+        $request = Request::create('/api/v1/defi/staking?chain=ethereum&wallet_address=0xStaker');
+
+        $response = $this->controller->staking($request);
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue();
+        expect($data['data'])->toHaveKeys(['protocol', 'staking_apy', 'staked_balance']);
+        expect($data['data']['protocol'])->toBe('lido');
+    });
+
+    it('returns yield opportunities', function () {
+        $request = Request::create('/api/v1/defi/yield?wallet_address=0xYieldUser');
+
+        $response = $this->controller->yield($request);
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue();
+        expect($data['data'])->toBeArray();
+    });
+
+    it('handles swap with custom slippage', function () {
+        $request = makeDefiPostRequest('/api/v1/defi/swap/quote', [
+            'chain'      => 'polygon',
+            'from_token' => 'WETH',
+            'to_token'   => 'USDC',
+            'amount'     => '1.00',
+            'slippage'   => 1.0,
+        ]);
+
+        $response = $this->controller->swapQuote($request);
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue();
+    });
+
+    it('handles error for invalid chain in swap quote', function () {
+        $request = makeDefiPostRequest('/api/v1/defi/swap/quote', [
+            'chain'      => 'invalid_chain',
+            'from_token' => 'USDC',
+            'to_token'   => 'WETH',
+            'amount'     => '1000.00',
+        ]);
+
+        $response = $this->controller->swapQuote($request);
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeFalse();
+        expect($response->getStatusCode())->toBe(400);
+    });
+
+    it('returns lending markets for polygon', function () {
+        $request = Request::create('/api/v1/defi/lending/markets?chain=polygon');
+
+        $response = $this->controller->lendingMarkets($request);
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue();
+        expect($data['data'])->toBeArray();
+    });
+});


### PR DESCRIPTION
## Summary
- Add 6 CrossChain API endpoints (`/api/v1/crosschain/`): chains, bridge quote/initiate/status, cross-chain swap quote/execute
- Add 8 DeFi API endpoints (`/api/v1/defi/`): protocols, swap quote/execute, lending markets, portfolio, positions, staking, yield
- Update version to v3.0.0 across README, CHANGELOG, VERSION_ROADMAP, and CLAUDE.md
- 24 new controller tests (11 CrossChain + 13 DeFi), all passing

## Test plan
- [x] All 24 controller tests pass
- [x] All 161 v3.0.0 tests pass (CrossChain + DeFi domains + controllers)
- [x] Code style fixed via php-cs-fixer
- [x] Version badges and documentation updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)