### PR TITLE
feat: Complete module manifests and enable/disable (v3.2.0 Phase 1)

### DIFF
--- a/app/Domain/CardIssuance/module.json
+++ b/app/Domain/CardIssuance/module.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "https://finaegis.io/schemas/module.json",
+    "name": "finaegis/card-issuance",
+    "version": "1.0.0",
+    "description": "Virtual card provisioning with JIT funding and wallet integration",
+    "type": "optional",
+    "dependencies": {
+        "required": {
+            "finaegis/shared": "^1.0",
+            "finaegis/wallet": "^1.0",
+            "finaegis/banking": "^1.0",
+            "finaegis/payment": "^1.0"
+        },
+        "optional": {}
+    },
+    "provides": {
+        "interfaces": [
+            "App\\Domain\\CardIssuance\\Contracts\\CardIssuerInterface"
+        ],
+        "events": [
+            "CardProvisioned",
+            "AuthorizationApproved",
+            "AuthorizationDeclined"
+        ],
+        "commands": []
+    },
+    "paths": {
+        "routes": "Routes/api.php",
+        "migrations": "Database/Migrations",
+        "config": "Config/card-issuance.php",
+        "tests": "Tests"
+    }
+}

--- a/app/Domain/Commerce/module.json
+++ b/app/Domain/Commerce/module.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "https://finaegis.io/schemas/module.json",
+    "name": "finaegis/commerce",
+    "version": "1.2.0",
+    "description": "Soulbound tokens, merchant onboarding, payment attestations, and credential issuance",
+    "type": "optional",
+    "dependencies": {
+        "required": {
+            "finaegis/shared": "^1.0",
+            "finaegis/wallet": "^1.0",
+            "finaegis/account": "^1.0",
+            "finaegis/compliance": "^1.0"
+        },
+        "optional": {
+            "finaegis/trust-cert": "^1.0"
+        }
+    },
+    "provides": {
+        "interfaces": [
+            "App\\Domain\\Commerce\\Contracts\\TokenIssuerInterface",
+            "App\\Domain\\Commerce\\Contracts\\AttestationServiceInterface",
+            "App\\Domain\\Commerce\\Contracts\\OnChainSbtServiceInterface"
+        ],
+        "events": [
+            "SoulboundTokenIssued",
+            "SoulboundTokenRevoked",
+            "MerchantOnboarded",
+            "PaymentAttested",
+            "CredentialIssued",
+            "SoulboundTokenMintedOnChain",
+            "SoulboundTokenRevokedOnChain"
+        ],
+        "commands": []
+    },
+    "paths": {
+        "routes": "Routes/api.php",
+        "migrations": "Database/Migrations",
+        "config": "Config/commerce.php",
+        "tests": "Tests"
+    }
+}

--- a/app/Domain/CrossChain/module.json
+++ b/app/Domain/CrossChain/module.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "https://finaegis.io/schemas/module.json",
+    "name": "finaegis/cross-chain",
+    "version": "1.1.0",
+    "description": "Bridge protocols (Wormhole, LayerZero, Axelar), cross-chain swaps, multi-chain portfolio",
+    "type": "optional",
+    "dependencies": {
+        "required": {
+            "finaegis/shared": "^1.0",
+            "finaegis/wallet": "^1.0",
+            "finaegis/asset": "^1.0"
+        },
+        "optional": {
+            "finaegis/treasury": "^1.0",
+            "finaegis/defi": "^1.0"
+        }
+    },
+    "provides": {
+        "interfaces": [
+            "App\\Domain\\CrossChain\\Contracts\\BridgeAdapterInterface",
+            "App\\Domain\\CrossChain\\Contracts\\AssetMapperInterface",
+            "App\\Domain\\CrossChain\\Contracts\\CrossChainMessageInterface"
+        ],
+        "events": [
+            "BridgeTransactionInitiated",
+            "BridgeTransactionCompleted",
+            "BridgeTransactionFailed",
+            "CrossChainSwapInitiated",
+            "CrossChainSwapCompleted"
+        ],
+        "commands": []
+    },
+    "paths": {
+        "routes": "Routes/api.php",
+        "migrations": "Database/Migrations",
+        "config": "Config/cross-chain.php",
+        "tests": "Tests"
+    }
+}

