### PR TITLE
feat(admin): Add 8 Filament resources for secondary domains (Phase 6)

### DIFF
--- a/app/Domain/TrustCert/Models/Certificate.php
+++ b/app/Domain/TrustCert/Models/Certificate.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\TrustCert\Models;
+
+use App\Domain\TrustCert\Enums\CertificateStatus;
+use App\Domain\TrustCert\Enums\IssuerType;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Certificate extends Model
+{
+    use HasUuids;
+
+    protected $fillable = [
+        'user_id',
+        'subject',
+        'issuer_type',
+        'status',
+        'credential_type',
+        'claims',
+        'issued_at',
+        'expires_at',
+        'revoked_at',
+        'revocation_reason',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'issuer_type' => IssuerType::class,
+        'status'      => CertificateStatus::class,
+        'claims'      => 'array',
+        'metadata'    => 'array',
+        'issued_at'   => 'datetime',
+        'expires_at'  => 'datetime',
+        'revoked_at'  => 'datetime',
+    ];
+
+    /** @return BelongsTo<\App\Models\User, $this> */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(\App\Models\User::class);
+    }
+}

--- a/app/Filament/Admin/Resources/CertificateResource.php
+++ b/app/Filament/Admin/Resources/CertificateResource.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources;
+
+use App\Domain\TrustCert\Enums\CertificateStatus;
+use App\Domain\TrustCert\Enums\IssuerType;
+use App\Domain\TrustCert\Models\Certificate;
+use App\Filament\Admin\Resources\CertificateResource\Pages;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Support\Carbon;
+
+class CertificateResource extends Resource
+{
+    protected static ?string $model = Certificate::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-shield-check';
+
+    protected static ?string $navigationGroup = 'TrustCert';
+
+    protected static ?int $navigationSort = 1;
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema(
+                [
+                    Forms\Components\Section::make('Certificate Details')
+                        ->schema(
+                            [
+                                Forms\Components\TextInput::make('id')
+                                    ->label('Certificate ID')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('subject')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('issuer_type')
+                                    ->label('Issuer Type')
+                                    ->formatStateUsing(fn ($state) => $state->label())
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('status')
+                                    ->formatStateUsing(fn ($state) => $state->label())
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('credential_type')
+                                    ->label('Credential Type')
+                                    ->disabled(),
+                            ]
+                        )->columns(3),
+
+                    Forms\Components\Section::make('Dates')
+                        ->schema(
+                            [
+                                Forms\Components\TextInput::make('issued_at')
+                                    ->label('Issued At')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('expires_at')
+                                    ->label('Expires At')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('revoked_at')
+                                    ->label('Revoked At')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('revocation_reason')
+                                    ->label('Revocation Reason')
+                                    ->disabled(),
+                            ]
+                        )->columns(4),
+                ]
+            );
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns(
+                [
+                    Tables\Columns\TextColumn::make('subject')
+                        ->searchable()
+                        ->sortable(),
+                    Tables\Columns\TextColumn::make('issuer_type')
+                        ->label('Issuer Type')
+                        ->formatStateUsing(fn ($state) => $state->label())
+                        ->sortable(),
+                    Tables\Columns\TextColumn::make('credential_type')
+                        ->label('Credential Type')
+                        ->sortable(),
+                    Tables\Columns\TextColumn::make('status')
+                        ->badge()
+                        ->formatStateUsing(fn ($state) => $state->label())
+                        ->color(
+                            fn ($state): string => match ($state->value) {
+                                'pending'   => 'gray',
+                                'active'    => 'success',
+                                'suspended' => 'warning',
+                                'revoked'   => 'danger',
+                                'expired'   => 'gray',
+                                default     => 'gray',
+                            }
+                        ),
+                    Tables\Columns\TextColumn::make('issued_at')
+                        ->label('Issued')
+                        ->dateTime()
+                        ->sortable(),
+                    Tables\Columns\TextColumn::make('expires_at')
+                        ->label('Expires')
+                        ->dateTime()
+                        ->sortable()
+                        ->color(
+                            fn ($state): string => $state instanceof Carbon && $state->isPast()
+                                ? 'danger'
+                                : 'success'
+                        ),
+                    Tables\Columns\TextColumn::make('user.name')
+                        ->label('User')
+                        ->searchable()
+                        ->toggleable(),
+                ]
+            )
+            ->defaultSort('issued_at', 'desc')
+            ->filters(
+                [
+                    Tables\Filters\SelectFilter::make('status')
+                        ->options(
+                            collect(CertificateStatus::cases())
+                                ->mapWithKeys(fn ($case) => [$case->value => $case->label()])
+                                ->all()
+                        ),
+                    Tables\Filters\SelectFilter::make('issuer_type')
+                        ->label('Issuer Type')
+                        ->options(
+                            collect(IssuerType::cases())
+                                ->mapWithKeys(fn ($case) => [$case->value => $case->label()])
+                                ->all()
+                        ),
+                ]
+            )
+            ->actions(
+                [
+                    Tables\Actions\ViewAction::make(),
+                ]
+            )
+            ->bulkActions([]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListCertificates::route('/'),
+            'view'  => Pages\ViewCertificate::route('/{record}'),
+        ];
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+}

--- a/app/Filament/Admin/Resources/CertificateResource/Pages/ListCertificates.php
+++ b/app/Filament/Admin/Resources/CertificateResource/Pages/ListCertificates.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\CertificateResource\Pages;
+
+use App\Filament\Admin\Resources\CertificateResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListCertificates extends ListRecords
+{
+    protected static string $resource = CertificateResource::class;
+}

