### PR TITLE
feat: Add structured JSON logging with trace correlation (v3.3.0 Phase 3)

### DIFF
--- a/app/Domain/Shared/Traits/LogsWithDomainContext.php
+++ b/app/Domain/Shared/Traits/LogsWithDomainContext.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Shared\Traits;
+
+use Illuminate\Support\Facades\Log;
+
+trait LogsWithDomainContext
+{
+    /**
+     * Get the domain name from the class namespace.
+     */
+    protected function getDomainName(): string
+    {
+        $namespace = static::class;
+
+        if (preg_match('/App\\\\Domain\\\\([^\\\\]+)\\\\/', $namespace, $matches)) {
+            return $matches[1];
+        }
+
+        return 'Unknown';
+    }
+
+    /**
+     * Log a message with domain context.
+     *
+     * @param  array<string, mixed> $context
+     */
+    protected function logWithDomain(string $level, string $message, array $context = []): void
+    {
+        $context['domain'] = $this->getDomainName();
+        $context['service'] = class_basename(static::class);
+
+        Log::log($level, $message, $context);
+    }
+
+    /**
+     * Log a debug message with domain context.
+     *
+     * @param  array<string, mixed> $context
+     */
+    protected function logDebug(string $message, array $context = []): void
+    {
+        $this->logWithDomain('debug', $message, $context);
+    }
+
+    /**
+     * Log an info message with domain context.
+     *
+     * @param  array<string, mixed> $context
+     */
+    protected function logInfo(string $message, array $context = []): void
+    {
+        $this->logWithDomain('info', $message, $context);
+    }
+
+    /**
+     * Log a warning message with domain context.
+     *
+     * @param  array<string, mixed> $context
+     */
+    protected function logWarning(string $message, array $context = []): void
+    {
+        $this->logWithDomain('warning', $message, $context);
+    }
+
+    /**
+     * Log an error message with domain context.
+     *
+     * @param  array<string, mixed> $context
+     */
+    protected function logError(string $message, array $context = []): void
+    {
+        $this->logWithDomain('error', $message, $context);
+    }
+}

--- a/app/Http/Middleware/StructuredLoggingMiddleware.php
+++ b/app/Http/Middleware/StructuredLoggingMiddleware.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\Response;
+
+class StructuredLoggingMiddleware
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $requestId = (string) ($request->header('X-Request-ID') ?: Str::uuid());
+        $traceId = (string) ($request->header('X-Trace-ID') ?: Str::uuid());
+        $startTime = microtime(true);
+
+        // Attach identifiers to the request for downstream usage
+        $request->headers->set('X-Request-ID', $requestId);
+
+        // Push context to log stack
+        Log::shareContext([
+            'request_id' => $requestId,
+            'trace_id'   => $traceId,
+        ]);
+
+        Log::debug('Request started', [
+            'method' => $request->method(),
+            'path'   => $request->path(),
+            'ip'     => $request->ip(),
+        ]);
+
+        $response = $next($request);
+
+        $duration = round((microtime(true) - $startTime) * 1000, 2);
+        $statusCode = $response->getStatusCode();
+
+        // Add request ID to response
+        $response->headers->set('X-Request-ID', $requestId);
+
+        $logLevel = $statusCode >= 500 ? 'error' : 'debug';
+
+        Log::log($logLevel, 'Request completed', [
+            'method'      => $request->method(),
+            'path'        => $request->path(),
+            'status'      => $statusCode,
+            'duration_ms' => $duration,
+        ]);
+
+        return $response;
+    }
+}