--- a/app/Domain/DeFi/module.json
+++ b/app/Domain/DeFi/module.json
@@ -1,0 +1,38 @@
+{
+    "$schema": "https://finaegis.io/schemas/module.json",
+    "name": "finaegis/defi",
+    "version": "1.1.0",
+    "description": "DEX aggregation (Uniswap, Aave, Curve, Lido), flash loans, position tracking, yield optimization",
+    "type": "optional",
+    "dependencies": {
+        "required": {
+            "finaegis/shared": "^1.0",
+            "finaegis/wallet": "^1.0",
+            "finaegis/asset": "^1.0"
+        },
+        "optional": {
+            "finaegis/treasury": "^1.0",
+            "finaegis/cross-chain": "^1.0"
+        }
+    },
+    "provides": {
+        "interfaces": [
+            "App\\Domain\\DeFi\\Contracts\\SwapProtocolInterface",
+            "App\\Domain\\DeFi\\Contracts\\LendingProtocolInterface",
+            "App\\Domain\\DeFi\\Contracts\\LiquidStakingInterface",
+            "App\\Domain\\DeFi\\Contracts\\YieldVaultInterface"
+        ],
+        "events": [
+            "SwapExecuted",
+            "PositionOpened",
+            "PositionClosed"
+        ],
+        "commands": []
+    },
+    "paths": {
+        "routes": "Routes/api.php",
+        "migrations": "Database/Migrations",
+        "config": "Config/defi.php",
+        "tests": "Tests"
+    }
+}

--- a/app/Domain/KeyManagement/module.json
+++ b/app/Domain/KeyManagement/module.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "https://finaegis.io/schemas/module.json",
+    "name": "finaegis/key-management",
+    "version": "1.2.0",
+    "description": "Shamir's Secret Sharing, HSM integration (AWS KMS, Azure Key Vault), key rotation and reconstruction",
+    "type": "core",
+    "dependencies": {
+        "required": {
+            "finaegis/shared": "^1.0",
+            "finaegis/account": "^1.0"
+        },
+        "optional": {
+            "finaegis/wallet": "^1.0",
+            "finaegis/security": "^1.0"
+        }
+    },
+    "provides": {
+        "interfaces": [
+            "App\\Domain\\KeyManagement\\Contracts\\ShamirServiceInterface",
+            "App\\Domain\\KeyManagement\\Contracts\\HsmProviderInterface"
+        ],
+        "events": [
+            "KeyShardsCreated",
+            "KeyReconstructed",
+            "KeyShardsRotated",
+            "KeyReconstructionFailed"
+        ],
+        "commands": []
+    },
+    "paths": {
+        "routes": "Routes/api.php",
+        "migrations": "Database/Migrations",
+        "config": "Config/key-management.php",
+        "tests": "Tests"
+    }
+}

--- a/app/Domain/Mobile/module.json
+++ b/app/Domain/Mobile/module.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://finaegis.io/schemas/module.json",
+    "name": "finaegis/mobile",
+    "version": "1.3.0",
+    "description": "Mobile device management, biometric authentication, push notifications, passkey auth, session management",
+    "type": "core",
+    "dependencies": {
+        "required": {
+            "finaegis/shared": "^1.0",
+            "finaegis/account": "^1.0",
+            "finaegis/user": "^1.0"
+        },
+        "optional": {
+            "finaegis/security": "^1.0",
+            "finaegis/key-management": "^1.0"
+        }
+    },
+    "provides": {
+        "interfaces": [
+            "App\\Domain\\Mobile\\Contracts\\BiometricJWTServiceInterface"
+        ],
+        "events": [
+            "MobileDeviceRegistered",
+            "MobileDeviceTrusted",
+            "MobileDeviceBlocked",
+            "BiometricAuthSucceeded",
+            "BiometricAuthFailed",
+            "BiometricEnabled",
+            "BiometricDisabled",
+            "BiometricDeviceBlocked",
+            "PushNotificationSent",
+            "MobileSessionCreated"
+        ],
+        "commands": []
+    },
+    "paths": {
+        "routes": "Routes/api.php",
+        "migrations": "Database/Migrations",
+        "config": "Config/mobile.php",
+        "tests": "Tests"
+    }
+}