--- a/app/Filament/Admin/Resources/CertificateResource/Pages/ViewCertificate.php
+++ b/app/Filament/Admin/Resources/CertificateResource/Pages/ViewCertificate.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\CertificateResource\Pages;
+
+use App\Filament\Admin\Resources\CertificateResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewCertificate extends ViewRecord
+{
+    protected static string $resource = CertificateResource::class;
+}

--- a/app/Filament/Admin/Resources/DelegatedProofJobResource.php
+++ b/app/Filament/Admin/Resources/DelegatedProofJobResource.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources;
+
+use App\Domain\Privacy\Models\DelegatedProofJob;
+use App\Filament\Admin\Resources\DelegatedProofJobResource\Pages;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class DelegatedProofJobResource extends Resource
+{
+    protected static ?string $model = DelegatedProofJob::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-finger-print';
+
+    protected static ?string $navigationGroup = 'Privacy';
+
+    protected static ?int $navigationSort = 1;
+
+    protected static ?string $navigationLabel = 'Proof Verifications';
+
+    protected static ?string $pluralModelLabel = 'Proof Verifications';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema(
+                [
+                    Forms\Components\Section::make('Proof Details')
+                        ->schema(
+                            [
+                                Forms\Components\TextInput::make('id')
+                                    ->label('Job ID')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('proof_type')
+                                    ->label('Proof Type')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('network')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('status')
+                                    ->disabled(),
+                            ]
+                        )->columns(4),
+
+                    Forms\Components\Section::make('Progress')
+                        ->schema(
+                            [
+                                Forms\Components\TextInput::make('progress')
+                                    ->label('Progress (%)')
+                                    ->suffix('%')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('estimated_seconds')
+                                    ->label('Estimated Seconds')
+                                    ->disabled(),
+                                Forms\Components\Textarea::make('error')
+                                    ->label('Error')
+                                    ->disabled()
+                                    ->columnSpanFull(),
+                            ]
+                        )->columns(2),
+
+                    Forms\Components\Section::make('Timestamps')
+                        ->schema(
+                            [
+                                Forms\Components\TextInput::make('created_at')
+                                    ->label('Created At')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('updated_at')
+                                    ->label('Updated At')
+                                    ->disabled(),
+                            ]
+                        )->columns(2),
+                ]
+            );
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns(
+                [
+                    Tables\Columns\TextColumn::make('created_at')
+                        ->label('Date')
+                        ->dateTime()
+                        ->sortable(),
+                    Tables\Columns\TextColumn::make('proof_type')
+                        ->label('Proof Type')
+                        ->sortable()
+                        ->searchable(),
+                    Tables\Columns\TextColumn::make('network')
+                        ->sortable()
+                        ->searchable(),
+                    Tables\Columns\TextColumn::make('status')
+                        ->badge()
+                        ->color(
+                            fn (string $state): string => match ($state) {
+                                'queued'     => 'gray',
+                                'processing' => 'warning',
+                                'completed'  => 'success',
+                                'failed'     => 'danger',
+                                default      => 'gray',
+                            }
+                        ),
+                    Tables\Columns\TextColumn::make('progress')
+                        ->suffix('%')
+                        ->sortable(),
+                    Tables\Columns\TextColumn::make('user.name')
+                        ->label('User')
+                        ->searchable()
+                        ->toggleable(),
+                ]
+            )
+            ->defaultSort('created_at', 'desc')
+            ->filters(
+                [
+                    Tables\Filters\SelectFilter::make('status')
+                        ->options(
+                            [
+                                'queued'     => 'Queued',
+                                'processing' => 'Processing',
+                                'completed'  => 'Completed',
+                                'failed'     => 'Failed',
+                            ]
+                        ),
+                    Tables\Filters\SelectFilter::make('proof_type')
+                        ->label('Proof Type')
+                        ->options(
+                            fn () => DelegatedProofJob::query()
+                                ->distinct()
+                                ->pluck('proof_type', 'proof_type')
+                                ->all()
+                        ),
+                ]
+            )
+            ->actions(
+                [
+                    Tables\Actions\ViewAction::make(),
+                ]
+            )
+            ->bulkActions([]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListDelegatedProofJobs::route('/'),
+            'view'  => Pages\ViewDelegatedProofJob::route('/{record}'),
+        ];
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+}

--- a/app/Filament/Admin/Resources/DelegatedProofJobResource/Pages/ListDelegatedProofJobs.php
+++ b/app/Filament/Admin/Resources/DelegatedProofJobResource/Pages/ListDelegatedProofJobs.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\DelegatedProofJobResource\Pages;
+
+use App\Filament\Admin\Resources\DelegatedProofJobResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListDelegatedProofJobs extends ListRecords
+{
+    protected static string $resource = DelegatedProofJobResource::class;
+}

--- a/app/Filament/Admin/Resources/DelegatedProofJobResource/Pages/ViewDelegatedProofJob.php
+++ b/app/Filament/Admin/Resources/DelegatedProofJobResource/Pages/ViewDelegatedProofJob.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\DelegatedProofJobResource\Pages;
+
+use App\Filament\Admin\Resources\DelegatedProofJobResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewDelegatedProofJob extends ViewRecord
+{
+    protected static string $resource = DelegatedProofJobResource::class;
+}

