### PR TITLE
fix: v3.0.0 code review — security, correctness, DRY refactoring

### DIFF
--- a/app/Domain/CrossChain/Exceptions/BridgeTransactionFailedException.php
+++ b/app/Domain/CrossChain/Exceptions/BridgeTransactionFailedException.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Domain\CrossChain\Exceptions;
 
 use Exception;
+use Throwable;
 
 class BridgeTransactionFailedException extends Exception
 {
@@ -15,17 +16,19 @@ class BridgeTransactionFailedException extends Exception
         public readonly string $errorCode = self::CODE,
         public readonly int $httpStatusCode = 500,
         public readonly ?string $transactionId = null,
+        ?Throwable $previous = null,
     ) {
-        parent::__construct($message);
+        parent::__construct($message, 0, $previous);
     }
 
-    public static function executionFailed(string $transactionId, string $reason): self
+    public static function executionFailed(string $transactionId, string $reason, ?Throwable $previous = null): self
     {
         return new self(
             "Bridge transaction {$transactionId} failed: {$reason}",
             self::CODE,
             500,
             $transactionId,
+            $previous,
         );
     }
 

--- a/app/Domain/CrossChain/Services/Adapters/DemoBridgeAdapter.php
+++ b/app/Domain/CrossChain/Services/Adapters/DemoBridgeAdapter.php
@@ -89,7 +89,7 @@ class DemoBridgeAdapter implements BridgeAdapterInterface
 
     public function getBridgeStatus(string $transactionId): array
     {
-        $status = $this->transactionStatuses[$transactionId] ?? BridgeStatus::COMPLETED;
+        $status = $this->transactionStatuses[$transactionId] ?? BridgeStatus::FAILED;
 
         return [
             'status'         => $status,

--- a/app/Domain/CrossChain/Services/CrossChainSwapSaga.php
+++ b/app/Domain/CrossChain/Services/CrossChainSwapSaga.php
@@ -71,7 +71,7 @@ class CrossChainSwapSaga
      *
      * On failure, logs the compensation needed (tokens remain on dest chain).
      *
-     * @return array{tx_hash: string, output_amount: string}
+     * @return array{tx_hash: string, output_amount: string, swap_failed?: bool}
      */
     public function executeSwapAfterBridge(
         CrossChainSwapQuote $quote,
@@ -100,6 +100,7 @@ class CrossChainSwapSaga
             return [
                 'tx_hash'       => 'failed_swap_' . $bridgeResult['transaction_id'],
                 'output_amount' => $quote->bridgeQuote->outputAmount,
+                'swap_failed'   => true,
             ];
         }
     }

--- a/app/Domain/DeFi/Services/DeFiPortfolioService.php
+++ b/app/Domain/DeFi/Services/DeFiPortfolioService.php
@@ -97,17 +97,7 @@ class DeFiPortfolioService
      */
     private function getProtocolBreakdown(array $positions): array
     {
-        $breakdown = [];
-        foreach ($positions as $pos) {
-            $key = $pos->protocol->value;
-            if (! isset($breakdown[$key])) {
-                $breakdown[$key] = ['value_usd' => '0', 'positions' => 0];
-            }
-            $breakdown[$key]['value_usd'] = bcadd($breakdown[$key]['value_usd'], $pos->valueUsd, 2);
-            $breakdown[$key]['positions']++;
-        }
-
-        return $breakdown;
+        return $this->buildBreakdown($positions, fn (DeFiPosition $pos) => $pos->protocol->value);
     }
 
     /**
@@ -116,17 +106,7 @@ class DeFiPortfolioService
      */
     private function getChainBreakdown(array $positions): array
     {
-        $breakdown = [];
-        foreach ($positions as $pos) {
-            $key = $pos->chain->value;
-            if (! isset($breakdown[$key])) {
-                $breakdown[$key] = ['value_usd' => '0', 'positions' => 0];
-            }
-            $breakdown[$key]['value_usd'] = bcadd($breakdown[$key]['value_usd'], $pos->valueUsd, 2);
-            $breakdown[$key]['positions']++;
-        }
-
-        return $breakdown;
+        return $this->buildBreakdown($positions, fn (DeFiPosition $pos) => $pos->chain->value);
     }
 
     /**
@@ -135,9 +115,18 @@ class DeFiPortfolioService
      */
     private function getTypeBreakdown(array $positions): array
     {
+        return $this->buildBreakdown($positions, fn (DeFiPosition $pos) => $pos->type->value);
+    }
+
+    /**
+     * @param array<DeFiPosition> $positions
+     * @return array<string, array{value_usd: string, positions: int}>
+     */
+    private function buildBreakdown(array $positions, callable $keyExtractor): array
+    {
         $breakdown = [];
         foreach ($positions as $pos) {
-            $key = $pos->type->value;
+            $key = $keyExtractor($pos);
             if (! isset($breakdown[$key])) {
                 $breakdown[$key] = ['value_usd' => '0', 'positions' => 0];
             }

--- a/app/Domain/DeFi/ValueObjects/SwapQuote.php
+++ b/app/Domain/DeFi/ValueObjects/SwapQuote.php
@@ -32,7 +32,7 @@ final readonly class SwapQuote
 
     public function getEffectiveRate(): string
     {
-        if ($this->inputAmount === '0') {
+        if (empty($this->inputAmount) || bccomp($this->inputAmount, '0', 18) === 0) {
             return '0';
         }
 

--- a/app/Http/Controllers/Api/CrossChain/CrossChainController.php
+++ b/app/Http/Controllers/Api/CrossChain/CrossChainController.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\Rule;
 use Throwable;
 
 class CrossChainController extends Controller
@@ -42,8 +43,8 @@ class CrossChainController extends Controller
     public function bridgeQuote(Request $request): JsonResponse
     {
         $validated = $request->validate([
-            'from_chain' => 'required|string',
-            'to_chain'   => 'required|string',
+            'from_chain' => ['required', 'string', Rule::in(array_column(CrossChainNetwork::cases(), 'value'))],
+            'to_chain'   => ['required', 'string', Rule::in(array_column(CrossChainNetwork::cases(), 'value'))],
             'token'      => 'required|string|max:20',
             'amount'     => 'required|string|regex:/^\d+(\.\d+)?$/',
         ]);
@@ -82,8 +83,8 @@ class CrossChainController extends Controller
     public function bridgeInitiate(Request $request): JsonResponse
     {
         $validated = $request->validate([
-            'from_chain'        => 'required|string',
-            'to_chain'          => 'required|string',
+            'from_chain'        => ['required', 'string', Rule::in(array_column(CrossChainNetwork::cases(), 'value'))],
+            'to_chain'          => ['required', 'string', Rule::in(array_column(CrossChainNetwork::cases(), 'value'))],
             'token'             => 'required|string|max:20',
             'amount'            => 'required|string|regex:/^\d+(\.\d+)?$/',
             'sender_address'    => 'required|string|max:100',
@@ -157,8 +158,8 @@ class CrossChainController extends Controller
     public function swapQuote(Request $request): JsonResponse
     {
         $validated = $request->validate([
-            'from_chain' => 'required|string',
-            'to_chain'   => 'required|string',
+            'from_chain' => ['required', 'string', Rule::in(array_column(CrossChainNetwork::cases(), 'value'))],
+            'to_chain'   => ['required', 'string', Rule::in(array_column(CrossChainNetwork::cases(), 'value'))],
             'from_token' => 'required|string|max:20',
             'to_token'   => 'required|string|max:20',
             'amount'     => 'required|string|regex:/^\d+(\.\d+)?$/',
@@ -199,8 +200,8 @@ class CrossChainController extends Controller
     public function swapExecute(Request $request): JsonResponse
     {
         $validated = $request->validate([
-            'from_chain'     => 'required|string',
-            'to_chain'       => 'required|string',
+            'from_chain'     => ['required', 'string', Rule::in(array_column(CrossChainNetwork::cases(), 'value'))],
+            'to_chain'       => ['required', 'string', Rule::in(array_column(CrossChainNetwork::cases(), 'value'))],
             'from_token'     => 'required|string|max:20',
             'to_token'       => 'required|string|max:20',
             'amount'         => 'required|string|regex:/^\d+(\.\d+)?$/',

--- a/routes/api.php
+++ b/routes/api.php
@@ -1644,17 +1644,3 @@ Route::prefix('v1/defi')->name('api.defi.')->group(function () {
         Route::get('/yield', [DeFiController::class, 'yield'])->name('yield');
     });
 });
-
-// TEMPORARY DEBUG ROUTE - remove after testing
-Route::post('/debug-json', function (Request $request) {
-    return response()->json([
-        'content_type' => $request->header('Content-Type'),
-        'is_json'      => $request->isJson(),
-        'all'          => $request->all(),
-        'json_all'     => $request->json()->all(),
-        'raw_content'  => $request->getContent(),
-        'raw_length'   => strlen($request->getContent()),
-        'method'       => $request->method(),
-        'input_email'  => $request->input('email'),
-    ]);
-});

--- a/tests/Unit/Domain/CrossChain/Services/Adapters/DemoBridgeAdapterTest.php
+++ b/tests/Unit/Domain/CrossChain/Services/Adapters/DemoBridgeAdapterTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\CrossChain\Enums\BridgeProvider;
+use App\Domain\CrossChain\Enums\BridgeStatus;
+use App\Domain\CrossChain\Services\Adapters\DemoBridgeAdapter;
+
+uses(Tests\TestCase::class);
+
+beforeEach(function () {
+    $this->adapter = new DemoBridgeAdapter();
+});
+
+describe('DemoBridgeAdapter', function () {
+    it('returns FAILED for unknown transaction ID', function () {
+        $result = $this->adapter->getBridgeStatus('unknown_tx_id');
+
+        expect($result['status'])->toBe(BridgeStatus::FAILED);
+        expect($result['dest_tx_hash'])->toBeNull();
+        expect($result['confirmations'])->toBe(0);
+    });
+
+    it('returns demo as provider', function () {
+        expect($this->adapter->getProvider())->toBe(BridgeProvider::DEMO);
+    });
+});

--- a/tests/Unit/Domain/CrossChain/Services/BridgeOrchestratorServiceTest.php
+++ b/tests/Unit/Domain/CrossChain/Services/BridgeOrchestratorServiceTest.php
@@ -187,7 +187,14 @@ describe('BridgeOrchestratorService', function () {
 
         $this->service->registerAdapter($adapter);
 
-        $result = $this->service->checkStatus('tx-123', BridgeProvider::DEMO);
+        $result = $this->service->checkStatus(
+            'tx-123',
+            BridgeProvider::DEMO,
+            CrossChainNetwork::ETHEREUM,
+            CrossChainNetwork::POLYGON,
+            'USDC',
+            '1000.00',
+        );
 
         expect($result['status'])->toBe(BridgeStatus::BRIDGING);
         expect($result['confirmations'])->toBe(5);

--- a/tests/Unit/Domain/CrossChain/Services/CrossChainSwapSagaTest.php
+++ b/tests/Unit/Domain/CrossChain/Services/CrossChainSwapSagaTest.php
@@ -89,6 +89,7 @@ describe('CrossChainSwapSaga', function () {
         // Should return bridged amount as output (compensation)
         expect($result['tx_hash'])->toStartWith('failed_swap_');
         expect($result['output_amount'])->toBe($quote->bridgeQuote->outputAmount);
+        expect($result['swap_failed'])->toBeTrue();
     });
 
     it('checks swap status for tracked transactions', function () {

--- a/tests/Unit/Domain/DeFi/Services/DeFiPositionTrackerServiceTest.php
+++ b/tests/Unit/Domain/DeFi/Services/DeFiPositionTrackerServiceTest.php
@@ -76,6 +76,10 @@ describe('DeFiPositionTrackerService', function () {
         expect($atRisk)->toHaveCount(1);
     });
 
+    it('throws exception when closing non-existent position', function () {
+        $this->tracker->closePosition('0xWalletMissing', 'pos-nonexistent');
+    })->throws(InvalidArgumentException::class, 'Position pos-nonexistent not found');
+
     it('calculates total portfolio value', function () {
         $this->tracker->openPosition(DeFiProtocol::AAVE_V3, DeFiPositionType::SUPPLY, CrossChainNetwork::ETHEREUM, 'USDC', '1000.00', '1000.00', '3.50', '0xWallet6');
         $this->tracker->openPosition(DeFiProtocol::LIDO, DeFiPositionType::STAKE, CrossChainNetwork::ETHEREUM, 'ETH', '2.00', '5000.00', '3.80', '0xWallet6');

--- a/tests/Unit/Domain/DeFi/ValueObjects/SwapQuoteTest.php
+++ b/tests/Unit/Domain/DeFi/ValueObjects/SwapQuoteTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\CrossChain\Enums\CrossChainNetwork;
+use App\Domain\DeFi\Enums\DeFiProtocol;
+use App\Domain\DeFi\ValueObjects\SwapQuote;
+use Carbon\CarbonImmutable;
+
+uses(Tests\TestCase::class);
+
+describe('SwapQuote', function () {
+    it('returns zero rate for zero input amount', function () {
+        $quote = new SwapQuote(
+            quoteId: 'q-1',
+            chain: CrossChainNetwork::ETHEREUM,
+            inputToken: 'USDC',
+            outputToken: 'WETH',
+            inputAmount: '0',
+            outputAmount: '0',
+            priceImpact: '0',
+            protocol: DeFiProtocol::DEMO,
+            gasEstimate: '0.001',
+            feeTier: null,
+            expiresAt: CarbonImmutable::now()->addMinutes(5),
+        );
+
+        expect($quote->getEffectiveRate())->toBe('0');
+    });
+
+    it('returns zero rate for empty string input amount', function () {
+        $quote = new SwapQuote(
+            quoteId: 'q-2',
+            chain: CrossChainNetwork::ETHEREUM,
+            inputToken: 'USDC',
+            outputToken: 'WETH',
+            inputAmount: '',
+            outputAmount: '0',
+            priceImpact: '0',
+            protocol: DeFiProtocol::DEMO,
+            gasEstimate: '0.001',
+            feeTier: null,
+            expiresAt: CarbonImmutable::now()->addMinutes(5),
+        );
+
+        expect($quote->getEffectiveRate())->toBe('0');
+    });
+
+    it('calculates effective rate correctly', function () {
+        $quote = new SwapQuote(
+            quoteId: 'q-3',
+            chain: CrossChainNetwork::ETHEREUM,
+            inputToken: 'USDC',
+            outputToken: 'WETH',
+            inputAmount: '1000',
+            outputAmount: '500',
+            priceImpact: '0.1',
+            protocol: DeFiProtocol::DEMO,
+            gasEstimate: '0.001',
+            feeTier: null,
+            expiresAt: CarbonImmutable::now()->addMinutes(5),
+        );
+
+        expect($quote->getEffectiveRate())->toBe('0.500000000000000000');
+    });
+});

--- a/tests/Unit/Http/Controllers/Api/CrossChain/CrossChainControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/CrossChain/CrossChainControllerTest.php
@@ -155,7 +155,7 @@ describe('CrossChainController', function () {
         expect($data['data']['status'])->toBe('completed');
     });
 
-    it('handles errors for invalid chain in bridge quote', function () {
+    it('validates chain enum for invalid chain in bridge quote', function () {
         $request = makePostRequest('/api/v1/crosschain/bridge/quote', [
             'from_chain' => 'invalid_chain',
             'to_chain'   => 'polygon',
@@ -163,12 +163,21 @@ describe('CrossChainController', function () {
             'amount'     => '1000.00',
         ]);
 
-        $response = $this->controller->bridgeQuote($request);
-        $data = $response->getData(true);
+        $this->controller->bridgeQuote($request);
+    })->throws(Illuminate\Validation\ValidationException::class);
 
-        expect($data['success'])->toBeFalse();
-        expect($response->getStatusCode())->toBe(400);
-    });
+    it('validates chain enum for invalid to_chain in swap execute', function () {
+        $request = makePostRequest('/api/v1/crosschain/swap/execute', [
+            'from_chain'     => 'ethereum',
+            'to_chain'       => 'nonexistent',
+            'from_token'     => 'USDC',
+            'to_token'       => 'WETH',
+            'amount'         => '1000.00',
+            'wallet_address' => '0xTest',
+        ]);
+
+        $this->controller->swapExecute($request);
+    })->throws(Illuminate\Validation\ValidationException::class);
 
     it('returns bridge-only swap when tokens match', function () {
         $request = makePostRequest('/api/v1/crosschain/swap/quote', [


### PR DESCRIPTION
## Summary

Addresses findings from a professional code review of the v3.0.0 CrossChain and DeFi release (13 items, 17 files changed).

### Critical & Security Fixes
- **Remove debug route** (`/debug-json`) left in production `routes/api.php`
- **Fix hardcoded event data** in `BridgeOrchestratorService::checkStatus()` — events now dispatch with real transaction context instead of fake `ETHEREUM → POLYGON, USDC, '0'`
- **Add enum validation** (`Rule::in`) for all chain/protocol inputs across 6 CrossChain and 3 DeFi controller methods — prevents 500 errors on invalid enum values
- **Remove `0xDefault` fallback** — `wallet_address` is now required on portfolio, positions, staking, and yield endpoints
- **Reduce max slippage** from 50% to 5% on DeFi swap endpoints

### Correctness Fixes
- **DemoBridgeAdapter** now returns `FAILED` (not `COMPLETED`) for unknown transaction IDs
- **DeFiPositionTrackerService::closePosition()** throws `InvalidArgumentException` instead of silently succeeding when position not found
- **hydratePosition()** validates required cache keys — logs warning and skips corrupted entries instead of crashing
- **SwapQuote::getEffectiveRate()** guards against empty string input (not just `'0'`)
- **Exception chain preserved** in `BridgeOrchestratorService::initiateBridge()` — passes `$previous` to `BridgeTransactionFailedException`
- **Saga compensation** now includes `'swap_failed' => true` flag so callers can distinguish real tx hashes from compensation results

### Code Quality
- **DRY refactor** of `DeFiPortfolioService` — extracted `buildBreakdown()` helper to eliminate 3x duplicated breakdown logic

### Tests
- Updated existing tests for new method signatures
- Added 8 new edge case tests covering all fixes
- **All 3397 unit tests pass** (0 failures)

## Test plan
- [x] `./vendor/bin/pest tests/Unit/Domain/CrossChain/ --stop-on-failure` (79 passed)
- [x] `./vendor/bin/pest tests/Unit/Domain/DeFi/ --stop-on-failure` (64 passed)
- [x] `./vendor/bin/pest tests/Unit/Http/Controllers/Api/CrossChain/ --stop-on-failure` (12 passed)
- [x] `./vendor/bin/pest tests/Unit/Http/Controllers/Api/DeFi/ --stop-on-failure` (17 passed)
- [x] `./vendor/bin/php-cs-fixer fix` (clean)
- [x] `./vendor/bin/pest tests/Unit/ --parallel` (3397 passed, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)