### PR TITLE
feat(developers): Update developer portal for v2.0-v3.0 APIs

### DIFF
--- a/resources/views/developers/api-docs.blade.php
+++ b/resources/views/developers/api-docs.blade.php
@@ -29,15 +29,20 @@
         <!-- API Navigation -->
         <div class="bg-gray-50 border-b">
             <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-                <nav class="flex space-x-8 py-4">
+                <nav class="flex flex-wrap gap-x-6 gap-y-2 py-4">
                     <a href="#getting-started" class="text-blue-600 font-medium">Getting Started</a>
                     <a href="#authentication" class="text-gray-600 hover:text-gray-900">Authentication</a>
                     <a href="#accounts" class="text-gray-600 hover:text-gray-900">Accounts</a>
                     <a href="#transactions" class="text-gray-600 hover:text-gray-900">Transactions</a>
                     <a href="#transfers" class="text-gray-600 hover:text-gray-900">Transfers</a>
                     <a href="#gcu" class="text-gray-600 hover:text-gray-900">GCU</a>
-                    <a href="#assets" class="text-gray-600 hover:text-gray-900">Assets</a>
                     <a href="#baskets" class="text-gray-600 hover:text-gray-900">Baskets</a>
+                    <a href="#crosschain" class="text-cyan-600 hover:text-cyan-800">CrossChain</a>
+                    <a href="#defi" class="text-emerald-600 hover:text-emerald-800">DeFi</a>
+                    <a href="#regtech" class="text-amber-600 hover:text-amber-800">RegTech</a>
+                    <a href="#mobile-payment" class="text-violet-600 hover:text-violet-800">Mobile Payment</a>
+                    <a href="#partner-baas" class="text-rose-600 hover:text-rose-800">Partner BaaS</a>
+                    <a href="#ai" class="text-gray-600 hover:text-gray-900">AI</a>
                     <a href="#webhooks" class="text-gray-600 hover:text-gray-900">Webhooks</a>
                     <a href="#errors" class="text-gray-600 hover:text-gray-900">Errors</a>
                 </nav>
@@ -53,7 +58,7 @@
                         <h2 class="text-3xl font-bold text-gray-900 mb-8">Getting Started</h2>
                         
                         <div class="prose prose-lg max-w-none">
-                            <p>The FinAegis API provides programmatic access to our multi-asset banking platform. Our API is organized around REST principles with predictable, resource-oriented URLs.</p>
+                            <p>The FinAegis API provides programmatic access to our multi-asset banking platform spanning 41 DDD domains with over 1,150 routes. Our API is organized around REST principles with predictable, resource-oriented URLs. Domains include core banking, CrossChain bridging, DeFi protocols, RegTech compliance, Mobile Payment, Partner BaaS, and AI-powered queries.</p>
                             
                             <h3>Base URL</h3>
                             <x-code-block language="plaintext">
@@ -707,6 +712,535 @@ curl -H "Authorization: Bearer your_api_key" \
                             </div>
                         </div>
                     </section>
+
+                    <!-- CrossChain API -->
+                    <section id="crosschain" class="mb-16">
+                        <h2 class="text-3xl font-bold text-gray-900 mb-8">CrossChain API</h2>
+
+                        <div class="prose prose-lg max-w-none mb-8">
+                            <p>The CrossChain API enables multi-chain operations including bridge transfers via Wormhole, LayerZero, and Axelar protocols. Compare bridge fees, execute cross-chain swaps, and track portfolios across multiple blockchains.</p>
+                            <p class="text-sm text-gray-500">7 routes &middot; <a href="/api/documentation#/CrossChain" target="_blank" class="text-cyan-600 hover:text-cyan-800">View in Swagger UI</a></p>
+                        </div>
+
+                        <div class="space-y-8">
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">Initiate Bridge Transfer</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/crosschain/bridge</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Initiate a cross-chain bridge transfer through Wormhole, LayerZero, or Axelar.</p>
+                                <x-code-block language="bash">
+curl -X POST \
+  -H "Authorization: Bearer your_api_key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "source_chain": "ethereum",
+    "destination_chain": "polygon",
+    "token": "USDC",
+    "amount": "1000.00",
+    "protocol": "wormhole"
+  }' \
+  https://api.finaegis.org/v2/crosschain/bridge
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">Compare Bridge Fees</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/crosschain/bridge/fees</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Compare fees and estimated times across all supported bridge protocols for a given route.</p>
+                                <x-code-block language="bash">
+curl -H "Authorization: Bearer your_api_key" \
+     "https://api.finaegis.org/v2/crosschain/bridge/fees?from=ethereum&to=arbitrum&token=USDC&amount=5000"
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">Cross-Chain Swap</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/crosschain/swap</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Execute a token swap that bridges and swaps in a single atomic operation.</p>
+                                <x-code-block language="bash">
+curl -X POST \
+  -H "Authorization: Bearer your_api_key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "source_chain": "ethereum",
+    "destination_chain": "polygon",
+    "from_token": "ETH",
+    "to_token": "MATIC",
+    "amount": "1.5",
+    "slippage_bps": 50
+  }' \
+  https://api.finaegis.org/v2/crosschain/swap
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">Multi-Chain Portfolio</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/crosschain/portfolio</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Retrieve an aggregated portfolio view across all supported chains.</p>
+                                <x-code-block language="bash">
+curl -H "Authorization: Bearer your_api_key" \
+     https://api.finaegis.org/v2/crosschain/portfolio
+                                </x-code-block>
+                            </div>
+                        </div>
+                    </section>
+
+                    <!-- DeFi API -->
+                    <section id="defi" class="mb-16">
+                        <h2 class="text-3xl font-bold text-gray-900 mb-8">DeFi API</h2>
+
+                        <div class="prose prose-lg max-w-none mb-8">
+                            <p>The DeFi API provides access to decentralized finance protocols including DEX aggregation (Uniswap, Curve), lending (Aave), staking (Lido), yield optimization, and flash loan execution.</p>
+                            <p class="text-sm text-gray-500">8 routes &middot; <a href="/api/documentation#/DeFi" target="_blank" class="text-emerald-600 hover:text-emerald-800">View in Swagger UI</a></p>
+                        </div>
+
+                        <div class="space-y-8">
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">Get Swap Quote</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/defi/swap/quote</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Get the best swap quote aggregated across Uniswap, Curve, and other supported DEXes.</p>
+                                <x-code-block language="bash">
+curl -H "Authorization: Bearer your_api_key" \
+     "https://api.finaegis.org/v2/defi/swap/quote?from=ETH&to=USDC&amount=2.0&chain=ethereum"
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">Execute Swap</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/defi/swap/execute</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Execute a token swap through the optimal DEX route.</p>
+                                <x-code-block language="bash">
+curl -X POST \
+  -H "Authorization: Bearer your_api_key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "from_token": "ETH",
+    "to_token": "USDC",
+    "amount": "2.0",
+    "slippage_bps": 50,
+    "chain": "ethereum"
+  }' \
+  https://api.finaegis.org/v2/defi/swap/execute
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">DeFi Portfolio Positions</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/defi/portfolio</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Retrieve all DeFi positions including lending deposits, staking, liquidity pools, and yield farming.</p>
+                                <x-code-block language="bash">
+curl -H "Authorization: Bearer your_api_key" \
+     https://api.finaegis.org/v2/defi/portfolio
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">Flash Loan</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/defi/flash-loan</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Execute a flash loan with a sequence of operations that must complete atomically.</p>
+                                <x-code-block language="bash">
+curl -X POST \
+  -H "Authorization: Bearer your_api_key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "token": "USDC",
+    "amount": "100000.00",
+    "operations": [
+      {"type": "swap", "from": "USDC", "to": "ETH", "dex": "uniswap"},
+      {"type": "swap", "from": "ETH", "to": "USDC", "dex": "curve"}
+    ]
+  }' \
+  https://api.finaegis.org/v2/defi/flash-loan
+                                </x-code-block>
+                            </div>
+                        </div>
+                    </section>
+
+                    <!-- RegTech API -->
+                    <section id="regtech" class="mb-16">
+                        <h2 class="text-3xl font-bold text-gray-900 mb-8">RegTech API</h2>
+
+                        <div class="prose prose-lg max-w-none mb-8">
+                            <p>The RegTech API provides regulatory compliance capabilities including MiFID II transaction reporting, MiCA crypto-asset compliance, Travel Rule enforcement for cross-border transfers, and jurisdiction-specific adapter configuration.</p>
+                            <p class="text-sm text-gray-500">12 routes &middot; <a href="/api/documentation#/RegTech" target="_blank" class="text-amber-600 hover:text-amber-800">View in Swagger UI</a></p>
+                        </div>
+
+                        <div class="space-y-8">
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">Submit MiFID II Report</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/regtech/mifid/reports</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Submit a MiFID II transaction report to the configured National Competent Authority.</p>
+                                <x-code-block language="bash">
+curl -X POST \
+  -H "Authorization: Bearer your_api_key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "transaction_id": "txn_abc123",
+    "report_type": "transaction",
+    "jurisdiction": "EU"
+  }' \
+  https://api.finaegis.org/v2/regtech/mifid/reports
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">MiCA Compliance Check</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/regtech/mica/check</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Run a MiCA compliance validation against a crypto-asset or token issuance.</p>
+                                <x-code-block language="bash">
+curl -X POST \
+  -H "Authorization: Bearer your_api_key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "asset_type": "e-money-token",
+    "issuer_id": "issuer_xyz",
+    "whitepaper_hash": "sha256:abc..."
+  }' \
+  https://api.finaegis.org/v2/regtech/mica/check
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">Travel Rule Transfer</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/regtech/travel-rule/transfers</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Submit originator and beneficiary information for FATF Travel Rule compliance on cross-border transfers.</p>
+                                <x-code-block language="bash">
+curl -X POST \
+  -H "Authorization: Bearer your_api_key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "transfer_id": "xfer_789",
+    "originator": {"name": "Alice Smith", "account": "acc_123"},
+    "beneficiary": {"name": "Bob Jones", "vasp_id": "vasp_456"},
+    "amount": "15000.00",
+    "currency": "USDC"
+  }' \
+  https://api.finaegis.org/v2/regtech/travel-rule/transfers
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">Compliance Status</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/regtech/status</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Get overall compliance status across all active regulatory frameworks.</p>
+                                <x-code-block language="bash">
+curl -H "Authorization: Bearer your_api_key" \
+     https://api.finaegis.org/v2/regtech/status
+                                </x-code-block>
+                            </div>
+                        </div>
+                    </section>
+
+                    <!-- Mobile Payment API -->
+                    <section id="mobile-payment" class="mb-16">
+                        <h2 class="text-3xl font-bold text-gray-900 mb-8">Mobile Payment API</h2>
+
+                        <div class="prose prose-lg max-w-none mb-8">
+                            <p>The Mobile Payment API powers the FinAegis mobile wallet experience with payment intents, digital receipts, activity feeds, receive addresses, P2P transfers, passkey authentication, and biometric JWT sessions.</p>
+                            <p class="text-sm text-gray-500">25+ routes &middot; <a href="/api/documentation#/MobilePayment" target="_blank" class="text-violet-600 hover:text-violet-800">View in Swagger UI</a></p>
+                        </div>
+
+                        <div class="space-y-8">
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">Create Payment Intent</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/mobile/payments/intents</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Create a new payment intent for mobile wallet transactions.</p>
+                                <x-code-block language="bash">
+curl -X POST \
+  -H "Authorization: Bearer your_api_key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": "25.00",
+    "currency": "USD",
+    "recipient": "user_456",
+    "description": "Coffee payment"
+  }' \
+  https://api.finaegis.org/v2/mobile/payments/intents
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">Activity Feed</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/mobile/activity</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Retrieve the mobile wallet activity feed with payments, transfers, and notifications.</p>
+                                <x-code-block language="bash">
+curl -H "Authorization: Bearer your_api_key" \
+     "https://api.finaegis.org/v2/mobile/activity?page=1&per_page=20"
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">P2P Transfer</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/mobile/transfers/p2p</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Send a peer-to-peer transfer to another mobile wallet user.</p>
+                                <x-code-block language="bash">
+curl -X POST \
+  -H "Authorization: Bearer your_api_key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to_user": "user_789",
+    "amount": "50.00",
+    "currency": "USD",
+    "note": "Dinner split"
+  }' \
+  https://api.finaegis.org/v2/mobile/transfers/p2p
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">Passkey Authentication</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/mobile/auth/passkey/verify</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Verify a FIDO2/WebAuthn passkey for passwordless mobile authentication.</p>
+                                <x-code-block language="bash">
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d '{
+    "credential_id": "cred_abc",
+    "authenticator_data": "base64...",
+    "client_data_json": "base64...",
+    "signature": "base64..."
+  }' \
+  https://api.finaegis.org/v2/mobile/auth/passkey/verify
+                                </x-code-block>
+                            </div>
+                        </div>
+                    </section>
+
+                    <!-- Partner BaaS API -->
+                    <section id="partner-baas" class="mb-16">
+                        <h2 class="text-3xl font-bold text-gray-900 mb-8">Partner / BaaS API</h2>
+
+                        <div class="prose prose-lg max-w-none mb-8">
+                            <p>The Partner BaaS (Banking-as-a-Service) API enables third-party partners to provision tenants, generate branded SDKs, configure white-label deployments, and manage their partner integrations. Requires a Partner API key (<code>fpk_</code> prefix) in addition to standard authentication.</p>
+                            <p class="text-sm text-gray-500">24 routes &middot; <a href="/api/documentation#/Partner" target="_blank" class="text-rose-600 hover:text-rose-800">View in Swagger UI</a></p>
+                        </div>
+
+                        <div class="space-y-8">
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">Provision Tenant</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/partner/tenants</span>
+                                    </div>
+                                    <div class="text-right">
+                                        <span class="inline-block bg-rose-100 text-rose-800 text-xs font-medium px-2.5 py-0.5 rounded">Partner Key Required</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Provision a new tenant for a BaaS partner with isolated data and configuration.</p>
+                                <x-code-block language="bash">
+curl -X POST \
+  -H "Authorization: Bearer your_api_key" \
+  -H "X-Partner-Key: fpk_your_partner_key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Acme Bank",
+    "plan": "enterprise",
+    "domain": "acme.finaegis.io"
+  }' \
+  https://api.finaegis.org/v2/partner/tenants
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">Generate SDK</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/partner/sdk/generate</span>
+                                    </div>
+                                    <div class="text-right">
+                                        <span class="inline-block bg-rose-100 text-rose-800 text-xs font-medium px-2.5 py-0.5 rounded">Partner Key Required</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Generate a branded SDK package for the partner's platform and language.</p>
+                                <x-code-block language="bash">
+curl -X POST \
+  -H "Authorization: Bearer your_api_key" \
+  -H "X-Partner-Key: fpk_your_partner_key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "language": "javascript",
+    "branding": {"name": "AcmeSDK", "color": "#3B82F6"},
+    "modules": ["accounts", "transfers", "payments"]
+  }' \
+  https://api.finaegis.org/v2/partner/sdk/generate
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">White-Label Configuration</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-blue-100 text-blue-800 text-xs font-medium px-2.5 py-0.5 rounded">PUT</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/partner/config/whitelabel</span>
+                                    </div>
+                                    <div class="text-right">
+                                        <span class="inline-block bg-rose-100 text-rose-800 text-xs font-medium px-2.5 py-0.5 rounded">Partner Key Required</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Update white-label branding, theming, and feature toggles for the partner deployment.</p>
+                                <x-code-block language="bash">
+curl -X PUT \
+  -H "Authorization: Bearer your_api_key" \
+  -H "X-Partner-Key: fpk_your_partner_key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "logo_url": "https://acme.com/logo.svg",
+    "primary_color": "#3B82F6",
+    "features": {"defi": true, "crosschain": true, "lending": false}
+  }' \
+  https://api.finaegis.org/v2/partner/config/whitelabel
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">List Partner Tenants</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/partner/tenants</span>
+                                    </div>
+                                    <div class="text-right">
+                                        <span class="inline-block bg-rose-100 text-rose-800 text-xs font-medium px-2.5 py-0.5 rounded">Partner Key Required</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">List all tenants provisioned under this partner account.</p>
+                                <x-code-block language="bash">
+curl -H "Authorization: Bearer your_api_key" \
+     -H "X-Partner-Key: fpk_your_partner_key" \
+     https://api.finaegis.org/v2/partner/tenants
+                                </x-code-block>
+                            </div>
+                        </div>
+                    </section>
+
+                    <!-- AI API -->
+                    <section id="ai" class="mb-16">
+                        <h2 class="text-3xl font-bold text-gray-900 mb-8">AI Query API</h2>
+
+                        <div class="prose prose-lg max-w-none mb-8">
+                            <p>The AI Query API provides natural language access to transaction data and financial insights. Ask questions in plain English and receive structured, actionable responses.</p>
+                            <p class="text-sm text-gray-500">2 routes &middot; <a href="/api/documentation#/AI" target="_blank" class="text-gray-600 hover:text-gray-800">View in Swagger UI</a></p>
+                        </div>
+
+                        <div class="space-y-8">
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">Natural Language Query</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/ai/query</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Submit a natural language question about your transactions, balances, or financial activity.</p>
+                                <x-code-block language="bash">
+curl -X POST \
+  -H "Authorization: Bearer your_api_key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "What were my largest transactions last month?",
+    "context": {"account_id": "acc_123"}
+  }' \
+  https://api.finaegis.org/v2/ai/query
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">AI Query History</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/ai/queries</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Retrieve your past AI query history with cached results.</p>
+                                <x-code-block language="bash">
+curl -H "Authorization: Bearer your_api_key" \
+     https://api.finaegis.org/v2/ai/queries
+                                </x-code-block>
+                            </div>
+                        </div>
+                    </section>
                 </div>
 
                 <!-- Sidebar -->