--- a/app/Filament/Admin/Resources/KeyShardRecordResource.php
+++ b/app/Filament/Admin/Resources/KeyShardRecordResource.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources;
+
+use App\Domain\KeyManagement\Enums\ShardStatus;
+use App\Domain\KeyManagement\Enums\ShardType;
+use App\Domain\KeyManagement\Models\KeyShardRecord;
+use App\Filament\Admin\Resources\KeyShardRecordResource\Pages;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class KeyShardRecordResource extends Resource
+{
+    protected static ?string $model = KeyShardRecord::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-key';
+
+    protected static ?string $navigationGroup = 'Key Management';
+
+    protected static ?int $navigationSort = 1;
+
+    protected static ?string $navigationLabel = 'Key Shards';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema(
+                [
+                    Forms\Components\Section::make('Shard Details')
+                        ->schema(
+                            [
+                                Forms\Components\TextInput::make('uuid')
+                                    ->label('UUID')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('shard_type')
+                                    ->label('Shard Type')
+                                    ->formatStateUsing(fn ($state) => $state->label())
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('shard_index')
+                                    ->label('Shard Index')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('status')
+                                    ->formatStateUsing(fn ($state) => $state->label())
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('key_version')
+                                    ->label('Key Version')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('public_key_hash')
+                                    ->label('Public Key Hash')
+                                    ->disabled(),
+                            ]
+                        )->columns(3),
+
+                    Forms\Components\Section::make('Access')
+                        ->schema(
+                            [
+                                Forms\Components\TextInput::make('last_accessed_at')
+                                    ->label('Last Accessed At')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('created_at')
+                                    ->label('Created At')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('updated_at')
+                                    ->label('Updated At')
+                                    ->disabled(),
+                            ]
+                        )->columns(3),
+                ]
+            );
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns(
+                [
+                    Tables\Columns\TextColumn::make('uuid')
+                        ->label('UUID')
+                        ->limit(12)
+                        ->tooltip(fn ($record): string => $record->uuid)
+                        ->searchable(),
+                    Tables\Columns\TextColumn::make('shard_type')
+                        ->label('Type')
+                        ->badge()
+                        ->formatStateUsing(fn ($state) => $state->label()),
+                    Tables\Columns\TextColumn::make('shard_index')
+                        ->label('Index'),
+                    Tables\Columns\TextColumn::make('status')
+                        ->badge()
+                        ->formatStateUsing(fn ($state) => $state->label())
+                        ->color(
+                            fn ($state): string => match ($state->value) {
+                                'active'  => 'success',
+                                'revoked' => 'danger',
+                                'rotated' => 'gray',
+                                'pending' => 'warning',
+                                default   => 'gray',
+                            }
+                        ),
+                    Tables\Columns\TextColumn::make('key_version')
+                        ->label('Key Version'),
+                    Tables\Columns\TextColumn::make('last_accessed_at')
+                        ->label('Last Accessed')
+                        ->dateTime()
+                        ->sortable(),
+                    Tables\Columns\TextColumn::make('created_at')
+                        ->label('Created')
+                        ->dateTime()
+                        ->sortable()
+                        ->toggleable(),
+                ]
+            )
+            ->defaultSort('created_at', 'desc')
+            ->filters(
+                [
+                    Tables\Filters\SelectFilter::make('shard_type')
+                        ->label('Shard Type')
+                        ->options(
+                            collect(ShardType::cases())
+                                ->mapWithKeys(fn ($case) => [$case->value => $case->label()])
+                                ->all()
+                        ),
+                    Tables\Filters\SelectFilter::make('status')
+                        ->options(
+                            collect(ShardStatus::cases())
+                                ->mapWithKeys(fn ($case) => [$case->value => $case->label()])
+                                ->all()
+                        ),
+                ]
+            )
+            ->actions(
+                [
+                    Tables\Actions\ViewAction::make(),
+                ]
+            )
+            ->bulkActions([]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListKeyShardRecords::route('/'),
+            'view'  => Pages\ViewKeyShardRecord::route('/{record}'),
+        ];
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+}

--- a/app/Filament/Admin/Resources/KeyShardRecordResource/Pages/ListKeyShardRecords.php
+++ b/app/Filament/Admin/Resources/KeyShardRecordResource/Pages/ListKeyShardRecords.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\KeyShardRecordResource\Pages;
+
+use App\Filament\Admin\Resources\KeyShardRecordResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListKeyShardRecords extends ListRecords
+{
+    protected static string $resource = KeyShardRecordResource::class;
+}

--- a/app/Filament/Admin/Resources/KeyShardRecordResource/Pages/ViewKeyShardRecord.php
+++ b/app/Filament/Admin/Resources/KeyShardRecordResource/Pages/ViewKeyShardRecord.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\KeyShardRecordResource\Pages;
+
+use App\Filament\Admin\Resources\KeyShardRecordResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewKeyShardRecord extends ViewRecord
+{
+    protected static string $resource = KeyShardRecordResource::class;
+}

