### PR TITLE
feat: Module Admin & Health API (v3.2.0 Phase 3)

### DIFF
--- a/app/Filament/Admin/Pages/Modules.php
+++ b/app/Filament/Admin/Pages/Modules.php
@@ -1,0 +1,293 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Pages;
+
+use App\Infrastructure\Domain\DataObjects\DomainInfo;
+use App\Infrastructure\Domain\DomainManager;
+use App\Infrastructure\Domain\Enums\DomainStatus;
+use Exception;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+use Livewire\Attributes\Url;
+
+class Modules extends Page
+{
+    protected static ?string $navigationIcon = 'heroicon-o-puzzle-piece';
+
+    protected static ?string $navigationGroup = 'System';
+
+    protected static ?int $navigationSort = 10;
+
+    protected static ?string $title = 'Module Management';
+
+    protected static string $view = 'filament.admin.pages.modules';
+
+    #[Url]
+    public string $search = '';
+
+    #[Url]
+    public string $statusFilter = '';
+
+    #[Url]
+    public string $typeFilter = '';
+
+    private ?DomainManager $domainManager = null;
+
+    public function getDomainManager(): DomainManager
+    {
+        if ($this->domainManager === null) {
+            $this->domainManager = app(DomainManager::class);
+        }
+
+        return $this->domainManager;
+    }
+
+    /**
+     * Get all modules filtered by current search and status criteria.
+     *
+     * @return Collection<int, DomainInfo>
+     */
+    public function getModulesProperty(): Collection
+    {
+        $domains = $this->getDomainManager()->getAvailableDomains();
+
+        if ($this->search !== '') {
+            $search = mb_strtolower($this->search);
+            $domains = $domains->filter(
+                fn (DomainInfo $info) => str_contains(mb_strtolower($info->name), $search)
+                    || str_contains(mb_strtolower($info->displayName), $search)
+                    || str_contains(mb_strtolower($info->description), $search)
+            );
+        }
+
+        if ($this->statusFilter !== '') {
+            $status = DomainStatus::tryFrom($this->statusFilter);
+            if ($status !== null) {
+                $domains = $domains->filter(
+                    fn (DomainInfo $info) => $info->status === $status
+                );
+            }
+        }
+
+        if ($this->typeFilter !== '') {
+            $domains = $domains->filter(
+                fn (DomainInfo $info) => $info->type->value === $this->typeFilter
+            );
+        }
+
+        return $domains->sortBy('displayName')->values();
+    }
+
+    /**
+     * Get summary statistics for the module overview.
+     *
+     * @return array<string, int>
+     */
+    public function getStatsProperty(): array
+    {
+        $domains = $this->getDomainManager()->getAvailableDomains();
+
+        return [
+            'total'     => $domains->count(),
+            'installed' => $domains->filter(fn (DomainInfo $info) => $info->status === DomainStatus::INSTALLED)->count(),
+            'available' => $domains->filter(fn (DomainInfo $info) => $info->status === DomainStatus::AVAILABLE)->count(),
+            'disabled'  => $domains->filter(fn (DomainInfo $info) => $info->status === DomainStatus::DISABLED)->count(),
+            'core'      => $domains->filter(fn (DomainInfo $info) => $info->type->isRequired())->count(),
+            'optional'  => $domains->filter(fn (DomainInfo $info) => ! $info->type->isRequired())->count(),
+        ];
+    }
+
+    /**
+     * Check if a domain has declared routes.
+     */
+    public function hasRoutes(DomainInfo $info): bool
+    {
+        $manifests = $this->getDomainManager()->loadAllManifests();
+
+        if (! isset($manifests[$info->name])) {
+            return false;
+        }
+
+        return $manifests[$info->name]->getPath('routes') !== null;
+    }
+
+    /**
+     * Enable a disabled domain.
+     */
+    public function enableModule(string $domain): void
+    {
+        try {
+            $result = $this->getDomainManager()->enable($domain);
+
+            if ($result->success) {
+                Notification::make()
+                    ->title('Module Enabled')
+                    ->body("Successfully enabled {$domain}.")
+                    ->success()
+                    ->send();
+
+                Log::info('Module enabled via admin panel', [
+                    'domain'   => $domain,
+                    'user'     => auth()->user()->email ?? 'system',
+                    'warnings' => $result->warnings,
+                ]);
+            } else {
+                Notification::make()
+                    ->title('Enable Failed')
+                    ->body(implode('. ', $result->errors))
+                    ->danger()
+                    ->send();
+            }
+        } catch (Exception $e) {
+            Notification::make()
+                ->title('Error')
+                ->body("Failed to enable module: {$e->getMessage()}")
+                ->danger()
+                ->send();
+
+            Log::error('Module enable failed', [
+                'domain' => $domain,
+                'error'  => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Disable an active domain.
+     */
+    public function disableModule(string $domain): void
+    {
+        try {
+            $result = $this->getDomainManager()->disable($domain);
+
+            if ($result->success) {
+                Notification::make()
+                    ->title('Module Disabled')
+                    ->body("Successfully disabled {$domain}. Migrations are preserved.")
+                    ->success()
+                    ->send();
+
+                Log::info('Module disabled via admin panel', [
+                    'domain'   => $domain,
+                    'user'     => auth()->user()->email ?? 'system',
+                    'warnings' => $result->warnings,
+                ]);
+            } else {
+                Notification::make()
+                    ->title('Disable Failed')
+                    ->body(implode('. ', $result->errors))
+                    ->danger()
+                    ->send();
+            }
+        } catch (Exception $e) {
+            Notification::make()
+                ->title('Error')
+                ->body("Failed to disable module: {$e->getMessage()}")
+                ->danger()
+                ->send();
+
+            Log::error('Module disable failed', [
+                'domain' => $domain,
+                'error'  => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Verify a domain's health and configuration.
+     */
+    public function verifyModule(string $domain): void
+    {
+        try {
+            $result = $this->getDomainManager()->verify($domain);
+
+            if ($result->valid) {
+                $totalChecks = count($result->checks);
+                $message = "Verified: {$result->getPassedCount()}/{$totalChecks} checks passed.";
+
+                if (! empty($result->warnings)) {
+                    $message .= ' Warnings: ' . implode(', ', $result->warnings);
+                }
+
+                Notification::make()
+                    ->title('Verification Passed')
+                    ->body($message)
+                    ->success()
+                    ->duration(8000)
+                    ->send();
+            } else {
+                $totalChecks = count($result->checks);
+                $message = "Failed: {$result->getPassedCount()}/{$totalChecks} checks passed.";
+
+                if (! empty($result->errors)) {
+                    $message .= ' Errors: ' . implode(', ', $result->errors);
+                }
+
+                Notification::make()
+                    ->title('Verification Failed')
+                    ->body($message)
+                    ->danger()
+                    ->duration(10000)
+                    ->send();
+            }
+
+            Log::info('Module verified via admin panel', [
+                'domain' => $domain,
+                'valid'  => $result->valid,
+                'passed' => $result->getPassedCount(),
+                'failed' => $result->getFailedCount(),
+                'user'   => auth()->user()->email ?? 'system',
+            ]);
+        } catch (Exception $e) {
+            Notification::make()
+                ->title('Error')
+                ->body("Failed to verify module: {$e->getMessage()}")
+                ->danger()
+                ->send();
+
+            Log::error('Module verification failed', [
+                'domain' => $domain,
+                'error'  => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Clear the domain manager cache and refresh the page.
+     */
+    public function refreshModules(): void
+    {
+        $this->getDomainManager()->clearCache();
+
+        Notification::make()
+            ->title('Cache Cleared')
+            ->body('Module cache has been refreshed.')
+            ->success()
+            ->send();
+    }
+
+    /**
+     * Reset all filters to defaults.
+     */
+    public function resetFilters(): void
+    {
+        $this->search = '';
+        $this->statusFilter = '';
+        $this->typeFilter = '';
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            \Filament\Actions\Action::make('refresh')
+                ->label('Refresh Cache')
+                ->icon('heroicon-o-arrow-path')
+                ->color('gray')
+                ->action(fn () => $this->refreshModules()),
+        ];
+    }
+}

--- a/app/Filament/Admin/Widgets/ModuleHealthWidget.php
+++ b/app/Filament/Admin/Widgets/ModuleHealthWidget.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Widgets;
+
+use App\Infrastructure\Domain\DomainManager;
+use App\Infrastructure\Domain\Enums\DomainStatus;
+use App\Infrastructure\Domain\Enums\DomainType;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\File;
+
+class ModuleHealthWidget extends BaseWidget
+{
+    protected static ?string $pollingInterval = '60s';
+
+    protected static ?int $sort = 3;
+
+    protected function getStats(): array
+    {
+        $data = Cache::remember('module_health_widget_stats', 60, function () {
+            return $this->computeStats();
+        });
+
+        return $this->buildStats($data);
+    }
+
+    /**
+     * Compute raw statistics from the domain system.
+     *
+     * @return array<string, mixed>
+     */
+    private function computeStats(): array
+    {
+        $domainManager = app(DomainManager::class);
+
+        // Count all domain directories (total modules, regardless of manifest)
+        $basePath = base_path('app/Domain');
+        $totalModules = File::isDirectory($basePath)
+            ? count(File::directories($basePath))
+            : 0;
+
+        // Load manifests and domain info
+        $manifests = $domainManager->loadAllManifests();
+        $domains = $domainManager->getAvailableDomains();
+
+        $withManifests = count($manifests);
+
+        // Count by status
+        $disabledCount = $domains->filter(
+            fn ($domain) => $domain->status === DomainStatus::DISABLED,
+        )->count();
+
+        $missingDepsCount = $domains->filter(
+            fn ($domain) => $domain->status === DomainStatus::MISSING_DEPS,
+        )->count();
+
+        // Count by type
+        $typeCounts = [];
+        foreach (DomainType::cases() as $type) {
+            $typeCounts[$type->value] = $domains->filter(
+                fn ($domain) => $domain->type === $type,
+            )->count();
+        }
+
+        return [
+            'total_modules'  => $totalModules,
+            'with_manifests' => $withManifests,
+            'disabled'       => $disabledCount,
+            'missing_deps'   => $missingDepsCount,
+            'type_counts'    => $typeCounts,
+        ];
+    }
+
+    /**
+     * Build Filament Stat objects from computed data.
+     *
+     * @param  array<string, mixed> $data
+     * @return array<Stat>
+     */
+    private function buildStats(array $data): array
+    {
+        $totalModules = (int) $data['total_modules'];
+        $withManifests = (int) $data['with_manifests'];
+        $disabled = (int) $data['disabled'];
+        $missingDeps = (int) $data['missing_deps'];
+        /** @var array<string, int> $typeCounts */
+        $typeCounts = $data['type_counts'];
+
+        // Stat 1: Total Modules
+        $totalStat = Stat::make('Total Modules', (string) $totalModules)
+            ->description('Domain directories discovered')
+            ->descriptionIcon('heroicon-m-puzzle-piece')
+            ->color('primary');
+
+        // Stat 2: With Manifests
+        $manifestCoverage = $totalModules > 0
+            ? (int) round(($withManifests / $totalModules) * 100)
+            : 0;
+
+        $manifestColor = $manifestCoverage >= 90 ? 'success' : ($manifestCoverage >= 70 ? 'warning' : 'danger');
+
+        $manifestStat = Stat::make('With Manifests', (string) $withManifests)
+            ->description("{$manifestCoverage}% coverage")
+            ->descriptionIcon('heroicon-m-document-check')
+            ->color($manifestColor);
+
+        // Stat 3: Disabled
+        $disabledColor = $disabled === 0 ? 'success' : 'warning';
+        $disabledDescription = $missingDeps > 0
+            ? "{$missingDeps} with missing dependencies"
+            : 'All active modules healthy';
+
+        $disabledStat = Stat::make('Disabled', (string) $disabled)
+            ->description($disabledDescription)
+            ->descriptionIcon($disabled > 0 ? 'heroicon-m-pause-circle' : 'heroicon-m-check-circle')
+            ->color($missingDeps > 0 ? 'danger' : $disabledColor);
+
+        // Stat 4: Module Types breakdown
+        $typeParts = [];
+        foreach ($typeCounts as $type => $count) {
+            if ($count > 0) {
+                $typeParts[] = "{$count} " . ucfirst($type);
+            }
+        }
+
+        $typeBreakdown = implode(', ', $typeParts) ?: 'No modules';
+
+        $typeStat = Stat::make('Module Types', $typeBreakdown)
+            ->description('Distribution by domain type')
+            ->descriptionIcon('heroicon-m-squares-2x2')
+            ->color('info');
+
+        return [$totalStat, $manifestStat, $disabledStat, $typeStat];
+    }
+}

--- a/app/Http/Controllers/Api/ModuleController.php
+++ b/app/Http/Controllers/Api/ModuleController.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Infrastructure\Domain\DataObjects\DomainInfo;
+use App\Infrastructure\Domain\DomainManager;
+use App\Infrastructure\Domain\Enums\DomainStatus;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Module Management API Controller.
+ *
+ * Provides REST endpoints for managing FinAegis domain modules:
+ * listing, inspecting, enabling/disabling, and health verification.
+ */
+class ModuleController extends Controller
+{
+    public function __construct(
+        private readonly DomainManager $domainManager,
+    ) {
+    }
+
+    /**
+     * List all modules with optional status filter.
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $domains = $this->domainManager->getAvailableDomains();
+
+        // Apply status filter if provided
+        $statusFilter = $request->query('status');
+        if (is_string($statusFilter) && $statusFilter !== '') {
+            $status = DomainStatus::tryFrom($statusFilter);
+            if ($status === null) {
+                return response()->json([
+                    'error' => [
+                        'code'    => 'INVALID_FILTER',
+                        'message' => 'Invalid status filter. Allowed values: ' . implode(', ', DomainStatus::values()),
+                    ],
+                ], 422);
+            }
+
+            $domains = $domains->filter(fn (DomainInfo $info) => $info->status === $status)->values();
+        }
+
+        // Apply type filter if provided
+        $typeFilter = $request->query('type');
+        if (is_string($typeFilter) && $typeFilter !== '') {
+            $domains = $domains->filter(fn (DomainInfo $info) => $info->type->value === $typeFilter)->values();
+        }
+
+        $installed = $this->domainManager->getInstalledDomains();
+        $disabled = $this->domainManager->getDisabledDomains();
+
+        return response()->json([
+            'data' => $domains->map(fn (DomainInfo $info) => $info->toArray()),
+            'meta' => [
+                'total'     => $domains->count(),
+                'installed' => count($installed),
+                'disabled'  => count($disabled),
+                'statuses'  => DomainStatus::values(),
+            ],
+        ]);
+    }
+
+    /**
+     * Get detailed information about a single module.
+     */
+    public function show(string $name): JsonResponse
+    {
+        $domains = $this->domainManager->getAvailableDomains();
+        $normalizedName = $this->normalizeName($name);
+
+        $domain = $domains->first(fn (DomainInfo $info) => $info->name === $normalizedName);
+
+        if ($domain === null) {
+            return response()->json([
+                'error' => [
+                    'code'    => 'MODULE_NOT_FOUND',
+                    'message' => "Module '{$name}' not found",
+                ],
+            ], 404);
+        }
+
+        // Load manifest for detailed info
+        $manifests = $this->domainManager->loadAllManifests();
+        $manifest = $manifests[$normalizedName] ?? null;
+
+        // Run verification for health status
+        $verification = $this->domainManager->verify($name);
+
+        return response()->json([
+            'data' => [
+                'module'       => $domain->toArray(),
+                'manifest'     => $manifest?->toArray(),
+                'verification' => $verification->toArray(),
+            ],
+        ]);
+    }
+
+    /**
+     * Enable a disabled module.
+     *
+     * Requires admin privileges (enforced via route middleware).
+     */
+    public function enable(string $name): JsonResponse
+    {
+        $result = $this->domainManager->enable($name);
+
+        if (! $result->success) {
+            return response()->json([
+                'error' => [
+                    'code'    => 'ENABLE_FAILED',
+                    'message' => $result->getSummary(),
+                    'errors'  => $result->errors,
+                ],
+            ], 422);
+        }
+
+        return response()->json([
+            'data'    => $result->toArray(),
+            'message' => "Module '{$name}' enabled successfully",
+        ]);
+    }
+
+    /**
+     * Disable an active module.
+     *
+     * Requires admin privileges (enforced via route middleware).
+     * Core modules cannot be disabled.
+     */
+    public function disable(string $name): JsonResponse
+    {
+        $result = $this->domainManager->disable($name);
+
+        if (! $result->success) {
+            return response()->json([
+                'error' => [
+                    'code'    => 'DISABLE_FAILED',
+                    'message' => $result->getSummary(),
+                    'errors'  => $result->errors,
+                ],
+            ], 422);
+        }
+
+        return response()->json([
+            'data'    => $result->toArray(),
+            'message' => "Module '{$name}' disabled successfully",
+        ]);
+    }
+
+    /**
+     * Get overall module health summary across all domains.
+     */
+    public function health(): JsonResponse
+    {
+        $domains = $this->domainManager->getAvailableDomains();
+        $installed = $domains->filter(fn (DomainInfo $info) => $info->status === DomainStatus::INSTALLED);
+
+        $results = [];
+        $healthyCount = 0;
+        $unhealthyCount = 0;
+
+        foreach ($installed as $domain) {
+            $verification = $this->domainManager->verify($domain->name);
+            $results[] = [
+                'name'    => $domain->name,
+                'healthy' => $verification->valid,
+                'passed'  => $verification->getPassedCount(),
+                'failed'  => $verification->getFailedCount(),
+                'errors'  => $verification->errors,
+            ];
+
+            if ($verification->valid) {
+                $healthyCount++;
+            } else {
+                $unhealthyCount++;
+            }
+        }
+
+        $overallHealthy = $unhealthyCount === 0;
+
+        return response()->json([
+            'data' => [
+                'healthy' => $overallHealthy,
+                'modules' => $results,
+            ],
+            'meta' => [
+                'total_installed' => $installed->count(),
+                'healthy'         => $healthyCount,
+                'unhealthy'       => $unhealthyCount,
+                'checked_at'      => now()->toIso8601String(),
+            ],
+        ]);
+    }
+
+    /**
+     * Verify health of a specific module.
+     *
+     * Requires admin privileges (enforced via route middleware).
+     */
+    public function verify(string $name): JsonResponse
+    {
+        $verification = $this->domainManager->verify($name);
+
+        if (empty($verification->checks) && ! empty($verification->errors)) {
+            return response()->json([
+                'error' => [
+                    'code'    => 'MODULE_NOT_FOUND',
+                    'message' => "Module '{$name}' not found",
+                    'errors'  => $verification->errors,
+                ],
+            ], 404);
+        }
+
+        $statusCode = $verification->valid ? 200 : 503;
+
+        return response()->json([
+            'data' => $verification->toArray(),
+            'meta' => [
+                'summary'    => $verification->getSummary(),
+                'checked_at' => now()->toIso8601String(),
+            ],
+        ], $statusCode);
+    }
+
+    /**
+     * Normalize a module name to the full package format.
+     */
+    private function normalizeName(string $name): string
+    {
+        if (! str_contains($name, '/')) {
+            return "finaegis/{$name}";
+        }
+
+        return $name;
+    }
+}

--- a/resources/views/filament/admin/pages/modules.blade.php
+++ b/resources/views/filament/admin/pages/modules.blade.php
@@ -1,0 +1,268 @@
+<x-filament-panels::page>
+    <div class="space-y-6">
+        {{-- Summary Stats --}}
+        <div class="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-6">
+            <div class="rounded-xl bg-white p-4 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
+                <div class="text-sm font-medium text-gray-500 dark:text-gray-400">Total Modules</div>
+                <div class="mt-1 text-2xl font-bold text-gray-950 dark:text-white">{{ $this->stats['total'] }}</div>
+            </div>
+            <div class="rounded-xl bg-white p-4 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
+                <div class="text-sm font-medium text-gray-500 dark:text-gray-400">Installed</div>
+                <div class="mt-1 text-2xl font-bold text-success-600 dark:text-success-400">{{ $this->stats['installed'] }}</div>
+            </div>
+            <div class="rounded-xl bg-white p-4 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
+                <div class="text-sm font-medium text-gray-500 dark:text-gray-400">Available</div>
+                <div class="mt-1 text-2xl font-bold text-info-600 dark:text-info-400">{{ $this->stats['available'] }}</div>
+            </div>
+            <div class="rounded-xl bg-white p-4 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
+                <div class="text-sm font-medium text-gray-500 dark:text-gray-400">Disabled</div>
+                <div class="mt-1 text-2xl font-bold text-warning-600 dark:text-warning-400">{{ $this->stats['disabled'] }}</div>
+            </div>
+            <div class="rounded-xl bg-white p-4 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
+                <div class="text-sm font-medium text-gray-500 dark:text-gray-400">Core</div>
+                <div class="mt-1 text-2xl font-bold text-primary-600 dark:text-primary-400">{{ $this->stats['core'] }}</div>
+            </div>
+            <div class="rounded-xl bg-white p-4 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
+                <div class="text-sm font-medium text-gray-500 dark:text-gray-400">Optional</div>
+                <div class="mt-1 text-2xl font-bold text-gray-600 dark:text-gray-400">{{ $this->stats['optional'] }}</div>
+            </div>
+        </div>
+
+        {{-- Filters --}}
+        <div class="rounded-xl bg-white p-4 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
+            <div class="flex flex-col gap-4 sm:flex-row sm:items-end">
+                <div class="flex-1">
+                    <label for="search" class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Search</label>
+                    <input
+                        wire:model.live.debounce.300ms="search"
+                        id="search"
+                        type="text"
+                        placeholder="Search by name or description..."
+                        class="fi-input block w-full rounded-lg border-gray-300 shadow-sm transition duration-75 focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white sm:text-sm"
+                    />
+                </div>
+                <div class="w-full sm:w-48">
+                    <label for="statusFilter" class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Status</label>
+                    <select
+                        wire:model.live="statusFilter"
+                        id="statusFilter"
+                        class="fi-input block w-full rounded-lg border-gray-300 shadow-sm transition duration-75 focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white sm:text-sm"
+                    >
+                        <option value="">All Statuses</option>
+                        <option value="installed">Installed</option>
+                        <option value="available">Available</option>
+                        <option value="disabled">Disabled</option>
+                        <option value="missing_dependencies">Missing Dependencies</option>
+                    </select>
+                </div>
+                <div class="w-full sm:w-40">
+                    <label for="typeFilter" class="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300">Type</label>
+                    <select
+                        wire:model.live="typeFilter"
+                        id="typeFilter"
+                        class="fi-input block w-full rounded-lg border-gray-300 shadow-sm transition duration-75 focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white sm:text-sm"
+                    >
+                        <option value="">All Types</option>
+                        <option value="core">Core</option>
+                        <option value="optional">Optional</option>
+                    </select>
+                </div>
+                <div>
+                    <x-filament::button
+                        wire:click="resetFilters"
+                        color="gray"
+                        size="sm"
+                        icon="heroicon-m-x-mark"
+                    >
+                        Clear
+                    </x-filament::button>
+                </div>
+            </div>
+        </div>
+
+        {{-- Module Table --}}
+        <div class="rounded-xl bg-white shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
+            <div class="overflow-x-auto">
+                <table class="w-full table-auto divide-y divide-gray-200 dark:divide-gray-700">
+                    <thead class="bg-gray-50 dark:bg-gray-800">
+                        <tr>
+                            <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                                Module
+                            </th>
+                            <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                                Version
+                            </th>
+                            <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                                Type
+                            </th>
+                            <th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                                Status
+                            </th>
+                            <th class="px-4 py-3 text-center text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                                Deps
+                            </th>
+                            <th class="px-4 py-3 text-center text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                                Routes
+                            </th>
+                            <th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                                Actions
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
+                        @forelse ($this->modules as $module)
+                            <tr class="transition-colors hover:bg-gray-50 dark:hover:bg-gray-800/50" wire:key="module-{{ $module->name }}">
+                                {{-- Name & Description --}}
+                                <td class="px-4 py-3">
+                                    <div class="flex flex-col">
+                                        <span class="text-sm font-semibold text-gray-950 dark:text-white">
+                                            {{ $module->displayName }}
+                                        </span>
+                                        <span class="text-xs text-gray-500 dark:text-gray-400">
+                                            {{ $module->name }}
+                                        </span>
+                                        @if ($module->description)
+                                            <span class="mt-0.5 line-clamp-1 text-xs text-gray-400 dark:text-gray-500">
+                                                {{ $module->description }}
+                                            </span>
+                                        @endif
+                                    </div>
+                                </td>
+
+                                {{-- Version --}}
+                                <td class="px-4 py-3">
+                                    <span class="text-sm font-mono text-gray-700 dark:text-gray-300">
+                                        {{ $module->version }}
+                                    </span>
+                                </td>
+
+                                {{-- Type Badge --}}
+                                <td class="px-4 py-3">
+                                    @if ($module->type->value === 'core')
+                                        <span class="inline-flex items-center rounded-md bg-primary-50 px-2 py-1 text-xs font-medium text-primary-700 ring-1 ring-inset ring-primary-600/20 dark:bg-primary-400/10 dark:text-primary-400 dark:ring-primary-400/30">
+                                            Core
+                                        </span>
+                                    @else
+                                        <span class="inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 dark:bg-gray-400/10 dark:text-gray-400 dark:ring-gray-400/20">
+                                            Optional
+                                        </span>
+                                    @endif
+                                </td>
+
+                                {{-- Status Badge --}}
+                                <td class="px-4 py-3">
+                                    @switch($module->status->value)
+                                        @case('installed')
+                                            <span class="inline-flex items-center gap-x-1 rounded-md bg-success-50 px-2 py-1 text-xs font-medium text-success-700 ring-1 ring-inset ring-success-600/20 dark:bg-success-400/10 dark:text-success-400 dark:ring-success-400/30">
+                                                <x-heroicon-m-check-circle class="h-3.5 w-3.5" />
+                                                Installed
+                                            </span>
+                                            @break
+                                        @case('available')
+                                            <span class="inline-flex items-center gap-x-1 rounded-md bg-info-50 px-2 py-1 text-xs font-medium text-info-700 ring-1 ring-inset ring-info-600/20 dark:bg-info-400/10 dark:text-info-400 dark:ring-info-400/30">
+                                                <x-heroicon-m-arrow-down-tray class="h-3.5 w-3.5" />
+                                                Available
+                                            </span>
+                                            @break
+                                        @case('disabled')
+                                            <span class="inline-flex items-center gap-x-1 rounded-md bg-warning-50 px-2 py-1 text-xs font-medium text-warning-700 ring-1 ring-inset ring-warning-600/20 dark:bg-warning-400/10 dark:text-warning-400 dark:ring-warning-400/30">
+                                                <x-heroicon-m-pause-circle class="h-3.5 w-3.5" />
+                                                Disabled
+                                            </span>
+                                            @break
+                                        @case('missing_dependencies')
+                                            <span class="inline-flex items-center gap-x-1 rounded-md bg-danger-50 px-2 py-1 text-xs font-medium text-danger-700 ring-1 ring-inset ring-danger-600/20 dark:bg-danger-400/10 dark:text-danger-400 dark:ring-danger-400/30">
+                                                <x-heroicon-m-exclamation-triangle class="h-3.5 w-3.5" />
+                                                Missing Deps
+                                            </span>
+                                            @break
+                                    @endswitch
+                                </td>
+
+                                {{-- Dependencies Count --}}
+                                <td class="px-4 py-3 text-center">
+                                    @if (count($module->dependencies) > 0)
+                                        <span
+                                            class="text-sm text-gray-700 dark:text-gray-300"
+                                            title="{{ implode(', ', $module->dependencies) }}"
+                                            x-data x-tooltip.raw="{{ implode(', ', $module->dependencies) }}"
+                                        >
+                                            {{ count($module->dependencies) }}
+                                        </span>
+                                    @else
+                                        <span class="text-sm text-gray-400 dark:text-gray-600">0</span>
+                                    @endif
+                                </td>
+
+                                {{-- Has Routes --}}
+                                <td class="px-4 py-3 text-center">
+                                    @if ($this->hasRoutes($module))
+                                        <x-heroicon-m-check class="mx-auto h-5 w-5 text-success-500" />
+                                    @else
+                                        <x-heroicon-m-minus class="mx-auto h-5 w-5 text-gray-300 dark:text-gray-600" />
+                                    @endif
+                                </td>
+
+                                {{-- Actions --}}
+                                <td class="px-4 py-3 text-right">
+                                    <div class="flex items-center justify-end gap-1">
+                                        {{-- Verify Button --}}
+                                        <x-filament::button
+                                            wire:click="verifyModule('{{ $module->name }}')"
+                                            color="gray"
+                                            size="xs"
+                                            icon="heroicon-m-shield-check"
+                                            tooltip="Verify module health"
+                                        >
+                                            Verify
+                                        </x-filament::button>
+
+                                        @if ($module->status === \App\Infrastructure\Domain\Enums\DomainStatus::DISABLED)
+                                            {{-- Enable Button --}}
+                                            <x-filament::button
+                                                wire:click="enableModule('{{ $module->name }}')"
+                                                wire:confirm="Are you sure you want to enable this module?"
+                                                color="success"
+                                                size="xs"
+                                                icon="heroicon-m-play"
+                                                tooltip="Enable this module"
+                                            >
+                                                Enable
+                                            </x-filament::button>
+                                        @elseif ($module->status === \App\Infrastructure\Domain\Enums\DomainStatus::INSTALLED && !$module->type->isRequired())
+                                            {{-- Disable Button (not for core domains) --}}
+                                            <x-filament::button
+                                                wire:click="disableModule('{{ $module->name }}')"
+                                                wire:confirm="Are you sure you want to disable this module? Migrations will be preserved."
+                                                color="warning"
+                                                size="xs"
+                                                icon="heroicon-m-pause"
+                                                tooltip="Disable this module"
+                                            >
+                                                Disable
+                                            </x-filament::button>
+                                        @endif
+                                    </div>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="7" class="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+                                    No modules found matching your criteria.
+                                </td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+
+            {{-- Table Footer --}}
+            <div class="border-t border-gray-200 px-4 py-3 dark:border-gray-700">
+                <p class="text-xs text-gray-500 dark:text-gray-400">
+                    Showing {{ $this->modules->count() }} of {{ $this->stats['total'] }} modules.
+                    Core domains cannot be disabled.
+                </p>
+            </div>
+        </div>
+    </div>
+</x-filament-panels::page>

--- a/routes/api-modules.php
+++ b/routes/api-modules.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\Api\ModuleController;
+use Illuminate\Support\Facades\Route;
+
+/*
+|--------------------------------------------------------------------------
+| Module Management API Routes
+|--------------------------------------------------------------------------
+|
+| Routes for the FinAegis module management system.
+| Provides endpoints for listing, inspecting, enabling/disabling,
+| and verifying health of domain modules.
+|
+*/
+
+Route::prefix('v2/modules')->name('api.modules.')->group(function () {
+    Route::middleware(['auth:sanctum', 'check.token.expiration'])->group(function () {
+        Route::get('/', [ModuleController::class, 'index'])->name('index');
+        Route::get('/health', [ModuleController::class, 'health'])->name('health');
+        Route::get('/{name}', [ModuleController::class, 'show'])->name('show');
+
+        Route::middleware('is_admin')->group(function () {
+            Route::post('/{name}/enable', [ModuleController::class, 'enable'])->name('enable');
+            Route::post('/{name}/disable', [ModuleController::class, 'disable'])->name('disable');
+            Route::post('/{name}/verify', [ModuleController::class, 'verify'])->name('verify');
+        });
+    });
+});

--- a/routes/api.php
+++ b/routes/api.php
@@ -225,6 +225,9 @@ require __DIR__ . '/api/fraud.php';
 // Include enhanced regulatory routes
 require __DIR__ . '/api/regulatory.php';
 
+// Include module management API routes
+require __DIR__ . '/api-modules.php';
+
 /*
 |--------------------------------------------------------------------------
 | Domain Module Routes (v3.2.0)


### PR DESCRIPTION
## Summary
- **ModuleController** — REST API with 6 endpoints (`GET /api/v2/modules`, `GET /api/v2/modules/health`, `GET /api/v2/modules/{name}`, `POST /{name}/enable`, `POST /{name}/disable`, `POST /{name}/verify`) with auth + admin middleware
- **Filament Modules page** — Custom admin page at `/admin/modules` with search, status/type filters, enable/disable/verify actions, full dark mode support
- **ModuleHealthWidget** — Stats overview widget showing total modules, manifest coverage %, disabled count, and type breakdown

## Details
Phase 3 of the v3.2.0 Production Readiness & Plugin Architecture plan. Builds on the module manifest system (Phase 1, PR #466) and modular route loading (Phase 2, PR #467).

### New Files
| File | Purpose |
|------|---------|
| `app/Http/Controllers/Api/ModuleController.php` | REST API controller (6 endpoints) |
| `routes/api-modules.php` | Route definitions under `v2/modules` |
| `app/Filament/Admin/Pages/Modules.php` | Filament admin page with Livewire |
| `resources/views/filament/admin/pages/modules.blade.php` | Blade view with Tailwind CSS |
| `app/Filament/Admin/Widgets/ModuleHealthWidget.php` | Stats overview widget |

### Route Count
- Before: 1131 routes
- After: 1138 routes (+6 API + 1 Filament page)

## Test plan
- [x] PHPStan passes with zero errors
- [x] php-cs-fixer applied
- [x] Full test suite: 2294 passed (3 pre-existing failures unchanged)
- [x] Route count verified: 1138 total (1131 + 7 new)
- [x] All 7 new routes registered correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)