--- a/app/Domain/MobilePayment/module.json
+++ b/app/Domain/MobilePayment/module.json
@@ -1,0 +1,38 @@
+{
+    "$schema": "https://finaegis.io/schemas/module.json",
+    "name": "finaegis/mobile-payment",
+    "version": "1.1.0",
+    "description": "Payment intents, receipts, activity feed, receive addresses, fee estimation, network availability",
+    "type": "optional",
+    "dependencies": {
+        "required": {
+            "finaegis/shared": "^1.0",
+            "finaegis/mobile": "^1.0",
+            "finaegis/wallet": "^1.0",
+            "finaegis/payment": "^1.0",
+            "finaegis/account": "^1.0"
+        },
+        "optional": {
+            "finaegis/commerce": "^1.0"
+        }
+    },
+    "provides": {
+        "interfaces": [
+            "App\\Domain\\MobilePayment\\Contracts\\MerchantLookupServiceInterface",
+            "App\\Domain\\MobilePayment\\Contracts\\PaymentIntentServiceInterface"
+        ],
+        "events": [
+            "PaymentIntentConfirmed",
+            "PaymentIntentCancelled",
+            "PaymentIntentFailed",
+            "PaymentStatusChanged"
+        ],
+        "commands": []
+    },
+    "paths": {
+        "routes": "Routes/api.php",
+        "migrations": "Database/Migrations",
+        "config": "Config/mobile-payment.php",
+        "tests": "Tests"
+    }
+}

--- a/app/Domain/Privacy/module.json
+++ b/app/Domain/Privacy/module.json
@@ -1,0 +1,41 @@
+{
+    "$schema": "https://finaegis.io/schemas/module.json",
+    "name": "finaegis/privacy",
+    "version": "1.2.0",
+    "description": "ZK-KYC, Proof of Innocence, Merkle trees, delegated proofs, selective disclosure, SRS manifests",
+    "type": "optional",
+    "dependencies": {
+        "required": {
+            "finaegis/shared": "^1.0",
+            "finaegis/account": "^1.0",
+            "finaegis/wallet": "^1.0"
+        },
+        "optional": {
+            "finaegis/security": "^1.0",
+            "finaegis/key-management": "^1.0"
+        }
+    },
+    "provides": {
+        "interfaces": [
+            "App\\Domain\\Privacy\\Contracts\\ZkProverInterface",
+            "App\\Domain\\Privacy\\Contracts\\MerkleTreeServiceInterface"
+        ],
+        "events": [
+            "ZkKycVerified",
+            "ZkKycVerificationFailed",
+            "ProofOfInnocenceGenerated",
+            "DelegatedProofRequested",
+            "DelegatedProofCompleted",
+            "DelegatedProofFailed",
+            "DelegatedProofProgress",
+            "MerkleRootUpdated"
+        ],
+        "commands": []
+    },
+    "paths": {
+        "routes": "Routes/api.php",
+        "migrations": "Database/Migrations",
+        "config": "Config/privacy.php",
+        "tests": "Tests"
+    }
+}