--- a/app/Filament/Admin/Resources/MerchantResource.php
+++ b/app/Filament/Admin/Resources/MerchantResource.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources;
+
+use App\Domain\Commerce\Enums\MerchantStatus;
+use App\Domain\Commerce\Models\Merchant;
+use App\Filament\Admin\Resources\MerchantResource\Pages;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class MerchantResource extends Resource
+{
+    protected static ?string $model = Merchant::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-building-storefront';
+
+    protected static ?string $navigationGroup = 'Commerce';
+
+    protected static ?int $navigationSort = 1;
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema(
+                [
+                    Forms\Components\Section::make('Merchant Details')
+                        ->schema(
+                            [
+                                Forms\Components\TextInput::make('public_id')
+                                    ->label('Public ID')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('display_name')
+                                    ->label('Display Name')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('icon_url')
+                                    ->label('Icon URL')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('status')
+                                    ->formatStateUsing(fn ($state) => $state->label())
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('terminal_id')
+                                    ->label('Terminal ID')
+                                    ->disabled(),
+                            ]
+                        )->columns(3),
+                ]
+            );
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns(
+                [
+                    Tables\Columns\TextColumn::make('display_name')
+                        ->label('Display Name')
+                        ->searchable()
+                        ->sortable(),
+                    Tables\Columns\TextColumn::make('public_id')
+                        ->label('Public ID')
+                        ->limit(12)
+                        ->tooltip(fn ($record): string => $record->public_id)
+                        ->sortable(),
+                    Tables\Columns\TextColumn::make('status')
+                        ->badge()
+                        ->formatStateUsing(fn ($state) => $state->label())
+                        ->color(
+                            fn ($state): string => match ($state->value) {
+                                'pending'      => 'gray',
+                                'under_review' => 'warning',
+                                'approved'     => 'info',
+                                'active'       => 'success',
+                                'suspended'    => 'danger',
+                                'terminated'   => 'gray',
+                                default        => 'gray',
+                            }
+                        ),
+                    Tables\Columns\TextColumn::make('terminal_id')
+                        ->label('Terminal ID')
+                        ->sortable(),
+                    Tables\Columns\TextColumn::make('created_at')
+                        ->label('Created')
+                        ->dateTime()
+                        ->sortable()
+                        ->toggleable(),
+                ]
+            )
+            ->defaultSort('created_at', 'desc')
+            ->filters(
+                [
+                    Tables\Filters\SelectFilter::make('status')
+                        ->options(
+                            collect(MerchantStatus::cases())
+                                ->mapWithKeys(fn ($case) => [$case->value => $case->label()])
+                                ->all()
+                        ),
+                ]
+            )
+            ->actions(
+                [
+                    Tables\Actions\ViewAction::make(),
+                ]
+            )
+            ->bulkActions([]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListMerchants::route('/'),
+            'view'  => Pages\ViewMerchant::route('/{record}'),
+        ];
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+}

--- a/app/Filament/Admin/Resources/MerchantResource/Pages/ListMerchants.php
+++ b/app/Filament/Admin/Resources/MerchantResource/Pages/ListMerchants.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\MerchantResource\Pages;
+
+use App\Filament\Admin\Resources\MerchantResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListMerchants extends ListRecords
+{
+    protected static string $resource = MerchantResource::class;
+}

--- a/app/Filament/Admin/Resources/MerchantResource/Pages/ViewMerchant.php
+++ b/app/Filament/Admin/Resources/MerchantResource/Pages/ViewMerchant.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\MerchantResource\Pages;
+
+use App\Filament\Admin\Resources\MerchantResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewMerchant extends ViewRecord
+{
+    protected static string $resource = MerchantResource::class;
+}

--- a/app/Filament/Admin/Resources/MobileDeviceResource.php
+++ b/app/Filament/Admin/Resources/MobileDeviceResource.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources;
+
+use App\Domain\Mobile\Models\MobileDevice;
+use App\Filament\Admin\Resources\MobileDeviceResource\Pages;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class MobileDeviceResource extends Resource
+{
+    protected static ?string $model = MobileDevice::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-device-phone-mobile';
+
+    protected static ?string $navigationGroup = 'Mobile';
+
+    protected static ?int $navigationSort = 1;
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema(
+                [
+                    Forms\Components\Section::make('Device Info')
+                        ->schema(
+                            [
+                                Forms\Components\TextInput::make('device_id')
+                                    ->label('Device ID')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('device_name')
+                                    ->label('Device Name')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('device_model')
+                                    ->label('Device Model')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('platform')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('os_version')
+                                    ->label('OS Version')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('app_version')
+                                    ->label('App Version')
+                                    ->disabled(),
+                            ]
+                        )->columns(3),
+
+                    Forms\Components\Section::make('Security')
+                        ->schema(
+                            [
+                                Forms\Components\Toggle::make('biometric_enabled')
+                                    ->label('Biometric Enabled')
+                                    ->disabled(),
+                                Forms\Components\Toggle::make('passkey_enabled')
+                                    ->label('Passkey Enabled')
+                                    ->disabled(),
+                                Forms\Components\Toggle::make('is_trusted')
+                                    ->label('Trusted')
+                                    ->disabled(),
+                                Forms\Components\Toggle::make('is_blocked')
+                                    ->label('Blocked')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('blocked_reason')
+                                    ->label('Blocked Reason')
+                                    ->disabled()
+                                    ->columnSpanFull(),
+                            ]
+                        )->columns(4),
+
+                    Forms\Components\Section::make('Activity')
+                        ->schema(
+                            [
+                                Forms\Components\TextInput::make('last_active_at')
+                                    ->label('Last Active At')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('created_at')
+                                    ->label('Created At')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('updated_at')
+                                    ->label('Updated At')
+                                    ->disabled(),
+                            ]
+                        )->columns(3),
+                ]
+            );
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns(
+                [
+                    Tables\Columns\TextColumn::make('device_name')
+                        ->label('Device Name')
+                        ->searchable(),
+                    Tables\Columns\TextColumn::make('platform')
+                        ->badge(),
+                    Tables\Columns\TextColumn::make('device_model')
+                        ->label('Model'),
+                    Tables\Columns\TextColumn::make('os_version')
+                        ->label('OS'),
+                    Tables\Columns\IconColumn::make('biometric_enabled')
+                        ->label('Bio')
+                        ->boolean(),
+                    Tables\Columns\IconColumn::make('passkey_enabled')
+                        ->label('Passkey')
+                        ->boolean(),
+                    Tables\Columns\IconColumn::make('is_trusted')
+                        ->label('Trusted')
+                        ->boolean(),
+                    Tables\Columns\IconColumn::make('is_blocked')
+                        ->label('Blocked')
+                        ->boolean()
+                        ->trueColor('danger'),
+                    Tables\Columns\TextColumn::make('last_active_at')
+                        ->label('Last Active')
+                        ->dateTime()
+                        ->sortable(),
+                    Tables\Columns\TextColumn::make('user.name')
+                        ->label('User')
+                        ->toggleable(),
+                ]
+            )
+            ->defaultSort('last_active_at', 'desc')
+            ->filters(
+                [
+                    Tables\Filters\SelectFilter::make('platform')
+                        ->options(
+                            fn (): array => MobileDevice::query()
+                                ->distinct()
+                                ->whereNotNull('platform')
+                                ->pluck('platform', 'platform')
+                                ->all()
+                        ),
+                    Tables\Filters\TernaryFilter::make('biometric_enabled')
+                        ->label('Biometric'),
+                    Tables\Filters\TernaryFilter::make('is_blocked')
+                        ->label('Blocked'),
+                ]
+            )
+            ->actions(
+                [
+                    Tables\Actions\ViewAction::make(),
+                ]
+            )
+            ->bulkActions([]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListMobileDevices::route('/'),
+            'view'  => Pages\ViewMobileDevice::route('/{record}'),
+        ];
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+}