@@ -719,6 +1253,18 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <li><a href="{{ route('developers.show', 'postman') }}" class="text-blue-600 hover:text-blue-800">Postman Collection</a></li>
                                 <li><a href="{{ route('developers.show', 'examples') }}" class="text-blue-600 hover:text-blue-800">Code Examples</a></li>
                                 <li><a href="{{ route('developers.show', 'webhooks') }}" class="text-blue-600 hover:text-blue-800">Webhooks Guide</a></li>
+                            </ul>
+                        </div>
+
+                        <div class="bg-white border rounded-lg p-6 mb-8">
+                            <h3 class="text-lg font-semibold mb-4">v2.0 - v3.0 API Areas</h3>
+                            <ul class="space-y-2 text-sm">
+                                <li><a href="#crosschain" class="text-cyan-600 hover:text-cyan-800 flex justify-between"><span>CrossChain</span><span class="text-gray-400">7 routes</span></a></li>
+                                <li><a href="#defi" class="text-emerald-600 hover:text-emerald-800 flex justify-between"><span>DeFi</span><span class="text-gray-400">8 routes</span></a></li>
+                                <li><a href="#regtech" class="text-amber-600 hover:text-amber-800 flex justify-between"><span>RegTech</span><span class="text-gray-400">12 routes</span></a></li>
+                                <li><a href="#mobile-payment" class="text-violet-600 hover:text-violet-800 flex justify-between"><span>Mobile Payment</span><span class="text-gray-400">25+ routes</span></a></li>
+                                <li><a href="#partner-baas" class="text-rose-600 hover:text-rose-800 flex justify-between"><span>Partner BaaS</span><span class="text-gray-400">24 routes</span></a></li>
+                                <li><a href="#ai" class="text-gray-600 hover:text-gray-800 flex justify-between"><span>AI Query</span><span class="text-gray-400">2 routes</span></a></li>
                             </ul>
                         </div>
 

--- a/resources/views/developers/examples.blade.php
+++ b/resources/views/developers/examples.blade.php
@@ -160,6 +160,46 @@
                     <h3 class="font-semibold text-gray-900 mb-2">MCP Tools</h3>
                     <p class="text-gray-600 text-sm">Model Context Protocol integration</p>
                 </a>
+
+                <a href="#crosschain-defi" class="group bg-white rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 p-6 hover:transform hover:-translate-y-1">
+                    <div class="w-12 h-12 bg-cyan-100 rounded-lg flex items-center justify-center mb-4 group-hover:bg-cyan-200 transition-colors">
+                        <svg class="w-6 h-6 text-cyan-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"/>
+                        </svg>
+                    </div>
+                    <h3 class="font-semibold text-gray-900 mb-2">Cross-Chain &amp; DeFi</h3>
+                    <p class="text-gray-600 text-sm">Bridge protocols, DEX swaps, and multi-chain operations</p>
+                </a>
+
+                <a href="#regtech-compliance" class="group bg-white rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 p-6 hover:transform hover:-translate-y-1">
+                    <div class="w-12 h-12 bg-emerald-100 rounded-lg flex items-center justify-center mb-4 group-hover:bg-emerald-200 transition-colors">
+                        <svg class="w-6 h-6 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/>
+                        </svg>
+                    </div>
+                    <h3 class="font-semibold text-gray-900 mb-2">RegTech &amp; Compliance</h3>
+                    <p class="text-gray-600 text-sm">Travel Rule, MiFID II, MiCA compliance checks</p>
+                </a>
+
+                <a href="#baas-partner" class="group bg-white rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 p-6 hover:transform hover:-translate-y-1">
+                    <div class="w-12 h-12 bg-amber-100 rounded-lg flex items-center justify-center mb-4 group-hover:bg-amber-200 transition-colors">
+                        <svg class="w-6 h-6 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"/>
+                        </svg>
+                    </div>
+                    <h3 class="font-semibold text-gray-900 mb-2">BaaS &amp; Partner API</h3>
+                    <p class="text-gray-600 text-sm">Partner onboarding and Banking-as-a-Service integration</p>
+                </a>
+
+                <a href="#ai-transactions" class="group bg-white rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 p-6 hover:transform hover:-translate-y-1">
+                    <div class="w-12 h-12 bg-violet-100 rounded-lg flex items-center justify-center mb-4 group-hover:bg-violet-200 transition-colors">
+                        <svg class="w-6 h-6 text-violet-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
+                        </svg>
+                    </div>
+                    <h3 class="font-semibold text-gray-900 mb-2">AI Transaction Query</h3>
+                    <p class="text-gray-600 text-sm">Natural language transaction search and analysis</p>
+                </a>
             </div>
         </div>
     </section>
@@ -1758,6 +1798,1088 @@ processLoanApplication('cust_456', {
   purpose: 'debt_consolidation'
 });
                             </x-code-block>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Cross-Chain & DeFi -->
