### PR TITLE
fix: Resolve parallel test flakes (v3.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the FinAegis Core Banking Platform will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.3] - 2026-02-12
+
+### Fixed
+- **PerformSystemHealthChecks**: Fixed `ini_set('memory_limit', '256M')` that crashed parallel test processes already using >256MB — now only increases the limit, never decreases it
+- **MobilePayment unit tests**: Added missing `uses(TestCase::class)` to `PaymentIntentServiceTest`, `ReceiptServiceTest`, `ReceiveAddressServiceTest`, and `NetworkAvailabilityServiceTest` — fixes `BindingResolutionException` for Spatie EventSubscriber in parallel execution
+
 ## [3.3.2] - 2026-02-12
 
 ### Fixed

--- a/tests/Unit/Domain/MobilePayment/Services/NetworkAvailabilityServiceTest.php
+++ b/tests/Unit/Domain/MobilePayment/Services/NetworkAvailabilityServiceTest.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Tests\TestCase;
+
+uses(TestCase::class);
+
 use App\Domain\MobilePayment\Enums\PaymentNetwork;
 use App\Domain\MobilePayment\Services\NetworkAvailabilityService;
 

--- a/tests/Unit/Domain/MobilePayment/Services/PaymentIntentServiceTest.php
+++ b/tests/Unit/Domain/MobilePayment/Services/PaymentIntentServiceTest.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Tests\TestCase;
+
+uses(TestCase::class);
+
 use App\Domain\Commerce\Enums\MerchantStatus;
 use App\Domain\Commerce\Models\Merchant;
 use App\Domain\MobilePayment\Contracts\MerchantLookupServiceInterface;

--- a/tests/Unit/Domain/MobilePayment/Services/ReceiptServiceTest.php
+++ b/tests/Unit/Domain/MobilePayment/Services/ReceiptServiceTest.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Tests\TestCase;
+
+uses(TestCase::class);
+
 use App\Domain\MobilePayment\Services\ReceiptService;
 
 describe('ReceiptService', function (): void {

--- a/tests/Unit/Domain/MobilePayment/Services/ReceiveAddressServiceTest.php
+++ b/tests/Unit/Domain/MobilePayment/Services/ReceiveAddressServiceTest.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Tests\TestCase;
+
+uses(TestCase::class);
+
 use App\Domain\MobilePayment\Enums\PaymentAsset;
 use App\Domain\MobilePayment\Enums\PaymentNetwork;
 use App\Domain\MobilePayment\Services\ReceiveAddressService;


### PR DESCRIPTION
## Summary
- **PerformSystemHealthChecks**: `ini_set('memory_limit', '256M')` was *lowering* the limit in parallel test processes already using >256MB, causing 4 test failures. Now only increases the limit via `parseMemoryLimit()` helper.
- **MobilePayment unit tests**: 4 service test files (`PaymentIntentServiceTest`, `ReceiptServiceTest`, `ReceiveAddressServiceTest`, `NetworkAvailabilityServiceTest`) were missing `uses(TestCase::class)`, causing Spatie `EventSubscriber` `BindingResolutionException` in parallel execution due to incomplete app bootstrapping.

## Test plan
- [ ] All 84 targeted tests pass in isolation
- [ ] PHPStan clean on modified files
- [ ] Full parallel suite passes (CI validates)
- [ ] No regressions in existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)