--- a/app/Filament/Admin/Resources/MobileDeviceResource/Pages/ListMobileDevices.php
+++ b/app/Filament/Admin/Resources/MobileDeviceResource/Pages/ListMobileDevices.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\MobileDeviceResource\Pages;
+
+use App\Filament\Admin\Resources\MobileDeviceResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListMobileDevices extends ListRecords
+{
+    protected static string $resource = MobileDeviceResource::class;
+}

--- a/app/Filament/Admin/Resources/MobileDeviceResource/Pages/ViewMobileDevice.php
+++ b/app/Filament/Admin/Resources/MobileDeviceResource/Pages/ViewMobileDevice.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\MobileDeviceResource\Pages;
+
+use App\Filament\Admin\Resources\MobileDeviceResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewMobileDevice extends ViewRecord
+{
+    protected static string $resource = MobileDeviceResource::class;
+}

--- a/app/Filament/Admin/Resources/PartnerResource.php
+++ b/app/Filament/Admin/Resources/PartnerResource.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources;
+
+use App\Domain\FinancialInstitution\Models\FinancialInstitutionPartner;
+use App\Filament\Admin\Resources\PartnerResource\Pages;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class PartnerResource extends Resource
+{
+    protected static ?string $model = FinancialInstitutionPartner::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-building-office-2';
+
+    protected static ?string $navigationGroup = 'BaaS Partners';
+
+    protected static ?int $navigationSort = 1;
+
+    protected static ?string $navigationLabel = 'Partners';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema(
+                [
+                    Forms\Components\Section::make('Partner Info')
+                        ->schema(
+                            [
+                                Forms\Components\TextInput::make('partner_code')
+                                    ->label('Partner Code')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('institution_name')
+                                    ->label('Institution Name')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('institution_type')
+                                    ->label('Institution Type')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('country')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('tier')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('status')
+                                    ->disabled(),
+                            ]
+                        )->columns(3),
+
+                    Forms\Components\Section::make('Access')
+                        ->schema(
+                            [
+                                Forms\Components\Toggle::make('sandbox_enabled')
+                                    ->label('Sandbox Enabled')
+                                    ->disabled(),
+                                Forms\Components\Toggle::make('production_enabled')
+                                    ->label('Production Enabled')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('rate_limit_per_minute')
+                                    ->label('Rate Limit / Minute')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('rate_limit_per_day')
+                                    ->label('Rate Limit / Day')
+                                    ->disabled(),
+                            ]
+                        )->columns(4),
+
+                    Forms\Components\Section::make('Risk')
+                        ->schema(
+                            [
+                                Forms\Components\TextInput::make('risk_rating')
+                                    ->label('Risk Rating')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('risk_score')
+                                    ->label('Risk Score')
+                                    ->disabled(),
+                            ]
+                        )->columns(2),
+
+                    Forms\Components\Section::make('Usage')
+                        ->schema(
+                            [
+                                Forms\Components\TextInput::make('total_transactions')
+                                    ->label('Total Transactions')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('total_volume')
+                                    ->label('Total Volume')
+                                    ->prefix('$')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('last_activity_at')
+                                    ->label('Last Activity At')
+                                    ->disabled(),
+                            ]
+                        )->columns(3),
+
+                    Forms\Components\Section::make('Key Dates')
+                        ->schema(
+                            [
+                                Forms\Components\TextInput::make('activated_at')
+                                    ->label('Activated At')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('suspended_at')
+                                    ->label('Suspended At')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('suspension_reason')
+                                    ->label('Suspension Reason')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('terminated_at')
+                                    ->label('Terminated At')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('termination_reason')
+                                    ->label('Termination Reason')
+                                    ->disabled(),
+                            ]
+                        )->columns(2),
+                ]
+            );
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns(
+                [
+                    Tables\Columns\TextColumn::make('institution_name')
+                        ->label('Institution')
+                        ->searchable()
+                        ->sortable(),
+                    Tables\Columns\TextColumn::make('partner_code')
+                        ->label('Code')
+                        ->searchable(),
+                    Tables\Columns\TextColumn::make('country'),
+                    Tables\Columns\TextColumn::make('tier')
+                        ->badge(),
+                    Tables\Columns\TextColumn::make('status')
+                        ->badge()
+                        ->color(
+                            fn (string $state): string => match ($state) {
+                                'active'     => 'success',
+                                'suspended'  => 'warning',
+                                'terminated' => 'danger',
+                                default      => 'gray',
+                            }
+                        ),
+                    Tables\Columns\IconColumn::make('sandbox_enabled')
+                        ->label('Sandbox')
+                        ->boolean(),
+                    Tables\Columns\IconColumn::make('production_enabled')
+                        ->label('Prod')
+                        ->boolean(),
+                    Tables\Columns\TextColumn::make('total_transactions')
+                        ->label('Transactions')
+                        ->numeric()
+                        ->sortable(),
+                    Tables\Columns\TextColumn::make('total_volume')
+                        ->label('Volume')
+                        ->money('USD')
+                        ->sortable(),
+                    Tables\Columns\TextColumn::make('risk_rating')
+                        ->label('Risk')
+                        ->badge()
+                        ->color(
+                            fn (string $state): string => match ($state) {
+                                'low'      => 'success',
+                                'medium'   => 'warning',
+                                'high'     => 'danger',
+                                'critical' => 'danger',
+                                default    => 'gray',
+                            }
+                        ),
+                    Tables\Columns\TextColumn::make('last_activity_at')
+                        ->label('Last Activity')
+                        ->dateTime()
+                        ->sortable()
+                        ->toggleable(),
+                ]
+            )
+            ->defaultSort('institution_name', 'asc')
+            ->filters(
+                [
+                    Tables\Filters\SelectFilter::make('status')
+                        ->options(
+                            [
+                                'active'     => 'Active',
+                                'suspended'  => 'Suspended',
+                                'terminated' => 'Terminated',
+                            ]
+                        ),
+                    Tables\Filters\SelectFilter::make('tier')
+                        ->options(
+                            fn (): array => FinancialInstitutionPartner::query()
+                                ->distinct()
+                                ->whereNotNull('tier')
+                                ->pluck('tier', 'tier')
+                                ->all()
+                        ),
+                    Tables\Filters\SelectFilter::make('risk_rating')
+                        ->label('Risk Rating')
+                        ->options(
+                            [
+                                'low'      => 'Low',
+                                'medium'   => 'Medium',
+                                'high'     => 'High',
+                                'critical' => 'Critical',
+                            ]
+                        ),
+                ]
+            )
+            ->actions(
+                [
+                    Tables\Actions\ViewAction::make(),
+                ]
+            )
+            ->bulkActions([]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListPartners::route('/'),
+            'view'  => Pages\ViewPartner::route('/{record}'),
+        ];
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+}

