### PR TITLE
feat(api): Add API version middleware with deprecation headers

### DIFF
--- a/app/Http/Middleware/ApiVersionMiddleware.php
+++ b/app/Http/Middleware/ApiVersionMiddleware.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class ApiVersionMiddleware
+{
+    /**
+     * Handle an incoming request — inject API version and deprecation headers.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        $version = $this->extractVersion($request);
+
+        $response->headers->set('X-API-Version', $version);
+
+        $versionConfig = config("api-versioning.versions.{$version}");
+
+        if (! is_array($versionConfig)) {
+            return $response;
+        }
+
+        if (! empty($versionConfig['deprecated'])) {
+            $deprecatedAt = $versionConfig['deprecated_at'] ?? 'true';
+            $response->headers->set('Deprecation', (string) $deprecatedAt);
+        }
+
+        if (! empty($versionConfig['sunset'])) {
+            $response->headers->set('Sunset', (string) $versionConfig['sunset']);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Extract API version from the request path (e.g. /api/v2/accounts → v2).
+     */
+    private function extractVersion(Request $request): string
+    {
+        $path = $request->path();
+
+        if (preg_match('#(?:^|/)v(\d+)(?:/|$)#', $path, $matches)) {
+            return 'v' . $matches[1];
+        }
+
+        return (string) config('api-versioning.current_version', 'v1');
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -78,6 +78,8 @@ return Application::configure(basePath: dirname(__DIR__))
             'query.performance' => App\Http\Middleware\QueryPerformanceMiddleware::class,
             // Structured logging middleware (v3.3.0)
             'structured.logging' => App\Http\Middleware\StructuredLoggingMiddleware::class,
+            // API versioning middleware (v3.4.0)
+            'api.version' => App\Http\Middleware\ApiVersionMiddleware::class,
         ]);
 
         // Prepend CORS middleware to handle it before other middleware
@@ -92,6 +94,7 @@ return Application::configure(basePath: dirname(__DIR__))
             Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
             Illuminate\Routing\Middleware\SubstituteBindings::class,
             App\Http\Middleware\SecurityHeaders::class,
+            App\Http\Middleware\ApiVersionMiddleware::class,
         ]);
 
         // Apply security headers to web routes

--- a/config/api-versioning.php
+++ b/config/api-versioning.php
@@ -1,0 +1,46 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | API Versioning Configuration
+    |--------------------------------------------------------------------------
+    |
+    | This file defines the API version registry including which versions are
+    | supported, deprecated, or scheduled for sunset. The ApiVersionMiddleware
+    | reads this config to inject RFC 8594 Deprecation and Sunset headers.
+    |
+    */
+
+    'current_version' => env('API_CURRENT_VERSION', 'v1'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Version Registry
+    |--------------------------------------------------------------------------
+    |
+    | Each version entry controls:
+    |  - supported:  Whether requests to this version are accepted
+    |  - deprecated: If true, a Deprecation header (RFC 8594) is added
+    |  - deprecated_at: ISO 8601 date when deprecation was announced
+    |  - sunset: ISO 8601 date after which the version will be removed
+    |
+    */
+
+    'versions' => [
+        'v1' => [
+            'supported'     => true,
+            'deprecated'    => false,
+            'deprecated_at' => null,
+            'sunset'        => null,
+        ],
+        'v2' => [
+            'supported'     => true,
+            'deprecated'    => false,
+            'deprecated_at' => null,
+            'sunset'        => null,
+        ],
+    ],
+
+];

--- a/tests/Feature/Middleware/ApiVersionMiddlewareTest.php
+++ b/tests/Feature/Middleware/ApiVersionMiddlewareTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Middleware;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class ApiVersionMiddlewareTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('api-versioning.current_version', 'v1');
+        Config::set('api-versioning.versions', [
+            'v1' => [
+                'supported'     => true,
+                'deprecated'    => false,
+                'deprecated_at' => null,
+                'sunset'        => null,
+            ],
+            'v2' => [
+                'supported'     => true,
+                'deprecated'    => false,
+                'deprecated_at' => null,
+                'sunset'        => null,
+            ],
+        ]);
+
+        Route::middleware(['api'])->group(function () {
+            Route::get('/api/v1/test-version', fn () => response()->json(['ok' => true]));
+            Route::get('/api/v2/test-version', fn () => response()->json(['ok' => true]));
+            Route::get('/api/test-no-version', fn () => response()->json(['ok' => true]));
+        });
+    }
+
+    public function test_adds_api_version_header_for_v1(): void
+    {
+        $response = $this->getJson('/api/v1/test-version');
+
+        $response->assertStatus(200);
+        $response->assertHeader('X-API-Version', 'v1');
+    }
+
+    public function test_adds_api_version_header_for_v2(): void
+    {
+        $response = $this->getJson('/api/v2/test-version');
+
+        $response->assertStatus(200);
+        $response->assertHeader('X-API-Version', 'v2');
+    }
+
+    public function test_defaults_to_current_version_when_no_version_in_path(): void
+    {
+        $response = $this->getJson('/api/test-no-version');
+
+        $response->assertStatus(200);
+        $response->assertHeader('X-API-Version', 'v1');
+    }
+
+    public function test_adds_deprecation_header_when_version_is_deprecated(): void
+    {
+        Config::set('api-versioning.versions.v1.deprecated', true);
+        Config::set('api-versioning.versions.v1.deprecated_at', '2026-06-01');
+
+        $response = $this->getJson('/api/v1/test-version');
+
+        $response->assertStatus(200);
+        $response->assertHeader('Deprecation', '2026-06-01');
+    }
+
+    public function test_adds_sunset_header_when_version_has_sunset_date(): void
+    {
+        Config::set('api-versioning.versions.v2.sunset', '2027-01-01');
+
+        $response = $this->getJson('/api/v2/test-version');
+
+        $response->assertStatus(200);
+        $response->assertHeader('Sunset', '2027-01-01');
+    }
+
+    public function test_adds_both_deprecation_and_sunset_headers(): void
+    {
+        Config::set('api-versioning.versions.v1.deprecated', true);
+        Config::set('api-versioning.versions.v1.deprecated_at', '2026-06-01');
+        Config::set('api-versioning.versions.v1.sunset', '2027-01-01');
+
+        $response = $this->getJson('/api/v1/test-version');
+
+        $response->assertStatus(200);
+        $response->assertHeader('Deprecation', '2026-06-01');
+        $response->assertHeader('Sunset', '2027-01-01');
+    }
+
+    public function test_no_deprecation_header_when_version_is_not_deprecated(): void
+    {
+        $response = $this->getJson('/api/v1/test-version');
+
+        $response->assertStatus(200);
+        $response->assertHeaderMissing('Deprecation');
+        $response->assertHeaderMissing('Sunset');
+    }
+}


### PR DESCRIPTION
## Summary
- Introduces `ApiVersionMiddleware` that extracts API version from URL path (`/v1/`, `/v2/`) and adds `X-API-Version` response header
- Adds RFC 8594 `Deprecation` and `Sunset` headers when a version is configured as deprecated or scheduled for removal
- New `config/api-versioning.php` version registry with per-version `supported`, `deprecated`, `deprecated_at`, and `sunset` fields
- Registered globally in the `api` middleware group in `bootstrap/app.php`

## Test plan
- [x] 7 new tests in `ApiVersionMiddlewareTest` covering v1/v2 detection, deprecation headers, sunset headers, combined headers, and fallback behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)