+            <div id="crosschain-defi" class="mb-20">
+                <h2 class="text-3xl font-bold text-gray-900 mb-8">Cross-Chain &amp; DeFi</h2>
+
+                <div class="space-y-12">
+                    <!-- Cross-Chain Bridge Quote + Initiate -->
+                    <div class="bg-white rounded-xl shadow-lg overflow-hidden">
+                        <div class="bg-gradient-to-r from-cyan-50 to-blue-50 px-6 py-5 border-b">
+                            <div class="flex items-center justify-between">
+                                <div>
+                                    <h3 class="text-xl font-semibold text-gray-900">Cross-Chain Bridge: Quote and Initiate</h3>
+                                    <p class="text-gray-600 mt-1">Get a bridge quote across chains (Wormhole, LayerZero, Axelar) and initiate the transfer</p>
+                                </div>
+                                <div class="flex items-center gap-2">
+                                    <span class="px-3 py-1 bg-cyan-100 text-cyan-700 rounded-full text-xs font-medium">v3.0</span>
+                                    <span class="px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-xs font-medium">POST</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="p-6">
+                            <!-- Tabs -->
+                            <div class="code-tabs">
+                                <button onclick="switchTab(event, 'bridge-curl')" class="code-tab active">cURL</button>
+                                <button onclick="switchTab(event, 'bridge-js')" class="code-tab">JavaScript</button>
+                                <button onclick="switchTab(event, 'bridge-py')" class="code-tab">Python</button>
+                                <button onclick="switchTab(event, 'bridge-response')" class="code-tab">Response</button>
+                            </div>
+
+                            <!-- cURL -->
+                            <div id="bridge-curl" class="tab-content active animate-fade-in">
+                                <x-code-block language="bash">
+# Step 1: Get a bridge quote
+curl -X POST https://api.finaegis.org/api/v1/crosschain/bridge/quote \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "source_chain": "ethereum",
+    "destination_chain": "polygon",
+    "token": "USDC",
+    "amount": "1000.00",
+    "preferred_bridge": "wormhole"
+  }'
+
+# Step 2: Initiate the bridge transfer using the quote_id
+curl -X POST https://api.finaegis.org/api/v1/crosschain/bridge/initiate \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "quote_id": "quote_br_abc123def456",
+    "sender_address": "0x1234...abcd",
+    "recipient_address": "0x5678...efgh",
+    "slippage_tolerance": 0.005,
+    "deadline_minutes": 30
+  }'
+                                </x-code-block>
+                            </div>
+
+                            <!-- JavaScript -->
+                            <div id="bridge-js" class="tab-content animate-fade-in">
+                                <x-code-block language="javascript">
+import { FinAegis } from '@finaegis/sdk';
+
+const client = new FinAegis({
+  apiKey: process.env.FINAEGIS_API_KEY,
+  baseURL: 'https://api.finaegis.org'
+});
+
+async function bridgeTokens(sourceChain, destChain, token, amount) {
+  try {
+    // Step 1: Get a bridge quote comparing protocols
+    const quote = await client.crosschain.bridge.quote({
+      source_chain: sourceChain,
+      destination_chain: destChain,
+      token: token,
+      amount: amount,
+      preferred_bridge: 'wormhole' // or 'layerzero', 'axelar'
+    });
+
+    console.log('Bridge Quote:');
+    console.log(`  Protocol: ${quote.data.bridge_protocol}`);
+    console.log(`  Estimated output: ${quote.data.estimated_receive_amount} ${token}`);
+    console.log(`  Fee: ${quote.data.fee_amount} ${quote.data.fee_currency}`);
+    console.log(`  Estimated time: ${quote.data.estimated_duration_seconds}s`);
+
+    // Step 2: Initiate the bridge transfer
+    const transfer = await client.crosschain.bridge.initiate({
+      quote_id: quote.data.quote_id,
+      sender_address: '0x1234...abcd',
+      recipient_address: '0x5678...efgh',
+      slippage_tolerance: 0.005,
+      deadline_minutes: 30
+    });
+
+    console.log('Bridge initiated:', transfer.data.bridge_tx_id);
+    console.log('Status:', transfer.data.status);
+
+    return transfer;
+  } catch (error) {
+    console.error('Bridge failed:', error.message);
+    throw error;
+  }
+}
+
+// Bridge 1000 USDC from Ethereum to Polygon
+bridgeTokens('ethereum', 'polygon', 'USDC', '1000.00');
+                                </x-code-block>
+                            </div>
+
+                            <!-- Python -->
+                            <div id="bridge-py" class="tab-content animate-fade-in">
+                                <x-code-block language="python">
+from finaegis import FinAegis
+import os
+
+client = FinAegis(
+    api_key=os.environ['FINAEGIS_API_KEY'],
+    base_url='https://api.finaegis.org'
+)
+
+def bridge_tokens(source_chain, dest_chain, token, amount):
+    try:
+        # Step 1: Get a bridge quote
+        quote = client.crosschain.bridge.quote(
+            source_chain=source_chain,
+            destination_chain=dest_chain,
+            token=token,
+            amount=amount,
+            preferred_bridge='wormhole'
+        )
+
+        print(f'Bridge Quote:')
+        print(f'  Protocol: {quote.data.bridge_protocol}')
+        print(f'  Estimated output: {quote.data.estimated_receive_amount} {token}')
+        print(f'  Fee: {quote.data.fee_amount} {quote.data.fee_currency}')
+        print(f'  Estimated time: {quote.data.estimated_duration_seconds}s')
+
+        # Step 2: Initiate the bridge transfer
+        transfer = client.crosschain.bridge.initiate(
+            quote_id=quote.data.quote_id,
+            sender_address='0x1234...abcd',
+            recipient_address='0x5678...efgh',
+            slippage_tolerance=0.005,
+            deadline_minutes=30
+        )
+
+        print(f'Bridge initiated: {transfer.data.bridge_tx_id}')
+        print(f'Status: {transfer.data.status}')
+
+        return transfer
+    except Exception as error:
+        print(f'Bridge failed: {error}')
+        raise
+
+# Bridge 1000 USDC from Ethereum to Polygon
+bridge_tokens('ethereum', 'polygon', 'USDC', '1000.00')
+                                </x-code-block>
+                            </div>
+
+                            <!-- Response -->
+                            <div id="bridge-response" class="tab-content animate-fade-in">
+                                <x-code-block language="json">
+// POST /api/v1/crosschain/bridge/quote response
+{
+  "data": {
+    "quote_id": "quote_br_abc123def456",
+    "bridge_protocol": "wormhole",
+    "source_chain": "ethereum",
+    "destination_chain": "polygon",
+    "token": "USDC",
+    "input_amount": "1000.00",
+    "estimated_receive_amount": "998.50",
+    "fee_amount": "1.50",
+    "fee_currency": "USDC",
+    "exchange_rate": "1.0000",
+    "estimated_duration_seconds": 180,
+    "quote_expires_at": "2026-01-15T12:15:00Z",
+    "alternative_quotes": [
+      {
+        "bridge_protocol": "layerzero",
+        "estimated_receive_amount": "997.80",
+        "fee_amount": "2.20",
+        "estimated_duration_seconds": 120
+      },
+      {
+        "bridge_protocol": "axelar",
+        "estimated_receive_amount": "998.00",
+        "fee_amount": "2.00",
+        "estimated_duration_seconds": 240
+      }
+    ]
+  }
+}
+
+// POST /api/v1/crosschain/bridge/initiate response
+{
+  "data": {
+    "bridge_tx_id": "btx_xyz789012345",
+    "quote_id": "quote_br_abc123def456",
+    "status": "pending",
+    "source_chain": "ethereum",
+    "destination_chain": "polygon",
+    "source_tx_hash": null,
+    "destination_tx_hash": null,
+    "sender_address": "0x1234...abcd",
+    "recipient_address": "0x5678...efgh",
+    "amount": "1000.00",
+    "token": "USDC",
+    "bridge_protocol": "wormhole",
+    "created_at": "2026-01-15T12:05:30Z",
+    "estimated_completion_at": "2026-01-15T12:08:30Z"
+  }
+}
+                                </x-code-block>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- DeFi Swap Quote + Execute -->
+                    <div class="bg-white rounded-xl shadow-lg overflow-hidden">
+                        <div class="bg-gradient-to-r from-teal-50 to-green-50 px-6 py-5 border-b">
+                            <div class="flex items-center justify-between">
+                                <div>
+                                    <h3 class="text-xl font-semibold text-gray-900">DeFi Swap: Quote and Execute</h3>
+                                    <p class="text-gray-600 mt-1">Aggregate DEX quotes (Uniswap, Curve, SushiSwap) and execute optimal swaps</p>
+                                </div>
+                                <div class="flex items-center gap-2">
+                                    <span class="px-3 py-1 bg-teal-100 text-teal-700 rounded-full text-xs font-medium">v3.0</span>
+                                    <span class="px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-xs font-medium">POST</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="p-6">
+                            <!-- Tabs -->
+                            <div class="code-tabs">
+                                <button onclick="switchTab(event, 'swap-curl')" class="code-tab active">cURL</button>
+                                <button onclick="switchTab(event, 'swap-js')" class="code-tab">JavaScript</button>
+                                <button onclick="switchTab(event, 'swap-py')" class="code-tab">Python</button>
+                                <button onclick="switchTab(event, 'swap-response')" class="code-tab">Response</button>
+                            </div>
+
+                            <!-- cURL -->
+                            <div id="swap-curl" class="tab-content active animate-fade-in">
+                                <x-code-block language="bash">
+# Step 1: Get a swap quote with DEX aggregation
+curl -X POST https://api.finaegis.org/api/v1/defi/swap/quote \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "chain": "ethereum",
+    "token_in": "WETH",
+    "token_out": "USDC",
+    "amount_in": "2.5",
+    "slippage_tolerance": 0.005,
+    "dex_sources": ["uniswap_v3", "curve", "sushiswap"]
+  }'
+
+# Step 2: Execute the swap with the best route
+curl -X POST https://api.finaegis.org/api/v1/defi/swap/execute \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "quote_id": "quote_sw_def456ghi789",
+    "wallet_address": "0xABCD...1234",
+    "max_gas_price_gwei": 50,
+    "deadline_minutes": 20
+  }'
+                                </x-code-block>
+                            </div>
+
+                            <!-- JavaScript -->
+                            <div id="swap-js" class="tab-content animate-fade-in">
+                                <x-code-block language="javascript">
+async function swapTokens(chain, tokenIn, tokenOut, amountIn) {
+  try {
+    // Step 1: Get aggregated swap quote from multiple DEXes
+    const quote = await client.defi.swap.quote({
+      chain: chain,
+      token_in: tokenIn,
+      token_out: tokenOut,
+      amount_in: amountIn,
+      slippage_tolerance: 0.005,
+      dex_sources: ['uniswap_v3', 'curve', 'sushiswap']
+    });
+
+    console.log('Swap Quote:');
+    console.log(`  Best DEX: ${quote.data.best_route.dex}`);
+    console.log(`  Input: ${amountIn} ${tokenIn}`);
+    console.log(`  Output: ${quote.data.estimated_output} ${tokenOut}`);
+    console.log(`  Price impact: ${quote.data.price_impact_percent}%`);
+    console.log(`  Gas estimate: ${quote.data.estimated_gas_usd} USD`);
+
+    // Step 2: Execute the swap
+    const execution = await client.defi.swap.execute({
+      quote_id: quote.data.quote_id,
+      wallet_address: '0xABCD...1234',
+      max_gas_price_gwei: 50,
+      deadline_minutes: 20
+    });
+
+    console.log('Swap executed:', execution.data.tx_hash);
+    console.log('Status:', execution.data.status);
+
+    return execution;
+  } catch (error) {
+    console.error('Swap failed:', error.message);
+    throw error;
+  }
+}
+
+// Swap 2.5 WETH for USDC on Ethereum
+swapTokens('ethereum', 'WETH', 'USDC', '2.5');
+                                </x-code-block>
+                            </div>
+
+                            <!-- Python -->
+                            <div id="swap-py" class="tab-content animate-fade-in">
+                                <x-code-block language="python">
+def swap_tokens(chain, token_in, token_out, amount_in):
+    try:
+        # Step 1: Get aggregated swap quote
+        quote = client.defi.swap.quote(
+            chain=chain,
+            token_in=token_in,
+            token_out=token_out,
+            amount_in=amount_in,
+            slippage_tolerance=0.005,
+            dex_sources=['uniswap_v3', 'curve', 'sushiswap']
+        )
+
+        print(f'Swap Quote:')
+        print(f'  Best DEX: {quote.data.best_route.dex}')
+        print(f'  Input: {amount_in} {token_in}')
+        print(f'  Output: {quote.data.estimated_output} {token_out}')
+        print(f'  Price impact: {quote.data.price_impact_percent}%')
+        print(f'  Gas estimate: {quote.data.estimated_gas_usd} USD')
+
+        # Step 2: Execute the swap
+        execution = client.defi.swap.execute(
+            quote_id=quote.data.quote_id,
+            wallet_address='0xABCD...1234',
+            max_gas_price_gwei=50,
+            deadline_minutes=20
+        )
+
+        print(f'Swap executed: {execution.data.tx_hash}')
+        print(f'Status: {execution.data.status}')
+
+        return execution
+    except Exception as error:
+        print(f'Swap failed: {error}')
+        raise
+
+# Swap 2.5 WETH for USDC on Ethereum
+swap_tokens('ethereum', 'WETH', 'USDC', '2.5')
+                                </x-code-block>
+                            </div>
+
+                            <!-- Response -->
+                            <div id="swap-response" class="tab-content animate-fade-in">
+                                <x-code-block language="json">
+// POST /api/v1/defi/swap/quote response
+{
+  "data": {
+    "quote_id": "quote_sw_def456ghi789",
+    "chain": "ethereum",
+    "token_in": "WETH",
+    "token_out": "USDC",
+    "amount_in": "2.5",
+    "estimated_output": "4875.32",
+    "price_impact_percent": "0.12",
+    "estimated_gas_usd": "8.45",
+    "best_route": {
+      "dex": "uniswap_v3",
+      "path": ["WETH", "USDC"],
+      "pools": ["0x8ad5...pool1"],
+      "fee_tier": "0.05%"
+    },
+    "alternative_routes": [
+      {
+        "dex": "curve",
+        "estimated_output": "4870.18",
+        "price_impact_percent": "0.15"
+      },
+      {
+        "dex": "sushiswap",
+        "estimated_output": "4865.90",
+        "price_impact_percent": "0.18"
+      }
+    ],
+    "quote_expires_at": "2026-01-15T12:10:00Z"
+  }
+}
+
+// POST /api/v1/defi/swap/execute response
+{
+  "data": {
+    "swap_id": "swap_mno345pqr678",
+    "quote_id": "quote_sw_def456ghi789",
+    "status": "submitted",
+    "tx_hash": "0x9f8e7d6c5b4a3...transaction_hash",
+    "chain": "ethereum",
+    "token_in": "WETH",
+    "token_out": "USDC",
+    "amount_in": "2.5",
+    "expected_output": "4875.32",
+    "dex": "uniswap_v3",
+    "gas_price_gwei": "35",
+    "created_at": "2026-01-15T12:06:00Z"
+  }
+}
+                                </x-code-block>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- RegTech & Compliance -->
+            <div id="regtech-compliance" class="mb-20">
+                <h2 class="text-3xl font-bold text-gray-900 mb-8">RegTech &amp; Compliance</h2>
+
+                <div class="space-y-12">
+                    <!-- Travel Rule Compliance Check -->
+                    <div class="bg-white rounded-xl shadow-lg overflow-hidden">
+                        <div class="bg-gradient-to-r from-emerald-50 to-green-50 px-6 py-5 border-b">
+                            <div class="flex items-center justify-between">
+                                <div>
+                                    <h3 class="text-xl font-semibold text-gray-900">Travel Rule Compliance Check</h3>
+                                    <p class="text-gray-600 mt-1">Validate FATF Travel Rule compliance before executing cross-border or virtual asset transfers</p>
+                                </div>
+                                <div class="flex items-center gap-2">
+                                    <span class="px-3 py-1 bg-emerald-100 text-emerald-700 rounded-full text-xs font-medium">v2.8</span>
+                                    <span class="px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-xs font-medium">POST</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="p-6">
+                            <!-- Tabs -->
+                            <div class="code-tabs">
+                                <button onclick="switchTab(event, 'travel-curl')" class="code-tab active">cURL</button>
+                                <button onclick="switchTab(event, 'travel-js')" class="code-tab">JavaScript</button>
+                                <button onclick="switchTab(event, 'travel-py')" class="code-tab">Python</button>
+                                <button onclick="switchTab(event, 'travel-response')" class="code-tab">Response</button>
+                            </div>
+
+                            <!-- cURL -->
+                            <div id="travel-curl" class="tab-content active animate-fade-in">
+                                <x-code-block language="bash">
+# Run a Travel Rule compliance check before a transfer
+curl -X POST https://api.finaegis.org/api/v1/regtech/travel-rule/check \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "transfer_id": "txfr_abc123def456",
+    "originator": {
+      "name": "Alice Johnson",
+      "account_number": "acct_1234567890",
+      "institution_name": "FinAegis",
+      "institution_country": "US"
+    },
+    "beneficiary": {
+      "name": "Bob Smith",
+      "account_number": "ext_0987654321",
+      "institution_name": "Partner Bank",
+      "institution_country": "DE"
+    },
+    "transfer_details": {
+      "amount": "15000.00",
+      "currency": "USD",
+      "asset_type": "fiat",
+      "purpose": "business_payment"
+    },
+    "jurisdiction": "EU"
+  }'
+                                </x-code-block>
+                            </div>
+
+                            <!-- JavaScript -->
+                            <div id="travel-js" class="tab-content animate-fade-in">
+                                <x-code-block language="javascript">
+async function checkTravelRuleCompliance(transferData) {
+  try {
+    const result = await client.regtech.travelRule.check({
+      transfer_id: transferData.transferId,
+      originator: {
+        name: 'Alice Johnson',
+        account_number: transferData.fromAccount,
+        institution_name: 'FinAegis',
+        institution_country: 'US'
+      },
+      beneficiary: {
+        name: transferData.recipientName,
+        account_number: transferData.toAccount,
+        institution_name: transferData.recipientInstitution,
+        institution_country: transferData.recipientCountry
+      },
+      transfer_details: {
+        amount: transferData.amount,
+        currency: transferData.currency,
+        asset_type: transferData.assetType || 'fiat',
+        purpose: transferData.purpose || 'business_payment'
+      },
+      jurisdiction: transferData.jurisdiction || 'EU'
+    });
+
+    console.log('Travel Rule Check:');
+    console.log(`  Compliant: ${result.data.is_compliant}`);
+    console.log(`  Risk level: ${result.data.risk_level}`);
+    console.log(`  Jurisdiction: ${result.data.applicable_jurisdiction}`);
+
+    if (!result.data.is_compliant) {
+      console.log('  Issues:');
+      result.data.compliance_issues.forEach(issue => {
+        console.log(`    - ${issue.code}: ${issue.description}`);
+      });
+    }
+
+    return result;
+  } catch (error) {
+    console.error('Compliance check failed:', error.message);
+    throw error;
+  }
+}
+
+// Check compliance before a cross-border transfer
+checkTravelRuleCompliance({
+  transferId: 'txfr_abc123def456',
+  fromAccount: 'acct_1234567890',
+  recipientName: 'Bob Smith',
+  toAccount: 'ext_0987654321',
+  recipientInstitution: 'Partner Bank',
+  recipientCountry: 'DE',
+  amount: '15000.00',
+  currency: 'USD',
+  jurisdiction: 'EU'
+});
+                                </x-code-block>
+                            </div>
+
+                            <!-- Python -->
+                            <div id="travel-py" class="tab-content animate-fade-in">
+                                <x-code-block language="python">
+def check_travel_rule_compliance(transfer_data):
+    try:
+        result = client.regtech.travel_rule.check(
+            transfer_id=transfer_data['transfer_id'],
+            originator={
+                'name': 'Alice Johnson',
+                'account_number': transfer_data['from_account'],
+                'institution_name': 'FinAegis',
+                'institution_country': 'US'
+            },
+            beneficiary={
+                'name': transfer_data['recipient_name'],
+                'account_number': transfer_data['to_account'],
+                'institution_name': transfer_data['recipient_institution'],
+                'institution_country': transfer_data['recipient_country']
+            },
+            transfer_details={
+                'amount': transfer_data['amount'],
+                'currency': transfer_data['currency'],
+                'asset_type': transfer_data.get('asset_type', 'fiat'),
+                'purpose': transfer_data.get('purpose', 'business_payment')
+            },
+            jurisdiction=transfer_data.get('jurisdiction', 'EU')
+        )
+
+        print(f'Travel Rule Check:')
+        print(f'  Compliant: {result.data.is_compliant}')
+        print(f'  Risk level: {result.data.risk_level}')
+        print(f'  Jurisdiction: {result.data.applicable_jurisdiction}')
+
+        if not result.data.is_compliant:
+            print('  Issues:')
+            for issue in result.data.compliance_issues:
+                print(f'    - {issue.code}: {issue.description}')
+
+        return result
+    except Exception as error:
+        print(f'Compliance check failed: {error}')
+        raise
+
+# Check compliance before a cross-border transfer
+check_travel_rule_compliance({
+    'transfer_id': 'txfr_abc123def456',
+    'from_account': 'acct_1234567890',
+    'recipient_name': 'Bob Smith',
+    'to_account': 'ext_0987654321',
+    'recipient_institution': 'Partner Bank',
+    'recipient_country': 'DE',
+    'amount': '15000.00',
+    'currency': 'USD',
+    'jurisdiction': 'EU'
+})
+                                </x-code-block>
+                            </div>
+
+                            <!-- Response -->
+                            <div id="travel-response" class="tab-content animate-fade-in">
+                                <x-code-block language="json">
+{
+  "data": {
+    "check_id": "trc_mno345pqr678",
+    "transfer_id": "txfr_abc123def456",
+    "is_compliant": true,
+    "risk_level": "low",
+    "applicable_jurisdiction": "EU",
+    "applicable_regulations": [
+      "FATF_Recommendation_16",
+      "EU_Transfer_of_Funds_Regulation",
+      "MiCA_Article_76"
+    ],
+    "originator_verified": true,
+    "beneficiary_verified": true,
+    "threshold_analysis": {
+      "amount_usd": "15000.00",
+      "exceeds_threshold": true,
+      "threshold_amount": "1000.00",
+      "full_identification_required": true
+    },
+    "sanctions_screening": {
+      "originator_cleared": true,
+      "beneficiary_cleared": true,
+      "screening_provider": "internal",
+      "screened_at": "2026-01-15T12:00:05Z"
+    },
+    "compliance_issues": [],
+    "recommendations": [
+      "Enhanced due diligence recommended for transfers above 10000 USD"
+    ],
+    "checked_at": "2026-01-15T12:00:05Z",
+    "valid_until": "2026-01-15T12:30:05Z"
+  }
+}
+                                </x-code-block>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- BaaS & Partner API -->
+            <div id="baas-partner" class="mb-20">
+                <h2 class="text-3xl font-bold text-gray-900 mb-8">BaaS &amp; Partner API</h2>
+
+                <div class="space-y-12">
+                    <!-- Partner Onboarding -->
+                    <div class="bg-white rounded-xl shadow-lg overflow-hidden">
+                        <div class="bg-gradient-to-r from-amber-50 to-yellow-50 px-6 py-5 border-b">
+                            <div class="flex items-center justify-between">
+                                <div>
+                                    <h3 class="text-xl font-semibold text-gray-900">BaaS Partner Onboarding</h3>
+                                    <p class="text-gray-600 mt-1">Onboard a new partner organization onto the Banking-as-a-Service platform with API keys and SDK access</p>
+                                </div>
+                                <div class="flex items-center gap-2">
+                                    <span class="px-3 py-1 bg-amber-100 text-amber-700 rounded-full text-xs font-medium">v2.9</span>
+                                    <span class="px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-xs font-medium">POST</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="p-6">
+                            <!-- Tabs -->
+                            <div class="code-tabs">
+                                <button onclick="switchTab(event, 'partner-curl')" class="code-tab active">cURL</button>
+                                <button onclick="switchTab(event, 'partner-js')" class="code-tab">JavaScript</button>
+                                <button onclick="switchTab(event, 'partner-py')" class="code-tab">Python</button>
+                                <button onclick="switchTab(event, 'partner-response')" class="code-tab">Response</button>
+                            </div>
+
+                            <!-- cURL -->
+                            <div id="partner-curl" class="tab-content active animate-fade-in">
+                                <x-code-block language="bash">
+# Onboard a new BaaS partner
+curl -X POST https://api.finaegis.org/api/v1/partner/onboard \
+  -H "Authorization: Bearer YOUR_ADMIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "organization_name": "Acme Fintech",
+    "contact_email": "integration@acmefintech.com",
+    "tier": "growth",
+    "modules": ["accounts", "transfers", "compliance", "crosschain"],
+    "sdk_languages": ["typescript", "python"],
+    "webhook_url": "https://acmefintech.com/webhooks/finaegis",
+    "ip_whitelist": ["203.0.113.0/24"],
+    "rate_limit_override": 5000,
+    "metadata": {
+      "use_case": "neobank",
+      "expected_monthly_volume": "500000"
+    }
+  }'
+                                </x-code-block>
+                            </div>
+
+                            <!-- JavaScript -->
+                            <div id="partner-js" class="tab-content animate-fade-in">
+                                <x-code-block language="javascript">
+async function onboardPartner(partnerDetails) {
+  try {
+    const partner = await client.partner.onboard({
+      organization_name: partnerDetails.name,
+      contact_email: partnerDetails.email,
+      tier: partnerDetails.tier || 'growth', // starter, growth, enterprise
+      modules: partnerDetails.modules,
+      sdk_languages: partnerDetails.sdkLanguages || ['typescript', 'python'],
+      webhook_url: partnerDetails.webhookUrl,
+      ip_whitelist: partnerDetails.ipWhitelist || [],
+      rate_limit_override: partnerDetails.rateLimit,
+      metadata: partnerDetails.metadata || {}
+    });
+
+    console.log('Partner Onboarded:');
+    console.log(`  Partner ID: ${partner.data.partner_id}`);
+    console.log(`  API Key: ${partner.data.api_credentials.api_key}`);
+    console.log(`  Sandbox Key: ${partner.data.api_credentials.sandbox_key}`);
+    console.log(`  Tier: ${partner.data.tier}`);
+    console.log(`  SDK Download URLs:`);
+    partner.data.sdk_packages.forEach(sdk => {
+      console.log(`    ${sdk.language}: ${sdk.download_url}`);
+    });
+
+    return partner;
+  } catch (error) {
+    console.error('Partner onboarding failed:', error.message);
+    throw error;
+  }
+}
+
+// Onboard a new fintech partner
+onboardPartner({
+  name: 'Acme Fintech',
+  email: 'integration@acmefintech.com',
+  tier: 'growth',
+  modules: ['accounts', 'transfers', 'compliance', 'crosschain'],
+  sdkLanguages: ['typescript', 'python'],
+  webhookUrl: 'https://acmefintech.com/webhooks/finaegis',
+  ipWhitelist: ['203.0.113.0/24'],
+  rateLimit: 5000,
+  metadata: {
+    use_case: 'neobank',
+    expected_monthly_volume: '500000'
+  }
+});
+                                </x-code-block>
+                            </div>
+
+                            <!-- Python -->
+                            <div id="partner-py" class="tab-content animate-fade-in">
+                                <x-code-block language="python">
+def onboard_partner(partner_details):
+    try:
+        partner = client.partner.onboard(
+            organization_name=partner_details['name'],
+            contact_email=partner_details['email'],
+            tier=partner_details.get('tier', 'growth'),
+            modules=partner_details['modules'],
+            sdk_languages=partner_details.get('sdk_languages', ['typescript', 'python']),
+            webhook_url=partner_details['webhook_url'],
+            ip_whitelist=partner_details.get('ip_whitelist', []),
+            rate_limit_override=partner_details.get('rate_limit'),
+            metadata=partner_details.get('metadata', {})
+        )
+
+        print(f'Partner Onboarded:')
+        print(f'  Partner ID: {partner.data.partner_id}')
+        print(f'  API Key: {partner.data.api_credentials.api_key}')
+        print(f'  Sandbox Key: {partner.data.api_credentials.sandbox_key}')
+        print(f'  Tier: {partner.data.tier}')
+        print(f'  SDK Download URLs:')
+        for sdk in partner.data.sdk_packages:
+            print(f'    {sdk.language}: {sdk.download_url}')
+
+        return partner
+    except Exception as error:
+        print(f'Partner onboarding failed: {error}')
+        raise
+
+# Onboard a new fintech partner
+onboard_partner({
+    'name': 'Acme Fintech',
+    'email': 'integration@acmefintech.com',
+    'tier': 'growth',
+    'modules': ['accounts', 'transfers', 'compliance', 'crosschain'],
+    'sdk_languages': ['typescript', 'python'],
+    'webhook_url': 'https://acmefintech.com/webhooks/finaegis',
+    'ip_whitelist': ['203.0.113.0/24'],
+    'rate_limit': 5000,
+    'metadata': {
+        'use_case': 'neobank',
+        'expected_monthly_volume': '500000'
+    }
+})
+                                </x-code-block>
+                            </div>
+
+                            <!-- Response -->
+                            <div id="partner-response" class="tab-content animate-fade-in">
+                                <x-code-block language="json">
+{
+  "data": {
+    "partner_id": "partner_acme_abc123",
+    "organization_name": "Acme Fintech",
+    "status": "active",
+    "tier": "growth",
+    "modules_enabled": [
+      "accounts",
+      "transfers",
+      "compliance",
+      "crosschain"
+    ],
+    "api_credentials": {
+      "api_key": "pk_live_xxxxxxxxxxxxxxxxxxxxxxxx",
+      "sandbox_key": "pk_test_xxxxxxxxxxxxxxxxxxxxxxxx",
+      "webhook_secret": "whsec_xxxxxxxxxxxxxxxxxxxxxxxx"
+    },
+    "sdk_packages": [
+      {
+        "language": "typescript",
+        "version": "3.0.0",
+        "package_name": "@finaegis/sdk",
+        "download_url": "https://sdk.finaegis.org/packages/typescript/finaegis-sdk-3.0.0.tgz",
+        "docs_url": "https://docs.finaegis.org/sdk/typescript"
+      },
+      {
+        "language": "python",
+        "version": "3.0.0",
+        "package_name": "finaegis-sdk",
+        "download_url": "https://sdk.finaegis.org/packages/python/finaegis-sdk-3.0.0.tar.gz",
+        "docs_url": "https://docs.finaegis.org/sdk/python"
+      }
+    ],
+    "rate_limits": {
+      "requests_per_minute": 5000,
+      "burst_limit": 500
+    },
+    "sandbox_url": "https://sandbox.finaegis.org",
+    "dashboard_url": "https://partners.finaegis.org/acme-fintech",
+    "created_at": "2026-01-15T12:00:00Z",
+    "onboarding_checklist": {
+      "api_key_generated": true,
+      "webhook_configured": true,
+      "sdk_generated": true,
+      "sandbox_tested": false,
+      "compliance_review": "pending"
+    }
+  }
+}
+                                </x-code-block>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- AI Transaction Query -->
+            <div id="ai-transactions" class="mb-20">
+                <h2 class="text-3xl font-bold text-gray-900 mb-8">AI Transaction Query</h2>
+
+                <div class="space-y-12">
+                    <!-- AI Transaction Search -->
+                    <div class="bg-white rounded-xl shadow-lg overflow-hidden">
+                        <div class="bg-gradient-to-r from-violet-50 to-purple-50 px-6 py-5 border-b">
+                            <div class="flex items-center justify-between">
+                                <div>
+                                    <h3 class="text-xl font-semibold text-gray-900">AI-Powered Transaction Search</h3>
+                                    <p class="text-gray-600 mt-1">Query transactions using natural language -- the AI engine translates to structured filters</p>
+                                </div>
+                                <div class="flex items-center gap-2">
+                                    <span class="px-3 py-1 bg-violet-100 text-violet-700 rounded-full text-xs font-medium">v2.8</span>
+                                    <span class="px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-xs font-medium">POST</span>
+                                    <span class="px-3 py-1 bg-indigo-100 text-indigo-700 rounded-full text-xs font-medium">AI</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="p-6">
+                            <!-- Tabs -->
+                            <div class="code-tabs">
+                                <button onclick="switchTab(event, 'aitx-curl')" class="code-tab active">cURL</button>
+                                <button onclick="switchTab(event, 'aitx-js')" class="code-tab">JavaScript</button>
+                                <button onclick="switchTab(event, 'aitx-py')" class="code-tab">Python</button>
+                                <button onclick="switchTab(event, 'aitx-response')" class="code-tab">Response</button>
+                            </div>
+
+                            <!-- cURL -->
+                            <div id="aitx-curl" class="tab-content active animate-fade-in">
+                                <x-code-block language="bash">
+# Query transactions with natural language
+curl -X POST https://api.finaegis.org/api/v1/ai/transactions \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "Show me all cross-chain transfers over $5000 in the last 7 days that had compliance flags",
+    "account_id": "acct_1234567890",
+    "options": {
+      "include_analytics": true,
+      "include_risk_scores": true,
+      "max_results": 50,
+      "format": "detailed"
+    }
+  }'
+                                </x-code-block>
+                            </div>
+
+                            <!-- JavaScript -->
+                            <div id="aitx-js" class="tab-content animate-fade-in">
+                                <x-code-block language="javascript">
+async function queryTransactionsWithAI(naturalLanguageQuery, accountId) {
+  try {
+    const result = await client.ai.transactions({
+      query: naturalLanguageQuery,
+      account_id: accountId,
+      options: {
+        include_analytics: true,
+        include_risk_scores: true,
+        max_results: 50,
+        format: 'detailed'
+      }
+    });
+
+    console.log('AI Query Interpretation:');
+    console.log(`  Parsed filters: ${JSON.stringify(result.data.interpreted_query)}`);
+    console.log(`  Confidence: ${result.data.interpretation_confidence}`);
+    console.log(`  Results found: ${result.data.total_results}`);
+
+    result.data.transactions.forEach(tx => {
+      console.log(`  ${tx.created_at}: ${tx.type} ${tx.amount} ${tx.currency}`);
+      console.log(`    Status: ${tx.status} | Risk: ${tx.risk_score}`);
+      if (tx.compliance_flags.length > 0) {
+        console.log(`    Flags: ${tx.compliance_flags.join(', ')}`);
+      }
+    });
+
+    if (result.data.analytics) {
+      console.log('\nAnalytics Summary:');
+      console.log(`  Total volume: ${result.data.analytics.total_volume}`);
+      console.log(`  Average amount: ${result.data.analytics.avg_amount}`);
+      console.log(`  Flagged count: ${result.data.analytics.flagged_count}`);
+    }
+
+    return result;
+  } catch (error) {
+    console.error('AI query failed:', error.message);
+    throw error;
+  }
+}
+
+// Natural language transaction search
+queryTransactionsWithAI(
+  'Show me all cross-chain transfers over $5000 in the last 7 days that had compliance flags',
+  'acct_1234567890'
+);
+                                </x-code-block>
+                            </div>
+
+                            <!-- Python -->
+                            <div id="aitx-py" class="tab-content animate-fade-in">
+                                <x-code-block language="python">
+def query_transactions_with_ai(natural_language_query, account_id):
+    try:
+        result = client.ai.transactions(
+            query=natural_language_query,
+            account_id=account_id,
+            options={
+                'include_analytics': True,
+                'include_risk_scores': True,
+                'max_results': 50,
+                'format': 'detailed'
+            }
+        )
+
+        print(f'AI Query Interpretation:')
+        print(f'  Parsed filters: {result.data.interpreted_query}')
+        print(f'  Confidence: {result.data.interpretation_confidence}')
+        print(f'  Results found: {result.data.total_results}')
+
+        for tx in result.data.transactions:
+            print(f'  {tx.created_at}: {tx.type} {tx.amount} {tx.currency}')
+            print(f'    Status: {tx.status} | Risk: {tx.risk_score}')
+            if tx.compliance_flags:
+                print(f'    Flags: {", ".join(tx.compliance_flags)}')
+
+        if result.data.analytics:
+            print(f'\nAnalytics Summary:')
+            print(f'  Total volume: {result.data.analytics.total_volume}')
+            print(f'  Average amount: {result.data.analytics.avg_amount}')
+            print(f'  Flagged count: {result.data.analytics.flagged_count}')
+
+        return result
+    except Exception as error:
+        print(f'AI query failed: {error}')
+        raise
+
+# Natural language transaction search
+query_transactions_with_ai(
+    'Show me all cross-chain transfers over $5000 in the last 7 days that had compliance flags',
+    'acct_1234567890'
+)
+                                </x-code-block>
+                            </div>
+
+                            <!-- Response -->
+                            <div id="aitx-response" class="tab-content animate-fade-in">
+                                <x-code-block language="json">
+{
+  "data": {
+    "query_id": "aiq_stu901vwx234",
+    "original_query": "Show me all cross-chain transfers over $5000 in the last 7 days that had compliance flags",
+    "interpreted_query": {
+      "type": ["cross_chain_transfer"],
+      "amount_min": 5000,
+      "currency": "USD",
+      "date_range": {
+        "from": "2026-01-08T00:00:00Z",
+        "to": "2026-01-15T23:59:59Z"
+      },
+      "has_compliance_flags": true
+    },
+    "interpretation_confidence": 0.96,
+    "total_results": 3,
+    "transactions": [
+      {
+        "uuid": "tx_cross_001",
+        "type": "cross_chain_transfer",
+        "amount": "7500.00",
+        "currency": "USDC",
+        "status": "completed",
+        "source_chain": "ethereum",
+        "destination_chain": "arbitrum",
+        "bridge_protocol": "wormhole",
+        "risk_score": 0.35,
+        "compliance_flags": ["high_value_transfer"],
+        "created_at": "2026-01-12T14:30:00Z"
+      },
+      {
+        "uuid": "tx_cross_002",
+        "type": "cross_chain_transfer",
+        "amount": "12000.00",
+        "currency": "USDT",
+        "status": "completed",
+        "source_chain": "polygon",
+        "destination_chain": "ethereum",
+        "bridge_protocol": "layerzero",
+        "risk_score": 0.62,
+        "compliance_flags": ["high_value_transfer", "new_destination"],
+        "created_at": "2026-01-10T09:15:00Z"
+      },
+      {
+        "uuid": "tx_cross_003",
+        "type": "cross_chain_transfer",
+        "amount": "25000.00",
+        "currency": "USDC",
+        "status": "pending_review",
+        "source_chain": "ethereum",
+        "destination_chain": "bsc",
+        "bridge_protocol": "axelar",
+        "risk_score": 0.78,
+        "compliance_flags": ["high_value_transfer", "jurisdiction_mismatch", "velocity_alert"],
+        "created_at": "2026-01-09T16:45:00Z"
+      }
+    ],
+    "analytics": {
+      "total_volume": "44500.00",
+      "avg_amount": "14833.33",
+      "median_amount": "12000.00",
+      "flagged_count": 3,
+      "avg_risk_score": 0.58,
+      "chains_involved": ["ethereum", "polygon", "arbitrum", "bsc"],
+      "bridges_used": ["wormhole", "layerzero", "axelar"]
+    }
+  }
+}
+                                </x-code-block>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/resources/views/developers/index.blade.php
+++ b/resources/views/developers/index.blade.php
@@ -140,7 +140,7 @@
                 <div class="text-center">
                     <div class="inline-flex items-center px-4 py-2 bg-white/10 backdrop-blur-sm rounded-full text-sm mb-6">
                         <span class="w-2 h-2 bg-green-400 rounded-full mr-2 animate-pulse"></span>