--- a/app/Filament/Admin/Resources/PartnerResource/Pages/ListPartners.php
+++ b/app/Filament/Admin/Resources/PartnerResource/Pages/ListPartners.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\PartnerResource\Pages;
+
+use App\Filament\Admin\Resources\PartnerResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListPartners extends ListRecords
+{
+    protected static string $resource = PartnerResource::class;
+}

--- a/app/Filament/Admin/Resources/PartnerResource/Pages/ViewPartner.php
+++ b/app/Filament/Admin/Resources/PartnerResource/Pages/ViewPartner.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\PartnerResource\Pages;
+
+use App\Filament\Admin\Resources\PartnerResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewPartner extends ViewRecord
+{
+    protected static string $resource = PartnerResource::class;
+}

--- a/app/Filament/Admin/Resources/PaymentIntentResource.php
+++ b/app/Filament/Admin/Resources/PaymentIntentResource.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources;
+
+use App\Domain\MobilePayment\Enums\PaymentIntentStatus;
+use App\Domain\MobilePayment\Models\PaymentIntent;
+use App\Filament\Admin\Resources\PaymentIntentResource\Pages;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class PaymentIntentResource extends Resource
+{
+    protected static ?string $model = PaymentIntent::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-device-phone-mobile';
+
+    protected static ?string $navigationGroup = 'Mobile Payments';
+
+    protected static ?int $navigationSort = 1;
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema(
+                [
+                    Forms\Components\Section::make('Payment Details')
+                        ->schema(
+                            [
+                                Forms\Components\TextInput::make('public_id')
+                                    ->label('Public ID')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('asset')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('network')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('amount')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('status')
+                                    ->formatStateUsing(fn ($state) => $state->label())
+                                    ->disabled(),
+                                Forms\Components\Toggle::make('shield_enabled')
+                                    ->label('Shield Enabled')
+                                    ->disabled(),
+                            ]
+                        )->columns(3),
+
+                    Forms\Components\Section::make('Timing')
+                        ->schema(
+                            [
+                                Forms\Components\TextInput::make('expires_at')
+                                    ->label('Expires At')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('submitted_at')
+                                    ->label('Submitted At')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('confirmed_at')
+                                    ->label('Confirmed At')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('failed_at')
+                                    ->label('Failed At')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('cancelled_at')
+                                    ->label('Cancelled At')
+                                    ->disabled(),
+                            ]
+                        )->columns(3),
+
+                    Forms\Components\Section::make('User & Merchant')
+                        ->schema(
+                            [
+                                Forms\Components\TextInput::make('user_id')
+                                    ->label('User ID')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('merchant_id')
+                                    ->label('Merchant ID')
+                                    ->disabled(),
+                            ]
+                        )->columns(2),
+                ]
+            );
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns(
+                [
+                    Tables\Columns\TextColumn::make('public_id')
+                        ->label('Public ID')
+                        ->searchable()
+                        ->limit(12)
+                        ->tooltip(fn ($record): string => $record->public_id),
+                    Tables\Columns\TextColumn::make('asset'),
+                    Tables\Columns\TextColumn::make('network'),
+                    Tables\Columns\TextColumn::make('amount')
+                        ->numeric(),
+                    Tables\Columns\TextColumn::make('status')
+                        ->badge()
+                        ->formatStateUsing(fn ($state) => $state->label())
+                        ->color(
+                            fn ($state): string => match ($state->value) {
+                                'created'       => 'gray',
+                                'awaiting_auth' => 'warning',
+                                'submitting'    => 'info',
+                                'pending'       => 'info',
+                                'confirmed'     => 'success',
+                                'failed'        => 'danger',
+                                'cancelled'     => 'gray',
+                                'expired'       => 'gray',
+                                default         => 'gray',
+                            }
+                        ),
+                    Tables\Columns\IconColumn::make('shield_enabled')
+                        ->label('Shield')
+                        ->boolean(),
+                    Tables\Columns\TextColumn::make('expires_at')
+                        ->label('Expires')
+                        ->dateTime(),
+                    Tables\Columns\TextColumn::make('user.name')
+                        ->label('User')
+                        ->toggleable(),
+                    Tables\Columns\TextColumn::make('created_at')
+                        ->label('Created')
+                        ->dateTime()
+                        ->sortable(),
+                ]
+            )
+            ->defaultSort('created_at', 'desc')
+            ->filters(
+                [
+                    Tables\Filters\SelectFilter::make('status')
+                        ->options(
+                            collect(PaymentIntentStatus::cases())
+                                ->mapWithKeys(fn ($case) => [$case->value => $case->label()])
+                                ->all()
+                        ),
+                    Tables\Filters\SelectFilter::make('asset')
+                        ->options(
+                            fn (): array => PaymentIntent::query()
+                                ->distinct()
+                                ->pluck('asset', 'asset')
+                                ->all()
+                        ),
+                ]
+            )
+            ->actions(
+                [
+                    Tables\Actions\ViewAction::make(),
+                ]
+            )
+            ->bulkActions([]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListPaymentIntents::route('/'),
+            'view'  => Pages\ViewPaymentIntent::route('/{record}'),
+        ];
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+}

