### PR TITLE
fix: Resolve route conflicts and security-harden EventReplayCommand (v3.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the FinAegis Core Banking Platform will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.2] - 2026-02-12
+
+### Fixed
+- **Compliance routes**: Fixed `POST /api/compliance/cases` and `POST /api/compliance/alerts` mapping to non-existent `create` method — domain route file now correctly references `store` method
+- **TransactionMonitoring routes**: Fixed `GET /api/transaction-monitoring/patterns` and `GET /api/transaction-monitoring/thresholds` returning 404 — moved `/{id}` wildcard route after static routes to prevent route shadowing
+- **EventReplayCommand**: Added projector class namespace validation (must be `App\` namespace) and Projector subclass check to prevent arbitrary class instantiation
+- **EventReplayCommand**: Fixed `--domain` filter not being applied during replay — `resolveProjectors()` now filters projectors by domain namespace
+
+### Changed
+- `event:replay --projector` now validates class exists, is in `App\` namespace, and extends `Spatie\EventSourcing\EventHandlers\Projectors\Projector`
+- `event:replay --domain` now filters projectors to only replay those in the matching `App\Domain\{domain}\` namespace
+
 ## [3.3.1] - 2026-02-12
 
 ### Fixed

--- a/app/Domain/Compliance/Routes/api.php
+++ b/app/Domain/Compliance/Routes/api.php
@@ -13,7 +13,7 @@ Route::middleware('auth:sanctum', 'check.token.expiration')->prefix('compliance'
     // Compliance alerts
     Route::prefix('alerts')->group(function () {
         Route::get('/', [ComplianceAlertController::class, 'index']);
-        Route::post('/', [ComplianceAlertController::class, 'create']);
+        Route::post('/', [ComplianceAlertController::class, 'store']);
         Route::get('/statistics', [ComplianceAlertController::class, 'statistics']);
         Route::get('/trends', [ComplianceAlertController::class, 'trends']);
         Route::get('/{alert}', [ComplianceAlertController::class, 'show']);
@@ -29,7 +29,7 @@ Route::middleware('auth:sanctum', 'check.token.expiration')->prefix('compliance'
     // Compliance cases
     Route::prefix('cases')->group(function () {
         Route::get('/', [ComplianceCaseController::class, 'index']);
-        Route::post('/', [ComplianceCaseController::class, 'create']);
+        Route::post('/', [ComplianceCaseController::class, 'store']);
         Route::get('/{case}', [ComplianceCaseController::class, 'show']);
         Route::put('/{case}', [ComplianceCaseController::class, 'update']);
         Route::delete('/{case}', [ComplianceCaseController::class, 'destroy']);

--- a/routes/api/regulatory.php
+++ b/routes/api/regulatory.php
@@ -79,9 +79,6 @@ Route::middleware(['auth:sanctum', 'check.token.expiration'])->group(function ()
     // Transaction Monitoring
     Route::prefix('transaction-monitoring')->group(function () {
         Route::get('/', [TransactionMonitoringController::class, 'getMonitoredTransactions']);
-        Route::get('/{id}', [TransactionMonitoringController::class, 'getTransactionDetails']);
-        Route::post('/{id}/flag', [TransactionMonitoringController::class, 'flagTransaction']);
-        Route::post('/{id}/clear', [TransactionMonitoringController::class, 'clearTransaction']);
         Route::get('/rules', [TransactionMonitoringController::class, 'getRules']);
         Route::post('/rules', [TransactionMonitoringController::class, 'createRule']);
         Route::put('/rules/{id}', [TransactionMonitoringController::class, 'updateRule']);
@@ -92,6 +89,10 @@ Route::middleware(['auth:sanctum', 'check.token.expiration'])->group(function ()
         Route::post('/analyze/realtime', [TransactionMonitoringController::class, 'analyzeRealtime']);
         Route::post('/analyze/batch', [TransactionMonitoringController::class, 'analyzeBatch']);
         Route::get('/analysis/{analysisId}', [TransactionMonitoringController::class, 'getAnalysisStatus']);
+        // Parameterized routes must come AFTER static routes to avoid /{id} capturing /rules, /patterns, etc.
+        Route::get('/{id}', [TransactionMonitoringController::class, 'getTransactionDetails']);
+        Route::post('/{id}/flag', [TransactionMonitoringController::class, 'flagTransaction']);
+        Route::post('/{id}/clear', [TransactionMonitoringController::class, 'clearTransaction']);
     });
 
     // Audit Trail Management

--- a/tests/Console/Commands/EventReplayCommandTest.php
+++ b/tests/Console/Commands/EventReplayCommandTest.php
@@ -34,11 +34,16 @@ describe('EventReplayCommand', function () {
             ->assertSuccessful();
     });
 
-    it('shows dry run with projector filter', function () {
-        $this->artisan('event:replay --projector=SomeProjector --dry-run')
-            ->expectsOutput('DRY RUN - No events will be replayed.')
-            ->expectsOutput('Projector filter: SomeProjector')
-            ->assertSuccessful();
+    it('rejects projector outside App namespace', function () {
+        $this->artisan('event:replay', ['--projector' => 'SomeProjector', '--dry-run' => true])
+            ->expectsOutput('Invalid projector class: SomeProjector (must be in App\\ namespace)')
+            ->assertFailed();
+    });
+
+    it('rejects non-existent projector class', function () {
+        $this->artisan('event:replay', ['--projector' => 'App\\Domain\\Fake\\Projectors\\FakeProjector', '--dry-run' => true])
+            ->expectsOutput('Projector class not found: App\\Domain\\Fake\\Projectors\\FakeProjector')
+            ->assertFailed();
     });
 
     it('fails for unknown domain', function () {


### PR DESCRIPTION
## Summary
- **Route conflict fix**: `POST /api/compliance/cases` and `POST /api/compliance/alerts` were routed to non-existent `@create` method by domain route file `app/Domain/Compliance/Routes/api.php`, overriding the correct `@store` mapping from `routes/api/regulatory.php`. Fixed by changing domain routes to use `store`.
- **Route shadowing fix**: `GET /api/transaction-monitoring/patterns` and `GET /api/transaction-monitoring/thresholds` returned 404 because `GET /{id}` wildcard on line 82 captured them first. Fixed by moving parameterized routes after all static routes.
- **Security hardening**: `EventReplayCommand --projector` now validates class is in `App\` namespace, exists, and extends `Spatie\EventSourcing\EventHandlers\Projectors\Projector` — prevents arbitrary class instantiation from CLI input.
- **Filter logic fix**: `EventReplayCommand --domain` now actually filters projectors during replay (was only used for dry-run count display). New `resolveProjectors()` method filters by `App\Domain\{domain}\` namespace.

## Files Changed (5)
| File | Change |
|------|--------|
| `app/Domain/Compliance/Routes/api.php` | `create` → `store` on lines 16, 32 |
| `routes/api/regulatory.php` | Move `/{id}` routes after `/rules`, `/patterns`, `/thresholds` |
| `app/Console/Commands/EventReplayCommand.php` | Add projector validation, domain filtering, resolveProjectors() |
| `tests/Console/Commands/EventReplayCommandTest.php` | Replace SomeProjector test with namespace/existence validation tests |
| `CHANGELOG.md` | Add v3.3.2 section |

## Test plan
- [x] 4 previously-failing tests now pass (ComplianceCaseController, ComplianceAlertController, TransactionMonitoringController x2)
- [x] 7 EventReplayCommand tests pass (including 2 new validation tests)
- [x] 147 targeted tests pass (1057 assertions)
- [x] Full suite: 7153+ passed, 6 parallel-flaky failures (all pass individually)
- [x] PHPStan: 0 errors on all modified files
- [x] php-cs-fixer: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)