-                        <span>v2.1 Documentation</span>
+                        <span>v3.0 Documentation -- 41 Domains, 1,150+ Routes</span>
                     </div>
                     <h1 class="text-5xl md:text-7xl font-bold mb-6 bg-clip-text text-transparent bg-gradient-to-r from-white to-blue-200">
                         Built for Developers
@@ -174,14 +174,14 @@
         </section>
 
         <!-- Status Alert -->
-        <section class="py-6 bg-amber-50 border-b border-amber-200">
+        <section class="py-6 bg-green-50 border-b border-green-200">
             <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-                <div class="flex items-center justify-center text-amber-800">
+                <div class="flex items-center justify-center text-green-800">
                     <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                     </svg>
-                    <span class="font-medium">Alpha Version:</span>
-                    <span class="ml-2">Limited API endpoints available. Full API coming soon.</span>
+                    <span class="font-medium">v3.0 Released:</span>
+                    <span class="ml-2">41 DDD domains, 1,150+ API routes including CrossChain, DeFi, RegTech, and Partner BaaS endpoints.</span>
                 </div>
             </div>
         </section>
@@ -433,6 +433,129 @@
                         </p>
                     </div>
                 </div>
+
+                <!-- v2.0-v3.0 API Area Cards -->
+                <div class="mt-16">
+                    <h3 class="text-2xl font-bold text-gray-900 mb-2 text-center">Platform API Areas</h3>
+                    <p class="text-gray-600 text-center mb-8">Explore the full breadth of the FinAegis platform across 41 DDD domains</p>
+                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+
+                        <!-- CrossChain -->
+                        <a href="{{ route('developers.show', 'api-docs') }}#crosschain" class="group block">
+                            <div class="bg-white rounded-xl border border-gray-200 p-6 hover:shadow-lg transition-all hover:-translate-y-1 h-full">
+                                <div class="flex items-center mb-3">
+                                    <div class="w-10 h-10 bg-gradient-to-br from-cyan-500 to-blue-600 rounded-lg flex items-center justify-center text-white mr-3">
+                                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"></path>
+                                        </svg>
+                                    </div>
+                                    <div>
+                                        <h4 class="text-lg font-semibold text-gray-900">CrossChain</h4>
+                                        <span class="text-xs text-gray-500">7 routes</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 text-sm mb-3">Bridge protocols (Wormhole, LayerZero, Axelar), cross-chain swaps, fee comparison, and multi-chain portfolio tracking.</p>
+                                <span class="text-cyan-600 text-sm font-medium group-hover:text-cyan-700">View endpoints &rarr;</span>
+                            </div>
+                        </a>
+
+                        <!-- DeFi -->
+                        <a href="{{ route('developers.show', 'api-docs') }}#defi" class="group block">
+                            <div class="bg-white rounded-xl border border-gray-200 p-6 hover:shadow-lg transition-all hover:-translate-y-1 h-full">
+                                <div class="flex items-center mb-3">
+                                    <div class="w-10 h-10 bg-gradient-to-br from-emerald-500 to-teal-600 rounded-lg flex items-center justify-center text-white mr-3">
+                                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                                        </svg>
+                                    </div>
+                                    <div>
+                                        <h4 class="text-lg font-semibold text-gray-900">DeFi</h4>
+                                        <span class="text-xs text-gray-500">8 routes</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 text-sm mb-3">DEX aggregation (Uniswap, Curve), lending (Aave), staking (Lido), yield optimization, flash loans, and portfolio management.</p>
+                                <span class="text-emerald-600 text-sm font-medium group-hover:text-emerald-700">View endpoints &rarr;</span>
+                            </div>
+                        </a>
+
+                        <!-- RegTech -->
+                        <a href="{{ route('developers.show', 'api-docs') }}#regtech" class="group block">
+                            <div class="bg-white rounded-xl border border-gray-200 p-6 hover:shadow-lg transition-all hover:-translate-y-1 h-full">
+                                <div class="flex items-center mb-3">
+                                    <div class="w-10 h-10 bg-gradient-to-br from-amber-500 to-orange-600 rounded-lg flex items-center justify-center text-white mr-3">
+                                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path>
+                                        </svg>
+                                    </div>
+                                    <div>
+                                        <h4 class="text-lg font-semibold text-gray-900">RegTech</h4>
+                                        <span class="text-xs text-gray-500">12 routes</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 text-sm mb-3">MiFID II reporting, MiCA compliance, Travel Rule enforcement, jurisdiction adapters, and regulatory orchestration.</p>
+                                <span class="text-amber-600 text-sm font-medium group-hover:text-amber-700">View endpoints &rarr;</span>
+                            </div>
+                        </a>
+
+                        <!-- MobilePayment -->
+                        <a href="{{ route('developers.show', 'api-docs') }}#mobile-payment" class="group block">
+                            <div class="bg-white rounded-xl border border-gray-200 p-6 hover:shadow-lg transition-all hover:-translate-y-1 h-full">
+                                <div class="flex items-center mb-3">
+                                    <div class="w-10 h-10 bg-gradient-to-br from-violet-500 to-purple-600 rounded-lg flex items-center justify-center text-white mr-3">
+                                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"></path>
+                                        </svg>
+                                    </div>
+                                    <div>
+                                        <h4 class="text-lg font-semibold text-gray-900">Mobile Payment</h4>
+                                        <span class="text-xs text-gray-500">25+ routes</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 text-sm mb-3">Payment intents, receipts, activity feeds, receive addresses, P2P transfers, passkey auth, and biometric JWT.</p>
+                                <span class="text-violet-600 text-sm font-medium group-hover:text-violet-700">View endpoints &rarr;</span>
+                            </div>
+                        </a>
+
+                        <!-- Partner / BaaS -->
+                        <a href="{{ route('developers.show', 'api-docs') }}#partner-baas" class="group block">
+                            <div class="bg-white rounded-xl border border-gray-200 p-6 hover:shadow-lg transition-all hover:-translate-y-1 h-full">
+                                <div class="flex items-center mb-3">
+                                    <div class="w-10 h-10 bg-gradient-to-br from-rose-500 to-pink-600 rounded-lg flex items-center justify-center text-white mr-3">
+                                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"></path>
+                                        </svg>
+                                    </div>
+                                    <div>
+                                        <h4 class="text-lg font-semibold text-gray-900">Partner / BaaS</h4>
+                                        <span class="text-xs text-gray-500">24 routes</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 text-sm mb-3">Banking-as-a-Service partner onboarding, SDK generation, white-label configuration, and tenant provisioning.</p>
+                                <span class="text-rose-600 text-sm font-medium group-hover:text-rose-700">View endpoints &rarr;</span>
+                            </div>
+                        </a>
+
+                        <!-- AI -->
+                        <a href="{{ route('developers.show', 'api-docs') }}#ai" class="group block">
+                            <div class="bg-white rounded-xl border border-gray-200 p-6 hover:shadow-lg transition-all hover:-translate-y-1 h-full">
+                                <div class="flex items-center mb-3">
+                                    <div class="w-10 h-10 bg-gradient-to-br from-gray-700 to-gray-900 rounded-lg flex items-center justify-center text-white mr-3">
+                                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
+                                        </svg>
+                                    </div>
+                                    <div>
+                                        <h4 class="text-lg font-semibold text-gray-900">AI Query</h4>
+                                        <span class="text-xs text-gray-500">2 routes</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 text-sm mb-3">Natural language transaction queries and AI-powered financial insights via the intelligent query interface.</p>
+                                <span class="text-gray-600 text-sm font-medium group-hover:text-gray-800">View endpoints &rarr;</span>
+                            </div>
+                        </a>
+
+                    </div>
+                </div>
             </div>
         </section>
 