--- a/app/Filament/Admin/Resources/PaymentIntentResource/Pages/ListPaymentIntents.php
+++ b/app/Filament/Admin/Resources/PaymentIntentResource/Pages/ListPaymentIntents.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\PaymentIntentResource\Pages;
+
+use App\Filament\Admin\Resources\PaymentIntentResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListPaymentIntents extends ListRecords
+{
+    protected static string $resource = PaymentIntentResource::class;
+}

--- a/app/Filament/Admin/Resources/PaymentIntentResource/Pages/ViewPaymentIntent.php
+++ b/app/Filament/Admin/Resources/PaymentIntentResource/Pages/ViewPaymentIntent.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\PaymentIntentResource\Pages;
+
+use App\Filament\Admin\Resources\PaymentIntentResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewPaymentIntent extends ViewRecord
+{
+    protected static string $resource = PaymentIntentResource::class;
+}

--- a/app/Filament/Admin/Resources/SmartAccountResource.php
+++ b/app/Filament/Admin/Resources/SmartAccountResource.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources;
+
+use App\Domain\Relayer\Models\SmartAccount;
+use App\Filament\Admin\Resources\SmartAccountResource\Pages;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class SmartAccountResource extends Resource
+{
+    protected static ?string $model = SmartAccount::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-cpu-chip';
+
+    protected static ?string $navigationGroup = 'Relayer';
+
+    protected static ?int $navigationSort = 1;
+
+    protected static ?string $navigationLabel = 'Smart Accounts';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema(
+                [
+                    Forms\Components\Section::make('Account Details')
+                        ->schema(
+                            [
+                                Forms\Components\TextInput::make('id')
+                                    ->label('Account ID')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('account_address')
+                                    ->label('Account Address')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('owner_address')
+                                    ->label('Owner Address')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('network')
+                                    ->disabled(),
+                            ]
+                        )->columns(2),
+
+                    Forms\Components\Section::make('Deployment')
+                        ->schema(
+                            [
+                                Forms\Components\Toggle::make('deployed')
+                                    ->label('Deployed')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('deploy_tx_hash')
+                                    ->label('Deploy TX Hash')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('nonce')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('pending_ops')
+                                    ->label('Pending Ops')
+                                    ->disabled(),
+                            ]
+                        )->columns(4),
+
+                    Forms\Components\Section::make('Timestamps')
+                        ->schema(
+                            [
+                                Forms\Components\TextInput::make('created_at')
+                                    ->label('Created At')
+                                    ->disabled(),
+                                Forms\Components\TextInput::make('updated_at')
+                                    ->label('Updated At')
+                                    ->disabled(),
+                            ]
+                        )->columns(2),
+                ]
+            );
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns(
+                [
+                    Tables\Columns\TextColumn::make('account_address')
+                        ->label('Account Address')
+                        ->searchable()
+                        ->limit(20)
+                        ->tooltip(fn ($record): string => $record->account_address),
+                    Tables\Columns\TextColumn::make('owner_address')
+                        ->label('Owner Address')
+                        ->limit(20)
+                        ->tooltip(fn ($record): string => $record->owner_address),
+                    Tables\Columns\TextColumn::make('network')
+                        ->badge(),
+                    Tables\Columns\IconColumn::make('deployed')
+                        ->boolean(),
+                    Tables\Columns\TextColumn::make('nonce')
+                        ->numeric(),
+                    Tables\Columns\TextColumn::make('pending_ops')
+                        ->label('Pending Ops')
+                        ->numeric()
+                        ->color(
+                            fn ($state): string => match (true) {
+                                $state >= 5 => 'warning',
+                                $state >= 1 => 'info',
+                                default     => 'success',
+                            }
+                        ),
+                    Tables\Columns\TextColumn::make('user.name')
+                        ->label('User')
+                        ->toggleable(),
+                    Tables\Columns\TextColumn::make('created_at')
+                        ->label('Created')
+                        ->dateTime()
+                        ->sortable()
+                        ->toggleable(),
+                ]
+            )
+            ->defaultSort('created_at', 'desc')
+            ->filters(
+                [
+                    Tables\Filters\TernaryFilter::make('deployed'),
+                    Tables\Filters\SelectFilter::make('network')
+                        ->options(
+                            fn (): array => SmartAccount::query()
+                                ->distinct()
+                                ->pluck('network', 'network')
+                                ->all()
+                        ),
+                ]
+            )
+            ->actions(
+                [
+                    Tables\Actions\ViewAction::make(),
+                ]
+            )
+            ->bulkActions([]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListSmartAccounts::route('/'),
+            'view'  => Pages\ViewSmartAccount::route('/{record}'),
+        ];
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+}

