### PR TITLE
feat: Add real-time event store dashboards (v3.3.0 Phase 2)

### DIFF
--- a/app/Domain/Monitoring/Events/Broadcasting/MonitoringMetricsUpdated.php
+++ b/app/Domain/Monitoring/Events/Broadcasting/MonitoringMetricsUpdated.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Monitoring\Events\Broadcasting;
+
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class MonitoringMetricsUpdated implements ShouldBroadcast
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    /**
+     * @param  array<string, mixed> $metrics
+     */
+    public function __construct(
+        public readonly array $metrics,
+        public readonly string $source = 'system',
+    ) {
+    }
+
+    /**
+     * @return array<Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new Channel('monitoring'),
+        ];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'metrics.updated';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        return [
+            'metrics'   => $this->metrics,
+            'source'    => $this->source,
+            'timestamp' => now()->toIso8601String(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Pages/EventStoreDashboard.php
+++ b/app/Filament/Admin/Pages/EventStoreDashboard.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Pages;
+
+use Filament\Pages\Page;
+
+class EventStoreDashboard extends Page
+{
+    protected static ?string $navigationIcon = 'heroicon-o-circle-stack';
+
+    protected static ?string $navigationGroup = 'System';
+
+    protected static ?int $navigationSort = 11;
+
+    protected static ?string $title = 'Event Store Dashboard';
+
+    protected static string $view = 'filament.admin.pages.event-store-dashboard';
+
+    protected function getHeaderWidgets(): array
+    {
+        return [
+            \App\Filament\Admin\Widgets\EventStoreStatsWidget::class,
+            \App\Filament\Admin\Widgets\EventStoreThroughputWidget::class,
+            \App\Filament\Admin\Widgets\AggregateHealthWidget::class,
+            \App\Filament\Admin\Widgets\SystemMetricsWidget::class,
+        ];
+    }
+
+    public function getHeaderWidgetsColumns(): int|string|array
+    {
+        return 2;
+    }
+}

--- a/app/Filament/Admin/Widgets/AggregateHealthWidget.php
+++ b/app/Filament/Admin/Widgets/AggregateHealthWidget.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Widgets;
+
+use App\Domain\Monitoring\Services\EventStoreService;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+use Illuminate\Support\Facades\Cache;
+
+class AggregateHealthWidget extends BaseWidget
+{
+    protected static ?string $pollingInterval = '60s';
+
+    protected static ?int $sort = 3;
+
+    protected function getStats(): array
+    {
+        $data = Cache::remember('aggregate_health_widget', 60, function () {
+            return $this->computeStats();
+        });
+
+        return $this->buildStats($data);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function computeStats(): array
+    {
+        $service = app(EventStoreService::class);
+        $domainMap = $service->getDomainTableMap();
+        $domainCounts = $service->getPerDomainEventCounts();
+
+        $domainsWithSnapshots = 0;
+        $domainsTotal = 0;
+
+        foreach ($domainMap as $domain => $tables) {
+            $domainsTotal++;
+            if ($tables['snapshot_table'] !== null) {
+                $domainsWithSnapshots++;
+            }
+        }
+
+        $topDomains = array_slice($domainCounts, 0, 5, true);
+
+        return [
+            'domains_total'          => $domainsTotal,
+            'domains_with_snapshots' => $domainsWithSnapshots,
+            'top_domains'            => $topDomains,
+            'total_domain_events'    => array_sum($domainCounts),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed> $data
+     * @return array<Stat>
+     */
+    private function buildStats(array $data): array
+    {
+        $domainsTotal = (int) ($data['domains_total'] ?? 0);
+        $domainsWithSnapshots = (int) ($data['domains_with_snapshots'] ?? 0);
+
+        /** @var array<string, int> $topDomains */
+        $topDomains = $data['top_domains'] ?? [];
+        $topParts = [];
+        foreach ($topDomains as $domain => $count) {
+            $topParts[] = "{$domain}: " . number_format($count);
+        }
+        $topDescription = implode(', ', $topParts) ?: 'No events';
+
+        $snapshotCoverage = $domainsTotal > 0
+            ? (int) round(($domainsWithSnapshots / $domainsTotal) * 100)
+            : 0;
+
+        return [
+            Stat::make('Domains Tracked', (string) $domainsTotal)
+                ->description('Event-sourced domains')
+                ->descriptionIcon('heroicon-m-squares-2x2')
+                ->color('primary'),
+
+            Stat::make('Snapshot Coverage', "{$domainsWithSnapshots}/{$domainsTotal}")
+                ->description("{$snapshotCoverage}% of domains have snapshots")
+                ->descriptionIcon('heroicon-m-camera')
+                ->color($snapshotCoverage >= 50 ? 'success' : 'warning'),
+
+            Stat::make('Top Domains', $topDescription !== 'No events' ? (string) count($topDomains) . ' active' : 'None')
+                ->description($topDescription)
+                ->descriptionIcon('heroicon-m-chart-bar')
+                ->color('info'),
+        ];
+    }
+}