@@ -507,14 +630,23 @@
         <!-- Stats -->
         <section class="py-20 bg-indigo-900 text-white">
             <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-                <div class="grid grid-cols-2 md:grid-cols-4 gap-8 text-center">
+                <div class="grid grid-cols-2 md:grid-cols-5 gap-8 text-center">
                     <div>
-                        <div class="text-4xl md:text-5xl font-bold mb-2">{{ config('platform.statistics.api_endpoints') }}</div>
+                        <div class="text-4xl md:text-5xl font-bold mb-2">1,150+</div>
                         <p class="text-indigo-200 flex items-center justify-center">
                             <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
                             </svg>
-                            API Endpoints
+                            API Routes
+                        </p>
+                    </div>
+                    <div>
+                        <div class="text-4xl md:text-5xl font-bold mb-2">41</div>
+                        <p class="text-indigo-200 flex items-center justify-center">
+                            <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"></path>
+                            </svg>
+                            DDD Domains
                         </p>
                     </div>
                     <div>
@@ -543,6 +675,97 @@
                             </svg>
                             Support
                         </p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Partner API Key Authentication -->
+        <section id="partner-auth" class="py-20 bg-white">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                <div class="text-center mb-16">
+                    <h2 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4">Partner API Authentication</h2>
+                    <p class="text-xl text-gray-600 max-w-3xl mx-auto">
+                        BaaS partners and third-party integrators use dedicated Partner API keys with scoped permissions
+                    </p>
+                </div>
+
+                <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+                    <!-- Partner Key Overview -->
+                    <div class="bg-white rounded-xl shadow-lg border border-gray-200 overflow-hidden">
+                        <div class="p-8">
+                            <div class="flex items-center mb-4">
+                                <div class="w-12 h-12 bg-gradient-to-br from-rose-500 to-pink-600 rounded-lg flex items-center justify-center text-white mr-4">
+                                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"></path>
+                                    </svg>
+                                </div>
+                                <h3 class="text-xl font-semibold">Partner API Keys</h3>
+                            </div>
+                            <p class="text-gray-600 mb-6">
+                                Partner keys provide scoped access to BaaS endpoints, tenant provisioning, SDK generation, and white-label configuration. Keys are issued during partner onboarding.
+                            </p>
+                            <div class="bg-gray-50 rounded-lg p-6 space-y-3">
+                                <div class="flex items-center justify-between">
+                                    <span class="text-gray-700 font-medium">Key Prefix</span>
+                                    <code class="text-sm bg-gray-200 px-2 py-1 rounded">fpk_</code>
+                                </div>
+                                <div class="flex items-center justify-between">
+                                    <span class="text-gray-700 font-medium">Scopes</span>
+                                    <span class="text-sm text-gray-600">baas, tenants, sdk, config</span>
+                                </div>
+                                <div class="flex items-center justify-between">
+                                    <span class="text-gray-700 font-medium">Rate Limit</span>
+                                    <span class="text-sm text-gray-600">5,000 req/hour</span>
+                                </div>
+                                <div class="flex items-center justify-between">
+                                    <span class="text-gray-700 font-medium">IP Whitelist</span>
+                                    <span class="text-sm text-gray-600">Required</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Partner Auth Code Example -->
+                    <div class="bg-white rounded-xl shadow-lg border border-gray-200 overflow-hidden">
+                        <div class="p-8">
+                            <div class="flex items-center mb-4">
+                                <div class="w-12 h-12 bg-gradient-to-br from-indigo-500 to-blue-600 rounded-lg flex items-center justify-center text-white mr-4">
+                                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"></path>
+                                    </svg>
+                                </div>
+                                <h3 class="text-xl font-semibold">Partner Request Example</h3>
+                            </div>
+                            <p class="text-gray-600 mb-6">
+                                Include the Partner API key in the <code class="bg-gray-100 px-1 rounded">X-Partner-Key</code> header alongside your standard Bearer token.
+                            </p>
+                            <div class="code-container">
+                                <div class="code-header">
+                                    <div class="flex items-center gap-2">
+                                        <span class="terminal-dot bg-red-500"></span>
+                                        <span class="terminal-dot bg-yellow-500"></span>
+                                        <span class="terminal-dot bg-green-500"></span>
+                                        <span>cURL</span>
+                                    </div>
+                                    <button class="copy-button" onclick="copyCode(this, 'code-partner-auth')">
+                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
+                                        </svg>
+                                        <span>Copy</span>
+                                    </button>
+                                </div>
+                                <div class="p-4 font-mono text-sm">
+                                    <div id="code-partner-auth">
+                                        <div><span class="text-gray-500">$</span> <span class="text-green-400">curl</span> <span class="text-blue-400">-X</span> <span class="text-purple-400">POST</span> <span class="text-yellow-400">"https://api.finaegis.org/v2/partner/tenants"</span> <span class="text-gray-400">\</span></div>
+                                        <div>  <span class="text-blue-400">-H</span> <span class="text-yellow-400">"Authorization: Bearer YOUR_API_KEY"</span> <span class="text-gray-400">\</span></div>
+                                        <div>  <span class="text-blue-400">-H</span> <span class="text-yellow-400">"X-Partner-Key: fpk_your_partner_key"</span> <span class="text-gray-400">\</span></div>
+                                        <div>  <span class="text-blue-400">-H</span> <span class="text-yellow-400">"Content-Type: application/json"</span> <span class="text-gray-400">\</span></div>
+                                        <div>  <span class="text-blue-400">-d</span> <span class="text-yellow-400">'{"name": "Acme Bank", "plan": "enterprise"}'</span></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/resources/views/developers/sdks.blade.php
+++ b/resources/views/developers/sdks.blade.php
@@ -186,23 +186,23 @@
                     <div class="flex flex-wrap items-center justify-center gap-3 mb-6">
                         <span class="inline-flex items-center px-4 py-2 bg-green-500/20 backdrop-blur-sm rounded-full text-sm">
                             <span class="w-2 h-2 bg-green-400 rounded-full mr-2"></span>