--- a/app/Domain/RegTech/module.json
+++ b/app/Domain/RegTech/module.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "https://finaegis.io/schemas/module.json",
+    "name": "finaegis/regtech",
+    "version": "1.1.0",
+    "description": "MiFID II reporting, MiCA compliance, Travel Rule verification, multi-jurisdiction adapters",
+    "type": "core",
+    "dependencies": {
+        "required": {
+            "finaegis/shared": "^1.0",
+            "finaegis/compliance": "^1.0",
+            "finaegis/account": "^1.0"
+        },
+        "optional": {
+            "finaegis/banking": "^1.0",
+            "finaegis/payment": "^1.0",
+            "finaegis/regulatory": "^1.0"
+        }
+    },
+    "provides": {
+        "interfaces": [
+            "App\\Domain\\RegTech\\Contracts\\RegulatoryFilingAdapterInterface"
+        ],
+        "events": [],
+        "commands": []
+    },
+    "paths": {
+        "routes": "Routes/api.php",
+        "migrations": "Database/Migrations",
+        "config": "Config/regtech.php",
+        "tests": "Tests"
+    }
+}

--- a/app/Domain/Relayer/module.json
+++ b/app/Domain/Relayer/module.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "https://finaegis.io/schemas/module.json",
+    "name": "finaegis/relayer",
+    "version": "1.2.0",
+    "description": "ERC-4337 gas abstraction, smart accounts, UserOp signing, gas station, paymaster integration",
+    "type": "optional",
+    "dependencies": {
+        "required": {
+            "finaegis/shared": "^1.0",
+            "finaegis/wallet": "^1.0",
+            "finaegis/account": "^1.0"
+        },
+        "optional": {
+            "finaegis/key-management": "^1.0",
+            "finaegis/mobile": "^1.0"
+        }
+    },
+    "provides": {
+        "interfaces": [
+            "App\\Domain\\Relayer\\Contracts\\PaymasterInterface",
+            "App\\Domain\\Relayer\\Contracts\\BundlerInterface",
+            "App\\Domain\\Relayer\\Contracts\\SmartAccountFactoryInterface",
+            "App\\Domain\\Relayer\\Contracts\\UserOperationSignerInterface",
+            "App\\Domain\\Relayer\\Contracts\\WalletBalanceProviderInterface"
+        ],
+        "events": [
+            "TransactionSponsored"
+        ],
+        "commands": []
+    },
+    "paths": {
+        "routes": "Routes/api.php",
+        "migrations": "Database/Migrations",
+        "config": "Config/relayer.php",
+        "tests": "Tests"
+    }
+}

--- a/app/Domain/Security/module.json
+++ b/app/Domain/Security/module.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "https://finaegis.io/schemas/module.json",
+    "name": "finaegis/security",
+    "version": "1.1.0",
+    "description": "Security audit framework with automated vulnerability checks and compliance scanning",
+    "type": "core",
+    "dependencies": {
+        "required": {
+            "finaegis/shared": "^1.0",
+            "finaegis/account": "^1.0"
+        },
+        "optional": {
+            "finaegis/compliance": "^1.0",
+            "finaegis/key-management": "^1.0"
+        }
+    },
+    "provides": {
+        "interfaces": [
+            "App\\Domain\\Security\\Contracts\\SecurityCheckInterface"
+        ],
+        "events": [],
+        "commands": []
+    },
+    "paths": {
+        "routes": "Routes/api.php",
+        "migrations": "Database/Migrations",
+        "config": "Config/security.php",
+        "tests": "Tests"
+    }
+}

