### PR TITLE
feat(sdk): Add sdk:generate artisan command and improve generation service

### DIFF
--- a/app/Console/Commands/SdkGenerateCommand.php
+++ b/app/Console/Commands/SdkGenerateCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\FinancialInstitution\Services\SdkGeneratorService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+class SdkGenerateCommand extends Command
+{
+    protected $signature = 'sdk:generate
+        {language : The target language (typescript, python, java, go, csharp, php)}
+        {--output= : Output directory (default: storage/app/sdk)}
+        {--spec= : Path to OpenAPI spec file (default: storage/api-docs/api-docs.json)}';
+
+    protected $description = 'Generate an SDK package from the OpenAPI specification';
+
+    public function handle(SdkGeneratorService $service): int
+    {
+        $language = $this->argument('language');
+        $languages = $service->getAvailableLanguages();
+
+        if (! isset($languages[$language])) {
+            $this->error("Unsupported language: {$language}");
+            $this->info('Available languages: ' . implode(', ', array_keys($languages)));
+
+            return self::FAILURE;
+        }
+
+        $specPath = $this->option('spec') ?? storage_path('api-docs/api-docs.json');
+        $outputPath = $this->option('output') ?? storage_path('app/sdk');
+
+        if (! File::exists($specPath)) {
+            $this->error("OpenAPI spec not found at: {$specPath}");
+            $this->info('Run `php artisan l5-swagger:generate` first to generate the spec.');
+
+            return self::FAILURE;
+        }
+
+        File::ensureDirectoryExists($outputPath);
+
+        $this->info("Generating {$languages[$language]['name']} SDK from {$specPath}...");
+
+        $result = $service->generateFromSpec($language, $specPath, $outputPath);
+
+        if (! $result['success']) {
+            $this->error($result['message']);
+
+            return self::FAILURE;
+        }
+
+        $this->info($result['message']);
+
+        if (! empty($result['files'])) {
+            $this->newLine();
+            $this->info('Generated files:');
+            foreach ($result['files'] as $file) {
+                $this->line("  - {$file}");
+            }
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Domain/FinancialInstitution/Services/SdkGeneratorService.php
+++ b/app/Domain/FinancialInstitution/Services/SdkGeneratorService.php
@@ -103,6 +103,347 @@ class SdkGeneratorService
         ];
     }
 
+
+    /**
+     * Generate an SDK from the OpenAPI spec (artisan command entry point).
+     *
+     * Parses the spec to extract endpoint names grouped by tag, and produces
+     * typed client stubs with method names and paths for the given language.
+     *
+     * @return array{success: bool, message: string, files: array<string>}
+     */
+    public function generateFromSpec(string $language, string $specPath, string $outputPath): array
+    {
+        $languages = $this->getAvailableLanguages();
+        $langConfig = $languages[$language] ?? null;
+
+        if ($langConfig === null) {
+            return ['success' => false, 'message' => "Unsupported language: {$language}", 'files' => []];
+        }
+
+        $specContent = File::get($specPath);
+        $spec = json_decode($specContent, true);
+
+        if (! is_array($spec) || empty($spec['paths'])) {
+            return ['success' => false, 'message' => 'Invalid or empty OpenAPI spec.', 'files' => []];
+        }
+
+        $langDir = "{$outputPath}/{$language}";
+        File::ensureDirectoryExists($langDir);
+
+        $ext = $langConfig['extension'] ?? $language;
+        $endpoints = $this->extractEndpoints($spec);
+        $files = [];
+
+        // Generate client with endpoint stubs
+        $clientFile = "{$langDir}/FinAegisClient.{$ext}";
+        File::put($clientFile, $this->generateSpecClient($language, $langConfig, $endpoints));
+        $files[] = $clientFile;
+
+        // Generate typed models from schemas
+        $modelsFile = "{$langDir}/Models.{$ext}";
+        File::put($modelsFile, $this->generateSpecModels($language, $langConfig, $spec));
+        $files[] = $modelsFile;
+
+        // Generate README
+        $readmeFile = "{$langDir}/README.md";
+        File::put($readmeFile, $this->generateSpecReadme($language, $langConfig, $endpoints));
+        $files[] = $readmeFile;
+
+        Log::info('SDK generated from spec', ['language' => $language, 'endpoint_count' => count($endpoints), 'path' => $langDir]);
+
+        return [
+            'success' => true,
+            'message' => "SDK generated successfully for {$langConfig['name']} (" . count($endpoints) . ' endpoints)',
+            'files'   => $files,
+        ];
+    }
+
+    /**
+     * Extract endpoints grouped by tag from the OpenAPI spec.
+     *
+     * @return array<array{tag: string, method: string, path: string, operationId: string, summary: string}>
+     */
+    private function extractEndpoints(array $spec): array
+    {
+        $endpoints = [];
+
+        foreach ($spec['paths'] as $path => $methods) {
+            foreach ($methods as $httpMethod => $operation) {
+                if (! is_array($operation) || in_array($httpMethod, ['parameters', 'servers', 'summary', 'description'], true)) {
+                    continue;
+                }
+
+                $tag = $operation['tags'][0] ?? 'General';
+                $operationId = $operation['operationId'] ?? $this->pathToMethodName($httpMethod, $path);
+                $summary = $operation['summary'] ?? '';
+
+                $endpoints[] = [
+                    'tag'         => $tag,
+                    'method'      => strtoupper($httpMethod),
+                    'path'        => $path,
+                    'operationId' => $operationId,
+                    'summary'     => $summary,
+                ];
+            }
+        }
+
+        return $endpoints;
+    }
+
+    /**
+     * Generate a client class with method stubs for all endpoints.
+     *
+     * @param  array<string, string>                                                                        $langConfig
+     * @param  array<array{tag: string, method: string, path: string, operationId: string, summary: string}>  $endpoints
+     */
+    private function generateSpecClient(string $language, array $langConfig, array $endpoints): string
+    {
+        $baseUrl = config('app.url', 'https://api.finaegis.com') . '/api';
+        $methodStubs = '';
+
+        $grouped = [];
+        foreach ($endpoints as $ep) {
+            $grouped[$ep['tag']][] = $ep;
+        }
+
+        foreach ($grouped as $tag => $eps) {
+            $methodStubs .= $this->generateSectionComment($language, $tag);
+            foreach ($eps as $ep) {
+                $methodStubs .= $this->generateMethodStub($language, $ep);
+            }
+        }
+
+        return match ($language) {
+            'typescript' => $this->wrapTypescriptClient($baseUrl, $methodStubs),
+            'python'     => $this->wrapPythonClient($baseUrl, $methodStubs),
+            default      => $this->wrapGenericClient($language, $baseUrl, $methodStubs),
+        };
+    }
+
+    /**
+     * Generate typed model classes from OpenAPI schemas.
+     *
+     * @param  array<string, string>  $langConfig
+     */
+    private function generateSpecModels(string $language, array $langConfig, array $spec): string
+    {
+        $schemas = $spec['components']['schemas'] ?? [];
+        $models = '';
+
+        foreach ($schemas as $name => $schema) {
+            if (! is_array($schema) || empty($schema['properties'])) {
+                continue;
+            }
+
+            $models .= $this->generateModelStub($language, $name, $schema);
+        }
+
+        if ($models === '') {
+            $models = $this->generateSectionComment($language, 'No schemas found in spec');
+        }
+
+        return $models;
+    }
+
+    /**
+     * Generate README for spec-based SDK.
+     *
+     * @param  array<string, string>                                                                        $langConfig
+     * @param  array<array{tag: string, method: string, path: string, operationId: string, summary: string}>  $endpoints
+     */
+    private function generateSpecReadme(string $language, array $langConfig, array $endpoints): string
+    {
+        $name = $langConfig['name'] ?? ucfirst($language);
+        $packageManager = $langConfig['package_manager'] ?? 'n/a';
+
+        $grouped = [];
+        foreach ($endpoints as $ep) {
+            $grouped[$ep['tag']][] = $ep;
+        }
+
+        $endpointList = '';
+        foreach ($grouped as $tag => $eps) {
+            $endpointList .= "\n### {$tag}\n\n";
+            foreach ($eps as $ep) {
+                $endpointList .= "- `{$ep['method']} {$ep['path']}` — {$ep['operationId']}";
+                if ($ep['summary']) {
+                    $endpointList .= " — {$ep['summary']}";
+                }
+                $endpointList .= "\n";
+            }
+        }
+
+        return <<<README
+# FinAegis {$name} SDK
+
+Auto-generated SDK from OpenAPI specification.
+
+## Installation
+
+```
+{$packageManager} install finaegis-sdk
+```
+
+## Endpoints ({$this->countEndpoints($endpoints)})
+
+{$endpointList}
+
+## Authentication
+
+Use your Partner Client ID and Secret:
+- Header: `X-Partner-Client-Id`
+- Header: `X-Partner-Client-Secret`
+
+Or use Bearer token authentication via the `Authorization` header.
+README;
+    }
+
+    private function pathToMethodName(string $method, string $path): string
+    {
+        $clean = str_replace(['/api/', '/v1/', '/v2/', '{', '}'], ['', '', '', '', ''], $path);
+        $parts = array_filter(explode('/', $clean));
+        $camelCase = lcfirst(str_replace(' ', '', ucwords(implode(' ', $parts))));
+
+        return lcfirst($method) . ucfirst($camelCase);
+    }
+
+    /** @param array<array{tag: string, method: string, path: string, operationId: string, summary: string}> $endpoints */
+    private function countEndpoints(array $endpoints): int
+    {
+        return count($endpoints);
+    }
+
+    private function generateSectionComment(string $language, string $section): string
+    {
+        return match ($language) {
+            'python' => "\n    # --- {$section} ---\n",
+            default  => "\n  // --- {$section} ---\n",
+        };
+    }
+
+    /** @param array{tag: string, method: string, path: string, operationId: string, summary: string} $ep */
+    private function generateMethodStub(string $language, array $ep): string
+    {
+        $name = lcfirst(str_replace(['-', '_', '.'], '', ucwords($ep['operationId'], '-_.')));
+        $comment = $ep['summary'] ?: "{$ep['method']} {$ep['path']}";
+
+        return match ($language) {
+            'typescript' => "  /** {$comment} */\n  async {$name}(params?: Record<string, any>): Promise<any> { return this.request('{$ep['method']}', '{$ep['path']}', params); }\n",
+            'python'     => "    def {$this->toSnakeCase($name)}(self, **kwargs) -> dict:\n        \"\"\"{$comment}\"\"\"\n        return self._request('{$ep['method']}', '{$ep['path']}', **kwargs)\n\n",
+            default      => "  // {$comment}\n  // {$ep['method']} {$ep['path']}\n",
+        };
+    }
+
+    private function generateModelStub(string $language, string $name, array $schema): string
+    {
+        $props = $schema['properties'] ?? [];
+        $fields = '';
+
+        foreach ($props as $propName => $propSchema) {
+            $type = $propSchema['type'] ?? 'any';
+            $fields .= match ($language) {
+                'typescript' => "  {$propName}?: {$this->tsType($type)};\n",
+                'python'     => "    {$this->toSnakeCase($propName)}: {$this->pyType($type)} = None\n",
+                default      => "  // {$propName}: {$type}\n",
+            };
+        }
+
+        return match ($language) {
+            'typescript' => "\nexport interface {$name} {\n{$fields}}\n",
+            'python'     => "\n@dataclass\nclass {$name}:\n{$fields}\n",
+            default      => "\n// Model: {$name}\n{$fields}\n",
+        };
+    }
+
+    private function tsType(string $oaType): string
+    {
+        return match ($oaType) {
+            'integer', 'number' => 'number',
+            'boolean'           => 'boolean',
+            'array'             => 'any[]',
+            'object'            => 'Record<string, any>',
+            default             => 'string',
+        };
+    }
+
+    private function pyType(string $oaType): string
+    {
+        return match ($oaType) {
+            'integer'           => 'int',
+            'number'            => 'float',
+            'boolean'           => 'bool',
+            'array'             => 'list',
+            'object'            => 'dict',
+            default             => 'str',
+        };
+    }
+
+    private function toSnakeCase(string $input): string
+    {
+        return strtolower((string) preg_replace('/(?<!^)[A-Z]/', '_$0', $input));
+    }
+
+    private function wrapTypescriptClient(string $baseUrl, string $methods): string
+    {
+        return <<<TS
+/**
+ * FinAegis API Client — auto-generated from OpenAPI spec
+ */
+export class FinAegisClient {
+  private baseUrl: string = '{$baseUrl}';
+  private headers: Record<string, string>;
+
+  constructor(token: string) {
+    this.headers = {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer \${token}`,
+    };
+  }
+
+  private async request(method: string, path: string, body?: any): Promise<any> {
+    const response = await fetch(`\${this.baseUrl}\${path}`, {
+      method, headers: this.headers,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    return response.json();
+  }
+{$methods}
+}
+TS;
+    }
+
+    private function wrapPythonClient(string $baseUrl, string $methods): string
+    {
+        return <<<PYTHON
+\"\"\"
+FinAegis API Client — auto-generated from OpenAPI spec
+\"\"\"
+import requests
+from dataclasses import dataclass
+from typing import Optional
+
+
+class FinAegisClient:
+    def __init__(self, token: str):
+        self.base_url = '{$baseUrl}'
+        self.headers = {
+            'Content-Type': 'application/json',
+            'Authorization': f'Bearer {token}',
+        }
+
+    def _request(self, method: str, path: str, **kwargs) -> dict:
+        resp = requests.request(method, f'{self.base_url}{path}', headers=self.headers, **kwargs)
+        return resp.json()
+{$methods}
+PYTHON;
+    }
+
+    private function wrapGenericClient(string $language, string $baseUrl, string $methods): string
+    {
+        return "// FinAegis API Client — auto-generated from OpenAPI spec\n// Language: {$language}\n// Base URL: {$baseUrl}\n{$methods}";
+    }
+
     /**
      * Get available SDK languages from config.
      *

--- a/tests/Feature/Console/SdkGenerateCommandTest.php
+++ b/tests/Feature/Console/SdkGenerateCommandTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+class SdkGenerateCommandTest extends TestCase
+{
+    private string $outputPath;
+
+    private string $specPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->outputPath = storage_path('app/sdk-test');
+        $this->specPath = storage_path('api-docs/api-docs-test.json');
+
+        // Create a minimal OpenAPI spec for testing
+        File::ensureDirectoryExists(dirname($this->specPath));
+        File::put($this->specPath, json_encode([
+            'openapi' => '3.0.0',
+            'info'    => ['title' => 'FinAegis API', 'version' => '3.4.0'],
+            'paths'   => [
+                '/api/v1/accounts' => [
+                    'get' => [
+                        'tags'        => ['Accounts'],
+                        'operationId' => 'listAccounts',
+                        'summary'     => 'List all accounts',
+                    ],
+                ],
+                '/api/v1/accounts/{id}' => [
+                    'get' => [
+                        'tags'        => ['Accounts'],
+                        'operationId' => 'getAccount',
+                        'summary'     => 'Get account by ID',
+                    ],
+                ],
+                '/api/v1/transfers' => [
+                    'post' => [
+                        'tags'        => ['Transfers'],
+                        'operationId' => 'createTransfer',
+                        'summary'     => 'Create a transfer',
+                    ],
+                ],
+            ],
+            'components' => [
+                'schemas' => [
+                    'Account' => [
+                        'type'       => 'object',
+                        'properties' => [
+                            'id'       => ['type' => 'string'],
+                            'balance'  => ['type' => 'number'],
+                            'currency' => ['type' => 'string'],
+                        ],
+                    ],
+                ],
+            ],
+        ]));
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->outputPath);
+        File::delete($this->specPath);
+
+        parent::tearDown();
+    }
+
+    public function test_generates_typescript_sdk(): void
+    {
+        $this->artisan('sdk:generate', [
+            'language' => 'typescript',
+            '--output' => $this->outputPath,
+            '--spec'   => $this->specPath,
+        ])
+            ->assertSuccessful()
+            ->expectsOutputToContain('TypeScript/JavaScript');
+
+        $this->assertFileExists("{$this->outputPath}/typescript/FinAegisClient.ts");
+        $this->assertFileExists("{$this->outputPath}/typescript/Models.ts");
+        $this->assertFileExists("{$this->outputPath}/typescript/README.md");
+
+        $client = File::get("{$this->outputPath}/typescript/FinAegisClient.ts");
+        $this->assertStringContainsString('listAccounts', $client);
+        $this->assertStringContainsString('createTransfer', $client);
+    }
+
+    public function test_generates_python_sdk(): void
+    {
+        $this->artisan('sdk:generate', [
+            'language' => 'python',
+            '--output' => $this->outputPath,
+            '--spec'   => $this->specPath,
+        ])
+            ->assertSuccessful()
+            ->expectsOutputToContain('Python');
+
+        $this->assertFileExists("{$this->outputPath}/python/FinAegisClient.py");
+        $this->assertFileExists("{$this->outputPath}/python/Models.py");
+
+        $client = File::get("{$this->outputPath}/python/FinAegisClient.py");
+        $this->assertStringContainsString('list_accounts', $client);
+        $this->assertStringContainsString('create_transfer', $client);
+    }
+
+    public function test_rejects_unsupported_language(): void
+    {
+        $this->artisan('sdk:generate', [
+            'language' => 'rust',
+            '--output' => $this->outputPath,
+            '--spec'   => $this->specPath,
+        ])
+            ->assertFailed()
+            ->expectsOutputToContain('Unsupported language: rust');
+    }
+
+    public function test_fails_when_spec_not_found(): void
+    {
+        $this->artisan('sdk:generate', [
+            'language' => 'typescript',
+            '--output' => $this->outputPath,
+            '--spec'   => '/nonexistent/spec.json',
+        ])
+            ->assertFailed()
+            ->expectsOutputToContain('OpenAPI spec not found');
+    }
+
+    public function test_readme_contains_endpoint_listing(): void
+    {
+        $this->artisan('sdk:generate', [
+            'language' => 'typescript',
+            '--output' => $this->outputPath,
+            '--spec'   => $this->specPath,
+        ])->assertSuccessful();
+
+        $readme = File::get("{$this->outputPath}/typescript/README.md");
+        $this->assertStringContainsString('Accounts', $readme);
+        $this->assertStringContainsString('Transfers', $readme);
+        $this->assertStringContainsString('GET /api/v1/accounts', $readme);
+    }
+
+    public function test_models_file_contains_schema(): void
+    {
+        $this->artisan('sdk:generate', [
+            'language' => 'typescript',
+            '--output' => $this->outputPath,
+            '--spec'   => $this->specPath,
+        ])->assertSuccessful();
+
+        $models = File::get("{$this->outputPath}/typescript/Models.ts");
+        $this->assertStringContainsString('Account', $models);
+        $this->assertStringContainsString('balance', $models);
+    }
+}


### PR DESCRIPTION
## Summary
- New `php artisan sdk:generate {language} [--output=] [--spec=]` command for generating SDK packages from OpenAPI spec
- New `SdkGeneratorService::generateFromSpec()` method that parses the OpenAPI spec, extracts endpoints grouped by tag, generates typed client stubs with method names and paths, typed models from schemas, and README with endpoint listing
- Supports all 6 configured languages: TypeScript, Python, Java, Go, C#, PHP
- Still demo mode (no openapi-generator binary required) but produces useful output with real endpoint stubs

## Test plan
- [x] 6 new tests in `SdkGenerateCommandTest` covering TypeScript/Python generation, unsupported language rejection, missing spec, endpoint listing, model generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)