-                            <span>REST API v2.1</span>
+                            <span>REST API v3.0</span>
                         </span>
                         <span class="inline-flex items-center px-4 py-2 bg-green-500/20 backdrop-blur-sm rounded-full text-sm">
                             <span class="w-2 h-2 bg-green-400 rounded-full mr-2"></span>
-                            <span>Hardware Wallets</span>
+                            <span>Cross-Chain &amp; DeFi</span>
                         </span>
                         <span class="inline-flex items-center px-4 py-2 bg-green-500/20 backdrop-blur-sm rounded-full text-sm">
                             <span class="w-2 h-2 bg-green-400 rounded-full mr-2"></span>
-                            <span>WebSocket Streaming</span>
+                            <span>BaaS Partner SDKs</span>
                         </span>
                         <span class="inline-flex items-center px-4 py-2 bg-green-500/20 backdrop-blur-sm rounded-full text-sm">
                             <span class="w-2 h-2 bg-green-400 rounded-full mr-2"></span>
-                            <span>Webhooks Ready</span>
+                            <span>RegTech Compliance</span>
                         </span>
-                        <span class="inline-flex items-center px-4 py-2 bg-yellow-500/20 backdrop-blur-sm rounded-full text-sm">
-                            <span class="w-2 h-2 bg-yellow-400 rounded-full mr-2"></span>
-                            <span>SDKs Coming Soon</span>
+                        <span class="inline-flex items-center px-4 py-2 bg-green-500/20 backdrop-blur-sm rounded-full text-sm">
+                            <span class="w-2 h-2 bg-green-400 rounded-full mr-2"></span>
+                            <span>AI Transaction Query</span>
                         </span>
                     </div>
                     <h1 class="text-5xl md:text-7xl font-bold mb-6">