--- a/app/Domain/TrustCert/module.json
+++ b/app/Domain/TrustCert/module.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://finaegis.io/schemas/module.json",
+    "name": "finaegis/trust-cert",
+    "version": "1.2.0",
+    "description": "W3C Verifiable Credentials, Certificate Authority, trust framework, credential export",
+    "type": "optional",
+    "dependencies": {
+        "required": {
+            "finaegis/shared": "^1.0",
+            "finaegis/account": "^1.0",
+            "finaegis/wallet": "^1.0",
+            "finaegis/compliance": "^1.0"
+        },
+        "optional": {
+            "finaegis/commerce": "^1.0"
+        }
+    },
+    "provides": {
+        "interfaces": [
+            "App\\Domain\\TrustCert\\Contracts\\TrustFrameworkInterface",
+            "App\\Domain\\TrustCert\\Contracts\\RevocationRegistryInterface",
+            "App\\Domain\\TrustCert\\Contracts\\CertificateAuthorityInterface"
+        ],
+        "events": [
+            "CertificateIssued",
+            "CertificateRevoked",
+            "CertificateExpired",
+            "TrustLevelChanged",
+            "IssuerRegistered",
+            "CredentialRevoked"
+        ],
+        "commands": []
+    },
+    "paths": {
+        "routes": "Routes/api.php",
+        "migrations": "Database/Migrations",
+        "config": "Config/trust-cert.php",
+        "tests": "Tests"
+    }
+}

