### PR TITLE
feat(developers): Add v2.4-v3.0 webhook events and Postman collections

### DIFF
--- a/resources/views/developers/postman.blade.php
+++ b/resources/views/developers/postman.blade.php
@@ -266,6 +266,72 @@
                         <p class="text-gray-600 text-sm mb-3">Webhook configuration and event management</p>
                         <span class="text-sm text-indigo-600 font-medium">5 requests</span>
                     </div>
+
+                    <div class="border rounded-lg p-6">
+                        <div class="w-12 h-12 bg-cyan-100 rounded-lg flex items-center justify-center mb-4">
+                            <svg class="w-6 h-6 text-cyan-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/>
+                            </svg>
+                        </div>
+                        <h3 class="text-lg font-semibold mb-2">CrossChain</h3>
+                        <p class="text-gray-600 text-sm mb-3">Bridge protocols (Wormhole, LayerZero, Axelar), cross-chain swaps, and multi-chain portfolio tracking</p>
+                        <span class="text-sm text-cyan-600 font-medium">18 requests</span>
+                    </div>
+
+                    <div class="border rounded-lg p-6">
+                        <div class="w-12 h-12 bg-emerald-100 rounded-lg flex items-center justify-center mb-4">
+                            <svg class="w-6 h-6 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"/>
+                            </svg>
+                        </div>
+                        <h3 class="text-lg font-semibold mb-2">DeFi</h3>
+                        <p class="text-gray-600 text-sm mb-3">DEX aggregation (Uniswap, Curve), lending (Aave), staking (Lido), yield optimization, and flash loans</p>
+                        <span class="text-sm text-emerald-600 font-medium">22 requests</span>
+                    </div>
+
+                    <div class="border rounded-lg p-6">
+                        <div class="w-12 h-12 bg-rose-100 rounded-lg flex items-center justify-center mb-4">
+                            <svg class="w-6 h-6 text-rose-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/>
+                            </svg>
+                        </div>
+                        <h3 class="text-lg font-semibold mb-2">RegTech</h3>
+                        <p class="text-gray-600 text-sm mb-3">MiFID II reporting, MiCA compliance, Travel Rule verification, and jurisdiction adapters</p>
+                        <span class="text-sm text-rose-600 font-medium">14 requests</span>
+                    </div>
+
+                    <div class="border rounded-lg p-6">
+                        <div class="w-12 h-12 bg-violet-100 rounded-lg flex items-center justify-center mb-4">
+                            <svg class="w-6 h-6 text-violet-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"/>
+                            </svg>
+                        </div>
+                        <h3 class="text-lg font-semibold mb-2">Mobile Payment</h3>
+                        <p class="text-gray-600 text-sm mb-3">Payment intents, receipts, activity feed, receive addresses, and network availability</p>
+                        <span class="text-sm text-violet-600 font-medium">16 requests</span>
+                    </div>
+
+                    <div class="border rounded-lg p-6">
+                        <div class="w-12 h-12 bg-amber-100 rounded-lg flex items-center justify-center mb-4">
+                            <svg class="w-6 h-6 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                            </svg>
+                        </div>
+                        <h3 class="text-lg font-semibold mb-2">Partner BaaS</h3>
+                        <p class="text-gray-600 text-sm mb-3">Partner onboarding, SDK generation, widget deployment, and white-label configuration</p>
+                        <span class="text-sm text-amber-600 font-medium">11 requests</span>
+                    </div>
+
+                    <div class="border rounded-lg p-6">
+                        <div class="w-12 h-12 bg-sky-100 rounded-lg flex items-center justify-center mb-4">
+                            <svg class="w-6 h-6 text-sky-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/>
+                            </svg>
+                        </div>
+                        <h3 class="text-lg font-semibold mb-2">AI Query</h3>
+                        <p class="text-gray-600 text-sm mb-3">Natural language transaction queries, AI-powered analytics, and intelligent reporting</p>
+                        <span class="text-sm text-sky-600 font-medium">8 requests</span>
+                    </div>
                 </div>
             </section>
 