@@ -511,6 +511,432 @@ console.<span style="color: #89ddff;">log</span>(<span style="color: #82aaff;">r
                         <span class="bg-white px-4 py-2 rounded-lg border border-gray-200">C#/.NET</span>
                         <span class="bg-white px-4 py-2 rounded-lg border border-gray-200">Rust</span>
                         <span class="bg-white px-4 py-2 rounded-lg border border-gray-200">& more</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- BaaS SDK Generation via Partner API -->
+        <section id="baas-sdk-generation" class="py-20 bg-white">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                <div class="text-center mb-12">
+                    <span class="inline-flex items-center px-4 py-2 bg-green-100 rounded-full text-sm font-medium text-green-700 mb-4">
+                        <span class="w-2 h-2 bg-green-500 rounded-full mr-2"></span>
+                        Available Now via Partner API (v2.9+)
+                    </span>
+                    <h2 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4">BaaS SDK Generation</h2>
+                    <p class="text-xl text-gray-600 max-w-3xl mx-auto">
+                        Generate type-safe, versioned SDKs for your partner integration in TypeScript, Python, Java, Go, and PHP -- directly through the Partner API.
+                    </p>
+                </div>
+
+                <!-- Language Cards -->
+                <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-6 mb-12">
+                    <div class="sdk-card bg-white rounded-xl shadow-lg p-6 text-center">
+                        <div class="w-14 h-14 bg-blue-100 rounded-xl flex items-center justify-center mx-auto mb-3">
+                            <svg class="w-8 h-8 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
+                            </svg>
+                        </div>
+                        <h4 class="font-semibold text-gray-900 mb-1">TypeScript</h4>
+                        <p class="text-xs text-gray-500">@finaegis/sdk</p>
+                        <span class="inline-block mt-2 px-2 py-0.5 bg-green-100 text-green-700 rounded text-xs font-medium">Available</span>
+                    </div>
+                    <div class="sdk-card bg-white rounded-xl shadow-lg p-6 text-center">
+                        <div class="w-14 h-14 bg-yellow-100 rounded-xl flex items-center justify-center mx-auto mb-3">
+                            <svg class="w-8 h-8 text-yellow-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
+                            </svg>
+                        </div>
+                        <h4 class="font-semibold text-gray-900 mb-1">Python</h4>
+                        <p class="text-xs text-gray-500">finaegis-sdk</p>
+                        <span class="inline-block mt-2 px-2 py-0.5 bg-green-100 text-green-700 rounded text-xs font-medium">Available</span>
+                    </div>
+                    <div class="sdk-card bg-white rounded-xl shadow-lg p-6 text-center">
+                        <div class="w-14 h-14 bg-red-100 rounded-xl flex items-center justify-center mx-auto mb-3">
+                            <svg class="w-8 h-8 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
+                            </svg>
+                        </div>
+                        <h4 class="font-semibold text-gray-900 mb-1">Java</h4>
+                        <p class="text-xs text-gray-500">com.finaegis:sdk</p>
+                        <span class="inline-block mt-2 px-2 py-0.5 bg-green-100 text-green-700 rounded text-xs font-medium">Available</span>
+                    </div>
+                    <div class="sdk-card bg-white rounded-xl shadow-lg p-6 text-center">
+                        <div class="w-14 h-14 bg-cyan-100 rounded-xl flex items-center justify-center mx-auto mb-3">
+                            <svg class="w-8 h-8 text-cyan-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
+                            </svg>
+                        </div>
+                        <h4 class="font-semibold text-gray-900 mb-1">Go</h4>
+                        <p class="text-xs text-gray-500">finaegis-go</p>
+                        <span class="inline-block mt-2 px-2 py-0.5 bg-green-100 text-green-700 rounded text-xs font-medium">Available</span>
+                    </div>
+                    <div class="sdk-card bg-white rounded-xl shadow-lg p-6 text-center">
+                        <div class="w-14 h-14 bg-purple-100 rounded-xl flex items-center justify-center mx-auto mb-3">
+                            <svg class="w-8 h-8 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/>
+                            </svg>
+                        </div>
+                        <h4 class="font-semibold text-gray-900 mb-1">PHP</h4>
+                        <p class="text-xs text-gray-500">finaegis/sdk</p>
+                        <span class="inline-block mt-2 px-2 py-0.5 bg-green-100 text-green-700 rounded text-xs font-medium">Available</span>
+                    </div>
+                </div>
+
+                <!-- SDK Generation Code Example -->
+                <div class="max-w-4xl mx-auto">
+                    <h3 class="text-xl font-semibold text-gray-900 mb-4">Generate Your SDK via Partner API</h3>
+                    <p class="text-gray-600 mb-6">
+                        When you onboard as a BaaS partner, SDKs are automatically generated for your requested languages.
+                        You can also regenerate or request additional language SDKs at any time.
+                    </p>
+
+                    <div class="bg-gray-900 rounded-lg p-6 font-mono text-green-400 text-sm overflow-x-auto mb-8">
+<pre><span class="text-gray-500"># Request SDK generation for your partner account</span>
+curl -X POST https://api.finaegis.org/api/v1/partner/sdk/generate \
+  -H "Authorization: Bearer YOUR_PARTNER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "languages": ["typescript", "python", "java", "go", "php"],
+    "api_version": "v3",
+    "include_modules": ["accounts", "transfers", "crosschain", "defi", "compliance"],
+    "options": {
+      "include_types": true,
+      "include_examples": true,
+      "include_tests": true
+    }
+  }'
+
+<span class="text-gray-500"># Response includes download URLs for each SDK</span>
+{
+  "data": {
+    "generation_id": "sdkgen_abc123",
+    "status": "completed",
+    "packages": [
+      {
+        "language": "typescript",
+        "version": "3.0.0",
+        "package_name": "@finaegis/sdk",
+        "download_url": "https://sdk.finaegis.org/packages/typescript/finaegis-sdk-3.0.0.tgz",
+        "install_command": "npm install @finaegis/sdk@3.0.0"
+      },
+      {
+        "language": "python",
+        "version": "3.0.0",
+        "package_name": "finaegis-sdk",
+        "download_url": "https://sdk.finaegis.org/packages/python/finaegis-sdk-3.0.0.tar.gz",
+        "install_command": "pip install finaegis-sdk==3.0.0"
+      },
+      {
+        "language": "java",
+        "version": "3.0.0",
+        "package_name": "com.finaegis:sdk",
+        "download_url": "https://sdk.finaegis.org/packages/java/finaegis-sdk-3.0.0.jar",
+        "install_command": "mvn install com.finaegis:sdk:3.0.0"
+      },
+      {
+        "language": "go",
+        "version": "3.0.0",
+        "package_name": "github.com/finaegis/sdk-go",
+        "download_url": "https://sdk.finaegis.org/packages/go/finaegis-sdk-go-3.0.0.tar.gz",
+        "install_command": "go get github.com/finaegis/sdk-go@v3.0.0"
+      },
+      {
+        "language": "php",
+        "version": "3.0.0",
+        "package_name": "finaegis/sdk",
+        "download_url": "https://sdk.finaegis.org/packages/php/finaegis-sdk-3.0.0.zip",
+        "install_command": "composer require finaegis/sdk:^3.0"
+      }
+    ]
+  }
+}</pre>
+                    </div>
+
+                    <!-- Install Commands Grid -->
+                    <h4 class="text-lg font-semibold text-gray-900 mb-4">Quick Install</h4>
+                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+                        <div>
+                            <p class="text-sm font-medium text-gray-700 mb-2">TypeScript / JavaScript</p>
+                            <div class="bg-gray-900 rounded-lg p-4 font-mono text-green-400 text-sm">
+                                <code>npm install @finaegis/sdk@3.0.0</code>
+                            </div>
+                        </div>
+                        <div>
+                            <p class="text-sm font-medium text-gray-700 mb-2">Python</p>
+                            <div class="bg-gray-900 rounded-lg p-4 font-mono text-green-400 text-sm">
+                                <code>pip install finaegis-sdk==3.0.0</code>
+                            </div>
+                        </div>
+                        <div>
+                            <p class="text-sm font-medium text-gray-700 mb-2">Java (Maven)</p>
+                            <div class="bg-gray-900 rounded-lg p-4 font-mono text-green-400 text-sm">
+                                <code>mvn install com.finaegis:sdk:3.0.0</code>
+                            </div>
+                        </div>
+                        <div>
+                            <p class="text-sm font-medium text-gray-700 mb-2">Go</p>
+                            <div class="bg-gray-900 rounded-lg p-4 font-mono text-green-400 text-sm">
+                                <code>go get github.com/finaegis/sdk-go@v3.0.0</code>
+                            </div>
+                        </div>
+                        <div>
+                            <p class="text-sm font-medium text-gray-700 mb-2">PHP (Composer)</p>
+                            <div class="bg-gray-900 rounded-lg p-4 font-mono text-green-400 text-sm">
+                                <code>composer require finaegis/sdk:^3.0</code>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Partner SDK Integration Guide -->
+        <section id="partner-sdk-guide" class="py-20 bg-gradient-to-br from-amber-50 to-orange-50">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                <div class="text-center mb-12">
+                    <h2 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4">Partner SDK Integration Guide</h2>
+                    <p class="text-xl text-gray-600 max-w-3xl mx-auto">
+                        Step-by-step guide to integrating the FinAegis BaaS SDK into your partner application,
+                        covering authentication, module access, and advanced features like Cross-Chain and DeFi.
+                    </p>
+                </div>
+
+                <div class="max-w-5xl mx-auto space-y-8">
+                    <!-- Step 1: Initialize the SDK -->
+                    <div class="bg-white rounded-2xl shadow-lg overflow-hidden">
+                        <div class="bg-gradient-to-r from-blue-600 to-indigo-600 px-6 py-4">
+                            <div class="flex items-center">
+                                <span class="w-8 h-8 bg-white text-blue-600 rounded-full flex items-center justify-center font-bold text-sm mr-3">1</span>
+                                <h3 class="text-lg font-semibold text-white">Initialize the SDK with Your Partner Credentials</h3>
+                            </div>
+                        </div>
+                        <div class="p-6">
+                            <p class="text-gray-600 mb-4">
+                                Use the API key and partner ID from your onboarding response. The SDK auto-configures based on your enabled modules.
+                            </p>
+                            <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                                <div>
+                                    <p class="text-sm font-medium text-gray-700 mb-2">TypeScript</p>
+                                    <div class="bg-gray-900 rounded-lg p-6 font-mono text-green-400 text-sm overflow-x-auto">
+<pre>import { FinAegis } from '@finaegis/sdk';
+
+const client = new FinAegis({
+  apiKey: process.env.FINAEGIS_PARTNER_KEY,
+  partnerId: 'partner_acme_abc123',
+  environment: 'production', // or 'sandbox'
+  modules: ['accounts', 'transfers',
+    'crosschain', 'defi', 'compliance']
+});</pre>
+                                    </div>
+                                </div>
+                                <div>
+                                    <p class="text-sm font-medium text-gray-700 mb-2">Python</p>
+                                    <div class="bg-gray-900 rounded-lg p-6 font-mono text-green-400 text-sm overflow-x-auto">
+<pre>from finaegis import FinAegis
+
+client = FinAegis(
+    api_key=os.environ['FINAEGIS_PARTNER_KEY'],
+    partner_id='partner_acme_abc123',
+    environment='production',
+    modules=['accounts', 'transfers',
+        'crosschain', 'defi', 'compliance']
+)</pre>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Step 2: Use Cross-Chain & DeFi Modules -->
+                    <div class="bg-white rounded-2xl shadow-lg overflow-hidden">
+                        <div class="bg-gradient-to-r from-cyan-600 to-teal-600 px-6 py-4">
+                            <div class="flex items-center">
+                                <span class="w-8 h-8 bg-white text-cyan-600 rounded-full flex items-center justify-center font-bold text-sm mr-3">2</span>
+                                <h3 class="text-lg font-semibold text-white">Access Cross-Chain and DeFi Modules (v3.0)</h3>
+                            </div>
+                        </div>
+                        <div class="p-6">
+                            <p class="text-gray-600 mb-4">
+                                The SDK provides typed interfaces for bridge operations (Wormhole, LayerZero, Axelar), DEX aggregation (Uniswap, Aave, Curve, Lido),
+                                cross-chain swaps, and multi-chain portfolio management.
+                            </p>
+                            <div class="bg-gray-900 rounded-lg p-6 font-mono text-green-400 text-sm overflow-x-auto">
+<pre><span class="text-gray-500">// TypeScript -- Cross-Chain Bridge + DeFi Swap in one workflow</span>
+async function crossChainSwapWorkflow() {
+  <span class="text-gray-500">// Bridge USDC from Ethereum to Polygon</span>
+  const bridgeQuote = await client.crosschain.bridge.quote({
+    source_chain: 'ethereum',
+    destination_chain: 'polygon',
+    token: 'USDC',
+    amount: '5000.00'
+  });
+
+  const bridgeTx = await client.crosschain.bridge.initiate({
+    quote_id: bridgeQuote.data.quote_id,
+    sender_address: '0x1234...abcd',
+    recipient_address: '0x1234...abcd'
+  });
+
+  <span class="text-gray-500">// Wait for bridge completion, then swap on Polygon</span>
+  await client.crosschain.bridge.waitForCompletion(bridgeTx.data.bridge_tx_id);
+
+  const swapQuote = await client.defi.swap.quote({
+    chain: 'polygon',
+    token_in: 'USDC',
+    token_out: 'WMATIC',
+    amount_in: '5000.00'
+  });
+
+  const swap = await client.defi.swap.execute({
+    quote_id: swapQuote.data.quote_id,
+    wallet_address: '0x1234...abcd'
+  });
+
+  <span class="text-gray-500">// Get multi-chain portfolio overview</span>
+  const portfolio = await client.crosschain.portfolio.get({
+    wallet_address: '0x1234...abcd',
+    chains: ['ethereum', 'polygon', 'arbitrum']
+  });
+
+  console.log('Portfolio total value:', portfolio.data.total_value_usd);
+}</pre>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Step 3: RegTech Compliance Integration -->
+                    <div class="bg-white rounded-2xl shadow-lg overflow-hidden">
+                        <div class="bg-gradient-to-r from-emerald-600 to-green-600 px-6 py-4">
+                            <div class="flex items-center">
+                                <span class="w-8 h-8 bg-white text-emerald-600 rounded-full flex items-center justify-center font-bold text-sm mr-3">3</span>
+                                <h3 class="text-lg font-semibold text-white">Integrate RegTech Compliance (v2.8)</h3>
+                            </div>
+                        </div>
+                        <div class="p-6">
+                            <p class="text-gray-600 mb-4">
+                                Built-in compliance modules for MiFID II reporting, MiCA compliance, and FATF Travel Rule -- automatically enforced based on your jurisdiction configuration.
+                            </p>
+                            <div class="bg-gray-900 rounded-lg p-6 font-mono text-green-400 text-sm overflow-x-auto">
+<pre><span class="text-gray-500">// TypeScript -- Compliance-aware transfer</span>
+async function compliantTransfer(transferParams) {
+  <span class="text-gray-500">// Travel Rule check is automatic for transfers above threshold</span>
+  const complianceResult = await client.regtech.travelRule.check({
+    transfer_id: transferParams.id,
+    originator: transferParams.originator,
+    beneficiary: transferParams.beneficiary,
+    transfer_details: {
+      amount: transferParams.amount,
+      currency: transferParams.currency
+    }
+  });
+
+  if (!complianceResult.data.is_compliant) {
+    throw new Error(
+      `Compliance failed: ${complianceResult.data.compliance_issues
+        .map(i => i.description).join(', ')}`
+    );
+  }
+
+  <span class="text-gray-500">// MiCA compliance for crypto assets</span>
+  const micaCheck = await client.regtech.mica.validate({
+    asset_type: 'crypto',
+    transaction_type: 'transfer',
+    amount: transferParams.amount,
+    jurisdiction: 'EU'
+  });
+
+  <span class="text-gray-500">// Proceed with transfer only if all checks pass</span>
+  return await client.transfers.create(transferParams);
+}</pre>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Step 4: AI-Powered Queries -->
+                    <div class="bg-white rounded-2xl shadow-lg overflow-hidden">
+                        <div class="bg-gradient-to-r from-violet-600 to-purple-600 px-6 py-4">
+                            <div class="flex items-center">
+                                <span class="w-8 h-8 bg-white text-violet-600 rounded-full flex items-center justify-center font-bold text-sm mr-3">4</span>
+                                <h3 class="text-lg font-semibold text-white">Use AI Transaction Queries (v2.8)</h3>
+                            </div>
+                        </div>
+                        <div class="p-6">
+                            <p class="text-gray-600 mb-4">
+                                The SDK includes AI-powered transaction search that accepts natural language queries and returns structured, filterable results with risk scoring.
+                            </p>
+                            <div class="bg-gray-900 rounded-lg p-6 font-mono text-green-400 text-sm overflow-x-auto">
+<pre><span class="text-gray-500">// TypeScript -- AI-powered transaction intelligence</span>
+const insights = await client.ai.transactions({
+  query: 'Large DeFi swaps on Ethereum this month with high slippage',
+  account_id: 'acct_primary',
+  options: {
+    include_analytics: true,
+    include_risk_scores: true
+  }
+});
+
+console.log('Interpreted as:', insights.data.interpreted_query);
+console.log('Found:', insights.data.total_results, 'transactions');
+console.log('Total volume:', insights.data.analytics.total_volume);</pre>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- SDK Module Reference -->
+                    <div class="bg-white rounded-2xl shadow-lg p-8">
+                        <h3 class="text-xl font-bold text-gray-900 mb-6">SDK Module Reference</h3>
+                        <p class="text-gray-600 mb-6">
+                            Each BaaS partner SDK includes the following modules, based on the modules enabled during onboarding.
+                        </p>
+                        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                            <div class="border border-gray-200 rounded-lg p-4">
+                                <h4 class="font-semibold text-gray-900 mb-1">client.accounts</h4>
+                                <p class="text-sm text-gray-600">Account creation, balances, transactions</p>
+                                <span class="text-xs text-gray-400">v1.0+</span>
+                            </div>
+                            <div class="border border-gray-200 rounded-lg p-4">
+                                <h4 class="font-semibold text-gray-900 mb-1">client.transfers</h4>
+                                <p class="text-sm text-gray-600">Payments, P2P transfers, bulk operations</p>
+                                <span class="text-xs text-gray-400">v1.0+</span>
+                            </div>
+                            <div class="border border-gray-200 rounded-lg p-4">
+                                <h4 class="font-semibold text-gray-900 mb-1">client.wallets</h4>
+                                <p class="text-sm text-gray-600">Blockchain wallets, hardware wallet support</p>
+                                <span class="text-xs text-gray-400">v2.1+</span>
+                            </div>
+                            <div class="border border-gray-200 rounded-lg p-4">
+                                <h4 class="font-semibold text-gray-900 mb-1">client.compliance</h4>
+                                <p class="text-sm text-gray-600">KYC/AML, sanctions screening</p>
+                                <span class="text-xs text-gray-400">v1.0+</span>
+                            </div>
+                            <div class="border border-gray-200 rounded-lg p-4">
+                                <h4 class="font-semibold text-gray-900 mb-1">client.regtech</h4>
+                                <p class="text-sm text-gray-600">MiFID II, MiCA, Travel Rule compliance</p>
+                                <span class="text-xs text-gray-400">v2.8+</span>
+                            </div>
+                            <div class="border border-gray-200 rounded-lg p-4">
+                                <h4 class="font-semibold text-gray-900 mb-1">client.crosschain</h4>
+                                <p class="text-sm text-gray-600">Bridge protocols, multi-chain portfolio</p>
+                                <span class="text-xs text-gray-400">v3.0+</span>
+                            </div>
+                            <div class="border border-gray-200 rounded-lg p-4">
+                                <h4 class="font-semibold text-gray-900 mb-1">client.defi</h4>
+                                <p class="text-sm text-gray-600">DEX aggregation, lending, staking, yield</p>
+                                <span class="text-xs text-gray-400">v3.0+</span>
+                            </div>
+                            <div class="border border-gray-200 rounded-lg p-4">
+                                <h4 class="font-semibold text-gray-900 mb-1">client.ai</h4>
+                                <p class="text-sm text-gray-600">Transaction queries, spending insights</p>
+                                <span class="text-xs text-gray-400">v2.8+</span>
+                            </div>
+                            <div class="border border-gray-200 rounded-lg p-4">
+                                <h4 class="font-semibold text-gray-900 mb-1">client.partner</h4>
+                                <p class="text-sm text-gray-600">SDK generation, tenant management, config</p>
+                                <span class="text-xs text-gray-400">v2.9+</span>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Add 6 new API area cards and Partner API Key authentication to developer hub index
- Add 6 new API namespace sections (CrossChain, DeFi, RegTech, MobilePayment, Partner BaaS, AI) to API docs page
- Add 5 tabbed code examples (cURL/JS/Python/Response) for Cross-Chain Bridge, DeFi Swap, RegTech Travel Rule, BaaS Partner Onboarding, and AI Query
- Add BaaS SDK generation section (TypeScript, Python, Java, Go, PHP) and Partner SDK integration guide
- Update stats across developer portal to reflect 1,150+ routes / 41 domains

**Phase 4 of v3.1.0 plan** (Developer Portal)

Note: Webhook events and Postman collections were merged in PR #460.

## Test plan
- [x] Tests pass (`pest --parallel`: 4262 passed, 1 known flaky failure)
- [ ] Visit developer portal pages in browser to verify layout and content
- [ ] Verify all API area links and navigation work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)