--- a/app/Filament/Admin/Resources/SmartAccountResource/Pages/ListSmartAccounts.php
+++ b/app/Filament/Admin/Resources/SmartAccountResource/Pages/ListSmartAccounts.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\SmartAccountResource\Pages;
+
+use App\Filament\Admin\Resources\SmartAccountResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListSmartAccounts extends ListRecords
+{
+    protected static string $resource = SmartAccountResource::class;
+}

--- a/app/Filament/Admin/Resources/SmartAccountResource/Pages/ViewSmartAccount.php
+++ b/app/Filament/Admin/Resources/SmartAccountResource/Pages/ViewSmartAccount.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\SmartAccountResource\Pages;
+
+use App\Filament\Admin\Resources\SmartAccountResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewSmartAccount extends ViewRecord
+{
+    protected static string $resource = SmartAccountResource::class;
+}

--- a/database/migrations/2025_06_01_000001_create_bridge_transactions_table.php
+++ b/database/migrations/2025_06_01_000001_create_bridge_transactions_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     public function up(): void
     {
         Schema::create('bridge_transactions', function (Blueprint $table) {

--- a/database/migrations/2025_06_01_000002_create_defi_positions_table.php
+++ b/database/migrations/2025_06_01_000002_create_defi_positions_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     public function up(): void
     {
         Schema::create('defi_positions', function (Blueprint $table) {

--- a/database/migrations/2025_06_01_000003_create_certificates_table.php
+++ b/database/migrations/2025_06_01_000003_create_certificates_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('certificates', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('subject');
+            $table->string('issuer_type');
+            $table->string('status')->default('pending');
+            $table->string('credential_type')->nullable();
+            $table->json('claims')->nullable();
+            $table->timestamp('issued_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamp('revoked_at')->nullable();
+            $table->string('revocation_reason')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+            $table->index('user_id');
+            $table->index('status');
+            $table->index('issuer_type');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('certificates');
+    }
+};


### PR DESCRIPTION
## Summary
- Add Filament admin resources for 8 secondary domains: Privacy (DelegatedProofJob), Commerce (Merchant), TrustCert (Certificate), KeyManagement (KeyShardRecord), Relayer (SmartAccount), MobilePayment (PaymentIntent), Mobile (MobileDevice), FinancialInstitution (Partner)
- Create Certificate Eloquent model + migration for TrustCert domain (previously had no DB model)
- All resources are read-only with table views, filters, badge columns, and form detail views
- 28 files, 1,653 insertions — PHPStan clean, php-cs-fixer clean, 7082 tests pass

## Admin UI Coverage
After this PR, Filament admin covers **26 of 41 domains** (up from 11 pre-v3.1.0):
- Phase 5 (#462): CrossChain, DeFi, Fraud, RegTech, Wallet, Lending, Treasury
- **Phase 6 (this PR)**: Privacy, Commerce, TrustCert, KeyManagement, Relayer, MobilePayment, Mobile, FinancialInstitution

## Test plan
- [x] PHPStan Level 8 passes (0 errors)
- [x] php-cs-fixer passes (0 fixes needed)
- [x] `./vendor/bin/pest --parallel` — 7082 passed (2 flaky failures pre-existing)
- [ ] Manual: verify resources appear in admin panel navigation groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)