### PR TITLE
docs: Add OpenAPI annotations to FraudDetection and RiskAnalysis controllers

### DIFF
--- a/app/Http/Controllers/Api/FraudDetectionController.php
+++ b/app/Http/Controllers/Api/FraudDetectionController.php
@@ -7,6 +7,17 @@ use Illuminate\Http\JsonResponse;
 
 class FraudDetectionController extends Controller
 {
+    /**
+     * @OA\Get(
+     *     path="/api/fraud/dashboard",
+     *     operationId="fraudDashboard",
+     *     summary="Get fraud detection dashboard overview",
+     *     tags={"Fraud Detection"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(response=200, description="Success", @OA\JsonContent(@OA\Property(property="message", type="string"), @OA\Property(property="data", type="object"))),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function dashboard(): JsonResponse
     {
         return response()->json(
@@ -17,6 +28,17 @@ class FraudDetectionController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/fraud/alerts",
+     *     operationId="fraudGetAlerts",
+     *     summary="List all fraud alerts",
+     *     tags={"Fraud Detection"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(response=200, description="Success", @OA\JsonContent(@OA\Property(property="data", type="array", @OA\Items(type="object")), @OA\Property(property="meta", type="object", @OA\Property(property="total", type="integer")))),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function getAlerts(): JsonResponse
     {
         return response()->json(
@@ -27,6 +49,18 @@ class FraudDetectionController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/fraud/alerts/{id}",
+     *     operationId="fraudGetAlertDetails",
+     *     summary="Get details of a specific fraud alert",
+     *     tags={"Fraud Detection"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="id", in="path", required=true, description="Alert ID", @OA\Schema(type="string")),
+     *     @OA\Response(response=200, description="Success", @OA\JsonContent(@OA\Property(property="data", type="object"))),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function getAlertDetails($id): JsonResponse
     {
         return response()->json(
@@ -36,6 +70,19 @@ class FraudDetectionController extends Controller
         );
     }
 
+    /**
+     * @OA\Post(
+     *     path="/api/fraud/alerts/{id}/acknowledge",
+     *     operationId="fraudAcknowledgeAlert",
+     *     summary="Acknowledge a fraud alert",
+     *     tags={"Fraud Detection"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="id", in="path", required=true, description="Alert ID", @OA\Schema(type="string")),
+     *     @OA\RequestBody(required=false, @OA\JsonContent(type="object")),
+     *     @OA\Response(response=200, description="Success", @OA\JsonContent(@OA\Property(property="message", type="string"), @OA\Property(property="data", type="object"))),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function acknowledgeAlert($id): JsonResponse
     {
         return response()->json(
@@ -46,6 +93,19 @@ class FraudDetectionController extends Controller
         );
     }
 
+    /**
+     * @OA\Post(
+     *     path="/api/fraud/alerts/{id}/investigate",
+     *     operationId="fraudInvestigateAlert",
+     *     summary="Start investigation on a fraud alert",
+     *     tags={"Fraud Detection"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="id", in="path", required=true, description="Alert ID", @OA\Schema(type="string")),
+     *     @OA\RequestBody(required=false, @OA\JsonContent(type="object")),
+     *     @OA\Response(response=200, description="Success", @OA\JsonContent(@OA\Property(property="message", type="string"), @OA\Property(property="data", type="object"))),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function investigateAlert($id): JsonResponse
     {
         return response()->json(
@@ -56,6 +116,17 @@ class FraudDetectionController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/fraud/statistics",
+     *     operationId="fraudGetStatistics",
+     *     summary="Get fraud detection statistics",
+     *     tags={"Fraud Detection"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(response=200, description="Success", @OA\JsonContent(@OA\Property(property="data", type="object"))),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function getStatistics(): JsonResponse
     {
         return response()->json(
@@ -65,6 +136,17 @@ class FraudDetectionController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/fraud/patterns",
+     *     operationId="fraudGetPatterns",
+     *     summary="Get detected fraud patterns",
+     *     tags={"Fraud Detection"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(response=200, description="Success", @OA\JsonContent(@OA\Property(property="data", type="array", @OA\Items(type="object")))),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function getPatterns(): JsonResponse
     {
         return response()->json(
@@ -74,6 +156,17 @@ class FraudDetectionController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/fraud/cases",
+     *     operationId="fraudGetCases",
+     *     summary="List all fraud cases",
+     *     tags={"Fraud Detection"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(response=200, description="Success", @OA\JsonContent(@OA\Property(property="data", type="array", @OA\Items(type="object")), @OA\Property(property="meta", type="object", @OA\Property(property="total", type="integer")))),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function getCases(): JsonResponse
     {
         return response()->json(
@@ -84,6 +177,18 @@ class FraudDetectionController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/fraud/cases/{id}",
+     *     operationId="fraudGetCaseDetails",
+     *     summary="Get details of a specific fraud case",
+     *     tags={"Fraud Detection"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="id", in="path", required=true, description="Case ID", @OA\Schema(type="string")),
+     *     @OA\Response(response=200, description="Success", @OA\JsonContent(@OA\Property(property="data", type="object"))),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function getCaseDetails($id): JsonResponse
     {
         return response()->json(
@@ -93,6 +198,19 @@ class FraudDetectionController extends Controller
         );
     }
 
+    /**
+     * @OA\Put(
+     *     path="/api/fraud/cases/{id}",
+     *     operationId="fraudUpdateCase",
+     *     summary="Update a fraud case",
+     *     tags={"Fraud Detection"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="id", in="path", required=true, description="Case ID", @OA\Schema(type="string")),
+     *     @OA\RequestBody(required=true, @OA\JsonContent(type="object", @OA\Property(property="status", type="string"), @OA\Property(property="notes", type="string"))),
+     *     @OA\Response(response=200, description="Success", @OA\JsonContent(@OA\Property(property="message", type="string"), @OA\Property(property="data", type="object"))),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function updateCase($id): JsonResponse
     {
         return response()->json(

--- a/app/Http/Controllers/Api/RiskAnalysisController.php
+++ b/app/Http/Controllers/Api/RiskAnalysisController.php
@@ -8,6 +8,18 @@ use Illuminate\Http\Request;
 
 class RiskAnalysisController extends Controller
 {
+    /**
+     * @OA\Get(
+     *     path="/api/risk/users/{userId}/profile",
+     *     operationId="riskGetUserRiskProfile",
+     *     summary="Get risk profile for a specific user",
+     *     tags={"Risk Management"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="userId", in="path", required=true, description="User ID", @OA\Schema(type="string")),
+     *     @OA\Response(response=200, description="Success", @OA\JsonContent(@OA\Property(property="data", type="object", @OA\Property(property="user_id", type="string"), @OA\Property(property="risk_score", type="integer"), @OA\Property(property="risk_level", type="string")))),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function getUserRiskProfile($userId): JsonResponse
     {
         return response()->json(
@@ -21,6 +33,30 @@ class RiskAnalysisController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/risk/transactions/{transactionId}/analyze",
+     *     operationId="riskAnalyzeTransactionGet",
+     *     summary="Analyze risk for a specific transaction (GET)",
+     *     tags={"Risk Management"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="transactionId", in="path", required=true, description="Transaction ID", @OA\Schema(type="string")),
+     *     @OA\Response(response=200, description="Success", @OA\JsonContent(@OA\Property(property="data", type="object", @OA\Property(property="transaction_id", type="string"), @OA\Property(property="risk_score", type="integer"), @OA\Property(property="risk_factors", type="array", @OA\Items(type="object"))))),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     *
+     * @OA\Post(
+     *     path="/api/risk/transactions/{transactionId}/analyze",
+     *     operationId="riskAnalyzeTransactionPost",
+     *     summary="Analyze risk for a specific transaction (POST)",
+     *     tags={"Risk Management"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="transactionId", in="path", required=true, description="Transaction ID", @OA\Schema(type="string")),
+     *     @OA\RequestBody(required=false, @OA\JsonContent(type="object")),
+     *     @OA\Response(response=200, description="Success", @OA\JsonContent(@OA\Property(property="data", type="object", @OA\Property(property="transaction_id", type="string"), @OA\Property(property="risk_score", type="integer"), @OA\Property(property="risk_factors", type="array", @OA\Items(type="object"))))),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function analyzeTransaction($transactionId): JsonResponse
     {
         return response()->json(
@@ -34,6 +70,18 @@ class RiskAnalysisController extends Controller
         );
     }
 
+    /**
+     * @OA\Post(
+     *     path="/api/risk/calculate",
+     *     operationId="riskCalculateRiskScore",
+     *     summary="Calculate risk score based on provided parameters",
+     *     tags={"Risk Management"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(required=true, @OA\JsonContent(type="object", @OA\Property(property="user_id", type="string"), @OA\Property(property="transaction_data", type="object"))),
+     *     @OA\Response(response=200, description="Success", @OA\JsonContent(@OA\Property(property="data", type="object", @OA\Property(property="risk_score", type="integer"), @OA\Property(property="risk_level", type="string")))),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function calculateRiskScore(Request $request): JsonResponse
     {
         return response()->json(
@@ -46,6 +94,17 @@ class RiskAnalysisController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/risk/factors",
+     *     operationId="riskGetRiskFactors",
+     *     summary="List all risk factors",
+     *     tags={"Risk Management"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(response=200, description="Success", @OA\JsonContent(@OA\Property(property="data", type="array", @OA\Items(type="object")))),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function getRiskFactors(): JsonResponse
     {
         return response()->json(
@@ -55,6 +114,17 @@ class RiskAnalysisController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/risk/models",
+     *     operationId="riskGetRiskModels",
+     *     summary="List all risk analysis models",
+     *     tags={"Risk Management"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(response=200, description="Success", @OA\JsonContent(@OA\Property(property="data", type="array", @OA\Items(type="object")))),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function getRiskModels(): JsonResponse
     {
         return response()->json(
@@ -64,6 +134,18 @@ class RiskAnalysisController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/risk/users/{userId}/history",
+     *     operationId="riskGetRiskHistory",
+     *     summary="Get risk assessment history for a specific user",
+     *     tags={"Risk Management"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="userId", in="path", required=true, description="User ID", @OA\Schema(type="string")),
+     *     @OA\Response(response=200, description="Success", @OA\JsonContent(@OA\Property(property="data", type="array", @OA\Items(type="object")), @OA\Property(property="meta", type="object", @OA\Property(property="user_id", type="string")))),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function getRiskHistory($userId): JsonResponse
     {
         return response()->json(
@@ -74,6 +156,18 @@ class RiskAnalysisController extends Controller
         );
     }
 
+    /**
+     * @OA\Post(
+     *     path="/api/risk/device-fingerprint",
+     *     operationId="riskStoreDeviceFingerprint",
+     *     summary="Store a device fingerprint for risk analysis",
+     *     tags={"Risk Management"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(required=true, @OA\JsonContent(type="object", @OA\Property(property="device_id", type="string"), @OA\Property(property="fingerprint", type="string"), @OA\Property(property="user_agent", type="string"), @OA\Property(property="ip_address", type="string"))),
+     *     @OA\Response(response=200, description="Success", @OA\JsonContent(@OA\Property(property="message", type="string"), @OA\Property(property="data", type="object"))),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function storeDeviceFingerprint(Request $request): JsonResponse
     {
         return response()->json(
@@ -84,6 +178,18 @@ class RiskAnalysisController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/risk/users/{userId}/devices",
+     *     operationId="riskGetDeviceHistory",
+     *     summary="Get device history for a specific user",
+     *     tags={"Risk Management"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="userId", in="path", required=true, description="User ID", @OA\Schema(type="string")),
+     *     @OA\Response(response=200, description="Success", @OA\JsonContent(@OA\Property(property="data", type="array", @OA\Items(type="object")), @OA\Property(property="meta", type="object", @OA\Property(property="user_id", type="string")))),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function getDeviceHistory($userId): JsonResponse
     {
         return response()->json(


### PR DESCRIPTION
## Summary
- Added `@OA` Swagger annotations to all 10 public methods in `FraudDetectionController` (tag: "Fraud Detection", operationId prefix: `fraud`)
- Added `@OA` Swagger annotations to all 8 public methods in `RiskAnalysisController` (tag: "Risk Management", operationId prefix: `risk`)
- All annotations include correct HTTP methods, paths (verified from route files), path parameters, request bodies for POST/PUT, and `sanctum` security

## Test plan
- [ ] Verify `php artisan l5-swagger:generate` completes without errors
- [ ] Confirm new endpoints appear under "Fraud Detection" and "Risk Management" tags in Swagger UI
- [ ] Validate that operationIds are unique and paths match registered routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)