--- a/app/Infrastructure/Logging/StructuredJsonFormatter.php
+++ b/app/Infrastructure/Logging/StructuredJsonFormatter.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Logging;
+
+use Monolog\Formatter\JsonFormatter;
+use Monolog\LogRecord;
+
+class StructuredJsonFormatter extends JsonFormatter
+{
+    /**
+     * Format a log record with structured context.
+     */
+    public function format(LogRecord $record): string
+    {
+        $data = [
+            'timestamp'  => $record->datetime->format('Y-m-d\TH:i:s.uP'),
+            'level'      => $record->level->getName(),
+            'message'    => $record->message,
+            'channel'    => $record->channel,
+            'hostname'   => gethostname() ?: 'unknown',
+            'request_id' => $record->extra['request_id'] ?? null,
+            'trace_id'   => $record->extra['trace_id'] ?? null,
+            'span_id'    => $record->extra['span_id'] ?? null,
+            'domain'     => $record->extra['domain'] ?? null,
+        ];
+
+        // Merge context data
+        if (! empty($record->context)) {
+            $data['context'] = $record->context;
+        }
+
+        // Merge extra data (excluding already-extracted fields)
+        $extraKeys = ['request_id', 'trace_id', 'span_id', 'domain'];
+        $extra = array_diff_key($record->extra, array_flip($extraKeys));
+        if (! empty($extra)) {
+            $data['extra'] = $extra;
+        }
+
+        // Remove null values for cleaner output
+        $data = array_filter($data, fn ($value) => $value !== null);
+
+        return $this->toJson($data) . "\n";
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -76,6 +76,8 @@ return Application::configure(basePath: dirname(__DIR__))
             'tenant' => App\Http\Middleware\InitializeTenancyByTeam::class,
             // Performance monitoring middleware
             'query.performance' => App\Http\Middleware\QueryPerformanceMiddleware::class,
+            // Structured logging middleware (v3.3.0)
+            'structured.logging' => App\Http\Middleware\StructuredLoggingMiddleware::class,
         ]);
 
         // Prepend CORS middleware to handle it before other middleware

--- a/config/logging.php
+++ b/config/logging.php
@@ -127,6 +127,17 @@ return [
             'path' => storage_path('logs/laravel.log'),
         ],
 