--- a/app/Infrastructure/Domain/Commands/DomainDisableCommand.php
+++ b/app/Infrastructure/Domain/Commands/DomainDisableCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Domain\Commands;
+
+use App\Infrastructure\Domain\DomainManager;
+use Illuminate\Console\Command;
+
+/**
+ * Disable a domain module without reverting migrations.
+ */
+class DomainDisableCommand extends Command
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'module:disable {domain : The domain name to disable}';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Disable a domain module (routes will stop loading, migrations are preserved)';
+
+    public function handle(DomainManager $manager): int
+    {
+        $domain = $this->argument('domain');
+
+        $result = $manager->disable((string) $domain);
+
+        if (! $result->success) {
+            $this->error($result->getSummary());
+
+            return self::FAILURE;
+        }
+
+        $this->info($result->getSummary());
+
+        if (! empty($result->warnings)) {
+            foreach ($result->warnings as $warning) {
+                $this->warn("  Warning: {$warning}");
+            }
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Infrastructure/Domain/Commands/DomainEnableCommand.php
+++ b/app/Infrastructure/Domain/Commands/DomainEnableCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Domain\Commands;
+
+use App\Infrastructure\Domain\DomainManager;
+use Illuminate\Console\Command;
+
+/**
+ * Enable a previously disabled domain module.
+ */
+class DomainEnableCommand extends Command
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'module:enable {domain : The domain name to enable}';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Enable a disabled domain module';
+
+    public function handle(DomainManager $manager): int
+    {
+        $domain = $this->argument('domain');
+
+        $result = $manager->enable((string) $domain);
+
+        if (! $result->success) {
+            $this->error($result->getSummary());
+
+            return self::FAILURE;
+        }
+
+        $this->info($result->getSummary());
+
+        if (! empty($result->warnings)) {
+            foreach ($result->warnings as $warning) {
+                $this->warn("  Warning: {$warning}");
+            }
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Infrastructure/Domain/DomainServiceProvider.php
+++ b/app/Infrastructure/Domain/DomainServiceProvider.php
@@ -6,6 +6,8 @@ namespace App\Infrastructure\Domain;
 
 use App\Infrastructure\Domain\Commands\DomainCreateCommand;
 use App\Infrastructure\Domain\Commands\DomainDependenciesCommand;
+use App\Infrastructure\Domain\Commands\DomainDisableCommand;
+use App\Infrastructure\Domain\Commands\DomainEnableCommand;
 use App\Infrastructure\Domain\Commands\DomainInstallCommand;
 use App\Infrastructure\Domain\Commands\DomainListCommand;
 use App\Infrastructure\Domain\Commands\DomainRemoveCommand;
@@ -32,6 +34,8 @@ class DomainServiceProvider extends ServiceProvider
         DomainRemoveCommand::class,
         DomainVerifyCommand::class,
         DomainDependenciesCommand::class,
+        DomainEnableCommand::class,
+        DomainDisableCommand::class,
     ];
 
     /**

--- a/config/modules.php
+++ b/config/modules.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Module System Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Controls the FinAegis modular domain system. When all_enabled is true,
+    | every domain is active. Set to false and populate the disabled list
+    | to selectively disable specific domain modules.
+    |
+    */
+
+    'all_enabled' => env('MODULES_ALL_ENABLED', true),
+
+    'disabled' => array_filter(explode(',', env('MODULES_DISABLED', ''))),
+
+];

--- a/tests/Unit/Infrastructure/Domain/DomainEnableDisableTest.php
+++ b/tests/Unit/Infrastructure/Domain/DomainEnableDisableTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Infrastructure\Domain\DomainManager;
+use Illuminate\Support\Facades\Cache;
+
+uses(Tests\TestCase::class);
+
+beforeEach(function () {
+    Cache::flush();
+});
+
+describe('Domain Enable/Disable', function () {
+    it('can disable an optional domain', function () {
+        /** @var DomainManager $manager */
+        $manager = app(DomainManager::class);
+
+        $result = $manager->disable('exchange');
+
+        expect($result->success)->toBeTrue();
+        expect($manager->isDisabled('finaegis/exchange'))->toBeTrue();
+    });
+
+    it('cannot disable a core domain', function () {
+        /** @var DomainManager $manager */
+        $manager = app(DomainManager::class);
+
+        $result = $manager->disable('account');
+
+        expect($result->success)->toBeFalse();
+        expect($result->errors)->not->toBeEmpty();
+    });
+
+    it('can enable a disabled domain', function () {
+        /** @var DomainManager $manager */
+        $manager = app(DomainManager::class);
+
+        $manager->disable('exchange');
+        expect($manager->isDisabled('finaegis/exchange'))->toBeTrue();
+
+        $result = $manager->enable('exchange');
+        expect($result->success)->toBeTrue();
+        expect($manager->isDisabled('finaegis/exchange'))->toBeFalse();
+    });
+
+    it('returns warning when disabling already disabled domain', function () {
+        /** @var DomainManager $manager */
+        $manager = app(DomainManager::class);
+
+        $manager->disable('exchange');
+        $result = $manager->disable('exchange');
+
+        expect($result->success)->toBeTrue();
+        expect($result->warnings)->not->toBeEmpty();
+    });
+
+    it('returns warning when enabling already enabled domain', function () {
+        /** @var DomainManager $manager */
+        $manager = app(DomainManager::class);
+
+        $result = $manager->enable('exchange');
+
+        expect($result->success)->toBeTrue();
+        expect($result->warnings)->not->toBeEmpty();
+    });
+
+    it('fails when enabling non-existent domain', function () {
+        /** @var DomainManager $manager */
+        $manager = app(DomainManager::class);
+
+        $result = $manager->enable('nonexistent');
+
+        expect($result->success)->toBeFalse();
+    });
+
+    it('fails when disabling non-existent domain', function () {
+        /** @var DomainManager $manager */
+        $manager = app(DomainManager::class);
+
+        $result = $manager->disable('nonexistent');
+
+        expect($result->success)->toBeFalse();
+    });
+
+    it('shows disabled status in available domains list', function () {
+        /** @var DomainManager $manager */
+        $manager = app(DomainManager::class);
+
+        $manager->disable('exchange');
+
+        $domains = $manager->getAvailableDomains();
+        $exchange = $domains->first(fn ($d) => str_contains($d->name, 'exchange'));
+
+        expect($exchange)->not->toBeNull();
+        expect($exchange->status->value)->toBe('disabled');
+    });
+
+    it('reads disabled list from config as fallback', function () {
+        config(['modules.disabled' => ['finaegis/wallet']]);
+
+        /** @var DomainManager $manager */
+        $manager = app(DomainManager::class);
+
+        expect($manager->isDisabled('finaegis/wallet'))->toBeTrue();
+    });
+
+    it('clears disabled cache on clearCache', function () {
+        /** @var DomainManager $manager */
+        $manager = app(DomainManager::class);
+
+        $manager->disable('exchange');
+        expect($manager->isDisabled('finaegis/exchange'))->toBeTrue();
+
+        $manager->clearCache();
+        // After clearing, falls back to config which is empty
+        config(['modules.disabled' => []]);
+        expect($manager->isDisabled('finaegis/exchange'))->toBeFalse();
+    });
+});

--- a/tests/Unit/Infrastructure/Domain/ModuleManifestCompletenessTest.php
+++ b/tests/Unit/Infrastructure/Domain/ModuleManifestCompletenessTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Infrastructure\Domain\DomainManager;
+
+uses(Tests\TestCase::class);
+
+describe('Module Manifest Completeness', function () {
+    it('has module.json for every domain directory', function () {
+        $domainPath = base_path('app/Domain');
+        $directories = array_filter(glob("{$domainPath}/*"), 'is_dir');
+
+        $missing = [];
+        foreach ($directories as $dir) {
+            $manifestPath = $dir . '/module.json';
+            if (! file_exists($manifestPath)) {
+                $missing[] = basename($dir);
+            }
+        }
+
+        expect($missing)->toBeEmpty(
+            'Missing module.json for domains: ' . implode(', ', $missing)
+        );
+    });
+
+    it('loads all 41 domain manifests', function () {
+        /** @var DomainManager $manager */
+        $manager = app(DomainManager::class);
+        $manifests = $manager->loadAllManifests();
+
+        expect(count($manifests))->toBeGreaterThanOrEqual(41);
+    });
+
+    it('has valid JSON in all module.json files', function () {
+        $domainPath = base_path('app/Domain');
+        $manifests = glob("{$domainPath}/*/module.json");
+
+        foreach ($manifests as $manifestPath) {
+            $content = file_get_contents($manifestPath);
+            $data = json_decode($content !== false ? $content : '', true);
+
+            expect($data)->not->toBeNull(
+                'Invalid JSON in ' . basename(dirname($manifestPath)) . '/module.json'
+            );
+            expect($data)->toHaveKeys(['name', 'version', 'description', 'type']);
+        }
+    });
+
+    it('has valid schema reference in all manifests', function () {
+        $domainPath = base_path('app/Domain');
+        $manifests = glob("{$domainPath}/*/module.json");
+
+        foreach ($manifests as $manifestPath) {
+            $content = file_get_contents($manifestPath);
+            $data = json_decode($content !== false ? $content : '', true);
+
+            expect($data['$schema'] ?? null)->toBe('https://finaegis.io/schemas/module.json');
+        }
+    });
+
+    it('has no duplicate domain names across manifests', function () {
+        $domainPath = base_path('app/Domain');
+        $manifestFiles = glob("{$domainPath}/*/module.json");
+        $names = [];
+
+        foreach ($manifestFiles as $manifestPath) {
+            $content = file_get_contents($manifestPath);
+            $data = json_decode($content !== false ? $content : '', true);
+            $names[] = $data['name'];
+        }
+
+        expect(count($names))->toBe(count(array_unique($names)));
+    });
+});


### PR DESCRIPTION
## Summary
- Create `module.json` for 12 missing domains — all 41 domains now have manifests
- Add `enable()`/`disable()` methods to `DomainManager` with core domain protection
- Create `config/modules.php` for module system configuration
- Add `module:enable` and `module:disable` artisan commands
- 15 new tests (268 assertions) covering manifest completeness and enable/disable

## Test plan
- [x] All 41 domains have valid `module.json` files
- [x] `module:enable` / `module:disable` artisan commands work correctly
- [x] Core domains cannot be disabled
- [x] Disabled status reflects in `domain:list`
- [x] Tests pass: `./vendor/bin/pest tests/Unit/Infrastructure/Domain/ --parallel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)