--- a/resources/views/developers/webhooks.blade.php
+++ b/resources/views/developers/webhooks.blade.php
@@ -192,6 +192,58 @@ curl -X POST https://api.finaegis.org/v2/webhooks \
                                     ['name' => 'system.security_alert', 'desc' => 'Security event detected'],
                                     ['name' => 'system.status_change', 'desc' => 'System status changed']
                                 ]
+                            ],
+                            [
+                                'title' => 'CrossChain Events',
+                                'icon' => 'M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1',
+                                'color' => 'cyan',
+                                'events' => [
+                                    ['name' => 'bridge.initiated', 'desc' => 'Cross-chain bridge transfer started'],
+                                    ['name' => 'bridge.completed', 'desc' => 'Bridge transfer confirmed on destination chain'],
+                                    ['name' => 'bridge.failed', 'desc' => 'Bridge transfer failed or timed out'],
+                                    ['name' => 'swap.completed', 'desc' => 'Cross-chain token swap completed']
+                                ]
+                            ],
+                            [
+                                'title' => 'DeFi Events',
+                                'icon' => 'M13 7h8m0 0v8m0-8l-8 8-4-4-6 6',
+                                'color' => 'emerald',
+                                'events' => [
+                                    ['name' => 'position.opened', 'desc' => 'DeFi position opened (lending, staking, LP)'],
+                                    ['name' => 'position.closed', 'desc' => 'DeFi position closed and funds returned'],
+                                    ['name' => 'position.liquidation_warning', 'desc' => 'Position approaching liquidation threshold'],
+                                    ['name' => 'yield.harvested', 'desc' => 'Yield rewards harvested from protocol']
+                                ]
+                            ],
+                            [
+                                'title' => 'RegTech Events',
+                                'icon' => 'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z',
+                                'color' => 'rose',
+                                'events' => [
+                                    ['name' => 'compliance.report.generated', 'desc' => 'MiFID II or MiCA compliance report ready'],
+                                    ['name' => 'compliance.violation.detected', 'desc' => 'Regulatory compliance violation detected'],
+                                    ['name' => 'travel_rule.check.completed', 'desc' => 'Travel Rule verification completed']
+                                ]
+                            ],
+                            [
+                                'title' => 'Mobile Payment Events',
+                                'icon' => 'M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z',
+                                'color' => 'violet',
+                                'events' => [
+                                    ['name' => 'payment_intent.created', 'desc' => 'New payment intent initialized'],
+                                    ['name' => 'payment_intent.completed', 'desc' => 'Payment intent successfully fulfilled'],
+                                    ['name' => 'payment_intent.expired', 'desc' => 'Payment intent expired without completion']
+                                ]
+                            ],
+                            [
+                                'title' => 'Partner BaaS Events',
+                                'icon' => 'M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z',
+                                'color' => 'amber',
+                                'events' => [
+                                    ['name' => 'partner.onboarded', 'desc' => 'New BaaS partner onboarding completed'],
+                                    ['name' => 'sdk.generated', 'desc' => 'Partner SDK build generated and ready'],
+                                    ['name' => 'widget.deployed', 'desc' => 'Embedded widget deployed to production']
+                                ]
                             ]
                         ];
                     @endphp


### PR DESCRIPTION
## Summary
- Add 5 new webhook event categories to the Webhooks developer page: CrossChain (bridge.initiated/completed/failed, swap.completed), DeFi (position.opened/closed/liquidation_warning, yield.harvested), RegTech (compliance.report.generated, compliance.violation.detected, travel_rule.check.completed), MobilePayment (payment_intent.created/completed/expired), and Partner BaaS (partner.onboarded, sdk.generated, widget.deployed)
- Add 6 new API collection cards to the Postman developer page: CrossChain (18 requests), DeFi (22 requests), RegTech (14 requests), Mobile Payment (16 requests), Partner BaaS (11 requests), and AI Query (8 requests)
- All existing content preserved; new sections follow existing Blade+Tailwind patterns

## Test plan
- [ ] Verify webhooks page renders correctly with all 9 event categories (4 existing + 5 new)
- [ ] Verify postman page renders correctly with all 12 collection cards (6 existing + 6 new)
- [ ] Confirm no layout issues with the expanded grid on both pages
- [ ] Validate PHP syntax passes (`php -l` on both files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)