+        // Structured JSON logging (v3.3.0)
+        'structured' => [
+            'driver'  => 'monolog',
+            'handler' => StreamHandler::class,
+            'with'    => [
+                'stream' => storage_path('logs/structured.log'),
+            ],
+            'formatter' => App\Infrastructure\Logging\StructuredJsonFormatter::class,
+            'level'     => env('LOG_LEVEL', 'debug'),
+        ],
+
         // Audit log channel for financial operations and compliance
         'audit' => [
             'driver'               => 'daily',

--- a/config/monitoring.php
+++ b/config/monitoring.php
@@ -77,10 +77,13 @@ return [
     ],
 
     'logging' => [
-        'structured'       => env('STRUCTURED_LOGGING', true),
-        'include_trace_id' => env('LOG_TRACE_ID', true),
-        'include_span_id'  => env('LOG_SPAN_ID', true),
-        'elk'              => [
+        'structured'         => env('STRUCTURED_LOGGING', true),
+        'include_trace_id'   => env('LOG_TRACE_ID', true),
+        'include_span_id'    => env('LOG_SPAN_ID', true),
+        'include_request_id' => env('LOG_REQUEST_ID', true),
+        'include_domain'     => env('LOG_DOMAIN_CONTEXT', true),
+        'format'             => env('LOG_FORMAT', 'json'),
+        'elk'                => [
             'enabled'            => env('ELK_ENABLED', false),
             'elasticsearch_host' => env('ELASTICSEARCH_HOST', 'http://localhost:9200'),
             'logstash_host'      => env('LOGSTASH_HOST', 'localhost'),

--- a/tests/Domain/Shared/Traits/LogsWithDomainContextTest.php
+++ b/tests/Domain/Shared/Traits/LogsWithDomainContextTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Shared\Traits\LogsWithDomainContext;
+use Illuminate\Support\Facades\Log;
+
+// Create a test class that uses the trait, simulating a domain service
+$testClass = new class () {
+    use LogsWithDomainContext;
+
+    public function getTestDomain(): string
+    {
+        return $this->getDomainName();
+    }
+
+    public function testLogDebug(string $message, array $context = []): void
+    {
+        $this->logDebug($message, $context);
+    }
+
+    public function testLogInfo(string $message, array $context = []): void
+    {
+        $this->logInfo($message, $context);
+    }
+
+    public function testLogWarning(string $message, array $context = []): void
+    {
+        $this->logWarning($message, $context);
+    }
+
+    public function testLogError(string $message, array $context = []): void
+    {
+        $this->logError($message, $context);
+    }
+};
+
+describe('LogsWithDomainContext', function () use ($testClass) {
+    it('extracts domain name as Unknown for non-domain classes', function () use ($testClass) {
+        // Anonymous class won't match the App\Domain\X pattern
+        expect($testClass->getTestDomain())->toBe('Unknown');
+    });
+
+    it('logs debug with domain context', function () use ($testClass) {
+        Log::spy();
+
+        $testClass->testLogDebug('Test debug message', ['key' => 'value']);
+
+        Log::shouldHaveReceived('log')
+            ->withArgs(function ($level, $message, $context) {
+                return $level === 'debug'
+                    && $message === 'Test debug message'
+                    && isset($context['domain'])
+                    && isset($context['service'])
+                    && $context['key'] === 'value';
+            })
+            ->once();
+    });
+
+    it('logs info with domain context', function () use ($testClass) {
+        Log::spy();
+
+        $testClass->testLogInfo('Test info message');
+
+        Log::shouldHaveReceived('log')
+            ->withArgs(function ($level, $message, $context) {
+                return $level === 'info'
+                    && $message === 'Test info message'
+                    && isset($context['domain'])
+                    && isset($context['service']);
+            })
+            ->once();
+    });
+
+    it('logs warning with domain context', function () use ($testClass) {
+        Log::spy();
+
+        $testClass->testLogWarning('Test warning');
+
+        Log::shouldHaveReceived('log')
+            ->withArgs(fn ($level) => $level === 'warning')
+            ->once();
+    });
+
+    it('logs error with domain context', function () use ($testClass) {
+        Log::spy();
+
+        $testClass->testLogError('Test error');
+
+        Log::shouldHaveReceived('log')
+            ->withArgs(fn ($level) => $level === 'error')
+            ->once();
+    });
+
+    it('includes service class name in context', function () use ($testClass) {
+        Log::spy();
+
+        $testClass->testLogInfo('Service check');
+
+        Log::shouldHaveReceived('log')
+            ->withArgs(function ($level, $message, $context) {
+                return isset($context['service']) && is_string($context['service']);
+            })
+            ->once();
+    });
+});

--- a/tests/Http/Middleware/StructuredLoggingMiddlewareTest.php
+++ b/tests/Http/Middleware/StructuredLoggingMiddlewareTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Middleware\StructuredLoggingMiddleware;
+
+describe('StructuredLoggingMiddleware', function () {
+    it('exists and is a valid class', function () {
+        expect(class_exists(StructuredLoggingMiddleware::class))->toBeTrue();
+    });
+
+    it('has handle method', function () {
+        expect(method_exists(StructuredLoggingMiddleware::class, 'handle'))->toBeTrue();
+    });
+
+    it('handle method accepts request and closure', function () {
+        $reflection = new ReflectionMethod(StructuredLoggingMiddleware::class, 'handle');
+        $params = $reflection->getParameters();
+
+        expect($params)->toHaveCount(2);
+        expect($params[0]->getName())->toBe('request');
+        expect($params[1]->getName())->toBe('next');
+    });
+
+    it('returns Symfony Response type', function () {
+        $reflection = new ReflectionMethod(StructuredLoggingMiddleware::class, 'handle');
+        $returnType = $reflection->getReturnType();
+
+        expect($returnType)->not->toBeNull();
+        expect($returnType->getName())->toBe('Symfony\Component\HttpFoundation\Response');
+    });
+
+    it('is registered as structured.logging middleware alias', function () {
+        // Verify the middleware alias is registered in bootstrap/app.php
+        $content = file_get_contents(dirname(__DIR__, 3) . '/bootstrap/app.php');
+        expect($content)->toContain("'structured.logging'");
+        expect($content)->toContain('StructuredLoggingMiddleware');
+    });
+});

--- a/tests/Infrastructure/Logging/StructuredJsonFormatterTest.php
+++ b/tests/Infrastructure/Logging/StructuredJsonFormatterTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Infrastructure\Logging\StructuredJsonFormatter;
+use Monolog\Level;
+use Monolog\LogRecord;
+
+describe('StructuredJsonFormatter', function () {
+    it('formats log record as structured JSON', function () {
+        $formatter = new StructuredJsonFormatter();
+        $record = new LogRecord(
+            datetime: new DateTimeImmutable(),
+            channel: 'test',
+            level: Level::Info,
+            message: 'Test message',
+            context: ['key' => 'value'],
+            extra: ['request_id' => 'req-123', 'trace_id' => 'trace-456'],
+        );
+
+        $output = $formatter->format($record);
+        $decoded = json_decode($output, true);
+
+        expect($decoded)->toBeArray();
+        expect($decoded)->toHaveKey('timestamp');
+        expect($decoded)->toHaveKey('level');
+        expect($decoded)->toHaveKey('message');
+        expect($decoded)->toHaveKey('channel');
+        expect($decoded)->toHaveKey('hostname');
+        expect($decoded['level'])->toBe('INFO');
+        expect($decoded['message'])->toBe('Test message');
+        expect($decoded['channel'])->toBe('test');
+        expect($decoded['request_id'])->toBe('req-123');
+        expect($decoded['trace_id'])->toBe('trace-456');
+        expect($decoded['context'])->toBe(['key' => 'value']);
+    });
+
+    it('includes domain context when present', function () {
+        $formatter = new StructuredJsonFormatter();
+        $record = new LogRecord(
+            datetime: new DateTimeImmutable(),
+            channel: 'test',
+            level: Level::Warning,
+            message: 'Domain warning',
+            context: [],
+            extra: ['domain' => 'Account'],
+        );
+
+        $output = $formatter->format($record);
+        $decoded = json_decode($output, true);
+
+        expect($decoded['domain'])->toBe('Account');
+    });
+
+    it('excludes null values from output', function () {
+        $formatter = new StructuredJsonFormatter();
+        $record = new LogRecord(
+            datetime: new DateTimeImmutable(),
+            channel: 'test',
+            level: Level::Debug,
+            message: 'Minimal log',
+            context: [],
+            extra: [],
+        );
+
+        $output = $formatter->format($record);
+        $decoded = json_decode($output, true);
+
+        expect($decoded)->not->toHaveKey('request_id');
+        expect($decoded)->not->toHaveKey('trace_id');
+        expect($decoded)->not->toHaveKey('span_id');
+        expect($decoded)->not->toHaveKey('domain');
+        expect($decoded)->not->toHaveKey('context');
+    });
+
+    it('includes span_id when present', function () {
+        $formatter = new StructuredJsonFormatter();
+        $record = new LogRecord(
+            datetime: new DateTimeImmutable(),
+            channel: 'test',
+            level: Level::Info,
+            message: 'With span',
+            context: [],
+            extra: ['span_id' => 'span-789'],
+        );
+
+        $output = $formatter->format($record);
+        $decoded = json_decode($output, true);
+
+        expect($decoded['span_id'])->toBe('span-789');
+    });
+
+    it('preserves extra fields beyond standard ones', function () {
+        $formatter = new StructuredJsonFormatter();
+        $record = new LogRecord(
+            datetime: new DateTimeImmutable(),
+            channel: 'test',
+            level: Level::Info,
+            message: 'Extra fields',
+            context: [],
+            extra: ['request_id' => 'req-1', 'custom_field' => 'custom_value'],
+        );
+
+        $output = $formatter->format($record);
+        $decoded = json_decode($output, true);
+
+        expect($decoded['request_id'])->toBe('req-1');
+        expect($decoded['extra'])->toHaveKey('custom_field');
+        expect($decoded['extra']['custom_field'])->toBe('custom_value');
+    });
+
+    it('outputs valid JSON ending with newline', function () {
+        $formatter = new StructuredJsonFormatter();
+        $record = new LogRecord(
+            datetime: new DateTimeImmutable(),
+            channel: 'test',
+            level: Level::Info,
+            message: 'Newline test',
+            context: [],
+            extra: [],
+        );
+
+        $output = $formatter->format($record);
+
+        expect($output)->toEndWith("\n");
+        expect(json_decode(trim($output), true))->toBeArray();
+    });
+
+    it('formats timestamp in ISO 8601 with microseconds', function () {
+        $formatter = new StructuredJsonFormatter();
+        $record = new LogRecord(
+            datetime: new DateTimeImmutable('2026-02-12T10:00:00.123456Z'),
+            channel: 'test',
+            level: Level::Info,
+            message: 'Timestamp test',
+            context: [],
+            extra: [],
+        );
+
+        $output = $formatter->format($record);
+        $decoded = json_decode($output, true);
+
+        expect($decoded['timestamp'])->toContain('2026-02-12T10:00:00');
+    });
+});


### PR DESCRIPTION
## Summary
- Add `StructuredJsonFormatter` extending Monolog JsonFormatter with timestamp, trace_id, span_id, domain, request_id, hostname
- Add `StructuredLoggingMiddleware` generating request_id, logging request start/end, error-level for 5xx
- Add `LogsWithDomainContext` trait for domain services with auto domain name extraction from namespace
- Register `structured.logging` middleware alias in bootstrap/app.php
- Add `structured` log channel in logging.php, extend monitoring.php logging section

## Test plan
- [x] 18 tests pass covering formatter (7), middleware (5), and trait (6)
- [x] Formatter outputs valid JSON with ISO 8601 timestamps
- [x] Null values excluded from output for cleaner logs
- [x] Middleware registered as alias in bootstrap/app.php

🤖 Generated with [Claude Code](https://claude.com/claude-code)