--- a/app/Filament/Admin/Widgets/EventStoreStatsWidget.php
+++ b/app/Filament/Admin/Widgets/EventStoreStatsWidget.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Widgets;
+
+use App\Domain\Monitoring\Services\EventStoreService;
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+use Illuminate\Support\Facades\Cache;
+
+class EventStoreStatsWidget extends BaseWidget
+{
+    protected static ?string $pollingInterval = '30s';
+
+    protected static ?int $sort = 1;
+
+    protected function getStats(): array
+    {
+        $data = Cache::remember('event_store_stats_widget', 30, function () {
+            return $this->computeStats();
+        });
+
+        return $this->buildStats($data);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function computeStats(): array
+    {
+        $service = app(EventStoreService::class);
+        $allStats = $service->getAllStats();
+
+        return $allStats['summary'] ?? [
+            'total_events'     => 0,
+            'total_aggregates' => 0,
+            'total_snapshots'  => 0,
+            'events_today'     => 0,
+            'domain_count'     => 0,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed> $data
+     * @return array<Stat>
+     */
+    private function buildStats(array $data): array
+    {
+        $totalEvents = (int) ($data['total_events'] ?? 0);
+        $totalAggregates = (int) ($data['total_aggregates'] ?? 0);
+        $totalSnapshots = (int) ($data['total_snapshots'] ?? 0);
+        $eventsToday = (int) ($data['events_today'] ?? 0);
+
+        return [
+            Stat::make('Total Events', number_format($totalEvents))
+                ->description('Across all event tables')
+                ->descriptionIcon('heroicon-m-circle-stack')
+                ->color('primary'),
+
+            Stat::make('Unique Aggregates', number_format($totalAggregates))
+                ->description('Active aggregate roots')
+                ->descriptionIcon('heroicon-m-cube')
+                ->color('success'),
+
+            Stat::make('Snapshots', number_format($totalSnapshots))
+                ->description('Stored snapshots')
+                ->descriptionIcon('heroicon-m-camera')
+                ->color('info'),
+
+            Stat::make('Events Today', number_format($eventsToday))
+                ->description('New events recorded today')
+                ->descriptionIcon('heroicon-m-bolt')
+                ->color($eventsToday > 0 ? 'success' : 'gray'),
+        ];
+    }
+}

--- a/app/Filament/Admin/Widgets/EventStoreThroughputWidget.php
+++ b/app/Filament/Admin/Widgets/EventStoreThroughputWidget.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Widgets;
+
+use App\Domain\Monitoring\Services\EventStoreService;
+use Filament\Widgets\ChartWidget;
+use Illuminate\Support\Facades\Cache;
+
+class EventStoreThroughputWidget extends ChartWidget
+{
+    protected static ?string $heading = 'Event Throughput (Events/Minute)';
+
+    protected static ?string $pollingInterval = '10s';
+
+    protected static ?int $sort = 2;
+
+    protected static ?string $maxHeight = '300px';
+
+    protected function getData(): array
+    {
+        $data = Cache::remember('event_store_throughput_widget', 10, function () {
+            $service = app(EventStoreService::class);
+
+            return $service->getEventThroughput('stored_events', 60);
+        });
+
+        $labels = array_keys($data);
+        $values = array_values($data);
+
+        // Show at most last 30 data points
+        if (count($labels) > 30) {
+            $labels = array_slice($labels, -30);
+            $values = array_slice($values, -30);
+        }
+
+        // Shorten labels to just time portion
+        $labels = array_map(function (string $label) {
+            $parts = explode(' ', $label);
+
+            return $parts[1] ?? $label;
+        }, $labels);
+
+        return [
+            'datasets' => [
+                [
+                    'label'           => 'Events/min',
+                    'data'            => $values,
+                    'borderColor'     => '#3b82f6',
+                    'backgroundColor' => 'rgba(59, 130, 246, 0.1)',
+                    'fill'            => true,
+                    'tension'         => 0.4,
+                ],
+            ],
+            'labels' => $labels,
+        ];
+    }
+
+    protected function getType(): string
+    {
+        return 'line';
+    }
+}

--- a/app/Filament/Admin/Widgets/SystemMetricsWidget.php
+++ b/app/Filament/Admin/Widgets/SystemMetricsWidget.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Widgets;
+
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+use Illuminate\Support\Facades\Cache;
+
+class SystemMetricsWidget extends BaseWidget
+{
+    protected static ?string $pollingInterval = '10s';
+
+    protected static ?int $sort = 4;
+
+    protected function getStats(): array
+    {
+        $data = Cache::remember('system_metrics_widget', 10, function () {
+            return $this->computeStats();
+        });
+
+        return $this->buildStats($data);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function computeStats(): array
+    {
+        $httpTotal = (int) Cache::get('metrics:http:requests:total', 0);
+        $httpErrors = (int) Cache::get('metrics:http:requests:errors', 0);
+        $cacheHits = (int) Cache::get('metrics:cache:hits', 0);
+        $cacheMisses = (int) Cache::get('metrics:cache:misses', 0);
+        $queueProcessed = (int) Cache::get('metrics:queue:processed', 0);
+        $queueFailed = (int) Cache::get('metrics:queue:failed', 0);
+        $eventsTotal = (int) Cache::get('metrics:events:total', 0);
+
+        return [
+            'http_total'      => $httpTotal,
+            'http_errors'     => $httpErrors,
+            'cache_hits'      => $cacheHits,
+            'cache_misses'    => $cacheMisses,
+            'queue_processed' => $queueProcessed,
+            'queue_failed'    => $queueFailed,
+            'events_total'    => $eventsTotal,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed> $data
+     * @return array<Stat>
+     */
+    private function buildStats(array $data): array
+    {
+        $httpTotal = (int) ($data['http_total'] ?? 0);
+        $httpErrors = (int) ($data['http_errors'] ?? 0);
+        $cacheHits = (int) ($data['cache_hits'] ?? 0);
+        $cacheMisses = (int) ($data['cache_misses'] ?? 0);
+        $eventsTotal = (int) ($data['events_total'] ?? 0);
+
+        $cacheTotal = $cacheHits + $cacheMisses;
+        $cacheHitRate = $cacheTotal > 0 ? round(($cacheHits / $cacheTotal) * 100) : 0;
+        $errorRate = $httpTotal > 0 ? round(($httpErrors / $httpTotal) * 100, 1) : 0;
+
+        return [
+            Stat::make('HTTP Requests', number_format($httpTotal))
+                ->description($httpErrors > 0 ? "{$errorRate}% error rate" : 'No errors')
+                ->descriptionIcon('heroicon-m-globe-alt')
+                ->color($errorRate > 5 ? 'danger' : ($errorRate > 1 ? 'warning' : 'success')),
+
+            Stat::make('Cache Hit Rate', "{$cacheHitRate}%")
+                ->description("{$cacheHits} hits / {$cacheMisses} misses")
+                ->descriptionIcon('heroicon-m-bolt')
+                ->color($cacheHitRate >= 80 ? 'success' : ($cacheHitRate >= 50 ? 'warning' : 'danger')),
+
+            Stat::make('Business Events', number_format($eventsTotal))
+                ->description('Domain events recorded')
+                ->descriptionIcon('heroicon-m-signal')
+                ->color('primary'),
+        ];
+    }
+}

--- a/config/websocket.php
+++ b/config/websocket.php
@@ -158,6 +158,16 @@ return [
                 'merkle.updated',
             ],
         ],
+
+        // Monitoring & observability (v3.3.0)
+        'monitoring' => [
+            'suffix' => 'monitoring',
+            'events' => [
+                'metrics.updated',
+                'health.changed',
+                'alert.triggered',
+            ],
+        ],
     ],
 
     /*

--- a/resources/views/filament/admin/pages/event-store-dashboard.blade.php
+++ b/resources/views/filament/admin/pages/event-store-dashboard.blade.php
@@ -1,0 +1,10 @@
+<x-filament-panels::page>
+    <div class="space-y-6">
+        <div class="rounded-xl bg-white p-4 shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10">
+            <h3 class="text-lg font-semibold text-gray-950 dark:text-white">Event Store Overview</h3>
+            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                Monitor event sourcing infrastructure, aggregate health, and system metrics in real-time.
+            </p>
+        </div>
+    </div>
+</x-filament-panels::page>

--- a/tests/Filament/Admin/Pages/EventStoreDashboardTest.php
+++ b/tests/Filament/Admin/Pages/EventStoreDashboardTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Admin\Pages\EventStoreDashboard;
+use Filament\Pages\Page;
+
+describe('EventStoreDashboard', function () {
+    it('extends Filament Page', function () {
+        $reflection = new ReflectionClass(EventStoreDashboard::class);
+        expect($reflection->isSubclassOf(Page::class))->toBeTrue();
+    });
+
+    it('has correct navigation icon', function () {
+        $reflection = new ReflectionClass(EventStoreDashboard::class);
+        $property = $reflection->getProperty('navigationIcon');
+        $property->setAccessible(true);
+        expect($property->getValue())->toBe('heroicon-o-circle-stack');
+    });
+
+    it('has correct navigation group', function () {
+        $reflection = new ReflectionClass(EventStoreDashboard::class);
+        $property = $reflection->getProperty('navigationGroup');
+        $property->setAccessible(true);
+        expect($property->getValue())->toBe('System');
+    });
+
+    it('has correct navigation sort', function () {
+        $reflection = new ReflectionClass(EventStoreDashboard::class);
+        $property = $reflection->getProperty('navigationSort');
+        $property->setAccessible(true);
+        expect($property->getValue())->toBe(11);
+    });
+
+    it('has correct view', function () {
+        $reflection = new ReflectionClass(EventStoreDashboard::class);
+        $property = $reflection->getProperty('view');
+        $property->setAccessible(true);
+        expect($property->getValue())->toBe('filament.admin.pages.event-store-dashboard');
+    });
+
+    it('has getHeaderWidgets method', function () {
+        expect(method_exists(EventStoreDashboard::class, 'getHeaderWidgets'))->toBeTrue();
+    });
+
+    it('has getHeaderWidgetsColumns method', function () {
+        expect(method_exists(EventStoreDashboard::class, 'getHeaderWidgetsColumns'))->toBeTrue();
+    });
+});

--- a/tests/Filament/Admin/Widgets/EventStoreWidgetsTest.php
+++ b/tests/Filament/Admin/Widgets/EventStoreWidgetsTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Monitoring\Events\Broadcasting\MonitoringMetricsUpdated;
+use App\Filament\Admin\Widgets\AggregateHealthWidget;
+use App\Filament\Admin\Widgets\EventStoreStatsWidget;
+use App\Filament\Admin\Widgets\EventStoreThroughputWidget;
+use App\Filament\Admin\Widgets\SystemMetricsWidget;
+use Filament\Widgets\ChartWidget;
+use Filament\Widgets\StatsOverviewWidget;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+describe('EventStoreStatsWidget', function () {
+    it('extends StatsOverviewWidget', function () {
+        $reflection = new ReflectionClass(EventStoreStatsWidget::class);
+        expect($reflection->isSubclassOf(StatsOverviewWidget::class))->toBeTrue();
+    });
+
+    it('has 30s polling interval', function () {
+        $reflection = new ReflectionClass(EventStoreStatsWidget::class);
+        $property = $reflection->getProperty('pollingInterval');
+        $property->setAccessible(true);
+        expect($property->getValue())->toBe('30s');
+    });
+
+    it('has getStats method', function () {
+        expect(method_exists(EventStoreStatsWidget::class, 'getStats'))->toBeTrue();
+    });
+
+    it('has sort order 1', function () {
+        $reflection = new ReflectionClass(EventStoreStatsWidget::class);
+        $property = $reflection->getProperty('sort');
+        $property->setAccessible(true);
+        expect($property->getValue())->toBe(1);
+    });
+});
+
+describe('EventStoreThroughputWidget', function () {
+    it('extends ChartWidget', function () {
+        $reflection = new ReflectionClass(EventStoreThroughputWidget::class);
+        expect($reflection->isSubclassOf(ChartWidget::class))->toBeTrue();
+    });
+
+    it('has 10s polling interval', function () {
+        $reflection = new ReflectionClass(EventStoreThroughputWidget::class);
+        $property = $reflection->getProperty('pollingInterval');
+        $property->setAccessible(true);
+        expect($property->getValue())->toBe('10s');
+    });
+
+    it('has correct heading', function () {
+        $reflection = new ReflectionClass(EventStoreThroughputWidget::class);
+        $property = $reflection->getProperty('heading');
+        $property->setAccessible(true);
+        expect($property->getValue())->toBe('Event Throughput (Events/Minute)');
+    });
+
+    it('has getData method', function () {
+        expect(method_exists(EventStoreThroughputWidget::class, 'getData'))->toBeTrue();
+    });
+
+    it('has getType method', function () {
+        expect(method_exists(EventStoreThroughputWidget::class, 'getType'))->toBeTrue();
+    });
+});
+
+describe('AggregateHealthWidget', function () {
+    it('extends StatsOverviewWidget', function () {
+        $reflection = new ReflectionClass(AggregateHealthWidget::class);
+        expect($reflection->isSubclassOf(StatsOverviewWidget::class))->toBeTrue();
+    });
+
+    it('has 60s polling interval', function () {
+        $reflection = new ReflectionClass(AggregateHealthWidget::class);
+        $property = $reflection->getProperty('pollingInterval');
+        $property->setAccessible(true);
+        expect($property->getValue())->toBe('60s');
+    });
+
+    it('has getStats method', function () {
+        expect(method_exists(AggregateHealthWidget::class, 'getStats'))->toBeTrue();
+    });
+});
+
+describe('SystemMetricsWidget', function () {
+    it('extends StatsOverviewWidget', function () {
+        $reflection = new ReflectionClass(SystemMetricsWidget::class);
+        expect($reflection->isSubclassOf(StatsOverviewWidget::class))->toBeTrue();
+    });
+
+    it('has 10s polling interval', function () {
+        $reflection = new ReflectionClass(SystemMetricsWidget::class);
+        $property = $reflection->getProperty('pollingInterval');
+        $property->setAccessible(true);
+        expect($property->getValue())->toBe('10s');
+    });
+
+    it('has getStats method', function () {
+        expect(method_exists(SystemMetricsWidget::class, 'getStats'))->toBeTrue();
+    });
+});
+
+describe('MonitoringMetricsUpdated', function () {
+    it('implements ShouldBroadcast', function () {
+        $reflection = new ReflectionClass(MonitoringMetricsUpdated::class);
+        expect($reflection->implementsInterface(ShouldBroadcast::class))->toBeTrue();
+    });
+
+    it('has metrics and source properties', function () {
+        $event = new MonitoringMetricsUpdated(['cpu' => 45.0], 'test');
+        expect($event->metrics)->toBe(['cpu' => 45.0]);
+        expect($event->source)->toBe('test');
+    });
+
+    it('has broadcastOn method', function () {
+        $event = new MonitoringMetricsUpdated(['test' => 1]);
+        $channels = $event->broadcastOn();
+        expect($channels)->toBeArray();
+        expect($channels[0])->toBeInstanceOf(Channel::class);
+        expect($channels[0]->name)->toBe('monitoring');
+    });
+
+    it('broadcasts as metrics.updated', function () {
+        $event = new MonitoringMetricsUpdated(['test' => 1]);
+        expect($event->broadcastAs())->toBe('metrics.updated');
+    });
+
+    it('includes metrics in broadcast data', function () {
+        $metrics = ['cpu' => 45.0, 'memory' => 78.5];
+        $event = new MonitoringMetricsUpdated($metrics, 'test-source');
+        $data = $event->broadcastWith();
+        expect($data)->toHaveKey('metrics');
+        expect($data)->toHaveKey('source');
+        expect($data)->toHaveKey('timestamp');
+        expect($data['metrics'])->toBe($metrics);
+        expect($data['source'])->toBe('test-source');
+    });
+
+    it('defaults source to system', function () {
+        $event = new MonitoringMetricsUpdated(['test' => 1]);
+        expect($event->source)->toBe('system');
+    });
+});


### PR DESCRIPTION
## Summary
- Add `EventStoreDashboard` Filament page (System group, navigation sort 11)
- Add 4 widgets: EventStoreStats (30s), EventStoreThroughput chart (10s), AggregateHealth (60s), SystemMetrics (10s)
- Add `MonitoringMetricsUpdated` broadcast event on `monitoring` WebSocket channel
- Add monitoring channel to websocket config with metrics.updated, health.changed, alert.triggered events

## Test plan
- [x] 28 tests pass covering all widgets, dashboard page, broadcast event
- [x] Widgets use `Cache::remember()` with staggered TTLs (10-60s)
- [x] MonitoringMetricsUpdated broadcasts on correct channel with correct data
- [x] WebSocket config includes monitoring channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)