### PR TITLE
docs: Add OpenAPI annotations to 13 medium-priority controllers

### DIFF
--- a/app/Http/Controllers/Api/BlockchainWalletController.php
+++ b/app/Http/Controllers/Api/BlockchainWalletController.php
@@ -22,6 +22,31 @@ class BlockchainWalletController extends Controller
 
     /**
      * List user's blockchain wallets.
+     *
+     * @OA\Get(
+     *     path="/api/v1/blockchain-wallets",
+     *     operationId="blockchainWalletsList",
+     *     summary="List blockchain wallets",
+     *     description="Returns a list of all blockchain wallets belonging to the authenticated user.",
+     *     tags={"Blockchain Wallets"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="array",
+     *                 @OA\Items(type="object",
+     *                     @OA\Property(property="wallet_id", type="string", example="wal_abc123"),
+     *                     @OA\Property(property="type", type="string", enum={"custodial", "non-custodial"}, example="custodial"),
+     *                     @OA\Property(property="user_id", type="integer", example=1),
+     *                     @OA\Property(property="settings", type="object"),
+     *                     @OA\Property(property="created_at", type="string", format="date-time")
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function index(Request $request)
     {
@@ -35,6 +60,43 @@ class BlockchainWalletController extends Controller
 
     /**
      * Create a new blockchain wallet.
+     *
+     * @OA\Post(
+     *     path="/api/v1/blockchain-wallets",
+     *     operationId="blockchainWalletsStore",
+     *     summary="Create a blockchain wallet",
+     *     description="Creates a new custodial or non-custodial blockchain wallet for the authenticated user.",
+     *     tags={"Blockchain Wallets"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"type"},
+     *             @OA\Property(property="type", type="string", enum={"custodial", "non-custodial"}, example="custodial"),
+     *             @OA\Property(property="mnemonic", type="string", description="Required if type is non-custodial", example="abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"),
+     *             @OA\Property(property="settings", type="object",
+     *                 @OA\Property(property="daily_limit", type="number", example=10000),
+     *                 @OA\Property(property="requires_2fa", type="boolean", example=true),
+     *                 @OA\Property(property="whitelisted_addresses", type="array", @OA\Items(type="string"))
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Wallet created successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="wallet_id", type="string", example="wal_abc123"),
+     *                 @OA\Property(property="type", type="string", example="custodial"),
+     *                 @OA\Property(property="user_id", type="integer", example=1),
+     *                 @OA\Property(property="settings", type="object"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=422, description="Validation error or invalid mnemonic")
+     * )
      */
     public function store(Request $request)
     {
@@ -78,6 +140,37 @@ class BlockchainWalletController extends Controller
 
     /**
      * Show wallet details.
+     *
+     * @OA\Get(
+     *     path="/api/v1/blockchain-wallets/{walletId}",
+     *     operationId="blockchainWalletsShow",
+     *     summary="Get wallet details",
+     *     description="Returns detailed information about a specific blockchain wallet owned by the authenticated user.",
+     *     tags={"Blockchain Wallets"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="walletId",
+     *         in="path",
+     *         required=true,
+     *         description="The wallet ID",
+     *         @OA\Schema(type="string", example="wal_abc123")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="wallet_id", type="string", example="wal_abc123"),
+     *                 @OA\Property(property="type", type="string", example="custodial"),
+     *                 @OA\Property(property="user_id", type="integer", example=1),
+     *                 @OA\Property(property="settings", type="object"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Wallet not found")
+     * )
      */
     public function show(Request $request, string $walletId)
     {
@@ -91,6 +184,49 @@ class BlockchainWalletController extends Controller
 
     /**
      * Update wallet settings.
+     *
+     * @OA\Put(
+     *     path="/api/v1/blockchain-wallets/{walletId}",
+     *     operationId="blockchainWalletsUpdate",
+     *     summary="Update wallet settings",
+     *     description="Updates the settings of a specific blockchain wallet owned by the authenticated user.",
+     *     tags={"Blockchain Wallets"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="walletId",
+     *         in="path",
+     *         required=true,
+     *         description="The wallet ID",
+     *         @OA\Schema(type="string", example="wal_abc123")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"settings"},
+     *             @OA\Property(property="settings", type="object",
+     *                 @OA\Property(property="daily_limit", type="number", example=10000),
+     *                 @OA\Property(property="requires_2fa", type="boolean", example=true),
+     *                 @OA\Property(property="whitelisted_addresses", type="array", @OA\Items(type="string"))
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Wallet settings updated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="wallet_id", type="string", example="wal_abc123"),
+     *                 @OA\Property(property="type", type="string", example="custodial"),
+     *                 @OA\Property(property="user_id", type="integer", example=1),
+     *                 @OA\Property(property="settings", type="object"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Wallet not found"),
+     *     @OA\Response(response=422, description="Validation error")
+     * )
      */
     public function update(Request $request, string $walletId)
     {
@@ -123,6 +259,39 @@ class BlockchainWalletController extends Controller
 
     /**
      * List wallet addresses.
+     *
+     * @OA\Get(
+     *     path="/api/v1/blockchain-wallets/{walletId}/addresses",
+     *     operationId="blockchainWalletsAddresses",
+     *     summary="List wallet addresses",
+     *     description="Returns all active addresses for a specific blockchain wallet owned by the authenticated user.",
+     *     tags={"Blockchain Wallets"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="walletId",
+     *         in="path",
+     *         required=true,
+     *         description="The wallet ID",
+     *         @OA\Schema(type="string", example="wal_abc123")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="array",
+     *                 @OA\Items(type="object",
+     *                     @OA\Property(property="wallet_id", type="string", example="wal_abc123"),
+     *                     @OA\Property(property="address", type="string", example="0x1234...abcd"),
+     *                     @OA\Property(property="chain", type="string", example="ethereum"),
+     *                     @OA\Property(property="is_active", type="boolean", example=true),
+     *                     @OA\Property(property="created_at", type="string", format="date-time")
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Wallet not found")
+     * )
      */
     public function addresses(Request $request, string $walletId)
     {
@@ -142,7 +311,47 @@ class BlockchainWalletController extends Controller
     }
 
     /**
-     * Generate new address.
+     * Generate new address for a wallet.
+     *
+     * @OA\Post(
+     *     path="/api/v1/blockchain-wallets/{walletId}/addresses",
+     *     operationId="blockchainWalletsGenerateAddress",
+     *     summary="Generate a new wallet address",
+     *     description="Generates a new blockchain address for the specified chain on a wallet owned by the authenticated user.",
+     *     tags={"Blockchain Wallets"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="walletId",
+     *         in="path",
+     *         required=true,
+     *         description="The wallet ID",
+     *         @OA\Schema(type="string", example="wal_abc123")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"chain"},
+     *             @OA\Property(property="chain", type="string", enum={"ethereum", "polygon", "bsc", "bitcoin"}, example="ethereum"),
+     *             @OA\Property(property="label", type="string", example="My savings address", maxLength=255)
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Address generated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="wallet_id", type="string", example="wal_abc123"),
+     *                 @OA\Property(property="address", type="string", example="0x1234...abcd"),
+     *                 @OA\Property(property="chain", type="string", example="ethereum"),
+     *                 @OA\Property(property="is_active", type="boolean", example=true),
+     *                 @OA\Property(property="created_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Wallet not found"),
+     *     @OA\Response(response=422, description="Validation error")
+     * )
      */
     public function generateAddress(Request $request, string $walletId)
     {
@@ -173,7 +382,62 @@ class BlockchainWalletController extends Controller
     }
 
     /**
-     * Get transaction history.
+     * Get transaction history for a wallet.
+     *
+     * @OA\Get(
+     *     path="/api/v1/blockchain-wallets/{walletId}/transactions",
+     *     operationId="blockchainWalletsTransactions",
+     *     summary="List wallet transactions",
+     *     description="Returns the transaction history for a specific blockchain wallet, with optional chain and status filters.",
+     *     tags={"Blockchain Wallets"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="walletId",
+     *         in="path",
+     *         required=true,
+     *         description="The wallet ID",
+     *         @OA\Schema(type="string", example="wal_abc123")
+     *     ),
+     *     @OA\Parameter(
+     *         name="chain",
+     *         in="query",
+     *         required=false,
+     *         description="Filter by blockchain network",
+     *         @OA\Schema(type="string", enum={"ethereum", "polygon", "bsc", "bitcoin"})
+     *     ),
+     *     @OA\Parameter(
+     *         name="status",
+     *         in="query",
+     *         required=false,
+     *         description="Filter by transaction status",
+     *         @OA\Schema(type="string", enum={"pending", "confirmed", "failed"})
+     *     ),
+     *     @OA\Parameter(
+     *         name="limit",
+     *         in="query",
+     *         required=false,
+     *         description="Number of transactions to return (1-100, default 50)",
+     *         @OA\Schema(type="integer", minimum=1, maximum=100, example=50)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="array",
+     *                 @OA\Items(type="object",
+     *                     @OA\Property(property="wallet_id", type="string", example="wal_abc123"),
+     *                     @OA\Property(property="chain", type="string", example="ethereum"),
+     *                     @OA\Property(property="status", type="string", example="confirmed"),
+     *                     @OA\Property(property="amount", type="string", example="1.5"),
+     *                     @OA\Property(property="tx_hash", type="string", example="0xabc...def"),
+     *                     @OA\Property(property="created_at", type="string", format="date-time")
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Wallet not found")
+     * )
      */
     public function transactions(Request $request, string $walletId)
     {
@@ -211,7 +475,42 @@ class BlockchainWalletController extends Controller
     }
 
     /**
-     * Create wallet backup.
+     * Create a wallet backup.
+     *
+     * @OA\Post(
+     *     path="/api/v1/blockchain-wallets/{walletId}/backup",
+     *     operationId="blockchainWalletsCreateBackup",
+     *     summary="Create wallet backup",
+     *     description="Creates a secure backup for a non-custodial blockchain wallet. Only non-custodial wallets can be backed up.",
+     *     tags={"Blockchain Wallets"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="walletId",
+     *         in="path",
+     *         required=true,
+     *         description="The wallet ID",
+     *         @OA\Schema(type="string", example="wal_abc123")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"password"},
+     *             @OA\Property(property="password", type="string", format="password", minLength=8, example="securepass123")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Backup created successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Wallet backup created successfully"),
+     *             @OA\Property(property="backup_id", type="string", example="backup_64a1b2c3"),
+     *             @OA\Property(property="instructions", type="string", example="Store your backup securely. You will need it to recover your wallet.")
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Wallet not found"),
+     *     @OA\Response(response=422, description="Only non-custodial wallets can be backed up")
+     * )
      */
     public function createBackup(Request $request, string $walletId)
     {
@@ -249,7 +548,26 @@ class BlockchainWalletController extends Controller
     }
 
     /**
-     * Generate new mnemonic.
+     * Generate a new mnemonic phrase.
+     *
+     * @OA\Post(
+     *     path="/api/v1/blockchain-wallets/generate-mnemonic",
+     *     operationId="blockchainWalletsGenerateMnemonic",
+     *     summary="Generate mnemonic phrase",
+     *     description="Generates a new BIP-39 mnemonic phrase for non-custodial wallet creation.",
+     *     tags={"Blockchain Wallets"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Mnemonic generated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="mnemonic", type="string", example="abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"),
+     *             @OA\Property(property="word_count", type="integer", example=12),
+     *             @OA\Property(property="warning", type="string", example="Store this mnemonic securely. It cannot be recovered if lost.")
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function generateMnemonic()
     {

--- a/app/Http/Controllers/Api/Commerce/MobileCommerceController.php
+++ b/app/Http/Controllers/Api/Commerce/MobileCommerceController.php
@@ -20,7 +20,33 @@ class MobileCommerceController extends Controller
     /**
      * List available merchants for the user.
      *
-     * GET /api/v1/commerce/merchants
+     * @OA\Get(
+     *     path="/api/v1/commerce/merchants",
+     *     operationId="commerceMerchants",
+     *     summary="List available merchants",
+     *     description="Returns a list of available merchants that accept crypto payments.",
+     *     tags={"Commerce"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="array",
+     *                 @OA\Items(type="object",
+     *                     @OA\Property(property="id", type="string", example="merchant_demo_001"),
+     *                     @OA\Property(property="display_name", type="string", example="Demo Coffee Shop"),
+     *                     @OA\Property(property="category", type="string", example="food_beverage"),
+     *                     @OA\Property(property="accepted_tokens", type="array", @OA\Items(type="string", example="USDC")),
+     *                     @OA\Property(property="accepted_networks", type="array", @OA\Items(type="string", example="polygon")),
+     *                     @OA\Property(property="icon_url", type="string", nullable=true, example=null),
+     *                     @OA\Property(property="active", type="boolean", example=true)
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function merchants(Request $request): JsonResponse
     {
@@ -54,7 +80,47 @@ class MobileCommerceController extends Controller
     /**
      * Parse a merchant QR code.
      *
-     * POST /api/v1/commerce/parse-qr
+     * @OA\Post(
+     *     path="/api/v1/commerce/parse-qr",
+     *     operationId="commerceParseQr",
+     *     summary="Parse a merchant QR code",
+     *     description="Parses a merchant QR code string and extracts payment details such as merchant ID, amount, asset, and network.",
+     *     tags={"Commerce"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"qr_data"},
+     *             @OA\Property(property="qr_data", type="string", example="finaegis://pay?merchant=merchant_demo_001&amount=25.00&asset=USDC&network=polygon", description="The raw QR code data string")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="QR code parsed successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="merchant_id", type="string", example="merchant_demo_001"),
+     *                 @OA\Property(property="amount", type="string", example="25.00"),
+     *                 @OA\Property(property="asset", type="string", example="USDC"),
+     *                 @OA\Property(property="network", type="string", example="polygon"),
+     *                 @OA\Property(property="metadata", type="object")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Invalid QR code or validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="INVALID_QR"),
+     *                 @OA\Property(property="message", type="string", example="Unable to parse QR code.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function parseQr(Request $request): JsonResponse
     {
@@ -96,7 +162,43 @@ class MobileCommerceController extends Controller
     /**
      * Create a payment request for a merchant.
      *
-     * POST /api/v1/commerce/payment-requests
+     * @OA\Post(
+     *     path="/api/v1/commerce/payment-requests",
+     *     operationId="commerceCreatePaymentRequest",
+     *     summary="Create a payment request",
+     *     description="Creates a new payment request for a merchant with a specified amount, asset, and network. The request expires after 15 minutes.",
+     *     tags={"Commerce"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"merchant_id", "amount", "asset", "network"},
+     *             @OA\Property(property="merchant_id", type="string", example="merchant_demo_001", description="The merchant ID to create the payment request for"),
+     *             @OA\Property(property="amount", type="string", example="25.00", description="The payment amount"),
+     *             @OA\Property(property="asset", type="string", enum={"USDC", "USDT", "WETH", "WBTC"}, example="USDC", description="The token asset for payment"),
+     *             @OA\Property(property="network", type="string", example="polygon", description="The blockchain network for the transaction")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Payment request created successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="string", example="pr_abc123def456"),
+     *                 @OA\Property(property="merchant_id", type="string", example="merchant_demo_001"),
+     *                 @OA\Property(property="amount", type="string", example="25.00"),
+     *                 @OA\Property(property="asset", type="string", example="USDC"),
+     *                 @OA\Property(property="network", type="string", example="polygon"),
+     *                 @OA\Property(property="status", type="string", example="pending"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="expires_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=422, description="Validation error")
+     * )
      */
     public function createPaymentRequest(Request $request): JsonResponse
     {
@@ -127,7 +229,36 @@ class MobileCommerceController extends Controller
     /**
      * Process a commerce payment.
      *
-     * POST /api/v1/commerce/payments
+     * @OA\Post(
+     *     path="/api/v1/commerce/payments",
+     *     operationId="commerceProcessPayment",
+     *     summary="Process a commerce payment",
+     *     description="Processes a payment for an existing payment request. Initiates the blockchain transaction for the commerce payment.",
+     *     tags={"Commerce"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"payment_request_id"},
+     *             @OA\Property(property="payment_request_id", type="string", example="pr_abc123def456", description="The payment request ID to process")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Payment processing initiated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="string", example="pay_abc123def456"),
+     *                 @OA\Property(property="payment_request_id", type="string", example="pr_abc123def456"),
+     *                 @OA\Property(property="status", type="string", example="processing"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=422, description="Validation error")
+     * )
      */
     public function processPayment(Request $request): JsonResponse
     {
@@ -151,7 +282,36 @@ class MobileCommerceController extends Controller
     /**
      * Generate a payment QR code.
      *
-     * POST /api/v1/commerce/generate-qr
+     * @OA\Post(
+     *     path="/api/v1/commerce/generate-qr",
+     *     operationId="commerceGenerateQr",
+     *     summary="Generate a payment QR code",
+     *     description="Generates a QR code data string for receiving a payment. The QR code expires after 30 minutes.",
+     *     tags={"Commerce"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"amount", "asset", "network"},
+     *             @OA\Property(property="amount", type="string", example="25.00", description="The payment amount"),
+     *             @OA\Property(property="asset", type="string", enum={"USDC", "USDT", "WETH", "WBTC"}, example="USDC", description="The token asset for payment"),
+     *             @OA\Property(property="network", type="string", example="polygon", description="The blockchain network for the transaction")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="QR code generated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="qr_data", type="string", example="finaegis://pay?to=user_1&amount=25.00&asset=USDC&network=polygon"),
+     *                 @OA\Property(property="expires_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=422, description="Validation error")
+     * )
      */
     public function generateQr(Request $request): JsonResponse
     {

--- a/app/Http/Controllers/Api/Documentation/OpenApiDoc.php
+++ b/app/Http/Controllers/Api/Documentation/OpenApiDoc.php
@@ -111,6 +111,46 @@ namespace App\Http\Controllers\Api\Documentation;
  *     name="Account Deletion",
  *     description="Account deletion and data removal requests"
  * )
+ * @OA\Tag(
+ *     name="Banking V2",
+ *     description="V2 open banking integration: bank connections, account aggregation, and transfers"
+ * )
+ * @OA\Tag(
+ *     name="Blockchain Wallets",
+ *     description="Blockchain wallet management: create, backup, generate addresses, and view transactions"
+ * )
+ * @OA\Tag(
+ *     name="Compliance V2",
+ *     description="V2 KYC/AML compliance: identity verification, document upload, risk profiling"
+ * )
+ * @OA\Tag(
+ *     name="BaaS Onboarding",
+ *     description="Financial institution onboarding: applications, document submission, and status tracking"
+ * )
+ * @OA\Tag(
+ *     name="TrustCert",
+ *     description="Trust certificates: applications, verification levels, requirements, and transaction limits"
+ * )
+ * @OA\Tag(
+ *     name="Commerce",
+ *     description="Mobile commerce: merchant discovery, QR payments, and payment processing"
+ * )
+ * @OA\Tag(
+ *     name="Relayer",
+ *     description="ERC-4337 gas relayer: user operations, gas estimation, and paymaster support"
+ * )
+ * @OA\Tag(
+ *     name="Mobile Wallet",
+ *     description="Mobile wallet: token balances, transaction history, address management, and transfers"
+ * )
+ * @OA\Tag(
+ *     name="Treasury",
+ *     description="Treasury management: liquidity forecasting, alerts, and workflow orchestration"
+ * )
+ * @OA\Tag(
+ *     name="Lending",
+ *     description="P2P lending: loan applications, payments, early settlement, and loan management"
+ * )
  */
 class OpenApiDoc
 {

--- a/app/Http/Controllers/Api/LiquidityForecastController.php
+++ b/app/Http/Controllers/Api/LiquidityForecastController.php
@@ -28,23 +28,47 @@ class LiquidityForecastController extends Controller
     /**
      * Generate liquidity forecast.
      *
-     * Generate a comprehensive liquidity forecast with risk metrics and scenarios
-     *
-     * @bodyParam treasury_id string required The treasury account ID
-     * @bodyParam forecast_days integer The number of days to forecast (default: 30, max: 365)
-     * @bodyParam scenarios array Optional custom scenarios for stress testing
-     *
-     * @response 200 {
-     *   "treasury_id": "uuid",
-     *   "forecast_period": 30,
-     *   "generated_at": "2024-01-01T00:00:00Z",
-     *   "base_forecast": [...],
-     *   "scenarios": {...},
-     *   "risk_metrics": {...},
-     *   "alerts": [...],
-     *   "confidence_level": 0.85,
-     *   "recommendations": [...]
-     * }
+     * @OA\Post(
+     *     path="/api/v1/treasury/liquidity-forecast/generate",
+     *     operationId="liquidityForecastGenerate",
+     *     summary="Generate liquidity forecast",
+     *     description="Generates a comprehensive liquidity forecast with risk metrics, scenario analysis, and actionable recommendations.",
+     *     tags={"Treasury"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"treasury_id"},
+     *             @OA\Property(property="treasury_id", type="string", format="uuid", example="550e8400-e29b-41d4-a716-446655440000", description="Treasury account ID"),
+     *             @OA\Property(property="forecast_days", type="integer", minimum=1, maximum=365, example=30, description="Number of days to forecast (default: 30)"),
+     *             @OA\Property(property="scenarios", type="array", description="Custom scenarios for stress testing",
+     *                 @OA\Items(
+     *                     @OA\Property(property="description", type="string", example="Market downturn"),
+     *                     @OA\Property(property="inflow_adjustment", type="number", format="float", minimum=0, maximum=2, example=0.7),
+     *                     @OA\Property(property="outflow_adjustment", type="number", format="float", minimum=0, maximum=3, example=1.5)
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Forecast generated",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="treasury_id", type="string", format="uuid"),
+     *             @OA\Property(property="forecast_period", type="integer", example=30),
+     *             @OA\Property(property="generated_at", type="string", format="date-time"),
+     *             @OA\Property(property="base_forecast", type="array", @OA\Items(type="object")),
+     *             @OA\Property(property="scenarios", type="object"),
+     *             @OA\Property(property="risk_metrics", type="object"),
+     *             @OA\Property(property="alerts", type="array", @OA\Items(type="object")),
+     *             @OA\Property(property="confidence_level", type="number", format="float", example=0.85),
+     *             @OA\Property(property="recommendations", type="array", @OA\Items(type="string"))
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=422, description="Validation error"),
+     *     @OA\Response(response=500, description="Failed to generate forecast")
+     * )
      */
     public function generateForecast(Request $request): JsonResponse
     {
@@ -83,20 +107,37 @@ class LiquidityForecastController extends Controller
     /**
      * Get current liquidity position.
      *
-     * Calculate real-time liquidity metrics and coverage ratios
-     *
-     * @urlParam treasury_id string required The treasury account ID
-     *
-     * @response 200 {
-     *   "timestamp": "2024-01-01T00:00:00Z",
-     *   "available_liquidity": 1000000.00,
-     *   "committed_outflows_24h": 50000.00,
-     *   "expected_inflows_24h": 75000.00,
-     *   "net_position_24h": 1025000.00,
-     *   "coverage_ratio": 20.0,
-     *   "status": "excellent",
-     *   "buffer_days": 45
-     * }
+     * @OA\Get(
+     *     path="/api/v1/treasury/liquidity-forecast/{treasuryId}/current",
+     *     operationId="liquidityForecastCurrent",
+     *     summary="Get current liquidity position",
+     *     description="Calculates real-time liquidity metrics and coverage ratios for a treasury account.",
+     *     tags={"Treasury"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="treasuryId",
+     *         in="path",
+     *         required=true,
+     *         description="Treasury account ID",
+     *         @OA\Schema(type="string", format="uuid")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Current liquidity position",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="timestamp", type="string", format="date-time"),
+     *             @OA\Property(property="available_liquidity", type="number", format="float", example=1000000.00),
+     *             @OA\Property(property="committed_outflows_24h", type="number", format="float", example=50000.00),
+     *             @OA\Property(property="expected_inflows_24h", type="number", format="float", example=75000.00),
+     *             @OA\Property(property="net_position_24h", type="number", format="float", example=1025000.00),
+     *             @OA\Property(property="coverage_ratio", type="number", format="float", example=20.0),
+     *             @OA\Property(property="status", type="string", example="excellent"),
+     *             @OA\Property(property="buffer_days", type="integer", example=45)
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=500, description="Failed to calculate liquidity")
+     * )
      */
     public function getCurrentLiquidity(string $treasuryId): JsonResponse
     {
@@ -115,19 +156,41 @@ class LiquidityForecastController extends Controller
     /**
      * Start automated forecasting workflow.
      *
-     * Initialize continuous liquidity monitoring and forecasting
-     *
-     * @bodyParam treasury_id string required The treasury account ID
-     * @bodyParam forecast_days integer Days to forecast (default: 30)
-     * @bodyParam update_interval_hours integer Hours between updates (default: 6)
-     * @bodyParam auto_mitigation boolean Enable automatic mitigation (default: false)
-     *
-     * @response 200 {
-     *   "workflow_id": "workflow-uuid",
-     *   "status": "started",
-     *   "treasury_id": "uuid",
-     *   "config": {...}
-     * }
+     * @OA\Post(
+     *     path="/api/v1/treasury/liquidity-forecast/workflow/start",
+     *     operationId="liquidityForecastWorkflowStart",
+     *     summary="Start forecasting workflow",
+     *     description="Initializes a continuous liquidity monitoring and forecasting workflow with configurable update intervals and automatic mitigation.",
+     *     tags={"Treasury"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"treasury_id"},
+     *             @OA\Property(property="treasury_id", type="string", format="uuid", example="550e8400-e29b-41d4-a716-446655440000", description="Treasury account ID"),
+     *             @OA\Property(property="forecast_days", type="integer", minimum=1, maximum=365, example=30, description="Days to forecast (default: 30)"),
+     *             @OA\Property(property="update_interval_hours", type="integer", minimum=1, maximum=24, example=6, description="Hours between forecast updates (default: 6)"),
+     *             @OA\Property(property="auto_mitigation", type="boolean", example=false, description="Enable automatic mitigation actions (default: false)")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Workflow started",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="workflow_id", type="string", example="liq-forecast-65a1b2c3"),
+     *             @OA\Property(property="status", type="string", example="started"),
+     *             @OA\Property(property="treasury_id", type="string", format="uuid"),
+     *             @OA\Property(property="config", type="object",
+     *                 @OA\Property(property="forecast_days", type="integer", example=30),
+     *                 @OA\Property(property="update_interval_hours", type="integer", example=6),
+     *                 @OA\Property(property="auto_mitigation", type="boolean", example=false)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=422, description="Validation error"),
+     *     @OA\Response(response=500, description="Failed to start workflow")
+     * )
      */
     public function startForecastingWorkflow(Request $request): JsonResponse
     {
@@ -175,25 +238,48 @@ class LiquidityForecastController extends Controller
     /**
      * Get forecast alerts.
      *
-     * Retrieve active liquidity alerts for a treasury account
-     *
-     * @urlParam treasury_id string required The treasury account ID
-     * @queryParam level string Filter by alert level (critical, warning, info)
-     *
-     * @response 200 {
-     *   "alerts": [
-     *     {
-     *       "level": "critical",
-     *       "type": "lcr_breach",
-     *       "message": "Liquidity Coverage Ratio below regulatory minimum",
-     *       "value": 0.85,
-     *       "threshold": 1.0,
-     *       "action_required": true
-     *     }
-     *   ],
-     *   "count": 1,
-     *   "has_critical": true
-     * }
+     * @OA\Get(
+     *     path="/api/v1/treasury/liquidity-forecast/{treasuryId}/alerts",
+     *     operationId="liquidityForecastAlerts",
+     *     summary="Get forecast alerts",
+     *     description="Retrieves active liquidity alerts for a treasury account, optionally filtered by severity level.",
+     *     tags={"Treasury"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="treasuryId",
+     *         in="path",
+     *         required=true,
+     *         description="Treasury account ID",
+     *         @OA\Schema(type="string", format="uuid")
+     *     ),
+     *     @OA\Parameter(
+     *         name="level",
+     *         in="query",
+     *         required=false,
+     *         description="Filter by alert level",
+     *         @OA\Schema(type="string", enum={"critical", "warning", "info"})
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="List of alerts",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="alerts", type="array",
+     *                 @OA\Items(
+     *                     @OA\Property(property="level", type="string", example="critical"),
+     *                     @OA\Property(property="type", type="string", example="lcr_breach"),
+     *                     @OA\Property(property="message", type="string", example="Liquidity Coverage Ratio below regulatory minimum"),
+     *                     @OA\Property(property="value", type="number", format="float", example=0.85),
+     *                     @OA\Property(property="threshold", type="number", format="float", example=1.0),
+     *                     @OA\Property(property="action_required", type="boolean", example=true)
+     *                 )
+     *             ),
+     *             @OA\Property(property="count", type="integer", example=1),
+     *             @OA\Property(property="has_critical", type="boolean", example=true)
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=500, description="Failed to retrieve alerts")
+     * )
      */
     public function getAlerts(Request $request, string $treasuryId): JsonResponse
     {

--- a/app/Http/Controllers/Api/LoanApplicationController.php
+++ b/app/Http/Controllers/Api/LoanApplicationController.php
@@ -10,6 +10,38 @@ use Illuminate\Support\Str;
 
 class LoanApplicationController extends Controller
 {
+    /**
+     * List loan applications.
+     *
+     * @OA\Get(
+     *     path="/api/v1/lending/applications",
+     *     operationId="loanApplicationsList",
+     *     summary="List loan applications",
+     *     description="Returns a paginated list of the authenticated user's loan applications ordered by submission date.",
+     *     tags={"Lending"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Paginated list of loan applications",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="array", @OA\Items(
+     *                 @OA\Property(property="id", type="string", example="app_uuid"),
+     *                 @OA\Property(property="borrower_id", type="string"),
+     *                 @OA\Property(property="status", type="string", example="submitted"),
+     *                 @OA\Property(property="requested_amount", type="number", example=10000),
+     *                 @OA\Property(property="term_months", type="integer", example=12),
+     *                 @OA\Property(property="purpose", type="string", example="personal"),
+     *                 @OA\Property(property="submitted_at", type="string", format="date-time")
+     *             )),
+     *             @OA\Property(property="current_page", type="integer", example=1),
+     *             @OA\Property(property="last_page", type="integer", example=1),
+     *             @OA\Property(property="per_page", type="integer", example=10),
+     *             @OA\Property(property="total", type="integer", example=5)
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function index(Request $request)
     {
         $applications = LoanApplication::where('borrower_id', $request->user()->id)
@@ -19,6 +51,40 @@ class LoanApplicationController extends Controller
         return response()->json($applications);
     }
 
+    /**
+     * Show loan application details.
+     *
+     * @OA\Get(
+     *     path="/api/v1/lending/applications/{id}",
+     *     operationId="loanApplicationsShow",
+     *     summary="Show loan application",
+     *     description="Returns detailed information about a specific loan application.",
+     *     tags={"Lending"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         description="Loan application ID",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Loan application details",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="id", type="string", example="app_uuid"),
+     *             @OA\Property(property="borrower_id", type="string"),
+     *             @OA\Property(property="status", type="string", example="submitted"),
+     *             @OA\Property(property="requested_amount", type="number", example=10000),
+     *             @OA\Property(property="term_months", type="integer", example=12),
+     *             @OA\Property(property="purpose", type="string", example="personal"),
+     *             @OA\Property(property="submitted_at", type="string", format="date-time")
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Application not found")
+     * )
+     */
     public function show($id)
     {
         $application = LoanApplication::where('borrower_id', auth()->id())
@@ -27,6 +93,46 @@ class LoanApplicationController extends Controller
         return response()->json($application);
     }
 
+    /**
+     * Submit a new loan application.
+     *
+     * @OA\Post(
+     *     path="/api/v1/lending/applications",
+     *     operationId="loanApplicationsStore",
+     *     summary="Submit loan application",
+     *     description="Submits a new loan application for processing. The application undergoes credit assessment and risk scoring.",
+     *     tags={"Lending"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"requested_amount", "term_months", "purpose", "employment_status", "monthly_income", "monthly_expenses"},
+     *             @OA\Property(property="requested_amount", type="number", format="float", minimum=1000, maximum=100000, example=15000, description="Loan amount requested"),
+     *             @OA\Property(property="term_months", type="integer", minimum=6, maximum=60, example=24, description="Loan term in months"),
+     *             @OA\Property(property="purpose", type="string", enum={"personal", "business", "debt_consolidation", "education", "medical", "home_improvement", "other"}, example="personal", description="Purpose of the loan"),
+     *             @OA\Property(property="employment_status", type="string", example="employed", description="Borrower's employment status"),
+     *             @OA\Property(property="monthly_income", type="number", format="float", minimum=0, example=5000, description="Monthly income"),
+     *             @OA\Property(property="monthly_expenses", type="number", format="float", minimum=0, example=2000, description="Monthly expenses"),
+     *             @OA\Property(property="additional_info", type="string", maxLength=500, example="First-time borrower", description="Optional additional information")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Application submitted",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="application", type="object",
+     *                 @OA\Property(property="id", type="string", example="app_uuid"),
+     *                 @OA\Property(property="status", type="string", example="submitted"),
+     *                 @OA\Property(property="requested_amount", type="number", example=15000),
+     *                 @OA\Property(property="term_months", type="integer", example=24)
+     *             ),
+     *             @OA\Property(property="result", type="object", description="Processing result from credit assessment")
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=422, description="Validation error")
+     * )
+     */
     public function store(Request $request, LoanApplicationService $service)
     {
         $validated = $request->validate(
@@ -73,6 +179,40 @@ class LoanApplicationController extends Controller
         );
     }
 
+    /**
+     * Cancel a loan application.
+     *
+     * @OA\Post(
+     *     path="/api/v1/lending/applications/{id}/cancel",
+     *     operationId="loanApplicationsCancel",
+     *     summary="Cancel loan application",
+     *     description="Cancels a submitted loan application. Only applications with 'submitted' status can be cancelled.",
+     *     tags={"Lending"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         description="Loan application ID",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Application cancelled",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Application cancelled successfully"),
+     *             @OA\Property(property="application", type="object",
+     *                 @OA\Property(property="id", type="string"),
+     *                 @OA\Property(property="status", type="string", example="cancelled"),
+     *                 @OA\Property(property="rejected_by", type="string", example="borrower"),
+     *                 @OA\Property(property="rejected_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Application not found or not in submitted status")
+     * )
+     */
     public function cancel($id)
     {
         $application = LoanApplication::where('borrower_id', auth()->id())

--- a/app/Http/Controllers/Api/LoanController.php
+++ b/app/Http/Controllers/Api/LoanController.php
@@ -10,6 +10,36 @@ use Illuminate\Support\Facades\DB;
 
 class LoanController extends Controller
 {
+    /**
+     * List user loans.
+     *
+     * @OA\Get(
+     *     path="/api/v1/lending/loans",
+     *     operationId="loansList",
+     *     summary="List loans",
+     *     description="Returns a paginated list of the authenticated user's loans with their applications and repayments.",
+     *     tags={"Lending"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Paginated list of loans",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="array", @OA\Items(
+     *                 @OA\Property(property="id", type="string", example="loan_uuid"),
+     *                 @OA\Property(property="borrower_id", type="string"),
+     *                 @OA\Property(property="status", type="string", example="active"),
+     *                 @OA\Property(property="application", type="object"),
+     *                 @OA\Property(property="repayments", type="array", @OA\Items(type="object"))
+     *             )),
+     *             @OA\Property(property="current_page", type="integer", example=1),
+     *             @OA\Property(property="last_page", type="integer", example=1),
+     *             @OA\Property(property="per_page", type="integer", example=10),
+     *             @OA\Property(property="total", type="integer", example=3)
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
     public function index(Request $request)
     {
         $loans = Loan::where('borrower_id', $request->user()->id)
@@ -20,6 +50,42 @@ class LoanController extends Controller
         return response()->json($loans);
     }
 
+    /**
+     * Show loan details.
+     *
+     * @OA\Get(
+     *     path="/api/v1/lending/loans/{id}",
+     *     operationId="loansShow",
+     *     summary="Show loan details",
+     *     description="Returns detailed information about a specific loan including next payment and outstanding balance.",
+     *     tags={"Lending"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         description="Loan ID",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Loan details",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="loan", type="object",
+     *                 @OA\Property(property="id", type="string"),
+     *                 @OA\Property(property="borrower_id", type="string"),
+     *                 @OA\Property(property="status", type="string", example="active"),
+     *                 @OA\Property(property="application", type="object"),
+     *                 @OA\Property(property="repayments", type="array", @OA\Items(type="object"))
+     *             ),
+     *             @OA\Property(property="next_payment", type="object"),
+     *             @OA\Property(property="outstanding_balance", type="string", example="5000.00")
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Loan not found")
+     * )
+     */
     public function show($id)
     {
         $loan = Loan::where('borrower_id', auth()->id())
@@ -35,6 +101,45 @@ class LoanController extends Controller
         );
     }
 
+    /**
+     * Make a loan payment.
+     *
+     * @OA\Post(
+     *     path="/api/v1/lending/loans/{id}/payments",
+     *     operationId="loansMakePayment",
+     *     summary="Make a loan payment",
+     *     description="Records a repayment against a scheduled payment for an active loan.",
+     *     tags={"Lending"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         description="Loan ID",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"amount", "payment_number"},
+     *             @OA\Property(property="amount", type="number", format="float", minimum=0.01, example=250.00, description="Payment amount"),
+     *             @OA\Property(property="payment_number", type="integer", minimum=1, example=1, description="Scheduled payment number")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Payment recorded",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Payment recorded successfully"),
+     *             @OA\Property(property="loan", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(response=400, description="Invalid payment number"),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Loan not found"),
+     *     @OA\Response(response=422, description="Validation error")
+     * )
+     */
     public function makePayment(Request $request, $id)
     {
         $validated = $request->validate(
@@ -84,6 +189,38 @@ class LoanController extends Controller
         );
     }
 
+    /**
+     * Get early settlement quote.
+     *
+     * @OA\Get(
+     *     path="/api/v1/lending/loans/{id}/settlement-quote",
+     *     operationId="loansSettlementQuote",
+     *     summary="Get early settlement quote",
+     *     description="Calculates the early settlement amount for a loan, showing outstanding balance, settlement amount, and potential savings.",
+     *     tags={"Lending"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         description="Loan ID",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Settlement quote",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="loan_id", type="string", example="loan_uuid"),
+     *             @OA\Property(property="outstanding_balance", type="string", example="5000.00"),
+     *             @OA\Property(property="settlement_amount", type="string", example="4800.00"),
+     *             @OA\Property(property="savings", type="string", example="200.00"),
+     *             @OA\Property(property="confirm_url", type="string", example="/api/v1/lending/loans/loan_uuid/settle")
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Loan not found")
+     * )
+     */
     public function settleEarly(Request $request, $id)
     {
         $loan = Loan::where('borrower_id', auth()->id())
@@ -106,6 +243,35 @@ class LoanController extends Controller
         );
     }
 
+    /**
+     * Confirm early settlement.
+     *
+     * @OA\Post(
+     *     path="/api/v1/lending/loans/{id}/settle",
+     *     operationId="loansConfirmSettlement",
+     *     summary="Confirm early settlement",
+     *     description="Confirms and processes the early settlement of a loan. The loan must be in active or delinquent status.",
+     *     tags={"Lending"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         description="Loan ID",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Loan settled",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Loan settled successfully"),
+     *             @OA\Property(property="loan", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Loan not found")
+     * )
+     */
     public function confirmSettlement(Request $request, $id)
     {
         $loan = Loan::where('borrower_id', auth()->id())

--- a/app/Http/Controllers/Api/Relayer/MobileRelayerController.php
+++ b/app/Http/Controllers/Api/Relayer/MobileRelayerController.php
@@ -22,7 +22,40 @@ class MobileRelayerController extends Controller
     /**
      * Get relayer status and gas prices.
      *
-     * GET /api/v1/relayer/status
+     * @OA\Get(
+     *     path="/api/v1/relayer/status",
+     *     operationId="relayerStatus",
+     *     summary="Get relayer status and gas prices",
+     *     description="Returns current relayer system health, supported networks with gas prices and congestion levels.",
+     *     tags={"Relayer"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="object",
+     *                 @OA\Property(property="healthy", type="boolean", example=true),
+     *                 @OA\Property(
+     *                     property="networks",
+     *                     type="array",
+     *                     @OA\Items(
+     *                         type="object",
+     *                         @OA\Property(property="network", type="string", example="polygon"),
+     *                         @OA\Property(property="chain_id", type="integer", example=137),
+     *                         @OA\Property(property="gas_price_gwei", type="string", example="30"),
+     *                         @OA\Property(property="congestion", type="string", example="low"),
+     *                         @OA\Property(property="native_currency", type="string", example="MATIC")
+     *                     )
+     *                 ),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function status(): JsonResponse
     {
@@ -50,7 +83,55 @@ class MobileRelayerController extends Controller
     /**
      * Estimate gas for a transaction.
      *
-     * POST /api/v1/relayer/estimate-gas
+     * @OA\Post(
+     *     path="/api/v1/relayer/estimate-gas",
+     *     operationId="relayerEstimateGas",
+     *     summary="Estimate gas for a transaction",
+     *     description="Estimates gas cost for a transaction on the specified network.",
+     *     tags={"Relayer"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"network", "to"},
+     *             @OA\Property(property="network", type="string", example="polygon", description="Target network"),
+     *             @OA\Property(property="to", type="string", example="0x1234...abcd", description="Destination address"),
+     *             @OA\Property(property="value", type="string", example="1000000", description="Transfer value"),
+     *             @OA\Property(property="data", type="string", example="0x", description="Call data")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Gas estimate returned",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="object",
+     *                 @OA\Property(property="network", type="string", example="polygon"),
+     *                 @OA\Property(property="gas_price", type="string", example="30"),
+     *                 @OA\Property(property="gas_limit", type="string", example="200000"),
+     *                 @OA\Property(property="total_cost", type="string", example="0.05"),
+     *                 @OA\Property(property="currency", type="string", example="MATIC"),
+     *                 @OA\Property(property="sponsored", type="boolean", example=true)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Unsupported network",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(
+     *                 property="error",
+     *                 type="object",
+     *                 @OA\Property(property="code", type="string", example="UNSUPPORTED_NETWORK"),
+     *                 @OA\Property(property="message", type="string", example="Network not supported.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function estimateGas(Request $request): JsonResponse
     {
@@ -91,7 +172,67 @@ class MobileRelayerController extends Controller
     /**
      * Build a UserOperation from parameters.
      *
-     * POST /api/v1/relayer/build-userop
+     * @OA\Post(
+     *     path="/api/v1/relayer/build-userop",
+     *     operationId="relayerBuildUserOp",
+     *     summary="Build a UserOperation from parameters",
+     *     description="Constructs an ERC-4337 UserOperation struct from the provided transaction parameters.",
+     *     tags={"Relayer"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"network", "to"},
+     *             @OA\Property(property="network", type="string", example="polygon", description="Target network"),
+     *             @OA\Property(property="to", type="string", example="0x1234...abcd", description="Destination address"),
+     *             @OA\Property(property="value", type="string", example="1000000", description="Transfer value"),
+     *             @OA\Property(property="data", type="string", example="0x", description="Call data"),
+     *             @OA\Property(property="from", type="string", example="0x0", description="Sender address")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="UserOperation built successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="object",
+     *                 @OA\Property(
+     *                     property="user_op",
+     *                     type="object",
+     *                     @OA\Property(property="sender", type="string", example="0x0"),
+     *                     @OA\Property(property="nonce", type="string", example="0x0"),
+     *                     @OA\Property(property="initCode", type="string", example="0x"),
+     *                     @OA\Property(property="callData", type="string", example="0x"),
+     *                     @OA\Property(property="callGasLimit", type="string", example="0x30D40"),
+     *                     @OA\Property(property="verificationGasLimit", type="string", example="0x186A0"),
+     *                     @OA\Property(property="preVerificationGas", type="string", example="0xC350"),
+     *                     @OA\Property(property="maxFeePerGas", type="string"),
+     *                     @OA\Property(property="maxPriorityFeePerGas", type="string"),
+     *                     @OA\Property(property="paymasterAndData", type="string", example="0x"),
+     *                     @OA\Property(property="signature", type="string", example="0x")
+     *                 ),
+     *                 @OA\Property(property="network", type="string", example="polygon"),
+     *                 @OA\Property(property="entry_point", type="string", example="0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Unsupported network",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(
+     *                 property="error",
+     *                 type="object",
+     *                 @OA\Property(property="code", type="string", example="UNSUPPORTED_NETWORK"),
+     *                 @OA\Property(property="message", type="string", example="Network not supported.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function buildUserOp(Request $request): JsonResponse
     {
@@ -140,7 +281,52 @@ class MobileRelayerController extends Controller
     /**
      * Submit a signed UserOperation to the bundler.
      *
-     * POST /api/v1/relayer/submit
+     * @OA\Post(
+     *     path="/api/v1/relayer/submit",
+     *     operationId="relayerSubmitUserOp",
+     *     summary="Submit a signed UserOperation",
+     *     description="Submits a signed ERC-4337 UserOperation to the bundler for on-chain execution.",
+     *     tags={"Relayer"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"network", "user_op", "signature"},
+     *             @OA\Property(property="network", type="string", example="polygon", description="Target network"),
+     *             @OA\Property(property="user_op", type="object", description="The UserOperation struct"),
+     *             @OA\Property(property="signature", type="string", example="0xabcdef...", description="Signed UserOperation signature")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="UserOperation submitted",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="object",
+     *                 @OA\Property(property="user_op_hash", type="string", example="0xabc123..."),
+     *                 @OA\Property(property="network", type="string", example="polygon"),
+     *                 @OA\Property(property="status", type="string", example="pending"),
+     *                 @OA\Property(property="submitted_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Unsupported network",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(
+     *                 property="error",
+     *                 type="object",
+     *                 @OA\Property(property="code", type="string", example="UNSUPPORTED_NETWORK"),
+     *                 @OA\Property(property="message", type="string", example="Network not supported.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function submitUserOp(Request $request): JsonResponse
     {
@@ -177,7 +363,38 @@ class MobileRelayerController extends Controller
     /**
      * Get UserOperation status by hash.
      *
-     * GET /api/v1/relayer/userop/{hash}
+     * @OA\Get(
+     *     path="/api/v1/relayer/userop/{hash}",
+     *     operationId="relayerGetUserOp",
+     *     summary="Get UserOperation status by hash",
+     *     description="Returns the current status and details of a previously submitted UserOperation.",
+     *     tags={"Relayer"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="hash",
+     *         in="path",
+     *         required=true,
+     *         description="The UserOperation hash",
+     *         @OA\Schema(type="string", example="0xabc123...")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="UserOperation details",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="object",
+     *                 @OA\Property(property="user_op_hash", type="string", example="0xabc123..."),
+     *                 @OA\Property(property="status", type="string", example="pending"),
+     *                 @OA\Property(property="tx_hash", type="string", nullable=true, example=null),
+     *                 @OA\Property(property="block_number", type="integer", nullable=true, example=null),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function getUserOp(string $hash): JsonResponse
     {
@@ -196,7 +413,32 @@ class MobileRelayerController extends Controller
     /**
      * Get tokens accepted for gas payment (paymaster).
      *
-     * GET /api/v1/relayer/supported-tokens
+     * @OA\Get(
+     *     path="/api/v1/relayer/supported-tokens",
+     *     operationId="relayerSupportedTokens",
+     *     summary="Get tokens accepted for gas payment",
+     *     description="Returns the list of tokens accepted by the paymaster for sponsored gas payments.",
+     *     tags={"Relayer"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Supported tokens list",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="array",
+     *                 @OA\Items(
+     *                     type="object",
+     *                     @OA\Property(property="symbol", type="string", example="USDC"),
+     *                     @OA\Property(property="name", type="string", example="USD Coin"),
+     *                     @OA\Property(property="sponsored", type="boolean", example=true)
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function supportedTokens(): JsonResponse
     {
@@ -215,7 +457,34 @@ class MobileRelayerController extends Controller
     /**
      * Get paymaster configuration data.
      *
-     * GET /api/v1/relayer/paymaster-data
+     * @OA\Get(
+     *     path="/api/v1/relayer/paymaster-data",
+     *     operationId="relayerPaymasterData",
+     *     summary="Get paymaster configuration data",
+     *     description="Returns paymaster addresses, entry points, sponsored tokens and gas limits per network.",
+     *     tags={"Relayer"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Paymaster configuration per network",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="array",
+     *                 @OA\Items(
+     *                     type="object",
+     *                     @OA\Property(property="network", type="string", example="polygon"),
+     *                     @OA\Property(property="paymaster_address", type="string", example="0x1234..."),
+     *                     @OA\Property(property="entry_point", type="string", example="0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789"),
+     *                     @OA\Property(property="sponsored_tokens", type="array", @OA\Items(type="string"), example={"USDC", "USDT"}),
+     *                     @OA\Property(property="max_gas_sponsored", type="string", example="500000")
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function paymasterData(): JsonResponse
     {
@@ -239,7 +508,64 @@ class MobileRelayerController extends Controller
     /**
      * Get per-network relayer status.
      *
-     * GET /api/v1/relayer/networks/{network}/status
+     * @OA\Get(
+     *     path="/api/v1/relayer/networks/{network}/status",
+     *     operationId="relayerNetworkStatus",
+     *     summary="Get per-network relayer status",
+     *     description="Returns detailed relayer status for a specific network including gas prices, block number and relayer queue depth.",
+     *     tags={"Relayer"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="network",
+     *         in="path",
+     *         required=true,
+     *         description="Network identifier (e.g. polygon, ethereum, arbitrum)",
+     *         @OA\Schema(type="string", example="polygon")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Network relayer status",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="object",
+     *                 @OA\Property(property="chainId", type="integer", example=137),
+     *                 @OA\Property(property="network", type="string", example="polygon"),
+     *                 @OA\Property(property="status", type="string", example="operational"),
+     *                 @OA\Property(
+     *                     property="gasPrice",
+     *                     type="object",
+     *                     @OA\Property(property="gwei", type="number", format="float", example=30.0),
+     *                     @OA\Property(property="usdEstimate", type="number", format="float", example=0.01)
+     *                 ),
+     *                 @OA\Property(property="blockNumber", type="integer", example=55000000),
+     *                 @OA\Property(
+     *                     property="relayer",
+     *                     type="object",
+     *                     @OA\Property(property="status", type="string", example="active"),
+     *                     @OA\Property(property="queueDepth", type="integer", example=0),
+     *                     @OA\Property(property="avgConfirmationMs", type="integer", example=2400)
+     *                 ),
+     *                 @OA\Property(property="updatedAt", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=400,
+     *         description="Unsupported network",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(
+     *                 property="error",
+     *                 type="object",
+     *                 @OA\Property(property="code", type="string", example="UNSUPPORTED_NETWORK"),
+     *                 @OA\Property(property="message", type="string", example="Network 'unsupported' is not supported")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function networkStatus(string $network): JsonResponse
     {

--- a/app/Http/Controllers/Api/TrustCert/CertificateApplicationController.php
+++ b/app/Http/Controllers/Api/TrustCert/CertificateApplicationController.php
@@ -22,7 +22,52 @@ class CertificateApplicationController extends Controller
     /**
      * Create a new certificate application.
      *
-     * POST /api/v1/trustcert/applications
+     * @OA\Post(
+     *     path="/api/v1/trustcert/applications",
+     *     operationId="trustCertApplicationCreate",
+     *     summary="Create a new certificate application",
+     *     description="Creates a new trust certificate application for the authenticated user. Only one active application is allowed at a time.",
+     *     tags={"TrustCert"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"target_level"},
+     *             @OA\Property(property="target_level", type="string", enum={"basic", "verified", "high", "ultimate"}, example="verified", description="The target trust level to apply for")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Application created successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="string", example="app_abc123def456"),
+     *                 @OA\Property(property="user_id", type="integer", example=1),
+     *                 @OA\Property(property="target_level", type="string", example="verified"),
+     *                 @OA\Property(property="status", type="string", example="draft"),
+     *                 @OA\Property(property="requirements", type="array", @OA\Items(type="string")),
+     *                 @OA\Property(property="documents", type="array", @OA\Items(type="object")),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                 @OA\Property(property="submitted_at", type="string", format="date-time", nullable=true)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=409,
+     *         description="An active application already exists",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="APPLICATION_EXISTS"),
+     *                 @OA\Property(property="message", type="string", example="An active application already exists.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=422, description="Validation error")
+     * )
      */
     public function create(Request $request): JsonResponse
     {
@@ -68,7 +113,51 @@ class CertificateApplicationController extends Controller
     /**
      * Get a specific application by ID.
      *
-     * GET /api/v1/trustcert/applications/{id}
+     * @OA\Get(
+     *     path="/api/v1/trustcert/applications/{id}",
+     *     operationId="trustCertApplicationShow",
+     *     summary="Get a specific certificate application",
+     *     description="Retrieves a specific trust certificate application by its ID for the authenticated user.",
+     *     tags={"TrustCert"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         description="The application ID",
+     *         @OA\Schema(type="string", example="app_abc123def456")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Application retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="string", example="app_abc123def456"),
+     *                 @OA\Property(property="user_id", type="integer", example=1),
+     *                 @OA\Property(property="target_level", type="string", example="verified"),
+     *                 @OA\Property(property="status", type="string", example="draft"),
+     *                 @OA\Property(property="requirements", type="array", @OA\Items(type="string")),
+     *                 @OA\Property(property="documents", type="array", @OA\Items(type="object")),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                 @OA\Property(property="submitted_at", type="string", format="date-time", nullable=true)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Application not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="APPLICATION_NOT_FOUND"),
+     *                 @OA\Property(property="message", type="string", example="Application not found.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function show(string $id, Request $request): JsonResponse
     {
@@ -94,7 +183,33 @@ class CertificateApplicationController extends Controller
     /**
      * Get the user's current active application.
      *
-     * GET /api/v1/trustcert/applications/current
+     * @OA\Get(
+     *     path="/api/v1/trustcert/applications/current",
+     *     operationId="trustCertApplicationCurrent",
+     *     summary="Get current active certificate application",
+     *     description="Returns the authenticated user's current active trust certificate application, or null if none exists.",
+     *     tags={"TrustCert"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object", nullable=true,
+     *                 @OA\Property(property="id", type="string", example="app_abc123def456"),
+     *                 @OA\Property(property="user_id", type="integer", example=1),
+     *                 @OA\Property(property="target_level", type="string", example="verified"),
+     *                 @OA\Property(property="status", type="string", example="draft"),
+     *                 @OA\Property(property="requirements", type="array", @OA\Items(type="string")),
+     *                 @OA\Property(property="documents", type="array", @OA\Items(type="object")),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                 @OA\Property(property="submitted_at", type="string", format="date-time", nullable=true)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function currentApplication(Request $request): JsonResponse
     {
@@ -110,7 +225,65 @@ class CertificateApplicationController extends Controller
     /**
      * Upload documents for a certificate application.
      *
-     * POST /api/v1/trustcert/applications/{id}/documents
+     * @OA\Post(
+     *     path="/api/v1/trustcert/applications/{id}/documents",
+     *     operationId="trustCertApplicationUploadDocuments",
+     *     summary="Upload documents for a certificate application",
+     *     description="Uploads a document to the specified certificate application. The application must be in draft status.",
+     *     tags={"TrustCert"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         description="The application ID",
+     *         @OA\Schema(type="string", example="app_abc123def456")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"document_type", "file_name"},
+     *             @OA\Property(property="document_type", type="string", enum={"identity", "address", "kyc", "audit"}, example="identity", description="The type of document being uploaded"),
+     *             @OA\Property(property="file_name", type="string", example="passport_scan.pdf", description="The name of the uploaded file")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Document uploaded successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="string", example="doc_abc123def456"),
+     *                 @OA\Property(property="document_type", type="string", example="identity"),
+     *                 @OA\Property(property="file_name", type="string", example="passport_scan.pdf"),
+     *                 @OA\Property(property="uploaded_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Application not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="APPLICATION_NOT_FOUND"),
+     *                 @OA\Property(property="message", type="string", example="Application not found.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Application is not editable or validation error",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="APPLICATION_NOT_EDITABLE"),
+     *                 @OA\Property(property="message", type="string", example="Application is not in a draft state.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function uploadDocuments(string $id, Request $request): JsonResponse
     {
@@ -162,7 +335,62 @@ class CertificateApplicationController extends Controller
     /**
      * Submit an application for review.
      *
-     * POST /api/v1/trustcert/applications/{id}/submit
+     * @OA\Post(
+     *     path="/api/v1/trustcert/applications/{id}/submit",
+     *     operationId="trustCertApplicationSubmit",
+     *     summary="Submit a certificate application for review",
+     *     description="Submits a draft certificate application for review. Only applications in draft status can be submitted.",
+     *     tags={"TrustCert"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         description="The application ID",
+     *         @OA\Schema(type="string", example="app_abc123def456")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Application submitted successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="string", example="app_abc123def456"),
+     *                 @OA\Property(property="user_id", type="integer", example=1),
+     *                 @OA\Property(property="target_level", type="string", example="verified"),
+     *                 @OA\Property(property="status", type="string", example="submitted"),
+     *                 @OA\Property(property="requirements", type="array", @OA\Items(type="string")),
+     *                 @OA\Property(property="documents", type="array", @OA\Items(type="object")),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                 @OA\Property(property="submitted_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Application not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="APPLICATION_NOT_FOUND"),
+     *                 @OA\Property(property="message", type="string", example="Application not found.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Application is not submittable",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="APPLICATION_NOT_SUBMITTABLE"),
+     *                 @OA\Property(property="message", type="string", example="Only draft applications can be submitted.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function submit(string $id, Request $request): JsonResponse
     {
@@ -203,7 +431,62 @@ class CertificateApplicationController extends Controller
     /**
      * Cancel a pending application.
      *
-     * POST /api/v1/trustcert/applications/{id}/cancel
+     * @OA\Post(
+     *     path="/api/v1/trustcert/applications/{id}/cancel",
+     *     operationId="trustCertApplicationCancel",
+     *     summary="Cancel a certificate application",
+     *     description="Cancels a pending certificate application. Applications that are already approved or cancelled cannot be cancelled.",
+     *     tags={"TrustCert"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         description="The application ID",
+     *         @OA\Schema(type="string", example="app_abc123def456")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Application cancelled successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="string", example="app_abc123def456"),
+     *                 @OA\Property(property="user_id", type="integer", example=1),
+     *                 @OA\Property(property="target_level", type="string", example="verified"),
+     *                 @OA\Property(property="status", type="string", example="cancelled"),
+     *                 @OA\Property(property="requirements", type="array", @OA\Items(type="string")),
+     *                 @OA\Property(property="documents", type="array", @OA\Items(type="object")),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time"),
+     *                 @OA\Property(property="submitted_at", type="string", format="date-time", nullable=true)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Application not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="APPLICATION_NOT_FOUND"),
+     *                 @OA\Property(property="message", type="string", example="Application not found.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Application cannot be cancelled",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="APPLICATION_NOT_CANCELLABLE"),
+     *                 @OA\Property(property="message", type="string", example="This application cannot be cancelled.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function cancel(string $id, Request $request): JsonResponse
     {

--- a/app/Http/Controllers/Api/TrustCert/MobileTrustCertController.php
+++ b/app/Http/Controllers/Api/TrustCert/MobileTrustCertController.php
@@ -20,7 +20,30 @@ class MobileTrustCertController extends Controller
     /**
      * Get user's current trust certificate and trust level.
      *
-     * GET /api/v1/trustcert/current
+     * @OA\Get(
+     *     path="/api/v1/trustcert/current",
+     *     operationId="trustCertCurrent",
+     *     summary="Get current trust certificate",
+     *     description="Returns the authenticated user's current trust certificate status and trust level information.",
+     *     tags={"TrustCert"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="trust_level", type="string", example="verified"),
+     *                 @OA\Property(property="label", type="string", example="Verified"),
+     *                 @OA\Property(property="numeric_value", type="integer", example=2),
+     *                 @OA\Property(property="certificate", type="object", nullable=true),
+     *                 @OA\Property(property="is_valid", type="boolean", example=true),
+     *                 @OA\Property(property="expires_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function current(Request $request): JsonResponse
     {
@@ -59,7 +82,35 @@ class MobileTrustCertController extends Controller
     /**
      * Get all trust levels and their requirements.
      *
-     * GET /api/v1/trustcert/requirements
+     * @OA\Get(
+     *     path="/api/v1/trustcert/requirements",
+     *     operationId="trustCertRequirements",
+     *     summary="Get all trust level requirements",
+     *     description="Returns all trust levels with their requirements and associated transaction limits.",
+     *     tags={"TrustCert"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="array",
+     *                 @OA\Items(type="object",
+     *                     @OA\Property(property="level", type="string", example="verified"),
+     *                     @OA\Property(property="label", type="string", example="Verified"),
+     *                     @OA\Property(property="numeric_value", type="integer", example=2),
+     *                     @OA\Property(property="requirements", type="array", @OA\Items(type="string")),
+     *                     @OA\Property(property="limits", type="object",
+     *                         @OA\Property(property="daily", type="number", example=5000),
+     *                         @OA\Property(property="monthly", type="number", example=50000),
+     *                         @OA\Property(property="single", type="number", example=2000)
+     *                     )
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function requirements(): JsonResponse
     {
@@ -83,7 +134,51 @@ class MobileTrustCertController extends Controller
     /**
      * Get requirements for a specific trust level.
      *
-     * GET /api/v1/trustcert/requirements/{level}
+     * @OA\Get(
+     *     path="/api/v1/trustcert/requirements/{level}",
+     *     operationId="trustCertRequirementsByLevel",
+     *     summary="Get requirements for a specific trust level",
+     *     description="Returns the requirements and transaction limits for a specific trust level.",
+     *     tags={"TrustCert"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="level",
+     *         in="path",
+     *         required=true,
+     *         description="The trust level to retrieve requirements for",
+     *         @OA\Schema(type="string", enum={"unknown", "basic", "verified", "high", "ultimate"}, example="verified")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="level", type="string", example="verified"),
+     *                 @OA\Property(property="label", type="string", example="Verified"),
+     *                 @OA\Property(property="numeric_value", type="integer", example=2),
+     *                 @OA\Property(property="requirements", type="array", @OA\Items(type="string")),
+     *                 @OA\Property(property="limits", type="object",
+     *                     @OA\Property(property="daily", type="number", example=5000),
+     *                     @OA\Property(property="monthly", type="number", example=50000),
+     *                     @OA\Property(property="single", type="number", example=2000)
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Invalid trust level",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="error", type="object",
+     *                 @OA\Property(property="code", type="string", example="INVALID_TRUST_LEVEL"),
+     *                 @OA\Property(property="message", type="string", example="Trust level not found.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function requirementsByLevel(string $level): JsonResponse
     {
@@ -114,7 +209,33 @@ class MobileTrustCertController extends Controller
     /**
      * Get transaction limits for all trust levels.
      *
-     * GET /api/v1/trustcert/limits
+     * @OA\Get(
+     *     path="/api/v1/trustcert/limits",
+     *     operationId="trustCertLimits",
+     *     summary="Get transaction limits for all trust levels",
+     *     description="Returns the transaction limits (daily, monthly, single) for each trust level.",
+     *     tags={"TrustCert"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="array",
+     *                 @OA\Items(type="object",
+     *                     @OA\Property(property="level", type="string", example="verified"),
+     *                     @OA\Property(property="label", type="string", example="Verified"),
+     *                     @OA\Property(property="limits", type="object",
+     *                         @OA\Property(property="daily", type="number", example=5000),
+     *                         @OA\Property(property="monthly", type="number", example=50000),
+     *                         @OA\Property(property="single", type="number", example=2000)
+     *                     )
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function limits(): JsonResponse
     {
@@ -136,7 +257,39 @@ class MobileTrustCertController extends Controller
     /**
      * Check if a transaction amount is within the user's trust level limits.
      *
-     * POST /api/v1/trustcert/check-limit
+     * @OA\Post(
+     *     path="/api/v1/trustcert/check-limit",
+     *     operationId="trustCertCheckLimit",
+     *     summary="Check transaction limit against trust level",
+     *     description="Checks whether a given transaction amount is within the authenticated user's trust level limits.",
+     *     tags={"TrustCert"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"amount", "transaction_type"},
+     *             @OA\Property(property="amount", type="number", example=1500.00, description="The transaction amount to check"),
+     *             @OA\Property(property="transaction_type", type="string", enum={"daily", "monthly", "single"}, example="single", description="The type of transaction limit to check against")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="allowed", type="boolean", example=true),
+     *                 @OA\Property(property="trust_level", type="string", example="verified"),
+     *                 @OA\Property(property="limit", type="number", example=2000),
+     *                 @OA\Property(property="amount", type="number", example=1500),
+     *                 @OA\Property(property="type", type="string", example="single"),
+     *                 @OA\Property(property="remaining", type="number", example=500)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=422, description="Validation error")
+     * )
      */
     public function checkLimit(Request $request): JsonResponse
     {

--- a/app/Http/Controllers/Api/V2/BankIntegrationController.php
+++ b/app/Http/Controllers/Api/V2/BankIntegrationController.php
@@ -20,6 +20,35 @@ class BankIntegrationController extends Controller
 
     /**
      * Get available banks.
+     *
+     * @OA\Get(
+     *     path="/api/v2/banks/available",
+     *     operationId="bankGetAvailableBanks",
+     *     summary="Get available banks",
+     *     description="Returns list of available bank connectors with their capabilities, supported currencies, and features.",
+     *     tags={"Banking V2"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="array",
+     *                 @OA\Items(type="object",
+     *                     @OA\Property(property="code", type="string", example="revolut"),
+     *                     @OA\Property(property="name", type="string", example="Revolut"),
+     *                     @OA\Property(property="available", type="boolean", example=true),
+     *                     @OA\Property(property="supported_currencies", type="array", @OA\Items(type="string", example="EUR")),
+     *                     @OA\Property(property="supported_transfer_types", type="array", @OA\Items(type="string", example="SEPA")),
+     *                     @OA\Property(property="features", type="array", @OA\Items(type="string", example="instant_transfers")),
+     *                     @OA\Property(property="supports_instant_transfers", type="boolean", example=true),
+     *                     @OA\Property(property="supports_multi_currency", type="boolean", example=true)
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=500, description="Server error")
+     * )
      */
     public function getAvailableBanks(): JsonResponse
     {
@@ -61,6 +90,36 @@ class BankIntegrationController extends Controller
 
     /**
      * Get user's bank connections.
+     *
+     * @OA\Get(
+     *     path="/api/v2/banks/connections",
+     *     operationId="bankGetUserConnections",
+     *     summary="Get user bank connections",
+     *     description="Returns list of the authenticated user's bank connections with status and sync information.",
+     *     tags={"Banking V2"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="array",
+     *                 @OA\Items(type="object",
+     *                     @OA\Property(property="id", type="string", example="conn_abc123"),
+     *                     @OA\Property(property="bank_code", type="string", example="revolut"),
+     *                     @OA\Property(property="status", type="string", example="active"),
+     *                     @OA\Property(property="active", type="boolean", example=true),
+     *                     @OA\Property(property="needs_renewal", type="boolean", example=false),
+     *                     @OA\Property(property="permissions", type="array", @OA\Items(type="string", example="read_accounts")),
+     *                     @OA\Property(property="last_sync_at", type="string", format="date-time", nullable=true),
+     *                     @OA\Property(property="expires_at", type="string", format="date-time", nullable=true),
+     *                     @OA\Property(property="created_at", type="string", format="date-time")
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=500, description="Server error")
+     * )
      */
     public function getUserConnections(Request $request): JsonResponse
     {
@@ -107,6 +166,41 @@ class BankIntegrationController extends Controller
 
     /**
      * Connect to a bank.
+     *
+     * @OA\Post(
+     *     path="/api/v2/banks/connect",
+     *     operationId="bankConnectBank",
+     *     summary="Connect to a bank",
+     *     description="Establishes a new connection between the authenticated user and a bank using provided credentials.",
+     *     tags={"Banking V2"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"bank_code", "credentials"},
+     *             @OA\Property(property="bank_code", type="string", example="revolut"),
+     *             @OA\Property(property="credentials", type="object",
+     *                 @OA\Property(property="api_key", type="string", example="sk_live_xxx"),
+     *                 @OA\Property(property="api_secret", type="string", example="secret_xxx")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Bank connected successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="string", example="conn_abc123"),
+     *                 @OA\Property(property="bank_code", type="string", example="revolut"),
+     *                 @OA\Property(property="status", type="string", example="active"),
+     *                 @OA\Property(property="expires_at", type="string", format="date-time", nullable=true),
+     *                 @OA\Property(property="message", type="string", example="Successfully connected to bank")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=422, description="Validation error or connection failure")
+     * )
      */
     public function connectBank(Request $request): JsonResponse
     {
@@ -157,6 +251,32 @@ class BankIntegrationController extends Controller
 
     /**
      * Disconnect from a bank.
+     *
+     * @OA\Delete(
+     *     path="/api/v2/banks/disconnect/{bankCode}",
+     *     operationId="bankDisconnectBank",
+     *     summary="Disconnect from a bank",
+     *     description="Removes the authenticated user's connection to the specified bank.",
+     *     tags={"Banking V2"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="bankCode",
+     *         in="path",
+     *         required=true,
+     *         description="Bank connector code",
+     *         @OA\Schema(type="string", example="revolut")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Successfully disconnected",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Successfully disconnected from bank")
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Bank connection not found"),
+     *     @OA\Response(response=500, description="Server error")
+     * )
      */
     public function disconnectBank(Request $request, string $bankCode): JsonResponse
     {
@@ -201,6 +321,43 @@ class BankIntegrationController extends Controller
 
     /**
      * Get user's bank accounts.
+     *
+     * @OA\Get(
+     *     path="/api/v2/banks/accounts",
+     *     operationId="bankGetBankAccounts",
+     *     summary="Get user bank accounts",
+     *     description="Returns list of the authenticated user's bank accounts, optionally filtered by bank code.",
+     *     tags={"Banking V2"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="bank_code",
+     *         in="query",
+     *         required=false,
+     *         description="Filter accounts by bank code",
+     *         @OA\Schema(type="string", example="revolut")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="array",
+     *                 @OA\Items(type="object",
+     *                     @OA\Property(property="id", type="string", example="acct_abc123"),
+     *                     @OA\Property(property="bank_code", type="string", example="revolut"),
+     *                     @OA\Property(property="account_number", type="string", example="***1234"),
+     *                     @OA\Property(property="iban", type="string", example="GB82***5678"),
+     *                     @OA\Property(property="currency", type="string", example="EUR"),
+     *                     @OA\Property(property="account_type", type="string", example="checking"),
+     *                     @OA\Property(property="status", type="string", example="active"),
+     *                     @OA\Property(property="label", type="string", example="Main Account"),
+     *                     @OA\Property(property="created_at", type="string", format="date-time")
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=500, description="Server error")
+     * )
      */
     public function getBankAccounts(Request $request): JsonResponse
     {
@@ -250,6 +407,32 @@ class BankIntegrationController extends Controller
 
     /**
      * Sync bank accounts.
+     *
+     * @OA\Post(
+     *     path="/api/v2/banks/accounts/sync/{bankCode}",
+     *     operationId="bankSyncAccounts",
+     *     summary="Sync bank accounts",
+     *     description="Triggers a synchronization of the authenticated user's accounts for the specified bank.",
+     *     tags={"Banking V2"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="bankCode",
+     *         in="path",
+     *         required=true,
+     *         description="Bank connector code",
+     *         @OA\Schema(type="string", example="revolut")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Accounts synced successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Bank accounts synced successfully"),
+     *             @OA\Property(property="accounts_synced", type="integer", example=3)
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=500, description="Server error")
+     * )
      */
     public function syncAccounts(Request $request, string $bankCode): JsonResponse
     {
@@ -283,6 +466,36 @@ class BankIntegrationController extends Controller
 
     /**
      * Get aggregated balance.
+     *
+     * @OA\Get(
+     *     path="/api/v2/banks/balance/aggregate",
+     *     operationId="bankGetAggregatedBalance",
+     *     summary="Get aggregated balance",
+     *     description="Returns the aggregated balance across all connected bank accounts for the specified currency.",
+     *     tags={"Banking V2"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="currency",
+     *         in="query",
+     *         required=true,
+     *         description="Three-letter ISO currency code",
+     *         @OA\Schema(type="string", minLength=3, maxLength=3, example="EUR")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="currency", type="string", example="EUR"),
+     *                 @OA\Property(property="balance", type="integer", example=150000),
+     *                 @OA\Property(property="formatted", type="string", example="1,500.00")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=422, description="Validation error"),
+     *     @OA\Response(response=500, description="Server error")
+     * )
      */
     public function getAggregatedBalance(Request $request): JsonResponse
     {
@@ -328,6 +541,49 @@ class BankIntegrationController extends Controller
 
     /**
      * Initiate inter-bank transfer.
+     *
+     * @OA\Post(
+     *     path="/api/v2/banks/transfer",
+     *     operationId="bankInitiateTransfer",
+     *     summary="Initiate inter-bank transfer",
+     *     description="Initiates a transfer between bank accounts, potentially across different banks. Amount is specified in the major currency unit (e.g., euros) and converted to minor units internally.",
+     *     tags={"Banking V2"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"from_bank_code", "from_account_id", "to_bank_code", "to_account_id", "amount", "currency"},
+     *             @OA\Property(property="from_bank_code", type="string", example="revolut"),
+     *             @OA\Property(property="from_account_id", type="string", example="acct_src_123"),
+     *             @OA\Property(property="to_bank_code", type="string", example="wise"),
+     *             @OA\Property(property="to_account_id", type="string", example="acct_dst_456"),
+     *             @OA\Property(property="amount", type="number", format="float", example=100.50),
+     *             @OA\Property(property="currency", type="string", minLength=3, maxLength=3, example="EUR"),
+     *             @OA\Property(property="reference", type="string", nullable=true, maxLength=140, example="Invoice #1234"),
+     *             @OA\Property(property="description", type="string", nullable=true, maxLength=500, example="Payment for services")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Transfer initiated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="string", example="txn_abc123"),
+     *                 @OA\Property(property="type", type="string", example="inter_bank"),
+     *                 @OA\Property(property="status", type="string", example="pending"),
+     *                 @OA\Property(property="amount", type="integer", example=10050),
+     *                 @OA\Property(property="currency", type="string", example="EUR"),
+     *                 @OA\Property(property="reference", type="string", example="Invoice #1234"),
+     *                 @OA\Property(property="total_amount", type="integer", example=10150),
+     *                 @OA\Property(property="fees", type="integer", example=100),
+     *                 @OA\Property(property="estimated_arrival", type="string", format="date-time", nullable=true),
+     *                 @OA\Property(property="created_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=422, description="Validation error or transfer failure")
+     * )
      */
     public function initiateTransfer(Request $request): JsonResponse
     {
@@ -397,6 +653,35 @@ class BankIntegrationController extends Controller
 
     /**
      * Get bank health status.
+     *
+     * @OA\Get(
+     *     path="/api/v2/banks/health/{bankCode}",
+     *     operationId="bankGetBankHealth",
+     *     summary="Get bank health status",
+     *     description="Returns the current health and availability status for the specified bank connector.",
+     *     tags={"Banking V2"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="bankCode",
+     *         in="path",
+     *         required=true,
+     *         description="Bank connector code",
+     *         @OA\Schema(type="string", example="revolut")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="status", type="string", example="healthy"),
+     *                 @OA\Property(property="latency_ms", type="integer", example=120),
+     *                 @OA\Property(property="last_checked_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=500, description="Server error")
+     * )
      */
     public function getBankHealth(string $bankCode): JsonResponse
     {
@@ -428,6 +713,47 @@ class BankIntegrationController extends Controller
 
     /**
      * Get recommended banks for user.
+     *
+     * @OA\Get(
+     *     path="/api/v2/banks/recommendations",
+     *     operationId="bankGetRecommendedBanks",
+     *     summary="Get recommended banks",
+     *     description="Returns a list of recommended banks for the authenticated user based on optional currency, feature, and country filters.",
+     *     tags={"Banking V2"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="currencies[]",
+     *         in="query",
+     *         required=false,
+     *         description="Filter by supported currencies (ISO 4217, 3-letter codes)",
+     *         @OA\Schema(type="array", @OA\Items(type="string", example="EUR"))
+     *     ),
+     *     @OA\Parameter(
+     *         name="features[]",
+     *         in="query",
+     *         required=false,
+     *         description="Filter by required features",
+     *         @OA\Schema(type="array", @OA\Items(type="string", example="instant_transfers"))
+     *     ),
+     *     @OA\Parameter(
+     *         name="countries[]",
+     *         in="query",
+     *         required=false,
+     *         description="Filter by supported countries (ISO 3166-1 alpha-2, 2-letter codes)",
+     *         @OA\Schema(type="array", @OA\Items(type="string", example="DE"))
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="array",
+     *                 @OA\Items(type="object")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=500, description="Server error")
+     * )
      */
     public function getRecommendedBanks(Request $request): JsonResponse
     {

--- a/app/Http/Controllers/Api/V2/ComplianceController.php
+++ b/app/Http/Controllers/Api/V2/ComplianceController.php
@@ -35,6 +35,42 @@ class ComplianceController extends Controller
 
     /**
      * Get user's KYC status.
+     *
+     * @OA\Get(
+     *     path="/api/v2/compliance/kyc/status",
+     *     operationId="complianceV2GetKycStatus",
+     *     summary="Get KYC status",
+     *     description="Returns the current KYC verification status, risk rating, verification history, and transaction limits for the authenticated user.",
+     *     tags={"Compliance V2"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="kyc_level", type="string", example="basic"),
+     *                 @OA\Property(property="kyc_status", type="string", example="verified"),
+     *                 @OA\Property(property="risk_rating", type="string", example="low"),
+     *                 @OA\Property(property="requires_verification", type="array", @OA\Items(type="string", example="address")),
+     *                 @OA\Property(property="verifications", type="array",
+     *                     @OA\Items(type="object",
+     *                         @OA\Property(property="id", type="string"),
+     *                         @OA\Property(property="type", type="string", example="identity"),
+     *                         @OA\Property(property="status", type="string", example="completed"),
+     *                         @OA\Property(property="completed_at", type="string", format="date-time", nullable=true),
+     *                         @OA\Property(property="expires_at", type="string", format="date-time", nullable=true)
+     *                     )
+     *                 ),
+     *                 @OA\Property(property="limits", type="object",
+     *                     @OA\Property(property="daily", type="number", example=10000),
+     *                     @OA\Property(property="monthly", type="number", example=50000),
+     *                     @OA\Property(property="single", type="number", example=5000)
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function getKycStatus(Request $request): JsonResponse
     {
@@ -75,6 +111,39 @@ class ComplianceController extends Controller
 
     /**
      * Start KYC verification.
+     *
+     * @OA\Post(
+     *     path="/api/v2/compliance/kyc/start",
+     *     operationId="complianceV2StartVerification",
+     *     summary="Start KYC verification",
+     *     description="Initiates a new KYC verification process for the authenticated user with the specified type and optional provider.",
+     *     tags={"Compliance V2"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"type"},
+     *             @OA\Property(property="type", type="string", enum={"identity", "address", "income", "enhanced_due_diligence"}, example="identity"),
+     *             @OA\Property(property="provider", type="string", enum={"jumio", "onfido", "manual"}, nullable=true, example="onfido")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Verification started successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="verification_id", type="string"),
+     *                 @OA\Property(property="verification_number", type="string"),
+     *                 @OA\Property(property="type", type="string", example="identity"),
+     *                 @OA\Property(property="status", type="string", example="pending"),
+     *                 @OA\Property(property="provider", type="string", example="onfido"),
+     *                 @OA\Property(property="next_steps", type="array", @OA\Items(type="string", example="upload_identity_document"))
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=422, description="Validation error or verification failed to start")
+     * )
      */
     public function startVerification(Request $request): JsonResponse
     {
@@ -128,6 +197,49 @@ class ComplianceController extends Controller
 
     /**
      * Upload verification document.
+     *
+     * @OA\Post(
+     *     path="/api/v2/compliance/kyc/{verificationId}/document",
+     *     operationId="complianceV2UploadDocument",
+     *     summary="Upload verification document",
+     *     description="Uploads a document (identity or address proof) for an active KYC verification. Supports JPG, PNG, and PDF up to 10MB.",
+     *     tags={"Compliance V2"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="verificationId",
+     *         in="path",
+     *         required=true,
+     *         description="The verification ID",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\MediaType(
+     *             mediaType="multipart/form-data",
+     *             @OA\Schema(
+     *                 required={"document_type", "document"},
+     *                 @OA\Property(property="document_type", type="string", description="Type of document being uploaded", example="passport"),
+     *                 @OA\Property(property="document", type="string", format="binary", description="Document file (jpg, jpeg, png, pdf, max 10MB)"),
+     *                 @OA\Property(property="document_side", type="string", enum={"front", "back"}, nullable=true, description="Which side of the document")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Document processed successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="success", type="boolean", example=true),
+     *                 @OA\Property(property="verification_id", type="string"),
+     *                 @OA\Property(property="confidence_score", type="number", format="float", nullable=true, example=95.5),
+     *                 @OA\Property(property="next_steps", type="array", @OA\Items(type="string", example="upload_selfie"))
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Verification not found"),
+     *     @OA\Response(response=422, description="Verification not in valid state or document verification failed")
+     * )
      */
     public function uploadDocument(Request $request, string $verificationId): JsonResponse
     {
@@ -202,6 +314,47 @@ class ComplianceController extends Controller
 
     /**
      * Upload selfie for biometric verification.
+     *
+     * @OA\Post(
+     *     path="/api/v2/compliance/kyc/{verificationId}/selfie",
+     *     operationId="complianceV2UploadSelfie",
+     *     summary="Upload selfie for biometric verification",
+     *     description="Uploads a selfie image for biometric liveness and face-match verification. If all checks pass with sufficient confidence, the verification is automatically completed.",
+     *     tags={"Compliance V2"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="verificationId",
+     *         in="path",
+     *         required=true,
+     *         description="The verification ID",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\MediaType(
+     *             mediaType="multipart/form-data",
+     *             @OA\Schema(
+     *                 required={"selfie"},
+     *                 @OA\Property(property="selfie", type="string", format="binary", description="Selfie image file (jpg, jpeg, png, max 5MB)")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Selfie processed successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="success", type="boolean", example=true),
+     *                 @OA\Property(property="liveness_score", type="number", format="float", example=98.2),
+     *                 @OA\Property(property="face_match_score", type="number", format="float", example=95.7),
+     *                 @OA\Property(property="verification_status", type="string", example="completed")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Verification not found"),
+     *     @OA\Response(response=422, description="Biometric verification failed")
+     * )
      */
     public function uploadSelfie(Request $request, string $verificationId): JsonResponse
     {
@@ -264,6 +417,39 @@ class ComplianceController extends Controller
 
     /**
      * Get AML screening status.
+     *
+     * @OA\Get(
+     *     path="/api/v2/compliance/aml/status",
+     *     operationId="complianceV2GetScreeningStatus",
+     *     summary="Get AML screening status",
+     *     description="Returns the current AML screening status, including PEP/sanctions/adverse media flags and screening history for the authenticated user.",
+     *     tags={"Compliance V2"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="is_pep", type="boolean", example=false),
+     *                 @OA\Property(property="is_sanctioned", type="boolean", example=false),
+     *                 @OA\Property(property="has_adverse_media", type="boolean", example=false),
+     *                 @OA\Property(property="last_screening_date", type="string", format="date-time", nullable=true),
+     *                 @OA\Property(property="screenings", type="array",
+     *                     @OA\Items(type="object",
+     *                         @OA\Property(property="id", type="string"),
+     *                         @OA\Property(property="screening_number", type="string"),
+     *                         @OA\Property(property="type", type="string", example="comprehensive"),
+     *                         @OA\Property(property="status", type="string", example="completed"),
+     *                         @OA\Property(property="overall_risk", type="string", example="low"),
+     *                         @OA\Property(property="total_matches", type="integer", example=0),
+     *                         @OA\Property(property="completed_at", type="string", format="date-time", nullable=true)
+     *                     )
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function getScreeningStatus(Request $request): JsonResponse
     {
@@ -301,7 +487,38 @@ class ComplianceController extends Controller
     }
 
     /**
-     * Request manual screening.
+     * Request AML screening.
+     *
+     * @OA\Post(
+     *     path="/api/v2/compliance/aml/request-screening",
+     *     operationId="complianceV2RequestScreening",
+     *     summary="Request AML screening",
+     *     description="Initiates a comprehensive AML screening for the authenticated user, checking sanctions lists, PEP databases, and adverse media.",
+     *     tags={"Compliance V2"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"type"},
+     *             @OA\Property(property="type", type="string", enum={"sanctions", "pep", "adverse_media", "comprehensive"}, example="comprehensive"),
+     *             @OA\Property(property="reason", type="string", nullable=true, maxLength=500, example="Routine periodic review")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Screening initiated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="screening_id", type="string"),
+     *                 @OA\Property(property="screening_number", type="string"),
+     *                 @OA\Property(property="status", type="string", example="pending"),
+     *                 @OA\Property(property="estimated_completion", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=422, description="Validation error or screening failed to initiate")
+     * )
      */
     public function requestScreening(Request $request): JsonResponse
     {
@@ -354,7 +571,41 @@ class ComplianceController extends Controller
     }
 
     /**
-     * Get risk profile.
+     * Get user's risk profile.
+     *
+     * @OA\Get(
+     *     path="/api/v2/compliance/risk-profile",
+     *     operationId="complianceV2GetRiskProfile",
+     *     summary="Get risk profile",
+     *     description="Returns the authenticated user's compliance risk profile including risk rating, score, CDD level, transaction limits, country/currency restrictions, and monitoring status.",
+     *     tags={"Compliance V2"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="profile_number", type="string"),
+     *                 @OA\Property(property="risk_rating", type="string", example="low"),
+     *                 @OA\Property(property="risk_score", type="number", example=25),
+     *                 @OA\Property(property="cdd_level", type="string", example="standard"),
+     *                 @OA\Property(property="factors", type="array", @OA\Items(type="string", example="high_risk_geography")),
+     *                 @OA\Property(property="limits", type="object",
+     *                     @OA\Property(property="daily", type="number", example=10000),
+     *                     @OA\Property(property="monthly", type="number", example=50000),
+     *                     @OA\Property(property="single", type="number", example=5000)
+     *                 ),
+     *                 @OA\Property(property="restrictions", type="object",
+     *                     @OA\Property(property="countries", type="array", @OA\Items(type="string", example="KP")),
+     *                     @OA\Property(property="currencies", type="array", @OA\Items(type="string", example="XMR"))
+     *                 ),
+     *                 @OA\Property(property="enhanced_monitoring", type="boolean", example=false),
+     *                 @OA\Property(property="next_review_date", type="string", format="date-time", nullable=true)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function getRiskProfile(Request $request): JsonResponse
     {
@@ -392,6 +643,40 @@ class ComplianceController extends Controller
 
     /**
      * Check transaction eligibility.
+     *
+     * @OA\Post(
+     *     path="/api/v2/compliance/check-transaction",
+     *     operationId="complianceV2CheckTransactionEligibility",
+     *     summary="Check transaction eligibility",
+     *     description="Checks whether the authenticated user is allowed to perform a transaction of the specified amount, currency, and type, based on their compliance profile and limits.",
+     *     tags={"Compliance V2"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"amount", "currency", "type"},
+     *             @OA\Property(property="amount", type="number", example=1500.00),
+     *             @OA\Property(property="currency", type="string", minLength=3, maxLength=3, example="USD"),
+     *             @OA\Property(property="type", type="string", example="transfer"),
+     *             @OA\Property(property="destination_country", type="string", minLength=2, maxLength=2, nullable=true, example="DE")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Eligibility check result",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="allowed", type="boolean", example=true),
+     *                 @OA\Property(property="reason", type="string", nullable=true, example="Within daily limit"),
+     *                 @OA\Property(property="limit", type="number", nullable=true, example=10000),
+     *                 @OA\Property(property="current_usage", type="number", nullable=true, example=3500),
+     *                 @OA\Property(property="requires_additional_verification", type="boolean", example=false)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=422, description="Validation error")
+     * )
      */
     public function checkTransactionEligibility(Request $request): JsonResponse
     {

--- a/app/Http/Controllers/Api/V2/FinancialInstitutionController.php
+++ b/app/Http/Controllers/Api/V2/FinancialInstitutionController.php
@@ -27,6 +27,40 @@ class FinancialInstitutionController extends Controller
 
     /**
      * Get application form structure.
+     *
+     * @OA\Get(
+     *     path="/api/v2/financial-institutions/application-form",
+     *     operationId="fiGetApplicationForm",
+     *     summary="Get application form structure",
+     *     description="Returns the application form structure including institution types, required fields, and document requirements for financial institution onboarding.",
+     *     tags={"BaaS Onboarding"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="institution_types", type="object"),
+     *                 @OA\Property(property="required_fields", type="object",
+     *                     @OA\Property(property="institution_details", type="object"),
+     *                     @OA\Property(property="contact_information", type="object"),
+     *                     @OA\Property(property="address_information", type="object"),
+     *                     @OA\Property(property="business_information", type="object"),
+     *                     @OA\Property(property="technical_requirements", type="object"),
+     *                     @OA\Property(property="compliance_information", type="object")
+     *                 ),
+     *                 @OA\Property(property="document_requirements", type="object",
+     *                     @OA\Property(property="certificate_of_incorporation", type="string", example="Certificate of Incorporation"),
+     *                     @OA\Property(property="regulatory_license", type="string", example="Regulatory License"),
+     *                     @OA\Property(property="audited_financials", type="string", example="Audited Financial Statements (Last 3 Years)"),
+     *                     @OA\Property(property="aml_policy", type="string", example="AML/KYC Policy Document"),
+     *                     @OA\Property(property="data_protection_policy", type="string", example="Data Protection Policy")
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function getApplicationForm(): JsonResponse
     {
@@ -99,6 +133,75 @@ class FinancialInstitutionController extends Controller
 
     /**
      * Submit new application.
+     *
+     * @OA\Post(
+     *     path="/api/v2/financial-institutions/apply",
+     *     operationId="fiSubmitApplication",
+     *     summary="Submit financial institution application",
+     *     description="Submits a new financial institution onboarding application with institution details, contact information, business information, technical requirements, and compliance information.",
+     *     tags={"BaaS Onboarding"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"institution_name", "legal_name", "registration_number", "tax_id", "country", "institution_type", "years_in_operation", "contact_name", "contact_email", "contact_phone", "contact_position", "headquarters_address", "headquarters_city", "headquarters_postal_code", "headquarters_country", "business_description", "target_markets", "product_offerings", "required_currencies", "integration_requirements", "has_aml_program", "has_kyc_procedures", "has_data_protection_policy", "is_pci_compliant", "is_gdpr_compliant"},
+     *             @OA\Property(property="institution_name", type="string", example="Acme Finance Ltd"),
+     *             @OA\Property(property="legal_name", type="string", example="Acme Finance Limited"),
+     *             @OA\Property(property="registration_number", type="string", example="REG-12345678"),
+     *             @OA\Property(property="tax_id", type="string", example="TAX-87654321"),
+     *             @OA\Property(property="country", type="string", minLength=2, maxLength=2, example="GB"),
+     *             @OA\Property(property="institution_type", type="string", example="bank"),
+     *             @OA\Property(property="assets_under_management", type="number", nullable=true, example=50000000),
+     *             @OA\Property(property="years_in_operation", type="integer", example=10),
+     *             @OA\Property(property="primary_regulator", type="string", nullable=true, example="FCA"),
+     *             @OA\Property(property="regulatory_license_number", type="string", nullable=true, example="FCA-123456"),
+     *             @OA\Property(property="contact_name", type="string", example="John Doe"),
+     *             @OA\Property(property="contact_email", type="string", format="email", example="john@acmefinance.com"),
+     *             @OA\Property(property="contact_phone", type="string", example="+44 20 7946 0958"),
+     *             @OA\Property(property="contact_position", type="string", example="CTO"),
+     *             @OA\Property(property="contact_department", type="string", nullable=true, example="Technology"),
+     *             @OA\Property(property="headquarters_address", type="string", example="123 Finance Street"),
+     *             @OA\Property(property="headquarters_city", type="string", example="London"),
+     *             @OA\Property(property="headquarters_state", type="string", nullable=true, example="Greater London"),
+     *             @OA\Property(property="headquarters_postal_code", type="string", example="EC1A 1BB"),
+     *             @OA\Property(property="headquarters_country", type="string", minLength=2, maxLength=2, example="GB"),
+     *             @OA\Property(property="business_description", type="string", example="A comprehensive digital banking platform providing retail and corporate banking services across Europe with focus on innovative payment solutions."),
+     *             @OA\Property(property="target_markets", type="array", @OA\Items(type="string", example="GB")),
+     *             @OA\Property(property="product_offerings", type="array", @OA\Items(type="string", example="payments")),
+     *             @OA\Property(property="expected_monthly_transactions", type="integer", nullable=true, example=50000),
+     *             @OA\Property(property="expected_monthly_volume", type="number", nullable=true, example=10000000),
+     *             @OA\Property(property="required_currencies", type="array", @OA\Items(type="string", example="GBP")),
+     *             @OA\Property(property="integration_requirements", type="array", @OA\Items(type="string", example="rest_api")),
+     *             @OA\Property(property="requires_api_access", type="boolean", example=true),
+     *             @OA\Property(property="requires_webhooks", type="boolean", example=true),
+     *             @OA\Property(property="requires_reporting", type="boolean", example=true),
+     *             @OA\Property(property="security_certifications", type="array", nullable=true, @OA\Items(type="string", example="ISO27001")),
+     *             @OA\Property(property="has_aml_program", type="boolean", example=true),
+     *             @OA\Property(property="has_kyc_procedures", type="boolean", example=true),
+     *             @OA\Property(property="has_data_protection_policy", type="boolean", example=true),
+     *             @OA\Property(property="is_pci_compliant", type="boolean", example=true),
+     *             @OA\Property(property="is_gdpr_compliant", type="boolean", example=true),
+     *             @OA\Property(property="compliance_certifications", type="array", nullable=true, @OA\Items(type="string", example="PCI-DSS")),
+     *             @OA\Property(property="source", type="string", nullable=true, example="website"),
+     *             @OA\Property(property="referral_code", type="string", nullable=true, example="REF-2024-001")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Application submitted successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="application_id", type="string", example="app_abc123"),
+     *                 @OA\Property(property="application_number", type="string", example="FI-2024-00001"),
+     *                 @OA\Property(property="status", type="string", example="pending_review"),
+     *                 @OA\Property(property="required_documents", type="array", @OA\Items(type="string", example="certificate_of_incorporation")),
+     *                 @OA\Property(property="message", type="string", example="Application submitted successfully")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=422, description="Validation error or submission failure")
+     * )
      */
     public function submitApplication(Request $request): JsonResponse
     {
@@ -200,6 +303,40 @@ class FinancialInstitutionController extends Controller
 
     /**
      * Get application status.
+     *
+     * @OA\Get(
+     *     path="/api/v2/financial-institutions/application/{applicationNumber}/status",
+     *     operationId="fiGetApplicationStatus",
+     *     summary="Get application status",
+     *     description="Returns the current status, review stage, risk rating, and document verification status for a specific financial institution application.",
+     *     tags={"BaaS Onboarding"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="applicationNumber",
+     *         in="path",
+     *         required=true,
+     *         description="The application number",
+     *         @OA\Schema(type="string", example="FI-2024-00001")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="application_number", type="string", example="FI-2024-00001"),
+     *                 @OA\Property(property="institution_name", type="string", example="Acme Finance Ltd"),
+     *                 @OA\Property(property="status", type="string", example="pending_review"),
+     *                 @OA\Property(property="review_stage", type="string", example="initial_review"),
+     *                 @OA\Property(property="risk_rating", type="string", nullable=true, example="low"),
+     *                 @OA\Property(property="submitted_at", type="string", format="date-time"),
+     *                 @OA\Property(property="documents", type="object"),
+     *                 @OA\Property(property="is_editable", type="boolean", example=true)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Application not found")
+     * )
      */
     public function getApplicationStatus(string $applicationNumber): JsonResponse
     {
@@ -235,6 +372,49 @@ class FinancialInstitutionController extends Controller
 
     /**
      * Upload document for application.
+     *
+     * @OA\Post(
+     *     path="/api/v2/financial-institutions/application/{applicationNumber}/documents",
+     *     operationId="fiUploadDocument",
+     *     summary="Upload application document",
+     *     description="Uploads a supporting document for a financial institution application. Accepts PDF, JPG, JPEG, and PNG files up to 10MB. Application must be in an editable status.",
+     *     tags={"BaaS Onboarding"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="applicationNumber",
+     *         in="path",
+     *         required=true,
+     *         description="The application number",
+     *         @OA\Schema(type="string", example="FI-2024-00001")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\MediaType(
+     *             mediaType="multipart/form-data",
+     *             @OA\Schema(
+     *                 required={"document_type", "document"},
+     *                 @OA\Property(property="document_type", type="string", example="certificate_of_incorporation"),
+     *                 @OA\Property(property="document", type="string", format="binary", description="Document file (PDF, JPG, JPEG, PNG; max 10MB)")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Document uploaded successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="document_type", type="string", example="certificate_of_incorporation"),
+     *                 @OA\Property(property="uploaded", type="boolean", example=true),
+     *                 @OA\Property(property="filename", type="string", example="certificate.pdf"),
+     *                 @OA\Property(property="size", type="integer", example=204800),
+     *                 @OA\Property(property="message", type="string", example="Document uploaded successfully")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Application not found"),
+     *     @OA\Response(response=422, description="Application not editable or validation error")
+     * )
      */
     public function uploadDocument(Request $request, string $applicationNumber): JsonResponse
     {
@@ -296,6 +476,42 @@ class FinancialInstitutionController extends Controller
 
     /**
      * Get partner API documentation.
+     *
+     * @OA\Get(
+     *     path="/api/v2/financial-institutions/api-documentation",
+     *     operationId="fiGetApiDocumentation",
+     *     summary="Get partner API documentation",
+     *     description="Returns the partner API documentation including base URL, authentication details, rate limits, available endpoints, webhook events, and error codes.",
+     *     tags={"BaaS Onboarding"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Success",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="base_url", type="string", example="https://app.example.com/api/partner/v1"),
+     *                 @OA\Property(property="authentication", type="object",
+     *                     @OA\Property(property="type", type="string", example="Bearer Token"),
+     *                     @OA\Property(property="header", type="string", example="Authorization: Bearer {api_client_id}:{api_client_secret}")
+     *                 ),
+     *                 @OA\Property(property="rate_limits", type="object",
+     *                     @OA\Property(property="sandbox", type="object",
+     *                         @OA\Property(property="per_minute", type="integer", example=60),
+     *                         @OA\Property(property="per_day", type="integer", example=10000)
+     *                     ),
+     *                     @OA\Property(property="production", type="object",
+     *                         @OA\Property(property="per_minute", type="integer", example=300),
+     *                         @OA\Property(property="per_day", type="integer", example=100000)
+     *                     )
+     *                 ),
+     *                 @OA\Property(property="endpoints", type="object"),
+     *                 @OA\Property(property="webhook_events", type="array", @OA\Items(type="string", example="account.created")),
+     *                 @OA\Property(property="error_codes", type="object")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function getApiDocumentation(): JsonResponse
     {

--- a/app/Http/Controllers/Api/Wallet/MobileWalletController.php
+++ b/app/Http/Controllers/Api/Wallet/MobileWalletController.php
@@ -29,7 +29,34 @@ class MobileWalletController extends Controller
     /**
      * Get supported token list with network and decimals info.
      *
-     * GET /api/v1/wallet/tokens
+     * @OA\Get(
+     *     path="/api/v1/wallet/tokens",
+     *     operationId="walletTokens",
+     *     summary="Get supported token list",
+     *     description="Returns the list of supported tokens with network availability and decimals info.",
+     *     tags={"Mobile Wallet"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Token list",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="array",
+     *                 @OA\Items(
+     *                     type="object",
+     *                     @OA\Property(property="symbol", type="string", example="USDC"),
+     *                     @OA\Property(property="name", type="string", example="USD Coin"),
+     *                     @OA\Property(property="decimals", type="integer", example=6),
+     *                     @OA\Property(property="networks", type="array", @OA\Items(type="string"), example={"polygon", "base", "arbitrum"}),
+     *                     @OA\Property(property="icon", type="string", example="usdc")
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function tokens(): JsonResponse
     {
@@ -73,7 +100,34 @@ class MobileWalletController extends Controller
     /**
      * Get ERC-20 balances across user's smart accounts.
      *
-     * GET /api/v1/wallet/balances
+     * @OA\Get(
+     *     path="/api/v1/wallet/balances",
+     *     operationId="walletBalances",
+     *     summary="Get ERC-20 balances",
+     *     description="Returns ERC-20 token balances across all of the authenticated user's smart accounts.",
+     *     tags={"Mobile Wallet"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Balances per token and network",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="array",
+     *                 @OA\Items(
+     *                     type="object",
+     *                     @OA\Property(property="token", type="string", example="USDC"),
+     *                     @OA\Property(property="network", type="string", example="polygon"),
+     *                     @OA\Property(property="address", type="string", example="0x1234...abcd"),
+     *                     @OA\Property(property="balance", type="string", example="1000.50"),
+     *                     @OA\Property(property="error", type="string", nullable=true, example=null, description="Present only if balance query failed")
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function balances(Request $request): JsonResponse
     {
@@ -126,7 +180,39 @@ class MobileWalletController extends Controller
     /**
      * Get aggregated wallet state (balances + addresses + sync info).
      *
-     * GET /api/v1/wallet/state
+     * @OA\Get(
+     *     path="/api/v1/wallet/state",
+     *     operationId="walletState",
+     *     summary="Get aggregated wallet state",
+     *     description="Returns aggregated wallet state including addresses, supported networks and sync information.",
+     *     tags={"Mobile Wallet"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Aggregated wallet state",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="object",
+     *                 @OA\Property(
+     *                     property="addresses",
+     *                     type="array",
+     *                     @OA\Items(
+     *                         type="object",
+     *                         @OA\Property(property="address", type="string", example="0x1234...abcd"),
+     *                         @OA\Property(property="network", type="string", example="polygon"),
+     *                         @OA\Property(property="deployed", type="boolean", example=true)
+     *                     )
+     *                 ),
+     *                 @OA\Property(property="networks", type="array", @OA\Items(type="string"), example={"polygon", "ethereum", "arbitrum"}),
+     *                 @OA\Property(property="synced_at", type="string", format="date-time"),
+     *                 @OA\Property(property="account_count", type="integer", example=2)
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function state(Request $request): JsonResponse
     {
@@ -156,7 +242,33 @@ class MobileWalletController extends Controller
     /**
      * List user's addresses per network.
      *
-     * GET /api/v1/wallet/addresses
+     * @OA\Get(
+     *     path="/api/v1/wallet/addresses",
+     *     operationId="walletAddresses",
+     *     summary="List user's addresses per network",
+     *     description="Returns all smart account addresses for the authenticated user across supported networks.",
+     *     tags={"Mobile Wallet"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="User addresses",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="array",
+     *                 @OA\Items(
+     *                     type="object",
+     *                     @OA\Property(property="address", type="string", example="0x1234...abcd"),
+     *                     @OA\Property(property="network", type="string", example="polygon"),
+     *                     @OA\Property(property="deployed", type="boolean", example=true),
+     *                     @OA\Property(property="created_at", type="string", format="date-time", nullable=true)
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function addresses(Request $request): JsonResponse
     {
@@ -182,7 +294,37 @@ class MobileWalletController extends Controller
     /**
      * Cursor-based transaction list from activity feed.
      *
-     * GET /api/v1/wallet/transactions
+     * @OA\Get(
+     *     path="/api/v1/wallet/transactions",
+     *     operationId="walletTransactions",
+     *     summary="List transactions with cursor-based pagination",
+     *     description="Returns a paginated list of transactions from the user's activity feed using cursor-based pagination.",
+     *     tags={"Mobile Wallet"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="cursor",
+     *         in="query",
+     *         required=false,
+     *         description="Pagination cursor for the next page",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="limit",
+     *         in="query",
+     *         required=false,
+     *         description="Number of items per page (max 100, default 20)",
+     *         @OA\Schema(type="integer", default=20, maximum=100)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Transaction feed",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object", description="Activity feed with items and pagination cursor")
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function transactions(Request $request): JsonResponse
     {
@@ -203,7 +345,43 @@ class MobileWalletController extends Controller
     /**
      * Get transaction detail.
      *
-     * GET /api/v1/wallet/transactions/{id}
+     * @OA\Get(
+     *     path="/api/v1/wallet/transactions/{id}",
+     *     operationId="walletTransactionDetail",
+     *     summary="Get transaction detail",
+     *     description="Returns detailed information for a specific transaction by ID.",
+     *     tags={"Mobile Wallet"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         description="Transaction identifier",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Transaction detail",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object", description="Transaction detail object")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Transaction not found",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(
+     *                 property="error",
+     *                 type="object",
+     *                 @OA\Property(property="code", type="string", example="TRANSACTION_NOT_FOUND"),
+     *                 @OA\Property(property="message", type="string", example="Transaction not found.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function transactionDetail(string $id, Request $request): JsonResponse
     {
@@ -229,7 +407,46 @@ class MobileWalletController extends Controller
     /**
      * Create and auto-submit a payment intent (send transaction).
      *
-     * POST /api/v1/wallet/transactions/send
+     * @OA\Post(
+     *     path="/api/v1/wallet/transactions/send",
+     *     operationId="walletSend",
+     *     summary="Send a transaction",
+     *     description="Creates a payment intent and auto-submits it to send tokens to a recipient address.",
+     *     tags={"Mobile Wallet"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"to", "token", "amount", "network"},
+     *             @OA\Property(property="to", type="string", example="0x1234...abcd", description="Recipient address"),
+     *             @OA\Property(property="token", type="string", enum={"USDC", "USDT", "WETH", "WBTC"}, example="USDC", description="Token symbol"),
+     *             @OA\Property(property="amount", type="string", example="100.00", description="Amount to send"),
+     *             @OA\Property(property="network", type="string", example="polygon", description="Target network")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Transaction submitted",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object", description="Payment intent result")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Send failed",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(
+     *                 property="error",
+     *                 type="object",
+     *                 @OA\Property(property="code", type="string", example="SEND_FAILED"),
+     *                 @OA\Property(property="message", type="string", example="Insufficient balance.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function send(Request $request): JsonResponse
     {

--- a/app/Http/Controllers/Api/Wallet/WalletTransferController.php
+++ b/app/Http/Controllers/Api/Wallet/WalletTransferController.php
@@ -22,7 +22,38 @@ class WalletTransferController extends Controller
     /**
      * Validate a blockchain address.
      *
-     * GET /v1/wallet/validate-address?address=...&network=SOLANA
+     * @OA\Get(
+     *     path="/api/v1/wallet/validate-address",
+     *     operationId="walletValidateAddress",
+     *     summary="Validate a blockchain address",
+     *     description="Validates a blockchain address format for the specified network.",
+     *     tags={"Mobile Wallet"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(
+     *         name="address",
+     *         in="query",
+     *         required=true,
+     *         description="Blockchain address to validate (20-128 characters)",
+     *         @OA\Schema(type="string", minLength=20, maxLength=128, example="0x1234567890abcdef1234567890abcdef12345678")
+     *     ),
+     *     @OA\Parameter(
+     *         name="network",
+     *         in="query",
+     *         required=true,
+     *         description="Target network for validation",
+     *         @OA\Schema(type="string", example="POLYGON")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Address validation result",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object", description="Validation result with address details")
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=422, description="Validation error")
+     * )
      */
     public function validateAddress(ValidateAddressRequest $request): JsonResponse
     {
@@ -42,7 +73,39 @@ class WalletTransferController extends Controller
     /**
      * Resolve an ENS/SNS name to a blockchain address.
      *
-     * POST /v1/wallet/resolve-name
+     * @OA\Post(
+     *     path="/api/v1/wallet/resolve-name",
+     *     operationId="walletResolveName",
+     *     summary="Resolve an ENS/SNS name to an address",
+     *     description="Resolves a domain name (e.g. vitalik.eth, alice.sol) to a blockchain address on the specified network.",
+     *     tags={"Mobile Wallet"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"name", "network"},
+     *             @OA\Property(property="name", type="string", example="vitalik.eth", description="Domain name to resolve (e.g. alice.sol, vitalik.eth)"),
+     *             @OA\Property(property="network", type="string", example="ETHEREUM", description="Target network")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Name resolved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object", description="Resolution result with resolved address")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Name could not be resolved",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(property="data", type="object", description="Resolution result indicating failure")
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
      */
     public function resolveName(ResolveNameRequest $request): JsonResponse
     {
@@ -64,7 +127,46 @@ class WalletTransferController extends Controller
     /**
      * Get a fee quote for a wallet-to-wallet transfer.
      *
-     * POST /v1/wallet/quote
+     * @OA\Post(
+     *     path="/api/v1/wallet/quote",
+     *     operationId="walletQuote",
+     *     summary="Get a fee quote for a transfer",
+     *     description="Returns a fee quote for a wallet-to-wallet transfer on the specified network and asset.",
+     *     tags={"Mobile Wallet"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"network", "asset", "amount"},
+     *             @OA\Property(property="network", type="string", example="POLYGON", description="Target network"),
+     *             @OA\Property(property="asset", type="string", example="USDC", description="Asset/token symbol"),
+     *             @OA\Property(property="amount", type="number", example=100.50, description="Transfer amount (must be > 0, max 1000000)")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Fee quote",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="data", type="object", description="Transfer quote with fee breakdown")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=400,
+     *         description="Quote failed",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=false),
+     *             @OA\Property(
+     *                 property="error",
+     *                 type="object",
+     *                 @OA\Property(property="code", type="string", example="QUOTE_FAILED"),
+     *                 @OA\Property(property="message", type="string", example="Unable to generate quote.")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=422, description="Validation error")
+     * )
      */
     public function quote(WalletQuoteRequest $request): JsonResponse
     {


### PR DESCRIPTION
## Summary
- Annotates **13 medium-priority controllers** with full OpenAPI/Swagger annotations (~79 endpoint methods)
- Adds **11 new tags** to OpenApiDoc.php: Banking V2, Blockchain Wallets, Compliance V2, BaaS Onboarding, TrustCert, Commerce, Relayer, Mobile Wallet, Treasury, Lending
- Completes Phase 5 of v3.4.0

### Controllers annotated:
| Controller | Tag | Methods |
|-----------|-----|---------|
| V2/BankIntegrationController | Banking V2 | 10 |
| BlockchainWalletController | Blockchain Wallets | 9 |
| V2/ComplianceController | Compliance V2 | 8 |
| MobileRelayerController | Relayer | 8 |
| MobileWalletController | Mobile Wallet | 7 |
| CertificateApplicationController | TrustCert | 6 |
| MobileTrustCertController | TrustCert | 5 |
| MobileCommerceController | Commerce | 5 |
| V2/FinancialInstitutionController | BaaS Onboarding | 5 |
| LoanController | Lending | 5 |
| LiquidityForecastController | Treasury | 4 |
| LoanApplicationController | Lending | 4 |
| WalletTransferController | Mobile Wallet | 3 |

## Test plan
- [ ] `php artisan l5-swagger:generate` succeeds
- [ ] Generated spec includes all new endpoint annotations
- [ ] All 11 new tags appear in the spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)