### PR TITLE
docs: Add OpenAPI annotations to AI, MobilePayment, Partner controllers

### DIFF
--- a/app/Http/Controllers/Api/AI/AIQueryController.php
+++ b/app/Http/Controllers/Api/AI/AIQueryController.php
@@ -12,6 +12,12 @@ use App\Http\Requests\AI\TransactionQueryRequest;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Log;
 
+/**
+ * @OA\Tag(
+ *     name="AI Query",
+ *     description="AI-powered natural language transaction queries and spending analysis"
+ * )
+ */
 class AIQueryController extends Controller
 {
     public function __construct(
@@ -24,6 +30,70 @@ class AIQueryController extends Controller
      * Query transactions using natural language or structured filters.
      *
      * POST /api/ai/query/transactions
+     *
+     * @OA\Post(
+     *     path="/api/ai/query/transactions",
+     *     operationId="aiQueryTransactions",
+     *     summary="Query transactions using natural language or structured filters",
+     *     description="Accepts a natural language query and/or structured filters to search transactions. The NLP engine parses intent and entities from the query, builds filters, and returns matching transactions with a natural language summary.",
+     *     tags={"AI Query"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="query", type="string", nullable=true, example="Show me all payments over $500 last month", description="Natural language query (max 500 chars)"),
+     *             @OA\Property(property="account_uuid", type="string", format="uuid", nullable=true, example="550e8400-e29b-41d4-a716-446655440000", description="Filter by specific account UUID"),
+     *             @OA\Property(property="date_from", type="string", format="date", nullable=true, example="2025-01-01", description="Start date filter"),
+     *             @OA\Property(property="date_to", type="string", format="date", nullable=true, example="2025-01-31", description="End date filter (must be >= date_from)"),
+     *             @OA\Property(property="amount_min", type="number", nullable=true, example=100.00, description="Minimum amount filter"),
+     *             @OA\Property(property="amount_max", type="number", nullable=true, example=5000.00, description="Maximum amount filter (must be >= amount_min)"),
+     *             @OA\Property(property="category", type="string", nullable=true, example="transfer", description="Transaction category filter (max 50 chars)"),
+     *             @OA\Property(property="asset_code", type="string", nullable=true, example="USD", description="Asset code filter (3-10 uppercase letters)"),
+     *             @OA\Property(property="limit", type="integer", nullable=true, example=20, description="Max results (1-100)")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Transaction query results",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="transactions", type="array", @OA\Items(type="object")),
+     *                 @OA\Property(property="summary", type="object", description="Aggregated summary of results"),
+     *                 @OA\Property(property="total_count", type="integer", example=15),
+     *                 @OA\Property(property="nl_summary", type="string", example="Found 15 transactions totaling $7,500 in the last month"),
+     *                 @OA\Property(property="query_parsed", type="object", nullable=true,
+     *                     @OA\Property(property="intent", type="string", example="search_transactions"),
+     *                     @OA\Property(property="confidence", type="number", example=0.95),
+     *                     @OA\Property(property="explanation", type="string", example="Searching for payments over $500")
+     *                 ),
+     *                 @OA\Property(property="filters_used", type="object", description="Filters applied to the query")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="VALIDATION_ERROR"),
+     *                 @OA\Property(property="message", type="string", example="The given data was invalid.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function transactions(TransactionQueryRequest $request): JsonResponse
     {
@@ -81,6 +151,58 @@ class AIQueryController extends Controller
      * Analyze spending patterns by category, merchant, and time.
      *
      * POST /api/ai/query/spending-analysis
+     *
+     * @OA\Post(
+     *     path="/api/ai/query/spending-analysis",
+     *     operationId="aiQuerySpendingAnalysis",
+     *     summary="Analyze spending patterns by category, merchant, and time",
+     *     description="Uses AI to analyze spending patterns from transaction history. Accepts natural language queries or structured filters to segment spending by category, merchant, and time period.",
+     *     tags={"AI Query"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="query", type="string", nullable=true, example="What did I spend on food this quarter?", description="Natural language query (max 500 chars)"),
+     *             @OA\Property(property="account_uuid", type="string", format="uuid", nullable=true, example="550e8400-e29b-41d4-a716-446655440000", description="Filter by specific account UUID"),
+     *             @OA\Property(property="date_from", type="string", format="date", nullable=true, example="2025-01-01", description="Start date filter"),
+     *             @OA\Property(property="date_to", type="string", format="date", nullable=true, example="2025-03-31", description="End date filter (must be >= date_from)"),
+     *             @OA\Property(property="category", type="string", nullable=true, example="food", description="Spending category filter (max 50 chars)"),
+     *             @OA\Property(property="asset_code", type="string", nullable=true, example="USD", description="Asset code filter (3-10 uppercase letters)")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Spending analysis results",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 description="Spending analysis breakdown by category, merchant, and time period"
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="VALIDATION_ERROR"),
+     *                 @OA\Property(property="message", type="string", example="The given data was invalid.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function spendingAnalysis(SpendingAnalysisRequest $request): JsonResponse
     {

--- a/app/Http/Controllers/Api/MobilePayment/ActivityController.php
+++ b/app/Http/Controllers/Api/MobilePayment/ActivityController.php
@@ -20,6 +20,76 @@ class ActivityController extends Controller
      * Get activity feed with cursor-based pagination.
      *
      * GET /v1/activity
+     *
+     * @OA\Get(
+     *     path="/api/v1/activity",
+     *     operationId="mobilePaymentActivityFeed",
+     *     summary="Get activity feed with cursor-based pagination",
+     *     description="Returns a paginated activity feed for the authenticated user. Supports cursor-based pagination and filtering by income/expenses.",
+     *     tags={"Mobile Payments"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="cursor",
+     *         in="query",
+     *         required=false,
+     *         description="Cursor for pagination (opaque string from previous response)",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="limit",
+     *         in="query",
+     *         required=false,
+     *         description="Number of items per page (1-50, default 20)",
+     *         @OA\Schema(type="integer", minimum=1, maximum=50, default=20)
+     *     ),
+     *     @OA\Parameter(
+     *         name="filter",
+     *         in="query",
+     *         required=false,
+     *         description="Filter activity type",
+     *         @OA\Schema(type="string", enum={"all", "income", "expenses"}, default="all")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Activity feed",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="items", type="array", @OA\Items(type="object",
+     *                     @OA\Property(property="id", type="string"),
+     *                     @OA\Property(property="type", type="string", example="payment"),
+     *                     @OA\Property(property="amount", type="number", example=25.50),
+     *                     @OA\Property(property="asset", type="string", example="USDC"),
+     *                     @OA\Property(property="created_at", type="string", format="date-time")
+     *                 )),
+     *                 @OA\Property(property="next_cursor", type="string", nullable=true, example="eyJpZCI6MTAwfQ=="),
+     *                 @OA\Property(property="has_more", type="boolean", example=true)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="VALIDATION_ERROR"),
+     *                 @OA\Property(property="message", type="string", example="The given data was invalid.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function index(Request $request): JsonResponse
     {

--- a/app/Http/Controllers/Api/MobilePayment/NetworkStatusController.php
+++ b/app/Http/Controllers/Api/MobilePayment/NetworkStatusController.php
@@ -19,6 +19,41 @@ class NetworkStatusController extends Controller
      * Get the status of all supported payment networks.
      *
      * GET /v1/networks/status
+     *
+     * @OA\Get(
+     *     path="/api/v1/networks/status",
+     *     operationId="mobilePaymentNetworkStatus",
+     *     summary="Get the status of all supported payment networks",
+     *     description="Returns the current availability and health status of all supported payment networks (e.g., Solana, Tron). Useful for checking network congestion or downtime before initiating payments.",
+     *     tags={"Mobile Payments"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Network statuses",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="networks", type="array", @OA\Items(type="object",
+     *                     @OA\Property(property="network", type="string", example="SOLANA"),
+     *                     @OA\Property(property="status", type="string", enum={"operational", "degraded", "down"}, example="operational"),
+     *                     @OA\Property(property="latency_ms", type="integer", example=120),
+     *                     @OA\Property(property="block_height", type="integer", example=245000000)
+     *                 ))
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function __invoke(): JsonResponse
     {

--- a/app/Http/Controllers/Api/MobilePayment/PaymentIntentController.php
+++ b/app/Http/Controllers/Api/MobilePayment/PaymentIntentController.php
@@ -14,6 +14,12 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
+/**
+ * @OA\Tag(
+ *     name="Mobile Payments",
+ *     description="Mobile payment intents, transactions, receipts, and wallet operations"
+ * )
+ */
 class PaymentIntentController extends Controller
 {
     public function __construct(
@@ -25,6 +31,83 @@ class PaymentIntentController extends Controller
      * Create a new payment intent.
      *
      * POST /v1/payments/intents
+     *
+     * @OA\Post(
+     *     path="/api/v1/payments/intents",
+     *     operationId="mobilePaymentCreateIntent",
+     *     summary="Create a new payment intent",
+     *     description="Creates a payment intent for a merchant transaction. Supports idempotency via X-Idempotency-Key header or body field. The intent must be submitted separately to authorize payment.",
+     *     tags={"Mobile Payments"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="X-Idempotency-Key",
+     *         in="header",
+     *         required=false,
+     *         description="Idempotency key to prevent duplicate payments",
+     *         @OA\Schema(type="string", maxLength=128)
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"merchantId", "amount", "asset", "preferredNetwork"},
+     *             @OA\Property(property="merchantId", type="string", example="merchant_abc123", description="Merchant identifier (max 64 chars)"),
+     *             @OA\Property(property="amount", type="number", example=25.50, description="Payment amount (must be > 0)"),
+     *             @OA\Property(property="asset", type="string", enum={"USDC"}, example="USDC", description="Payment asset"),
+     *             @OA\Property(property="preferredNetwork", type="string", enum={"SOLANA", "TRON"}, example="SOLANA", description="Preferred payment network"),
+     *             @OA\Property(property="shield", type="boolean", example=false, description="Enable privacy shield"),
+     *             @OA\Property(property="idempotencyKey", type="string", example="idem_key_123", description="Idempotency key (alternative to header)")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Payment intent created",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="intentId", type="string", example="pi_abc123"),
+     *                 @OA\Property(property="status", type="string", example="PENDING"),
+     *                 @OA\Property(property="amount", type="number", example=25.50),
+     *                 @OA\Property(property="asset", type="string", example="USDC"),
+     *                 @OA\Property(property="merchant", type="object",
+     *                     @OA\Property(property="displayName", type="string", example="Coffee Shop")
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Merchant not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="MERCHANT_NOT_FOUND"),
+     *                 @OA\Property(property="message", type="string", example="Merchant not found.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error or payment intent creation failed",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="PAYMENT_INTENT_ERROR"),
+     *                 @OA\Property(property="message", type="string", example="Unable to create payment intent.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function create(CreatePaymentIntentRequest $request): JsonResponse
     {
@@ -65,6 +148,60 @@ class PaymentIntentController extends Controller
      * Get payment intent status.
      *
      * GET /v1/payments/intents/{intentId}
+     *
+     * @OA\Get(
+     *     path="/api/v1/payments/intents/{intentId}",
+     *     operationId="mobilePaymentGetIntent",
+     *     summary="Get payment intent status",
+     *     description="Retrieves the current status and details of a payment intent by its ID.",
+     *     tags={"Mobile Payments"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="intentId",
+     *         in="path",
+     *         required=true,
+     *         description="Payment intent ID",
+     *         @OA\Schema(type="string", example="pi_abc123")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Payment intent details",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="intentId", type="string", example="pi_abc123"),
+     *                 @OA\Property(property="status", type="string", example="PENDING"),
+     *                 @OA\Property(property="amount", type="number", example=25.50),
+     *                 @OA\Property(property="asset", type="string", example="USDC"),
+     *                 @OA\Property(property="merchant", type="object",
+     *                     @OA\Property(property="displayName", type="string", example="Coffee Shop")
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Payment intent not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="INTENT_NOT_FOUND"),
+     *                 @OA\Property(property="message", type="string", example="Payment intent not found.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function show(Request $request, string $intentId): JsonResponse
     {
@@ -96,6 +233,73 @@ class PaymentIntentController extends Controller
      * Submit/authorize a payment intent.
      *
      * POST /v1/payments/intents/{intentId}/submit
+     *
+     * @OA\Post(
+     *     path="/api/v1/payments/intents/{intentId}/submit",
+     *     operationId="mobilePaymentSubmitIntent",
+     *     summary="Submit and authorize a payment intent",
+     *     description="Submits a pending payment intent for authorization. The user must authenticate via biometric or PIN before the payment is processed on-chain.",
+     *     tags={"Mobile Payments"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="intentId",
+     *         in="path",
+     *         required=true,
+     *         description="Payment intent ID",
+     *         @OA\Schema(type="string", example="pi_abc123")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=false,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="auth", type="string", enum={"biometric", "pin"}, example="biometric", description="Authentication method"),
+     *             @OA\Property(property="shield", type="boolean", example=false, description="Enable privacy shield")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Payment intent submitted",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="intentId", type="string", example="pi_abc123"),
+     *                 @OA\Property(property="status", type="string", example="SUBMITTED")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Payment intent not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="INTENT_NOT_FOUND"),
+     *                 @OA\Property(property="message", type="string", example="Payment intent not found.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Payment intent cannot be submitted (invalid state)",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="PAYMENT_INTENT_ERROR"),
+     *                 @OA\Property(property="message", type="string", example="Intent is not in a submittable state.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function submit(SubmitPaymentIntentRequest $request, string $intentId): JsonResponse
     {
@@ -136,6 +340,76 @@ class PaymentIntentController extends Controller
      * Cancel a payment intent.
      *
      * POST /v1/payments/intents/{intentId}/cancel
+     *
+     * @OA\Post(
+     *     path="/api/v1/payments/intents/{intentId}/cancel",
+     *     operationId="mobilePaymentCancelIntent",
+     *     summary="Cancel a payment intent",
+     *     description="Cancels a pending payment intent. An optional reason can be provided for auditing purposes.",
+     *     tags={"Mobile Payments"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="intentId",
+     *         in="path",
+     *         required=true,
+     *         description="Payment intent ID",
+     *         @OA\Schema(type="string", example="pi_abc123")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=false,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="reason", type="string", nullable=true, example="Changed my mind", description="Cancellation reason (max 500 chars)")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Payment intent cancelled",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="intentId", type="string", example="pi_abc123"),
+     *                 @OA\Property(property="status", type="string", example="CANCELLED"),
+     *                 @OA\Property(property="merchant", type="object",
+     *                     @OA\Property(property="displayName", type="string", example="Coffee Shop")
+     *                 ),
+     *                 @OA\Property(property="amount", type="number", example=25.50)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Payment intent not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="INTENT_NOT_FOUND"),
+     *                 @OA\Property(property="message", type="string", example="Payment intent not found.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Payment intent cannot be cancelled (invalid state)",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="PAYMENT_INTENT_ERROR"),
+     *                 @OA\Property(property="message", type="string", example="Intent is not in a cancellable state.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function cancel(Request $request, string $intentId): JsonResponse
     {

--- a/app/Http/Controllers/Api/MobilePayment/ReceiptController.php
+++ b/app/Http/Controllers/Api/MobilePayment/ReceiptController.php
@@ -20,6 +20,62 @@ class ReceiptController extends Controller
      * Generate a receipt for a transaction.
      *
      * POST /v1/transactions/{txId}/receipt
+     *
+     * @OA\Post(
+     *     path="/api/v1/transactions/{txId}/receipt",
+     *     operationId="mobilePaymentGenerateReceipt",
+     *     summary="Generate a receipt for a transaction",
+     *     description="Generates a digital receipt for a confirmed transaction. Receipts can only be generated for transactions that have been confirmed on-chain.",
+     *     tags={"Mobile Payments"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="txId",
+     *         in="path",
+     *         required=true,
+     *         description="Transaction ID",
+     *         @OA\Schema(type="string", example="tx_abc123")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Receipt generated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="receiptId", type="string", example="rcpt_abc123"),
+     *                 @OA\Property(property="transactionId", type="string", example="tx_abc123"),
+     *                 @OA\Property(property="amount", type="number", example=25.50),
+     *                 @OA\Property(property="asset", type="string", example="USDC"),
+     *                 @OA\Property(property="merchant", type="object",
+     *                     @OA\Property(property="displayName", type="string", example="Coffee Shop")
+     *                 ),
+     *                 @OA\Property(property="timestamp", type="string", format="date-time"),
+     *                 @OA\Property(property="hash", type="string", description="On-chain transaction hash")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Receipt cannot be generated (transaction not confirmed)",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="RECEIPT_UNAVAILABLE"),
+     *                 @OA\Property(property="message", type="string", example="Receipt can only be generated for confirmed transactions.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function store(Request $request, string $txId): JsonResponse
     {

--- a/app/Http/Controllers/Api/MobilePayment/TransactionController.php
+++ b/app/Http/Controllers/Api/MobilePayment/TransactionController.php
@@ -20,6 +20,68 @@ class TransactionController extends Controller
      * Get transaction details.
      *
      * GET /v1/transactions/{txId}
+     *
+     * @OA\Get(
+     *     path="/api/v1/transactions/{txId}",
+     *     operationId="mobilePaymentGetTransaction",
+     *     summary="Get transaction details",
+     *     description="Retrieves the full details of a transaction including on-chain status, merchant info, amount, and fees.",
+     *     tags={"Mobile Payments"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="txId",
+     *         in="path",
+     *         required=true,
+     *         description="Transaction ID",
+     *         @OA\Schema(type="string", example="tx_abc123")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Transaction details",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="transactionId", type="string", example="tx_abc123"),
+     *                 @OA\Property(property="status", type="string", example="CONFIRMED"),
+     *                 @OA\Property(property="amount", type="number", example=25.50),
+     *                 @OA\Property(property="asset", type="string", example="USDC"),
+     *                 @OA\Property(property="network", type="string", example="SOLANA"),
+     *                 @OA\Property(property="hash", type="string", description="On-chain transaction hash"),
+     *                 @OA\Property(property="merchant", type="object",
+     *                     @OA\Property(property="displayName", type="string", example="Coffee Shop")
+     *                 ),
+     *                 @OA\Property(property="fee", type="object",
+     *                     @OA\Property(property="amount", type="number", example=0.01),
+     *                     @OA\Property(property="asset", type="string", example="USDC")
+     *                 ),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="confirmed_at", type="string", format="date-time", nullable=true)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Transaction not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="TRANSACTION_NOT_FOUND"),
+     *                 @OA\Property(property="message", type="string", example="Transaction not found.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function show(Request $request, string $txId): JsonResponse
     {

--- a/app/Http/Controllers/Api/MobilePayment/WalletReceiveController.php
+++ b/app/Http/Controllers/Api/MobilePayment/WalletReceiveController.php
@@ -22,6 +22,64 @@ class WalletReceiveController extends Controller
      * Get a receive address for the authenticated user.
      *
      * GET /v1/wallet/receive?asset=USDC&network=SOLANA
+     *
+     * @OA\Get(
+     *     path="/api/v1/wallet/receive",
+     *     operationId="mobilePaymentWalletReceive",
+     *     summary="Get a receive address for the authenticated user",
+     *     description="Returns a wallet receive address for the specified asset and network. The address can be used to receive payments from external wallets or exchanges.",
+     *     tags={"Mobile Payments"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="asset",
+     *         in="query",
+     *         required=true,
+     *         description="Payment asset (currently only USDC supported)",
+     *         @OA\Schema(type="string", enum={"USDC"}, example="USDC")
+     *     ),
+     *     @OA\Parameter(
+     *         name="network",
+     *         in="query",
+     *         required=true,
+     *         description="Payment network",
+     *         @OA\Schema(type="string", enum={"SOLANA", "TRON"}, example="SOLANA")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Receive address",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="address", type="string", example="7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU"),
+     *                 @OA\Property(property="network", type="string", example="SOLANA"),
+     *                 @OA\Property(property="asset", type="string", example="USDC"),
+     *                 @OA\Property(property="qr_uri", type="string", example="solana:7xKXtg...?spl-token=USDC")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error (invalid asset or network)",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="VALIDATION_ERROR"),
+     *                 @OA\Property(property="message", type="string", example="The given data was invalid.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function __invoke(Request $request): JsonResponse
     {

--- a/app/Http/Controllers/Api/Partner/PartnerBillingController.php
+++ b/app/Http/Controllers/Api/Partner/PartnerBillingController.php
@@ -22,6 +22,43 @@ class PartnerBillingController extends Controller
      * List partner invoices.
      *
      * GET /api/partner/v1/billing/invoices
+     *
+     * @OA\Get(
+     *     path="/api/partner/v1/billing/invoices",
+     *     operationId="partnerListInvoices",
+     *     summary="List partner invoices",
+     *     description="Returns up to 50 most recent invoices for the authenticated partner, ordered by creation date descending.",
+     *     tags={"Partner BaaS"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="List of invoices",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="array", @OA\Items(type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="invoice_number", type="string", example="INV-2025-0001"),
+     *                 @OA\Property(property="amount", type="number", example=299.00),
+     *                 @OA\Property(property="currency", type="string", example="USD"),
+     *                 @OA\Property(property="status", type="string", example="paid"),
+     *                 @OA\Property(property="period_start", type="string", format="date"),
+     *                 @OA\Property(property="period_end", type="string", format="date"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time")
+     *             ))
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function invoices(Request $request): JsonResponse
     {
@@ -42,6 +79,58 @@ class PartnerBillingController extends Controller
      * Get a specific invoice.
      *
      * GET /api/partner/v1/billing/invoices/{id}
+     *
+     * @OA\Get(
+     *     path="/api/partner/v1/billing/invoices/{id}",
+     *     operationId="partnerGetInvoice",
+     *     summary="Get a specific invoice",
+     *     description="Retrieves the details of a single invoice by its ID for the authenticated partner.",
+     *     tags={"Partner BaaS"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         description="Invoice ID",
+     *         @OA\Schema(type="integer", example=1)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Invoice details",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="invoice_number", type="string", example="INV-2025-0001"),
+     *                 @OA\Property(property="amount", type="number", example=299.00),
+     *                 @OA\Property(property="currency", type="string", example="USD"),
+     *                 @OA\Property(property="status", type="string", example="paid"),
+     *                 @OA\Property(property="period_start", type="string", format="date"),
+     *                 @OA\Property(property="period_end", type="string", format="date"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Invoice not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Invoice not found")
+     *         )
+     *     )
+     * )
      */
     public function invoice(Request $request, int $id): JsonResponse
     {
@@ -68,6 +157,37 @@ class PartnerBillingController extends Controller
      * Get outstanding balance.
      *
      * GET /api/partner/v1/billing/outstanding
+     *
+     * @OA\Get(
+     *     path="/api/partner/v1/billing/outstanding",
+     *     operationId="partnerGetOutstandingBalance",
+     *     summary="Get outstanding balance",
+     *     description="Returns the total outstanding (unpaid) balance for the authenticated partner in USD.",
+     *     tags={"Partner BaaS"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Outstanding balance",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="outstanding_balance_usd", type="number", example=599.00),
+     *                 @OA\Property(property="currency", type="string", example="USD")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function outstanding(Request $request): JsonResponse
     {
@@ -87,6 +207,34 @@ class PartnerBillingController extends Controller
      * Get current period billing breakdown preview.
      *
      * GET /api/partner/v1/billing/breakdown
+     *
+     * @OA\Get(
+     *     path="/api/partner/v1/billing/breakdown",
+     *     operationId="partnerGetBillingBreakdown",
+     *     summary="Get current period billing breakdown preview",
+     *     description="Returns a detailed billing breakdown for the current month-to-date period, including base fees, overage charges, and per-endpoint costs.",
+     *     tags={"Partner BaaS"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Billing breakdown",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object", description="Detailed billing breakdown with line items and totals")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function breakdown(Request $request): JsonResponse
     {

--- a/app/Http/Controllers/Api/Partner/PartnerDashboardController.php
+++ b/app/Http/Controllers/Api/Partner/PartnerDashboardController.php
@@ -11,6 +11,12 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
+/**
+ * @OA\Tag(
+ *     name="Partner BaaS",
+ *     description="Partner Banking-as-a-Service dashboard, billing, SDK, widgets, and marketplace"
+ * )
+ */
 class PartnerDashboardController extends Controller
 {
     public function __construct(
@@ -23,6 +29,44 @@ class PartnerDashboardController extends Controller
      * Get partner profile and tier information.
      *
      * GET /api/partner/v1/profile
+     *
+     * @OA\Get(
+     *     path="/api/partner/v1/profile",
+     *     operationId="partnerGetProfile",
+     *     summary="Get partner profile and tier information",
+     *     description="Returns the authenticated partner's profile including institution name, current tier, status, and rate limits.",
+     *     tags={"Partner BaaS"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Partner profile",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="partner_code", type="string", example="PARTNER_ABC"),
+     *                 @OA\Property(property="institution_name", type="string", example="Acme Bank"),
+     *                 @OA\Property(property="tier", type="string", example="growth"),
+     *                 @OA\Property(property="tier_label", type="string", example="Growth"),
+     *                 @OA\Property(property="status", type="string", example="active"),
+     *                 @OA\Property(property="sandbox_enabled", type="boolean", example=true),
+     *                 @OA\Property(property="production_enabled", type="boolean", example=false),
+     *                 @OA\Property(property="rate_limit", type="integer", example=1000)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function profile(Request $request): JsonResponse
     {
@@ -49,6 +93,39 @@ class PartnerDashboardController extends Controller
      * Get current period usage summary.
      *
      * GET /api/partner/v1/usage
+     *
+     * @OA\Get(
+     *     path="/api/partner/v1/usage",
+     *     operationId="partnerGetUsage",
+     *     summary="Get current period usage summary",
+     *     description="Returns API usage summary for the current billing period (month-to-date), including call counts by endpoint and usage limit status.",
+     *     tags={"Partner BaaS"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Usage summary",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="period_start", type="string", format="date", example="2025-01-01"),
+     *                 @OA\Property(property="period_end", type="string", format="date", example="2025-01-15"),
+     *                 @OA\Property(property="summary", type="object", description="Usage breakdown by endpoint and total"),
+     *                 @OA\Property(property="limit", type="object", description="Usage limit status and remaining quota")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function usage(Request $request): JsonResponse
     {
@@ -75,6 +152,48 @@ class PartnerDashboardController extends Controller
      * Get historical usage records.
      *
      * GET /api/partner/v1/usage/history
+     *
+     * @OA\Get(
+     *     path="/api/partner/v1/usage/history",
+     *     operationId="partnerGetUsageHistory",
+     *     summary="Get historical usage records",
+     *     description="Returns historical API usage data for a custom date range. Defaults to the last 30 days if no dates are provided.",
+     *     tags={"Partner BaaS"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="start_date",
+     *         in="query",
+     *         required=false,
+     *         description="Start date for usage history (defaults to 1 month ago)",
+     *         @OA\Schema(type="string", format="date", example="2025-01-01")
+     *     ),
+     *     @OA\Parameter(
+     *         name="end_date",
+     *         in="query",
+     *         required=false,
+     *         description="End date for usage history (defaults to today)",
+     *         @OA\Schema(type="string", format="date", example="2025-01-31")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Historical usage data",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object", description="Usage summary for the requested period")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function usageHistory(Request $request): JsonResponse
     {
@@ -95,6 +214,42 @@ class PartnerDashboardController extends Controller
      * Get tier details.
      *
      * GET /api/partner/v1/tier
+     *
+     * @OA\Get(
+     *     path="/api/partner/v1/tier",
+     *     operationId="partnerGetTier",
+     *     summary="Get current tier details",
+     *     description="Returns detailed information about the partner's current tier including pricing, API call limits, available features, and access levels.",
+     *     tags={"Partner BaaS"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Tier details",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="tier", type="string", example="growth"),
+     *                 @OA\Property(property="label", type="string", example="Growth"),
+     *                 @OA\Property(property="monthly_price", type="number", example=299.00),
+     *                 @OA\Property(property="api_call_limit", type="integer", example=100000),
+     *                 @OA\Property(property="features", type="array", @OA\Items(type="string"), example={"core_banking", "payments", "compliance"}),
+     *                 @OA\Property(property="has_sdk", type="boolean", example=true),
+     *                 @OA\Property(property="has_widgets", type="boolean", example=true)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function tier(Request $request): JsonResponse
     {
@@ -119,6 +274,34 @@ class PartnerDashboardController extends Controller
      * Compare all tiers.
      *
      * GET /api/partner/v1/tier/comparison
+     *
+     * @OA\Get(
+     *     path="/api/partner/v1/tier/comparison",
+     *     operationId="partnerGetTierComparison",
+     *     summary="Compare all available tiers",
+     *     description="Returns a comparison of all available partnership tiers, highlighting the partner's current tier and the differences in features, pricing, and limits.",
+     *     tags={"Partner BaaS"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Tier comparison",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object", description="Tier comparison matrix with features, pricing, and limits per tier")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function tierComparison(Request $request): JsonResponse
     {
@@ -136,6 +319,41 @@ class PartnerDashboardController extends Controller
      * Get current branding configuration.
      *
      * GET /api/partner/v1/branding
+     *
+     * @OA\Get(
+     *     path="/api/partner/v1/branding",
+     *     operationId="partnerGetBranding",
+     *     summary="Get current branding configuration",
+     *     description="Returns the partner's current branding configuration used for white-label widgets, including colors, logos, and company information.",
+     *     tags={"Partner BaaS"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Branding configuration",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object", nullable=true,
+     *                 @OA\Property(property="primary_color", type="string", example="#1E40AF"),
+     *                 @OA\Property(property="secondary_color", type="string", example="#3B82F6"),
+     *                 @OA\Property(property="accent_color", type="string", example="#F59E0B"),
+     *                 @OA\Property(property="logo_url", type="string", nullable=true, example="https://example.com/logo.png"),
+     *                 @OA\Property(property="company_name", type="string", example="Acme Bank"),
+     *                 @OA\Property(property="support_email", type="string", example="support@acmebank.com")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function branding(Request $request): JsonResponse
     {
@@ -152,6 +370,66 @@ class PartnerDashboardController extends Controller
      * Update branding configuration.
      *
      * PUT /api/partner/v1/branding
+     *
+     * @OA\Put(
+     *     path="/api/partner/v1/branding",
+     *     operationId="partnerUpdateBranding",
+     *     summary="Update branding configuration",
+     *     description="Updates the partner's branding configuration for white-label widgets. All fields are optional; only provided fields will be updated.",
+     *     tags={"Partner BaaS"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="primary_color", type="string", example="#1E40AF", description="Primary brand color (hex, max 7 chars)"),
+     *             @OA\Property(property="secondary_color", type="string", example="#3B82F6", description="Secondary brand color"),
+     *             @OA\Property(property="accent_color", type="string", example="#F59E0B", description="Accent color"),
+     *             @OA\Property(property="text_color", type="string", example="#111827", description="Text color"),
+     *             @OA\Property(property="background_color", type="string", example="#FFFFFF", description="Background color"),
+     *             @OA\Property(property="logo_url", type="string", nullable=true, example="https://example.com/logo.png", description="Logo URL (max 500 chars)"),
+     *             @OA\Property(property="company_name", type="string", example="Acme Bank", description="Company display name (max 255 chars)"),
+     *             @OA\Property(property="tagline", type="string", nullable=true, example="Banking made simple", description="Company tagline (max 500 chars)"),
+     *             @OA\Property(property="support_email", type="string", format="email", example="support@acmebank.com", description="Support email"),
+     *             @OA\Property(property="privacy_policy_url", type="string", nullable=true, example="https://example.com/privacy", description="Privacy policy URL"),
+     *             @OA\Property(property="terms_of_service_url", type="string", nullable=true, example="https://example.com/terms", description="Terms of service URL")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Branding updated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="primary_color", type="string", example="#1E40AF"),
+     *                 @OA\Property(property="secondary_color", type="string", example="#3B82F6"),
+     *                 @OA\Property(property="company_name", type="string", example="Acme Bank")
+     *             ),
+     *             @OA\Property(property="message", type="string", example="Branding updated successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="VALIDATION_ERROR"),
+     *                 @OA\Property(property="message", type="string", example="The given data was invalid.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function updateBranding(Request $request): JsonResponse
     {

--- a/app/Http/Controllers/Api/Partner/PartnerMarketplaceController.php
+++ b/app/Http/Controllers/Api/Partner/PartnerMarketplaceController.php
@@ -21,6 +21,41 @@ class PartnerMarketplaceController extends Controller
      * List available integrations.
      *
      * GET /api/partner/v1/marketplace
+     *
+     * @OA\Get(
+     *     path="/api/partner/v1/marketplace",
+     *     operationId="partnerMarketplaceList",
+     *     summary="List available integrations",
+     *     description="Returns a catalog of all available third-party integrations that partners can enable, organized by category (KYC, payments, analytics, etc.).",
+     *     tags={"Partner BaaS"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Available integrations",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="array", @OA\Items(type="object",
+     *                 @OA\Property(property="category", type="string", example="kyc"),
+     *                 @OA\Property(property="providers", type="array", @OA\Items(type="object",
+     *                     @OA\Property(property="name", type="string", example="sumsub"),
+     *                     @OA\Property(property="label", type="string", example="SumSub"),
+     *                     @OA\Property(property="description", type="string")
+     *                 ))
+     *             ))
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function index(Request $request): JsonResponse
     {
@@ -34,6 +69,40 @@ class PartnerMarketplaceController extends Controller
      * Get partner's active integrations.
      *
      * GET /api/partner/v1/marketplace/integrations
+     *
+     * @OA\Get(
+     *     path="/api/partner/v1/marketplace/integrations",
+     *     operationId="partnerMarketplaceIntegrations",
+     *     summary="Get partner's active integrations",
+     *     description="Returns a list of integrations currently enabled for the authenticated partner, including their configuration and status.",
+     *     tags={"Partner BaaS"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Active integrations",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="array", @OA\Items(type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="category", type="string", example="kyc"),
+     *                 @OA\Property(property="provider", type="string", example="sumsub"),
+     *                 @OA\Property(property="status", type="string", example="active"),
+     *                 @OA\Property(property="enabled_at", type="string", format="date-time")
+     *             ))
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function integrations(Request $request): JsonResponse
     {
@@ -50,6 +119,61 @@ class PartnerMarketplaceController extends Controller
      * Enable an integration.
      *
      * POST /api/partner/v1/marketplace/integrations
+     *
+     * @OA\Post(
+     *     path="/api/partner/v1/marketplace/integrations",
+     *     operationId="partnerMarketplaceEnable",
+     *     summary="Enable an integration",
+     *     description="Enables a third-party integration for the partner. Requires specifying the category and provider, with optional configuration parameters.",
+     *     tags={"Partner BaaS"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"category", "provider"},
+     *             @OA\Property(property="category", type="string", example="kyc", description="Integration category"),
+     *             @OA\Property(property="provider", type="string", example="sumsub", description="Integration provider"),
+     *             @OA\Property(property="config", type="object", description="Optional provider-specific configuration",
+     *                 example={"api_key": "key_123", "webhook_url": "https://example.com/webhook"}
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Integration enabled",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="success", type="boolean", example=true),
+     *                 @OA\Property(property="integration_id", type="integer", example=1),
+     *                 @OA\Property(property="category", type="string", example="kyc"),
+     *                 @OA\Property(property="provider", type="string", example="sumsub")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Integration cannot be enabled (invalid provider or tier restriction)",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="success", type="boolean", example=false),
+     *                 @OA\Property(property="error", type="string", example="Provider not available for your tier")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function enable(Request $request): JsonResponse
     {
@@ -78,6 +202,49 @@ class PartnerMarketplaceController extends Controller
      * Disable an integration.
      *
      * DELETE /api/partner/v1/marketplace/integrations/{id}
+     *
+     * @OA\Delete(
+     *     path="/api/partner/v1/marketplace/integrations/{id}",
+     *     operationId="partnerMarketplaceDisable",
+     *     summary="Disable an integration",
+     *     description="Disables a previously enabled integration by its ID. The integration's configuration is preserved for potential re-enablement.",
+     *     tags={"Partner BaaS"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         description="Integration ID",
+     *         @OA\Schema(type="integer", example=1)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Integration disabled",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="message", type="string", example="Integration disabled successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Integration not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="Integration not found")
+     *         )
+     *     )
+     * )
      */
     public function disable(Request $request, int $id): JsonResponse
     {
@@ -94,6 +261,56 @@ class PartnerMarketplaceController extends Controller
      * Test an integration connection.
      *
      * POST /api/partner/v1/marketplace/integrations/{id}/test
+     *
+     * @OA\Post(
+     *     path="/api/partner/v1/marketplace/integrations/{id}/test",
+     *     operationId="partnerMarketplaceTestConnection",
+     *     summary="Test an integration connection",
+     *     description="Performs a connectivity test against the specified integration to verify that API keys and configuration are valid.",
+     *     tags={"Partner BaaS"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         description="Integration ID",
+     *         @OA\Schema(type="integer", example=1)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Connection test result",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="success", type="boolean", example=true),
+     *                 @OA\Property(property="latency_ms", type="integer", example=120),
+     *                 @OA\Property(property="message", type="string", example="Connection successful")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Integration not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="success", type="boolean", example=false),
+     *                 @OA\Property(property="error", type="string", example="Integration not found")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function test(Request $request, int $id): JsonResponse
     {
@@ -110,6 +327,45 @@ class PartnerMarketplaceController extends Controller
      * Get integration health overview.
      *
      * GET /api/partner/v1/marketplace/health
+     *
+     * @OA\Get(
+     *     path="/api/partner/v1/marketplace/health",
+     *     operationId="partnerMarketplaceHealth",
+     *     summary="Get integration health overview",
+     *     description="Returns a health status overview of all enabled integrations, including uptime, error rates, and last successful connection timestamps.",
+     *     tags={"Partner BaaS"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Integration health overview",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="total_integrations", type="integer", example=3),
+     *                 @OA\Property(property="healthy", type="integer", example=2),
+     *                 @OA\Property(property="degraded", type="integer", example=1),
+     *                 @OA\Property(property="down", type="integer", example=0),
+     *                 @OA\Property(property="integrations", type="array", @OA\Items(type="object",
+     *                     @OA\Property(property="id", type="integer", example=1),
+     *                     @OA\Property(property="provider", type="string", example="sumsub"),
+     *                     @OA\Property(property="status", type="string", enum={"healthy", "degraded", "down"}, example="healthy"),
+     *                     @OA\Property(property="last_check", type="string", format="date-time")
+     *                 ))
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function health(Request $request): JsonResponse
     {

--- a/app/Http/Controllers/Api/Partner/PartnerSdkController.php
+++ b/app/Http/Controllers/Api/Partner/PartnerSdkController.php
@@ -21,6 +21,38 @@ class PartnerSdkController extends Controller
      * Get available SDK languages.
      *
      * GET /api/partner/v1/sdk/languages
+     *
+     * @OA\Get(
+     *     path="/api/partner/v1/sdk/languages",
+     *     operationId="partnerSdkLanguages",
+     *     summary="Get available SDK languages",
+     *     description="Returns a list of programming languages for which SDKs can be generated.",
+     *     tags={"Partner BaaS"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Available SDK languages",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="array", @OA\Items(type="object",
+     *                 @OA\Property(property="language", type="string", example="typescript"),
+     *                 @OA\Property(property="label", type="string", example="TypeScript"),
+     *                 @OA\Property(property="version", type="string", example="1.0.0")
+     *             ))
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function languages(Request $request): JsonResponse
     {
@@ -34,6 +66,57 @@ class PartnerSdkController extends Controller
      * Generate an SDK.
      *
      * POST /api/partner/v1/sdk/generate
+     *
+     * @OA\Post(
+     *     path="/api/partner/v1/sdk/generate",
+     *     operationId="partnerSdkGenerate",
+     *     summary="Generate an SDK for a specific language",
+     *     description="Triggers SDK generation for the specified programming language. The SDK is customized with the partner's API keys and branding.",
+     *     tags={"Partner BaaS"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"language"},
+     *             @OA\Property(property="language", type="string", example="typescript", description="Programming language for SDK generation")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="SDK generated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="success", type="boolean", example=true),
+     *                 @OA\Property(property="language", type="string", example="typescript"),
+     *                 @OA\Property(property="download_url", type="string", example="https://example.com/sdk/download/abc123"),
+     *                 @OA\Property(property="version", type="string", example="1.0.0")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="SDK generation failed (unsupported language or tier restriction)",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="success", type="boolean", example=false),
+     *                 @OA\Property(property="error", type="string", example="Unsupported language")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function generate(Request $request): JsonResponse
     {
@@ -55,6 +138,46 @@ class PartnerSdkController extends Controller
      * Get SDK status for a language.
      *
      * GET /api/partner/v1/sdk/{language}
+     *
+     * @OA\Get(
+     *     path="/api/partner/v1/sdk/{language}",
+     *     operationId="partnerSdkStatus",
+     *     summary="Get SDK status for a specific language",
+     *     description="Returns the current status of the SDK for the specified language, including version, build status, and download URL if available.",
+     *     tags={"Partner BaaS"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="language",
+     *         in="path",
+     *         required=true,
+     *         description="SDK language identifier",
+     *         @OA\Schema(type="string", example="typescript")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="SDK status",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="language", type="string", example="typescript"),
+     *                 @OA\Property(property="status", type="string", example="ready"),
+     *                 @OA\Property(property="version", type="string", example="1.0.0"),
+     *                 @OA\Property(property="download_url", type="string", nullable=true)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function status(Request $request, string $language): JsonResponse
     {
@@ -71,6 +194,42 @@ class PartnerSdkController extends Controller
      * Get the OpenAPI spec.
      *
      * GET /api/partner/v1/sdk/openapi-spec
+     *
+     * @OA\Get(
+     *     path="/api/partner/v1/sdk/openapi-spec",
+     *     operationId="partnerSdkOpenapiSpec",
+     *     summary="Get the OpenAPI specification",
+     *     description="Returns the full OpenAPI (Swagger) specification as JSON. This spec can be used with code generators or API documentation tools.",
+     *     tags={"Partner BaaS"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="OpenAPI specification",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object", description="Full OpenAPI 3.0 specification")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="OpenAPI spec not available",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="message", type="string", example="OpenAPI spec not available")
+     *         )
+     *     )
+     * )
      */
     public function openapiSpec(Request $request): JsonResponse
     {

--- a/app/Http/Controllers/Api/Partner/PartnerWidgetController.php
+++ b/app/Http/Controllers/Api/Partner/PartnerWidgetController.php
@@ -21,6 +21,38 @@ class PartnerWidgetController extends Controller
      * Get available widget types.
      *
      * GET /api/partner/v1/widgets
+     *
+     * @OA\Get(
+     *     path="/api/partner/v1/widgets",
+     *     operationId="partnerListWidgets",
+     *     summary="Get available widget types",
+     *     description="Returns a list of all embeddable widget types available for the partner's tier, including their descriptions and configuration options.",
+     *     tags={"Partner BaaS"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Available widget types",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="array", @OA\Items(type="object",
+     *                 @OA\Property(property="type", type="string", example="exchange"),
+     *                 @OA\Property(property="label", type="string", example="Exchange Widget"),
+     *                 @OA\Property(property="description", type="string", example="Embeddable exchange trading widget")
+     *             ))
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function index(Request $request): JsonResponse
     {
@@ -34,6 +66,64 @@ class PartnerWidgetController extends Controller
      * Generate embed code for a widget.
      *
      * POST /api/partner/v1/widgets/{type}/embed
+     *
+     * @OA\Post(
+     *     path="/api/partner/v1/widgets/{type}/embed",
+     *     operationId="partnerGenerateWidgetEmbed",
+     *     summary="Generate embed code for a widget",
+     *     description="Generates HTML/JavaScript embed code for the specified widget type, customized with the partner's branding and optional layout parameters.",
+     *     tags={"Partner BaaS"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="type",
+     *         in="path",
+     *         required=true,
+     *         description="Widget type identifier",
+     *         @OA\Schema(type="string", example="exchange")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=false,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="container_id", type="string", example="widget-container", description="HTML container element ID (max 100 chars)"),
+     *             @OA\Property(property="width", type="string", example="400px", description="Widget width (max 20 chars)"),
+     *             @OA\Property(property="height", type="string", example="600px", description="Widget height (max 20 chars)")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Embed code generated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="success", type="boolean", example=true),
+     *                 @OA\Property(property="embed_code", type="string", description="HTML/JS embed snippet"),
+     *                 @OA\Property(property="type", type="string", example="exchange")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Invalid widget type or tier restriction",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="success", type="boolean", example=false),
+     *                 @OA\Property(property="error", type="string", example="Widget type not available for your tier")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function embed(Request $request, string $type): JsonResponse
     {
@@ -57,6 +147,56 @@ class PartnerWidgetController extends Controller
      * Preview a widget with branding.
      *
      * GET /api/partner/v1/widgets/{type}/preview
+     *
+     * @OA\Get(
+     *     path="/api/partner/v1/widgets/{type}/preview",
+     *     operationId="partnerPreviewWidget",
+     *     summary="Preview a widget with branding",
+     *     description="Returns a preview of the widget with the partner's current branding applied. Useful for testing branding changes before deploying to production.",
+     *     tags={"Partner BaaS"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="type",
+     *         in="path",
+     *         required=true,
+     *         description="Widget type identifier",
+     *         @OA\Schema(type="string", example="exchange")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Widget preview",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="success", type="boolean", example=true),
+     *                 @OA\Property(property="preview_url", type="string", example="https://example.com/widget/preview/abc123"),
+     *                 @OA\Property(property="type", type="string", example="exchange")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthorized",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="UNAUTHORIZED"),
+     *                 @OA\Property(property="message", type="string", example="Unauthenticated.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Invalid widget type or tier restriction",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="success", type="boolean", example=false),
+     *                 @OA\Property(property="error", type="string", example="Widget type not available for your tier")
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function preview(Request $request, string $type): JsonResponse
     {


### PR DESCRIPTION
## Summary
- Add `@OA\Post`, `@OA\Get`, `@OA\Put`, `@OA\Delete` annotations to **12 controllers** covering **32 API endpoints**
- **AI Query** (tag: `AI Query`): `aiQueryTransactions`, `aiQuerySpendingAnalysis`
- **Mobile Payments** (tag: `Mobile Payments`): payment intent CRUD (create/show/submit/cancel), activity feed, receipt generation, transaction details, wallet receive address, network status
- **Partner BaaS** (tag: `Partner BaaS`): dashboard (profile/usage/history/tier/comparison/branding), billing (invoices/invoice/outstanding/breakdown), SDK (languages/generate/status/openapi-spec), widgets (list/embed/preview), marketplace (list/integrations/enable/disable/test/health)

## Details
All annotations follow the existing project convention:
- `security={{"sanctum": {}}}` on every endpoint
- Request body properties derived from `validate()` / FormRequest rules
- Success responses: `{ success: true, data: {...} }`
- Error responses: `{ success: false, error: { code, message } }`
- Descriptive `operationId` values for each endpoint
- `@OA\Tag` declarations on primary controllers per group

## Test plan
- [x] `php-cs-fixer` reports 0 violations
- [x] All 230 related tests pass (Feature + Unit for Partner, MobilePayment, FinancialInstitution)
- [ ] `php artisan l5-swagger:generate` succeeds (pre-existing error in MobileController.php unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)