### PR TITLE
docs: Add OpenAPI annotations to EnhancedRegulatory, Compliance, Audit controllers

### DIFF
--- a/app/Http/Controllers/Api/AuditController.php
+++ b/app/Http/Controllers/Api/AuditController.php
@@ -8,6 +8,23 @@ use Illuminate\Http\Request;
 
 class AuditController extends Controller
 {
+    /**
+     * @OA\Get(
+     *     path="/api/audit/logs",
+     *     operationId="auditGetAuditLogs",
+     *     summary="Get audit logs",
+     *     description="Retrieves a paginated list of audit logs with optional filtering.",
+     *     tags={"Audit"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="page", in="query", required=false, description="Page number", @OA\Schema(type="integer")),
+     *     @OA\Parameter(name="per_page", in="query", required=false, description="Items per page", @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Audit logs retrieved successfully", @OA\JsonContent(
+     *         @OA\Property(property="data", type="array", @OA\Items(type="object")),
+     *         @OA\Property(property="meta", type="object", @OA\Property(property="total", type="integer"))
+     *     )),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function getAuditLogs(Request $request): JsonResponse
     {
         return response()->json(
@@ -18,6 +35,26 @@ class AuditController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/audit/logs/export",
+     *     operationId="auditExportAuditLogs",
+     *     summary="Export audit logs",
+     *     description="Initiates an export of audit logs. Returns an export ID and processing status.",
+     *     tags={"Audit"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="format", in="query", required=false, description="Export format (e.g. csv, json)", @OA\Schema(type="string")),
+     *     @OA\Parameter(name="from", in="query", required=false, description="Start date filter", @OA\Schema(type="string", format="date-time")),
+     *     @OA\Parameter(name="to", in="query", required=false, description="End date filter", @OA\Schema(type="string", format="date-time")),
+     *     @OA\Response(response=200, description="Export initiated successfully", @OA\JsonContent(
+     *         @OA\Property(property="data", type="object",
+     *             @OA\Property(property="export_id", type="string"),
+     *             @OA\Property(property="status", type="string", example="processing")
+     *         )
+     *     )),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function exportAuditLogs(Request $request): JsonResponse
     {
         return response()->json(
@@ -30,6 +67,20 @@ class AuditController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/audit/events",
+     *     operationId="auditGetAuditEvents",
+     *     summary="Get audit events",
+     *     description="Retrieves a list of audit events.",
+     *     tags={"Audit"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(response=200, description="Audit events retrieved successfully", @OA\JsonContent(
+     *         @OA\Property(property="data", type="array", @OA\Items(type="object"))
+     *     )),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function getAuditEvents(): JsonResponse
     {
         return response()->json(
@@ -39,6 +90,22 @@ class AuditController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/audit/events/{id}",
+     *     operationId="auditGetEventDetails",
+     *     summary="Get audit event details",
+     *     description="Retrieves the details of a specific audit event by its ID.",
+     *     tags={"Audit"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="id", in="path", required=true, description="Audit event ID", @OA\Schema(type="string")),
+     *     @OA\Response(response=200, description="Event details retrieved successfully", @OA\JsonContent(
+     *         @OA\Property(property="data", type="object", @OA\Property(property="id", type="string"))
+     *     )),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Event not found")
+     * )
+     */
     public function getEventDetails($id): JsonResponse
     {
         return response()->json(
@@ -48,6 +115,21 @@ class AuditController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/audit/reports",
+     *     operationId="auditGetAuditReports",
+     *     summary="Get audit reports",
+     *     description="Retrieves a list of audit reports with pagination metadata.",
+     *     tags={"Audit"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(response=200, description="Audit reports retrieved successfully", @OA\JsonContent(
+     *         @OA\Property(property="data", type="array", @OA\Items(type="object")),
+     *         @OA\Property(property="meta", type="object", @OA\Property(property="total", type="integer"))
+     *     )),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function getAuditReports(): JsonResponse
     {
         return response()->json(
@@ -58,6 +140,30 @@ class AuditController extends Controller
         );
     }
 
+    /**
+     * @OA\Post(
+     *     path="/api/audit/reports/generate",
+     *     operationId="auditGenerateAuditReport",
+     *     summary="Generate an audit report",
+     *     description="Initiates generation of a new audit report. Returns the report ID.",
+     *     tags={"Audit"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=false,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="type", type="string", description="Report type"),
+     *             @OA\Property(property="from", type="string", format="date-time", description="Start date"),
+     *             @OA\Property(property="to", type="string", format="date-time", description="End date"),
+     *             @OA\Property(property="filters", type="object", description="Additional filters")
+     *         )
+     *     ),
+     *     @OA\Response(response=201, description="Audit report generation initiated", @OA\JsonContent(
+     *         @OA\Property(property="message", type="string", example="Audit report generation initiated"),
+     *         @OA\Property(property="data", type="object", @OA\Property(property="report_id", type="string"))
+     *     )),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function generateAuditReport(Request $request): JsonResponse
     {
         return response()->json(
@@ -69,6 +175,27 @@ class AuditController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/audit/trail/{entityType}/{entityId}",
+     *     operationId="auditGetEntityAuditTrail",
+     *     summary="Get entity audit trail",
+     *     description="Retrieves the audit trail for a specific entity identified by type and ID.",
+     *     tags={"Audit"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="entityType", in="path", required=true, description="Entity type (e.g. user, account, transaction)", @OA\Schema(type="string")),
+     *     @OA\Parameter(name="entityId", in="path", required=true, description="Entity ID", @OA\Schema(type="string")),
+     *     @OA\Response(response=200, description="Entity audit trail retrieved successfully", @OA\JsonContent(
+     *         @OA\Property(property="data", type="array", @OA\Items(type="object")),
+     *         @OA\Property(property="meta", type="object",
+     *             @OA\Property(property="entity_type", type="string"),
+     *             @OA\Property(property="entity_id", type="string")
+     *         )
+     *     )),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Entity not found")
+     * )
+     */
     public function getEntityAuditTrail($entityType, $entityId): JsonResponse
     {
         return response()->json(
@@ -82,6 +209,23 @@ class AuditController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/audit/users/{userId}/activity",
+     *     operationId="auditGetUserActivity",
+     *     summary="Get user activity",
+     *     description="Retrieves the activity log for a specific user.",
+     *     tags={"Audit"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="userId", in="path", required=true, description="User ID", @OA\Schema(type="string")),
+     *     @OA\Response(response=200, description="User activity retrieved successfully", @OA\JsonContent(
+     *         @OA\Property(property="data", type="array", @OA\Items(type="object")),
+     *         @OA\Property(property="meta", type="object", @OA\Property(property="user_id", type="string"))
+     *     )),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="User not found")
+     * )
+     */
     public function getUserActivity($userId): JsonResponse
     {
         return response()->json(
@@ -92,6 +236,25 @@ class AuditController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/audit/search",
+     *     operationId="auditSearchAuditLogs",
+     *     summary="Search audit logs",
+     *     description="Searches audit logs with query parameters and returns matching results.",
+     *     tags={"Audit"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="query", in="query", required=false, description="Search query string", @OA\Schema(type="string")),
+     *     @OA\Parameter(name="from", in="query", required=false, description="Start date filter", @OA\Schema(type="string", format="date-time")),
+     *     @OA\Parameter(name="to", in="query", required=false, description="End date filter", @OA\Schema(type="string", format="date-time")),
+     *     @OA\Parameter(name="action", in="query", required=false, description="Filter by action type", @OA\Schema(type="string")),
+     *     @OA\Response(response=200, description="Search results returned successfully", @OA\JsonContent(
+     *         @OA\Property(property="data", type="array", @OA\Items(type="object")),
+     *         @OA\Property(property="meta", type="object", @OA\Property(property="total", type="integer"))
+     *     )),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function searchAuditLogs(Request $request): JsonResponse
     {
         return response()->json(
@@ -102,6 +265,28 @@ class AuditController extends Controller
         );
     }
 
+    /**
+     * @OA\Post(
+     *     path="/api/audit/archive",
+     *     operationId="auditArchiveAuditLogs",
+     *     summary="Archive audit logs",
+     *     description="Archives audit logs based on the provided criteria.",
+     *     tags={"Audit"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=false,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="before", type="string", format="date-time", description="Archive logs before this date"),
+     *             @OA\Property(property="retention_days", type="integer", description="Number of days to retain")
+     *         )
+     *     ),
+     *     @OA\Response(response=200, description="Audit logs archived successfully", @OA\JsonContent(
+     *         @OA\Property(property="message", type="string", example="Audit logs archived"),
+     *         @OA\Property(property="data", type="array", @OA\Items(type="object"))
+     *     )),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function archiveAuditLogs(Request $request): JsonResponse
     {
         return response()->json(

--- a/app/Http/Controllers/Api/ComplianceController.php
+++ b/app/Http/Controllers/Api/ComplianceController.php
@@ -8,6 +8,34 @@ use Illuminate\Http\Request;
 
 class ComplianceController extends Controller
 {
+    /**
+     * @OA\Get(
+     *     path="/api/compliance/dashboard",
+     *     operationId="complianceDashboard",
+     *     summary="Get compliance dashboard overview",
+     *     description="Returns the overall compliance dashboard with scores, KYC rates, pending reviews, violations, and audit dates.",
+     *     tags={"Compliance"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="string", example="success"),
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="object",
+     *                 @OA\Property(property="overall_compliance_score", type="number", format="float", example=94.5),
+     *                 @OA\Property(property="kyc_completion_rate", type="number", format="float", example=98.2),
+     *                 @OA\Property(property="pending_reviews", type="integer", example=12),
+     *                 @OA\Property(property="active_violations", type="integer", example=3),
+     *                 @OA\Property(property="last_audit_date", type="string", format="date", example="2025-01-03"),
+     *                 @OA\Property(property="next_audit_date", type="string", format="date", example="2025-02-03")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function dashboard(): JsonResponse
     {
         return response()->json(
@@ -25,6 +53,25 @@ class ComplianceController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/compliance/violations",
+     *     operationId="complianceGetViolations",
+     *     summary="List all compliance violations",
+     *     description="Returns a list of all compliance violations.",
+     *     tags={"Compliance"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="string", example="success"),
+     *             @OA\Property(property="data", type="array", @OA\Items(type="object"))
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function getViolations(): JsonResponse
     {
         return response()->json(
@@ -35,6 +82,33 @@ class ComplianceController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/compliance/violations/{id}",
+     *     operationId="complianceGetViolationDetails",
+     *     summary="Get violation details",
+     *     description="Returns detailed information about a specific compliance violation.",
+     *     tags={"Compliance"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         description="Violation ID",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="string", example="success"),
+     *             @OA\Property(property="data", type="object", nullable=true)
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Violation not found")
+     * )
+     */
     public function getViolationDetails($id): JsonResponse
     {
         return response()->json(
@@ -45,6 +119,33 @@ class ComplianceController extends Controller
         );
     }
 
+    /**
+     * @OA\Post(
+     *     path="/api/compliance/violations/{id}/resolve",
+     *     operationId="complianceResolveViolation",
+     *     summary="Resolve a compliance violation",
+     *     description="Marks a specific compliance violation as resolved.",
+     *     tags={"Compliance"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         description="Violation ID",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="string", example="success"),
+     *             @OA\Property(property="message", type="string", example="Violation resolved successfully")
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Violation not found")
+     * )
+     */
     public function resolveViolation($id): JsonResponse
     {
         return response()->json(
@@ -55,6 +156,25 @@ class ComplianceController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/compliance/rules",
+     *     operationId="complianceGetComplianceRules",
+     *     summary="List all compliance rules",
+     *     description="Returns a list of all configured compliance rules.",
+     *     tags={"Compliance"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="string", example="success"),
+     *             @OA\Property(property="data", type="array", @OA\Items(type="object"))
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function getComplianceRules(): JsonResponse
     {
         return response()->json(
@@ -65,6 +185,33 @@ class ComplianceController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/compliance/rules/{jurisdiction}",
+     *     operationId="complianceGetRulesByJurisdiction",
+     *     summary="Get compliance rules by jurisdiction",
+     *     description="Returns compliance rules filtered by a specific jurisdiction.",
+     *     tags={"Compliance"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="jurisdiction",
+     *         in="path",
+     *         required=true,
+     *         description="Jurisdiction code (e.g., US, EU, UK)",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="string", example="success"),
+     *             @OA\Property(property="data", type="array", @OA\Items(type="object"))
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Jurisdiction not found")
+     * )
+     */
     public function getRulesByJurisdiction($jurisdiction): JsonResponse
     {
         return response()->json(
@@ -75,6 +222,25 @@ class ComplianceController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/compliance/checks",
+     *     operationId="complianceGetComplianceChecks",
+     *     summary="List all compliance checks",
+     *     description="Returns a list of all compliance checks that have been performed.",
+     *     tags={"Compliance"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="string", example="success"),
+     *             @OA\Property(property="data", type="array", @OA\Items(type="object"))
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function getComplianceChecks(): JsonResponse
     {
         return response()->json(
@@ -85,6 +251,34 @@ class ComplianceController extends Controller
         );
     }
 
+    /**
+     * @OA\Post(
+     *     path="/api/compliance/checks/run",
+     *     operationId="complianceRunComplianceCheck",
+     *     summary="Run a compliance check",
+     *     description="Initiates a new compliance check with the provided parameters.",
+     *     tags={"Compliance"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="check_type", type="string", description="Type of compliance check to run", example="full_audit"),
+     *             @OA\Property(property="scope", type="string", description="Scope of the check", example="all_accounts"),
+     *             @OA\Property(property="parameters", type="object", description="Additional check parameters")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="string", example="success"),
+     *             @OA\Property(property="message", type="string", example="Compliance check initiated")
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=422, description="Validation error")
+     * )
+     */
     public function runComplianceCheck(Request $request): JsonResponse
     {
         return response()->json(
@@ -95,6 +289,25 @@ class ComplianceController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/compliance/certifications",
+     *     operationId="complianceGetCertifications",
+     *     summary="List all compliance certifications",
+     *     description="Returns a list of all compliance certifications and their statuses.",
+     *     tags={"Compliance"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="string", example="success"),
+     *             @OA\Property(property="data", type="array", @OA\Items(type="object"))
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function getCertifications(): JsonResponse
     {
         return response()->json(
@@ -105,6 +318,34 @@ class ComplianceController extends Controller
         );
     }
 
+    /**
+     * @OA\Post(
+     *     path="/api/compliance/certifications/renew",
+     *     operationId="complianceRenewCertification",
+     *     summary="Renew a compliance certification",
+     *     description="Initiates the renewal process for a compliance certification.",
+     *     tags={"Compliance"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="certification_id", type="string", description="ID of the certification to renew"),
+     *             @OA\Property(property="renewal_type", type="string", description="Type of renewal", example="standard"),
+     *             @OA\Property(property="notes", type="string", description="Additional notes for the renewal")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="string", example="success"),
+     *             @OA\Property(property="message", type="string", example="Certification renewal initiated")
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=422, description="Validation error")
+     * )
+     */
     public function renewCertification(Request $request): JsonResponse
     {
         return response()->json(
@@ -115,6 +356,25 @@ class ComplianceController extends Controller
         );
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/compliance/policies",
+     *     operationId="complianceGetPolicies",
+     *     summary="List all compliance policies",
+     *     description="Returns a list of all compliance policies.",
+     *     tags={"Compliance"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="string", example="success"),
+     *             @OA\Property(property="data", type="array", @OA\Items(type="object"))
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function getPolicies(): JsonResponse
     {
         return response()->json(
@@ -125,6 +385,43 @@ class ComplianceController extends Controller
         );
     }
 
+    /**
+     * @OA\Put(
+     *     path="/api/compliance/policies/{id}",
+     *     operationId="complianceUpdatePolicy",
+     *     summary="Update a compliance policy",
+     *     description="Updates a specific compliance policy with the provided data.",
+     *     tags={"Compliance"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         description="Policy ID",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="name", type="string", description="Policy name"),
+     *             @OA\Property(property="description", type="string", description="Policy description"),
+     *             @OA\Property(property="rules", type="array", @OA\Items(type="object"), description="Policy rules"),
+     *             @OA\Property(property="status", type="string", description="Policy status", example="active")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="status", type="string", example="success"),
+     *             @OA\Property(property="message", type="string", example="Policy updated successfully")
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Policy not found"),
+     *     @OA\Response(response=422, description="Validation error")
+     * )
+     */
     public function updatePolicy($id, Request $request): JsonResponse
     {
         return response()->json(

--- a/app/Http/Controllers/Api/Documentation/OpenApiDoc.php
+++ b/app/Http/Controllers/Api/Documentation/OpenApiDoc.php
@@ -83,6 +83,34 @@ namespace App\Http\Controllers\Api\Documentation;
  *     name="Partner BaaS",
  *     description="Banking-as-a-Service partner API: billing, SDKs, widgets, marketplace"
  * )
+ * @OA\Tag(
+ *     name="Compliance",
+ *     description="Compliance management: violations, rules, certifications, and policy enforcement"
+ * )
+ * @OA\Tag(
+ *     name="Audit",
+ *     description="Audit trail: logs, events, reports, entity trails, and user activity"
+ * )
+ * @OA\Tag(
+ *     name="Fraud Detection",
+ *     description="Fraud detection: alerts, patterns, cases, and investigation workflows"
+ * )
+ * @OA\Tag(
+ *     name="Risk Management",
+ *     description="Risk analysis: user risk profiles, transaction scoring, device fingerprinting"
+ * )
+ * @OA\Tag(
+ *     name="Module Management",
+ *     description="Platform module management: enable, disable, health checks, and verification"
+ * )
+ * @OA\Tag(
+ *     name="WebAuthn",
+ *     description="WebAuthn/FIDO2 passkey authentication: challenge, authenticate, and register"
+ * )
+ * @OA\Tag(
+ *     name="Account Deletion",
+ *     description="Account deletion and data removal requests"
+ * )
  */
 class OpenApiDoc
 {

--- a/app/Http/Controllers/Api/EnhancedRegulatoryController.php
+++ b/app/Http/Controllers/Api/EnhancedRegulatoryController.php
@@ -25,6 +25,37 @@ class EnhancedRegulatoryController extends Controller
 
     /**
      * List regulatory reports with enhanced filtering.
+     *
+     * @OA\Get(
+     *     path="/api/compliance/regulatory-reports",
+     *     operationId="regulatoryIndex",
+     *     summary="List regulatory reports with enhanced filtering",
+     *     description="Returns a paginated list of regulatory reports with support for filtering by type, jurisdiction, status, date range, overdue flag, and priority.",
+     *     tags={"Compliance"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="report_type", in="query", required=false, @OA\Schema(type="string"), description="Filter by report type"),
+     *     @OA\Parameter(name="jurisdiction", in="query", required=false, @OA\Schema(type="string"), description="Filter by jurisdiction"),
+     *     @OA\Parameter(name="status", in="query", required=false, @OA\Schema(type="string"), description="Filter by report status"),
+     *     @OA\Parameter(name="date_from", in="query", required=false, @OA\Schema(type="string", format="date"), description="Start of reporting period"),
+     *     @OA\Parameter(name="date_to", in="query", required=false, @OA\Schema(type="string", format="date"), description="End of reporting period"),
+     *     @OA\Parameter(name="overdue_only", in="query", required=false, @OA\Schema(type="boolean"), description="Show only overdue reports"),
+     *     @OA\Parameter(name="priority", in="query", required=false, @OA\Schema(type="integer", minimum=1, maximum=5), description="Minimum priority level"),
+     *     @OA\Parameter(name="page", in="query", required=false, @OA\Schema(type="integer", minimum=1), description="Page number"),
+     *     @OA\Parameter(name="per_page", in="query", required=false, @OA\Schema(type="integer", minimum=10, maximum=100), description="Results per page"),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Paginated list of regulatory reports",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="array", @OA\Items(type="object")),
+     *             @OA\Property(property="current_page", type="integer", example=1),
+     *             @OA\Property(property="last_page", type="integer", example=5),
+     *             @OA\Property(property="per_page", type="integer", example=20),
+     *             @OA\Property(property="total", type="integer", example=100)
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=422, description="Validation error")
+     * )
      */
     public function index(Request $request): JsonResponse
     {
@@ -79,6 +110,33 @@ class EnhancedRegulatoryController extends Controller
 
     /**
      * Show regulatory report details.
+     *
+     * @OA\Get(
+     *     path="/api/compliance/regulatory-reports/{reportId}",
+     *     operationId="regulatoryShow",
+     *     summary="Show regulatory report details",
+     *     description="Returns detailed information for a specific regulatory report, including time until due, submission eligibility, and full filing history.",
+     *     tags={"Compliance"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="reportId", in="path", required=true, @OA\Schema(type="string"), description="Regulatory report ID"),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Report details",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="report", type="object"),
+     *             @OA\Property(property="time_until_due", type="string", example="3 days", nullable=true),
+     *             @OA\Property(property="can_be_submitted", type="boolean", example=true),
+     *             @OA\Property(property="filing_history", type="array", @OA\Items(
+     *                 @OA\Property(property="filing_id", type="string"),
+     *                 @OA\Property(property="status", type="string"),
+     *                 @OA\Property(property="filed_at", type="string", format="date-time"),
+     *                 @OA\Property(property="processing_time", type="string", nullable=true)
+     *             ))
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Report not found")
+     * )
      */
     public function show(string $reportId): JsonResponse
     {
@@ -99,6 +157,35 @@ class EnhancedRegulatoryController extends Controller
 
     /**
      * Generate enhanced CTR report.
+     *
+     * @OA\Post(
+     *     path="/api/compliance/regulatory-reports/generate/ctr",
+     *     operationId="regulatoryGenerateEnhancedCTR",
+     *     summary="Generate enhanced Currency Transaction Report",
+     *     description="Generates an enhanced CTR (Currency Transaction Report) for the specified date, including fraud analysis indicators.",
+     *     tags={"Compliance"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"date"},
+     *             @OA\Property(property="date", type="string", format="date", example="2025-01-15", description="Report date (must be today or earlier)")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="CTR generated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Enhanced CTR generated successfully"),
+     *             @OA\Property(property="report", type="object"),
+     *             @OA\Property(property="fraud_analysis_included", type="boolean", example=true)
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=403, description="Forbidden"),
+     *     @OA\Response(response=422, description="Validation error"),
+     *     @OA\Response(response=500, description="Report generation failed")
+     * )
      */
     public function generateEnhancedCTR(Request $request): JsonResponse
     {
@@ -125,6 +212,36 @@ class EnhancedRegulatoryController extends Controller
 
     /**
      * Generate enhanced SAR report.
+     *
+     * @OA\Post(
+     *     path="/api/compliance/regulatory-reports/generate/sar",
+     *     operationId="regulatoryGenerateEnhancedSAR",
+     *     summary="Generate enhanced Suspicious Activity Report",
+     *     description="Generates an enhanced SAR (Suspicious Activity Report) for the specified date range. Flags reports that require immediate filing.",
+     *     tags={"Compliance"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"start_date", "end_date"},
+     *             @OA\Property(property="start_date", type="string", format="date", example="2025-01-01", description="Start date (must be today or earlier)"),
+     *             @OA\Property(property="end_date", type="string", format="date", example="2025-01-31", description="End date (must be on or after start_date and today or earlier)")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="SAR generated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Enhanced SAR generated successfully"),
+     *             @OA\Property(property="report", type="object"),
+     *             @OA\Property(property="requires_immediate_filing", type="boolean", example=false)
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=403, description="Forbidden"),
+     *     @OA\Response(response=422, description="Validation error"),
+     *     @OA\Response(response=500, description="Report generation failed")
+     * )
      */
     public function generateEnhancedSAR(Request $request): JsonResponse
     {
@@ -154,6 +271,34 @@ class EnhancedRegulatoryController extends Controller
 
     /**
      * Generate AML report.
+     *
+     * @OA\Post(
+     *     path="/api/compliance/regulatory-reports/generate/aml",
+     *     operationId="regulatoryGenerateAMLReport",
+     *     summary="Generate AML compliance report",
+     *     description="Generates an Anti-Money Laundering (AML) compliance report for the specified month.",
+     *     tags={"Compliance"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"month"},
+     *             @OA\Property(property="month", type="string", example="2025-01", description="Report month in Y-m format (must be current month or earlier)")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="AML report generated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="AML report generated successfully"),
+     *             @OA\Property(property="report", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=403, description="Forbidden"),
+     *     @OA\Response(response=422, description="Validation error"),
+     *     @OA\Response(response=500, description="Report generation failed")
+     * )
      */
     public function generateAMLReport(Request $request): JsonResponse
     {
@@ -179,6 +324,35 @@ class EnhancedRegulatoryController extends Controller
 
     /**
      * Generate OFAC report.
+     *
+     * @OA\Post(
+     *     path="/api/compliance/regulatory-reports/generate/ofac",
+     *     operationId="regulatoryGenerateOFACReport",
+     *     summary="Generate OFAC sanctions screening report",
+     *     description="Generates an OFAC (Office of Foreign Assets Control) sanctions screening report for the specified date. Flags reports that require immediate action.",
+     *     tags={"Compliance"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"date"},
+     *             @OA\Property(property="date", type="string", format="date", example="2025-01-15", description="Report date (must be today or earlier)")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="OFAC report generated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="OFAC report generated successfully"),
+     *             @OA\Property(property="report", type="object"),
+     *             @OA\Property(property="requires_immediate_action", type="boolean", example=false)
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=403, description="Forbidden"),
+     *     @OA\Response(response=422, description="Validation error"),
+     *     @OA\Response(response=500, description="Report generation failed")
+     * )
      */
     public function generateOFACReport(Request $request): JsonResponse
     {
@@ -205,6 +379,35 @@ class EnhancedRegulatoryController extends Controller
 
     /**
      * Generate BSA report.
+     *
+     * @OA\Post(
+     *     path="/api/compliance/regulatory-reports/generate/bsa",
+     *     operationId="regulatoryGenerateBSAReport",
+     *     summary="Generate BSA compliance report",
+     *     description="Generates a Bank Secrecy Act (BSA) compliance report for the specified quarter and year.",
+     *     tags={"Compliance"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"quarter", "year"},
+     *             @OA\Property(property="quarter", type="integer", minimum=1, maximum=4, example=1, description="Fiscal quarter (1-4)"),
+     *             @OA\Property(property="year", type="integer", minimum=2020, example=2025, description="Report year")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="BSA report generated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="BSA report generated successfully"),
+     *             @OA\Property(property="report", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=403, description="Forbidden"),
+     *     @OA\Response(response=422, description="Validation error"),
+     *     @OA\Response(response=500, description="Report generation failed")
+     * )
      */
     public function generateBSAReport(Request $request): JsonResponse
     {
@@ -231,6 +434,37 @@ class EnhancedRegulatoryController extends Controller
 
     /**
      * Submit report to regulatory authority.
+     *
+     * @OA\Post(
+     *     path="/api/compliance/regulatory-reports/{reportId}/submit",
+     *     operationId="regulatorySubmitReport",
+     *     summary="Submit a regulatory report to the authority",
+     *     description="Submits a regulatory report for filing with the appropriate regulatory authority. Supports initial, amendment, and correction filing types via API, portal, or email.",
+     *     tags={"Compliance"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="reportId", in="path", required=true, @OA\Schema(type="string"), description="Regulatory report ID"),
+     *     @OA\RequestBody(
+     *         required=false,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="filing_type", type="string", enum={"initial", "amendment", "correction"}, example="initial", description="Type of filing"),
+     *             @OA\Property(property="filing_method", type="string", enum={"api", "portal", "email"}, example="api", description="Filing submission method")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Report submitted successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Report submitted successfully"),
+     *             @OA\Property(property="filing", type="object"),
+     *             @OA\Property(property="reference", type="string", example="FIL-2025-00123")
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=403, description="Forbidden"),
+     *     @OA\Response(response=404, description="Report not found"),
+     *     @OA\Response(response=422, description="Validation error"),
+     *     @OA\Response(response=500, description="Submission failed")
+     * )
      */
     public function submitReport(Request $request, string $reportId): JsonResponse
     {
@@ -259,6 +493,28 @@ class EnhancedRegulatoryController extends Controller
 
     /**
      * Check filing status.
+     *
+     * @OA\Get(
+     *     path="/api/compliance/regulatory-reports/filings/{filingId}/status",
+     *     operationId="regulatoryCheckFilingStatus",
+     *     summary="Check the status of a regulatory filing",
+     *     description="Queries the current status of a previously submitted regulatory filing, returning the latest filing record and any status updates.",
+     *     tags={"Compliance"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="filingId", in="path", required=true, @OA\Schema(type="string"), description="Filing record ID"),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Filing status retrieved",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="filing", type="object"),
+     *             @OA\Property(property="status_check", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=403, description="Forbidden"),
+     *     @OA\Response(response=404, description="Filing not found"),
+     *     @OA\Response(response=500, description="Status check failed")
+     * )
      */
     public function checkFilingStatus(string $filingId): JsonResponse
     {
@@ -281,6 +537,28 @@ class EnhancedRegulatoryController extends Controller
 
     /**
      * Retry failed filing.
+     *
+     * @OA\Post(
+     *     path="/api/compliance/regulatory-reports/filings/{filingId}/retry",
+     *     operationId="regulatoryRetryFiling",
+     *     summary="Retry a failed regulatory filing",
+     *     description="Retries submission of a previously failed regulatory filing.",
+     *     tags={"Compliance"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="filingId", in="path", required=true, @OA\Schema(type="string"), description="Filing record ID"),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Filing retry initiated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Filing retry initiated"),
+     *             @OA\Property(property="filing", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=403, description="Forbidden"),
+     *     @OA\Response(response=404, description="Filing not found"),
+     *     @OA\Response(response=500, description="Retry failed")
+     * )
      */
     public function retryFiling(string $filingId): JsonResponse
     {
@@ -303,6 +581,34 @@ class EnhancedRegulatoryController extends Controller
 
     /**
      * Get regulatory thresholds.
+     *
+     * @OA\Get(
+     *     path="/api/compliance/regulatory-reports/thresholds",
+     *     operationId="regulatoryGetThresholds",
+     *     summary="Get regulatory thresholds",
+     *     description="Returns a paginated list of regulatory thresholds, with optional filtering by category, report type, jurisdiction, and active status.",
+     *     tags={"Compliance"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="category", in="query", required=false, @OA\Schema(type="string"), description="Filter by threshold category"),
+     *     @OA\Parameter(name="report_type", in="query", required=false, @OA\Schema(type="string"), description="Filter by report type"),
+     *     @OA\Parameter(name="jurisdiction", in="query", required=false, @OA\Schema(type="string"), description="Filter by jurisdiction"),
+     *     @OA\Parameter(name="active_only", in="query", required=false, @OA\Schema(type="boolean"), description="Show only active thresholds (default true)"),
+     *     @OA\Parameter(name="per_page", in="query", required=false, @OA\Schema(type="integer", minimum=10, maximum=100), description="Results per page"),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Paginated list of regulatory thresholds",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="array", @OA\Items(type="object")),
+     *             @OA\Property(property="current_page", type="integer", example=1),
+     *             @OA\Property(property="last_page", type="integer", example=3),
+     *             @OA\Property(property="per_page", type="integer", example=20),
+     *             @OA\Property(property="total", type="integer", example=50)
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=403, description="Forbidden"),
+     *     @OA\Response(response=422, description="Validation error")
+     * )
      */
     public function getThresholds(Request $request): JsonResponse
     {
@@ -339,6 +645,37 @@ class EnhancedRegulatoryController extends Controller
 
     /**
      * Update threshold.
+     *
+     * @OA\Put(
+     *     path="/api/compliance/regulatory-reports/thresholds/{thresholdId}",
+     *     operationId="regulatoryUpdateThreshold",
+     *     summary="Update a regulatory threshold",
+     *     description="Updates configuration for a specific regulatory threshold, including amount, count, active status, and review priority.",
+     *     tags={"Compliance"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="thresholdId", in="path", required=true, @OA\Schema(type="string"), description="Threshold ID"),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="amount_threshold", type="number", format="float", example=10000.00, description="Amount threshold"),
+     *             @OA\Property(property="count_threshold", type="integer", minimum=0, example=5, description="Transaction count threshold"),
+     *             @OA\Property(property="is_active", type="boolean", example=true, description="Whether the threshold is active"),
+     *             @OA\Property(property="review_priority", type="integer", minimum=1, maximum=5, example=3, description="Review priority level")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Threshold updated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Threshold updated successfully"),
+     *             @OA\Property(property="threshold", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=403, description="Forbidden"),
+     *     @OA\Response(response=404, description="Threshold not found"),
+     *     @OA\Response(response=422, description="Validation error")
+     * )
      */
     public function updateThreshold(Request $request, string $thresholdId): JsonResponse
     {
@@ -360,6 +697,48 @@ class EnhancedRegulatoryController extends Controller
 
     /**
      * Get regulatory dashboard.
+     *
+     * @OA\Get(
+     *     path="/api/compliance/regulatory-reports/dashboard",
+     *     operationId="regulatoryDashboard",
+     *     summary="Get the regulatory compliance dashboard",
+     *     description="Returns an aggregated dashboard view of regulatory reports, including totals, pending/overdue counts, breakdowns by type and jurisdiction, upcoming deadlines, recent filings, and top threshold triggers.",
+     *     tags={"Compliance"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="period", in="query", required=false, @OA\Schema(type="string", enum={"week", "month", "quarter", "year"}), description="Dashboard time period (default: month)"),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Dashboard data",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="dashboard", type="object",
+     *                 @OA\Property(property="reports", type="object",
+     *                     @OA\Property(property="total", type="integer", example=42),
+     *                     @OA\Property(property="pending", type="integer", example=5),
+     *                     @OA\Property(property="overdue", type="integer", example=2),
+     *                     @OA\Property(property="submitted", type="integer", example=35)
+     *                 ),
+     *                 @OA\Property(property="by_type", type="object"),
+     *                 @OA\Property(property="by_jurisdiction", type="object"),
+     *                 @OA\Property(property="upcoming_due", type="array", @OA\Items(type="object")),
+     *                 @OA\Property(property="recent_filings", type="array", @OA\Items(
+     *                     @OA\Property(property="filing_id", type="string"),
+     *                     @OA\Property(property="report_type", type="string"),
+     *                     @OA\Property(property="status", type="string"),
+     *                     @OA\Property(property="filed_at", type="string", format="date-time")
+     *                 )),
+     *                 @OA\Property(property="threshold_triggers", type="array", @OA\Items(
+     *                     @OA\Property(property="code", type="string"),
+     *                     @OA\Property(property="name", type="string"),
+     *                     @OA\Property(property="trigger_count", type="integer"),
+     *                     @OA\Property(property="last_triggered", type="string", format="date-time", nullable=true)
+     *                 ))
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=403, description="Forbidden"),
+     *     @OA\Response(response=422, description="Validation error")
+     * )
      */
     public function dashboard(Request $request): JsonResponse
     {
@@ -425,6 +804,23 @@ class EnhancedRegulatoryController extends Controller
 
     /**
      * Download report.
+     *
+     * @OA\Get(
+     *     path="/api/compliance/regulatory-reports/{reportId}/download",
+     *     operationId="regulatoryDownload",
+     *     summary="Download a regulatory report file",
+     *     description="Downloads the generated file for a specific regulatory report. Returns a 404 if the file has not been generated or is no longer available.",
+     *     tags={"Compliance"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="reportId", in="path", required=true, @OA\Schema(type="string"), description="Regulatory report ID"),
+     *     @OA\Response(
+     *         response=200,
+     *         description="File download",
+     *         @OA\MediaType(mediaType="application/octet-stream", @OA\Schema(type="string", format="binary"))
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Report or file not found")
+     * )
      */
     public function download(string $reportId)
     {


### PR DESCRIPTION
## Summary
- Annotates **EnhancedRegulatoryController** (14 methods), **ComplianceController** (12 methods), **AuditController** (10 methods) with full OpenAPI/Swagger annotations
- Adds 7 new tags to **OpenApiDoc.php**: Compliance, Audit, Fraud Detection, Risk Management, Module Management, WebAuthn, Account Deletion
- Completes Phase 4 of v3.4.0 (alongside merged PRs #506 and #507)

## Test plan
- [ ] `php artisan l5-swagger:generate` succeeds without annotation errors
- [ ] Generated spec includes new endpoints for Compliance, Audit, EnhancedRegulatory controllers
- [ ] All 7 new tags appear in the spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)