### PR TITLE
feat: Add Phase 1 SOC 2 certification services

### DIFF
--- a/app/Domain/Compliance/Services/Certification/AccessReviewService.php
+++ b/app/Domain/Compliance/Services/Certification/AccessReviewService.php
@@ -1,0 +1,352 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Compliance\Services\Certification;
+
+use App\Models\User;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use stdClass;
+
+/**
+ * SOC 2 Access Review Service.
+ *
+ * Provides user access reviews, privileged account auditing, permission matrix
+ * generation, and detection of stale accounts and dormant API tokens for
+ * SOC 2 Trust Services Criteria (CC6.1, CC6.2, CC6.3).
+ */
+class AccessReviewService
+{
+    /**
+     * Run a full access review and return the report.
+     *
+     * @return array<string, mixed>
+     */
+    public function runAccessReview(): array
+    {
+        if (config('compliance-certification.soc2.demo_mode', true)) {
+            return $this->getDemoAccessReview();
+        }
+
+        Log::info('SOC 2 access review initiated');
+
+        $report = $this->generateReviewReport();
+
+        Log::info('SOC 2 access review completed', [
+            'privileged_users' => count($report['privileged_users']),
+            'stale_accounts'   => count($report['stale_accounts']),
+            'dormant_tokens'   => count($report['dormant_tokens']),
+        ]);
+
+        return $report;
+    }
+
+    /**
+     * Get all users assigned to privileged roles.
+     *
+     * @return Collection<int, User>
+     */
+    public function getPrivilegedUsers(): Collection
+    {
+        $privilegedRoles = config('compliance-certification.soc2.privileged_roles', [
+            'admin',
+            'super-admin',
+            'compliance_officer',
+            'compliance_manager',
+        ]);
+
+        return User::role($privilegedRoles)
+            ->with('roles.permissions')
+            ->get();
+    }
+
+    /**
+     * Build a matrix mapping each role to its granted permissions.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public function getPermissionMatrix(): array
+    {
+        $roles = DB::table('roles')->get();
+        $matrix = [];
+
+        foreach ($roles as $role) {
+            $permissions = DB::table('role_has_permissions')
+                ->join('permissions', 'role_has_permissions.permission_id', '=', 'permissions.id')
+                ->where('role_has_permissions.role_id', $role->id)
+                ->pluck('permissions.name')
+                ->toArray();
+
+            $userCount = DB::table('model_has_roles')
+                ->where('role_id', $role->id)
+                ->count();
+
+            $matrix[$role->name] = [
+                'permissions'      => $permissions,
+                'permission_count' => count($permissions),
+                'user_count'       => $userCount,
+                'guard_name'       => $role->guard_name ?? 'web',
+            ];
+        }
+
+        return $matrix;
+    }
+
+    /**
+     * Find user accounts that have not logged in for the specified number of days.
+     *
+     * @param int $daysInactive Inactivity threshold in days
+     *
+     * @return Collection<int, User>
+     */
+    public function findStaleAccounts(int $daysInactive = 90): Collection
+    {
+        $cutoff = now()->subDays($daysInactive);
+
+        return User::where(function ($query) use ($cutoff) {
+            $query->where('last_login_at', '<', $cutoff)
+                ->orWhereNull('last_login_at');
+        })
+            ->with('roles')
+            ->get();
+    }
+
+    /**
+     * Find Sanctum personal access tokens that have not been used recently.
+     *
+     * @param int $daysUnused Number of days since last use to be considered dormant
+     *
+     * @return Collection<int, stdClass>
+     */
+    public function findDormantTokens(int $daysUnused = 30): Collection
+    {
+        $cutoff = now()->subDays($daysUnused);
+
+        return DB::table('personal_access_tokens')
+            ->where(function ($query) use ($cutoff) {
+                $query->where('last_used_at', '<', $cutoff)
+                    ->orWhereNull('last_used_at');
+            })
+            ->select([
+                'id',
+                'tokenable_type',
+                'tokenable_id',
+                'name',
+                'last_used_at',
+                'created_at',
+                'expires_at',
+            ])
+            ->orderBy('last_used_at', 'asc')
+            ->get();
+    }
+
+    /**
+     * Generate a comprehensive access review report combining all review data.
+     *
+     * @return array<string, mixed>
+     */
+    public function generateReviewReport(): array
+    {
+        $privilegedUsers = $this->getPrivilegedUsers();
+        $permissionMatrix = $this->getPermissionMatrix();
+        $staleAccounts = $this->findStaleAccounts();
+        $dormantTokens = $this->findDormantTokens();
+
+        $totalUsers = User::count();
+        $activeUsers = User::where('last_login_at', '>=', now()->subDays(30))->count();
+
+        return [
+            'review_date'   => now()->toIso8601String(),
+            'review_period' => config('compliance-certification.soc2.review_period', 'quarterly'),
+            'summary'       => [
+                'total_users'           => $totalUsers,
+                'active_users_30d'      => $activeUsers,
+                'privileged_user_count' => $privilegedUsers->count(),
+                'stale_account_count'   => $staleAccounts->count(),
+                'dormant_token_count'   => $dormantTokens->count(),
+                'total_roles'           => count($permissionMatrix),
+            ],
+            'privileged_users' => $privilegedUsers->map(function (User $user) {
+                return [
+                    'uuid'          => $user->uuid,
+                    'name'          => $user->name,
+                    'email'         => $user->email,
+                    'roles'         => $user->roles->pluck('name')->toArray(),
+                    'permissions'   => $user->getAllPermissions()->pluck('name')->toArray(),
+                    'last_login_at' => $user->last_login_at?->toIso8601String(),
+                ];
+            })->toArray(),
+            'permission_matrix' => $permissionMatrix,
+            'stale_accounts'    => $staleAccounts->map(function (User $user) {
+                return [
+                    'uuid'          => $user->uuid,
+                    'name'          => $user->name,
+                    'email'         => $user->email,
+                    'roles'         => $user->roles->pluck('name')->toArray(),
+                    'last_login_at' => $user->last_login_at?->toIso8601String(),
+                    'created_at'    => $user->created_at?->toIso8601String(),
+                ];
+            })->toArray(),
+            'dormant_tokens' => $dormantTokens->map(function ($token) {
+                return [
+                    'id'             => $token->id,
+                    'tokenable_type' => $token->tokenable_type,
+                    'tokenable_id'   => $token->tokenable_id,
+                    'name'           => $token->name,
+                    'last_used_at'   => $token->last_used_at,
+                    'created_at'     => $token->created_at,
+                    'expires_at'     => $token->expires_at ?? null,
+                ];
+            })->toArray(),
+            'recommendations' => $this->generateRecommendations(
+                $privilegedUsers,
+                $staleAccounts,
+                $dormantTokens
+            ),
+        ];
+    }
+
+    /**
+     * Generate review recommendations based on findings.
+     *
+     * @param Collection<int, User>     $privilegedUsers
+     * @param Collection<int, User>     $staleAccounts
+     * @param Collection<int, stdClass> $dormantTokens
+     *
+     * @return array<int, string>
+     */
+    private function generateRecommendations(
+        Collection $privilegedUsers,
+        Collection $staleAccounts,
+        Collection $dormantTokens
+    ): array {
+        $recommendations = [];
+
+        if ($staleAccounts->count() > 0) {
+            $recommendations[] = "Review and disable {$staleAccounts->count()} stale user account(s) that have not logged in for over 90 days.";
+        }
+
+        if ($dormantTokens->count() > 0) {
+            $recommendations[] = "Revoke {$dormantTokens->count()} dormant API token(s) that have not been used in over 30 days.";
+        }
+
+        $privilegedWithNoRecentLogin = $privilegedUsers->filter(function (User $user) {
+            return $user->last_login_at === null || $user->last_login_at->lt(now()->subDays(30));
+        });
+
+        if ($privilegedWithNoRecentLogin->count() > 0) {
+            $recommendations[] = "Investigate {$privilegedWithNoRecentLogin->count()} privileged user(s) with no recent login activity.";
+        }
+
+        if ($privilegedUsers->count() > 10) {
+            $recommendations[] = 'Consider reducing the number of privileged users. Current count exceeds recommended threshold of 10.';
+        }
+
+        if (empty($recommendations)) {
+            $recommendations[] = 'No immediate action items identified. Access controls appear healthy.';
+        }
+
+        return $recommendations;
+    }
+
+    /**
+     * Return realistic simulated access review data for demo mode.
+     *
+     * @return array<string, mixed>
+     */
+    private function getDemoAccessReview(): array
+    {
+        return [
+            'review_date'   => now()->toIso8601String(),
+            'review_period' => 'quarterly',
+            'summary'       => [
+                'total_users'           => 47,
+                'active_users_30d'      => 38,
+                'privileged_user_count' => 5,
+                'stale_account_count'   => 3,
+                'dormant_token_count'   => 7,
+                'total_roles'           => 6,
+            ],
+            'privileged_users' => [
+                [
+                    'uuid'          => 'demo-admin-001',
+                    'name'          => 'System Administrator',
+                    'email'         => 'admin@example.com',
+                    'roles'         => ['admin', 'compliance_officer'],
+                    'permissions'   => ['manage-users', 'manage-roles', 'view-audit-logs', 'manage-compliance'],
+                    'last_login_at' => now()->subHours(2)->toIso8601String(),
+                ],
+                [
+                    'uuid'          => 'demo-admin-002',
+                    'name'          => 'Compliance Manager',
+                    'email'         => 'compliance@example.com',
+                    'roles'         => ['compliance_manager'],
+                    'permissions'   => ['view-audit-logs', 'manage-compliance', 'export-reports'],
+                    'last_login_at' => now()->subDays(1)->toIso8601String(),
+                ],
+            ],
+            'permission_matrix' => [
+                'admin' => [
+                    'permissions'      => ['manage-users', 'manage-roles', 'view-audit-logs', 'manage-settings'],
+                    'permission_count' => 4,
+                    'user_count'       => 2,
+                    'guard_name'       => 'web',
+                ],
+                'compliance_officer' => [
+                    'permissions'      => ['view-audit-logs', 'manage-compliance', 'export-reports'],
+                    'permission_count' => 3,
+                    'user_count'       => 3,
+                    'guard_name'       => 'web',
+                ],
+                'analyst' => [
+                    'permissions'      => ['view-reports', 'view-transactions'],
+                    'permission_count' => 2,
+                    'user_count'       => 12,
+                    'guard_name'       => 'web',
+                ],
+                'operator' => [
+                    'permissions'      => ['view-transactions', 'process-transactions'],
+                    'permission_count' => 2,
+                    'user_count'       => 18,
+                    'guard_name'       => 'web',
+                ],
+            ],
+            'stale_accounts' => [
+                [
+                    'uuid'          => 'demo-stale-001',
+                    'name'          => 'Former Analyst',
+                    'email'         => 'former.analyst@example.com',
+                    'roles'         => ['analyst'],
+                    'last_login_at' => now()->subDays(120)->toIso8601String(),
+                    'created_at'    => now()->subYear()->toIso8601String(),
+                ],
+                [
+                    'uuid'          => 'demo-stale-002',
+                    'name'          => 'Contractor Account',
+                    'email'         => 'contractor@example.com',
+                    'roles'         => ['operator'],
+                    'last_login_at' => now()->subDays(95)->toIso8601String(),
+                    'created_at'    => now()->subMonths(8)->toIso8601String(),
+                ],
+            ],
+            'dormant_tokens' => [
+                [
+                    'id'             => 1,
+                    'tokenable_type' => 'App\\Models\\User',
+                    'tokenable_id'   => 'demo-stale-001',
+                    'name'           => 'api-token-analytics',
+                    'last_used_at'   => now()->subDays(60)->toIso8601String(),
+                    'created_at'     => now()->subMonths(6)->toIso8601String(),
+                    'expires_at'     => null,
+                ],
+            ],
+            'recommendations' => [
+                'Review and disable 3 stale user account(s) that have not logged in for over 90 days.',
+                'Revoke 7 dormant API token(s) that have not been used in over 30 days.',
+                'Investigate 1 privileged user(s) with no recent login activity.',
+            ],
+        ];
+    }
+}

--- a/app/Domain/Compliance/Services/Certification/ChangeManagementService.php
+++ b/app/Domain/Compliance/Services/Certification/ChangeManagementService.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Compliance\Services\Certification;
+
+use App\Domain\Compliance\Models\ComplianceChangeLog;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * SOC 2 Change Management Service.
+ *
+ * Records and tracks all system changes (deployments, configuration updates,
+ * access modifications, infrastructure changes) for SOC 2 audit trail
+ * requirements (CC8.1 Change Management).
+ */
+class ChangeManagementService
+{
+    /**
+     * Log a change management entry.
+     *
+     * @param string      $type            Change type (e.g. 'deployment', 'configuration', 'access_change', 'infrastructure')
+     * @param string      $description     Human-readable description of the change
+     * @param array<string, mixed>|null $oldValues Previous state values
+     * @param array<string, mixed>|null $newValues New state values
+     * @param string|null $changedBy       Identifier of the person or system that made the change
+     * @param string|null $ticketReference Reference to a ticket/issue tracking the change
+     */
+    public function logChange(
+        string $type,
+        string $description,
+        ?array $oldValues = null,
+        ?array $newValues = null,
+        ?string $changedBy = null,
+        ?string $ticketReference = null
+    ): ComplianceChangeLog {
+        $changeLog = ComplianceChangeLog::create([
+            'change_type'      => $type,
+            'description'      => $description,
+            'old_values'       => $oldValues,
+            'new_values'       => $newValues,
+            'changed_by'       => $changedBy ?? auth()->user()?->name ?? 'system',
+            'environment'      => app()->environment(),
+            'ticket_reference' => $ticketReference,
+            'metadata'         => [
+                'recorded_at' => now()->toIso8601String(),
+                'source'      => static::class,
+            ],
+        ]);
+
+        Log::info('SOC 2 change logged', [
+            'id'          => $changeLog->id,
+            'type'        => $type,
+            'description' => $description,
+            'changed_by'  => $changeLog->changed_by,
+        ]);
+
+        return $changeLog;
+    }
+
+    /**
+     * Retrieve change log entries with optional filters.
+     *
+     * @param string|null $period Filter by audit period (e.g. '2026-Q1', '2026-01')
+     * @param string|null $type   Filter by change type
+     *
+     * @return Collection<int, ComplianceChangeLog>
+     */
+    public function getChanges(?string $period = null, ?string $type = null): Collection
+    {
+        $query = ComplianceChangeLog::query();
+
+        if ($period !== null) {
+            [$startDate, $endDate] = $this->parsePeriodDates($period);
+            $query->where('created_at', '>=', $startDate)
+                ->where('created_at', '<=', $endDate);
+        }
+
+        if ($type !== null) {
+            $query->forType($type);
+        }
+
+        return $query->orderBy('created_at', 'desc')->get();
+    }
+
+    /**
+     * Generate a change management summary report for a period.
+     *
+     * @param string $period The audit period identifier
+     *
+     * @return array<string, mixed>
+     */
+    public function generateChangeReport(string $period): array
+    {
+        $changes = $this->getChanges($period);
+
+        $byType = $changes->groupBy('change_type')->map(function (Collection $typeChanges, string $type) {
+            return [
+                'type'           => $type,
+                'count'          => $typeChanges->count(),
+                'with_ticket'    => $typeChanges->filter(fn (ComplianceChangeLog $c) => $c->ticket_reference !== null)->count(),
+                'without_ticket' => $typeChanges->filter(fn (ComplianceChangeLog $c) => $c->ticket_reference === null)->count(),
+                'changers'       => $typeChanges->unique('changed_by')->pluck('changed_by')->filter()->values()->toArray(),
+            ];
+        })->toArray();
+
+        $byEnvironment = $changes->groupBy('environment')->map->count()->toArray();
+
+        $ticketCoverage = $changes->count() > 0
+            ? round(($changes->filter(fn (ComplianceChangeLog $c) => $c->ticket_reference !== null)->count() / $changes->count()) * 100, 2)
+            : 0.0;
+
+        return [
+            'period'       => $period,
+            'generated_at' => now()->toIso8601String(),
+            'summary'      => [
+                'total_changes'           => $changes->count(),
+                'change_types'            => array_keys($byType),
+                'ticket_coverage_percent' => $ticketCoverage,
+                'unique_changers'         => $changes->unique('changed_by')->count(),
+            ],
+            'by_type'        => $byType,
+            'by_environment' => $byEnvironment,
+            'timeline'       => $changes->map(function (ComplianceChangeLog $change) {
+                return [
+                    'id'               => $change->id,
+                    'type'             => $change->change_type,
+                    'description'      => $change->description,
+                    'changed_by'       => $change->changed_by,
+                    'environment'      => $change->environment,
+                    'ticket_reference' => $change->ticket_reference,
+                    'created_at'       => $change->created_at?->toIso8601String(),
+                ];
+            })->toArray(),
+        ];
+    }
+
+    /**
+     * Get the most recent deployment-type changes.
+     *
+     * @param int $limit Maximum number of results
+     *
+     * @return Collection<int, ComplianceChangeLog>
+     */
+    public function getRecentDeployments(int $limit = 10): Collection
+    {
+        return ComplianceChangeLog::forType('deployment')
+            ->orderBy('created_at', 'desc')
+            ->limit($limit)
+            ->get();
+    }
+
+    /**
+     * Parse a period string into start and end Carbon dates.
+     *
+     * @param string $period Period identifier ('YYYY-QN' or 'YYYY-MM')
+     *
+     * @return array{0: Carbon, 1: Carbon}
+     */
+    private function parsePeriodDates(string $period): array
+    {
+        if (preg_match('/^(\d{4})-Q(\d)$/', $period, $matches)) {
+            $year = (int) $matches[1];
+            $quarter = (int) $matches[2];
+            $startMonth = ($quarter - 1) * 3 + 1;
+
+            $startDate = Carbon::create($year, $startMonth, 1)->startOfDay();
+            $endDate = $startDate->copy()->addMonths(3)->subSecond();
+
+            return [$startDate, $endDate];
+        }
+
+        if (preg_match('/^(\d{4})-(\d{2})$/', $period, $matches)) {
+            $startDate = Carbon::create((int) $matches[1], (int) $matches[2], 1)->startOfDay();
+            $endDate = $startDate->copy()->endOfMonth();
+
+            return [$startDate, $endDate];
+        }
+
+        $reviewDays = (int) config('compliance-certification.soc2.review_period', 90);
+        $endDate = Carbon::now();
+        $startDate = $endDate->copy()->subDays($reviewDays);
+
+        return [$startDate, $endDate];
+    }
+}

--- a/app/Domain/Compliance/Services/Certification/EvidenceCollectionService.php
+++ b/app/Domain/Compliance/Services/Certification/EvidenceCollectionService.php
@@ -1,0 +1,353 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Compliance\Services\Certification;
+
+use App\Domain\Compliance\Models\AuditLog;
+use App\Domain\Compliance\Models\ComplianceChangeLog;
+use App\Domain\Compliance\Models\ComplianceEvidence;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * SOC 2 Evidence Collection Service.
+ *
+ * Collects, stores, and retrieves compliance evidence for SOC 2 audit periods.
+ * Supports access logs, configuration snapshots, and change management evidence
+ * with SHA-256 integrity hashing for tamper detection.
+ */
+class EvidenceCollectionService
+{
+    /**
+     * Collect evidence for a given audit period.
+     *
+     * @param string $period The audit period identifier (e.g. '2026-Q1')
+     * @param string $type   Evidence type to collect: 'all', 'access', 'config', or 'change_management'
+     *
+     * @return array<string, mixed>
+     */
+    public function collectEvidence(string $period, string $type = 'all'): array
+    {
+        if (config('compliance-certification.soc2.demo_mode', true)) {
+            return $this->getDemoEvidence($period);
+        }
+
+        $evidence = [];
+
+        if ($type === 'all' || $type === 'access') {
+            $accessData = $this->collectAccessEvidence($period);
+            $evidence['access'] = $this->storeEvidence('access', $period, $accessData);
+        }
+
+        if ($type === 'all' || $type === 'config') {
+            $configData = $this->collectConfigSnapshot();
+            $evidence['config'] = $this->storeEvidence('config_snapshot', $period, $configData);
+        }
+
+        if ($type === 'all' || $type === 'change_management') {
+            $changeData = $this->collectChangeLogEvidence($period);
+            $evidence['change_management'] = $this->storeEvidence('change_management', $period, $changeData);
+        }
+
+        Log::info('SOC 2 evidence collected', [
+            'period'         => $period,
+            'type'           => $type,
+            'evidence_types' => array_keys($evidence),
+        ]);
+
+        return $evidence;
+    }
+
+    /**
+     * Retrieve stored evidence with optional filters.
+     *
+     * @param string|null $period Filter by audit period
+     * @param string|null $type   Filter by evidence type
+     *
+     * @return Collection<int, ComplianceEvidence>
+     */
+    public function getEvidence(?string $period = null, ?string $type = null): Collection
+    {
+        $query = ComplianceEvidence::query();
+
+        if ($period !== null) {
+            $query->forPeriod($period);
+        }
+
+        if ($type !== null) {
+            $query->forType($type);
+        }
+
+        return $query->orderBy('created_at', 'desc')->get();
+    }
+
+    /**
+     * Collect access evidence from audit logs for a period.
+     *
+     * Queries AuditLog entries within the period date range and summarizes
+     * access patterns by user and action type.
+     *
+     * @param string $period The audit period identifier (e.g. '2026-Q1')
+     *
+     * @return array<string, mixed>
+     */
+    public function collectAccessEvidence(string $period): array
+    {
+        [$startDate, $endDate] = $this->parsePeriodDates($period);
+
+        $logs = AuditLog::where('created_at', '>=', $startDate)
+            ->where('created_at', '<=', $endDate)
+            ->get();
+
+        $byUser = $logs->groupBy('user_uuid')->map(function (Collection $userLogs) {
+            return [
+                'action_count'   => $userLogs->count(),
+                'actions'        => $userLogs->groupBy('action')->map->count()->toArray(),
+                'first_activity' => $userLogs->min('created_at')?->toIso8601String(),
+                'last_activity'  => $userLogs->max('created_at')?->toIso8601String(),
+            ];
+        })->toArray();
+
+        $byAction = $logs->groupBy('action')->map->count()->toArray();
+
+        return [
+            'period'       => $period,
+            'total_events' => $logs->count(),
+            'unique_users' => $logs->unique('user_uuid')->count(),
+            'by_user'      => $byUser,
+            'by_action'    => $byAction,
+            'collected_at' => now()->toIso8601String(),
+        ];
+    }
+
+    /**
+     * Capture a snapshot of security-relevant configuration values.
+     *
+     * @return array<string, mixed>
+     */
+    public function collectConfigSnapshot(): array
+    {
+        return [
+            'app_debug'            => config('app.debug'),
+            'app_env'              => config('app.env'),
+            'session_lifetime'     => config('session.lifetime'),
+            'session_driver'       => config('session.driver'),
+            'session_encrypt'      => config('session.encrypt'),
+            'auth_defaults'        => config('auth.defaults'),
+            'auth_guards'          => array_keys(config('auth.guards', [])),
+            'auth_providers'       => array_keys(config('auth.providers', [])),
+            'hashing_driver'       => config('hashing.driver'),
+            'mail_encryption'      => config('mail.mailers.smtp.encryption', null),
+            'cache_driver'         => config('cache.default'),
+            'queue_driver'         => config('queue.default'),
+            'logging_channel'      => config('logging.default'),
+            'password_timeout'     => config('auth.password_timeout'),
+            'sanctum_expiration'   => config('sanctum.expiration'),
+            'cors_allowed_origins' => config('cors.allowed_origins', []),
+            'collected_at'         => now()->toIso8601String(),
+        ];
+    }
+
+    /**
+     * Collect change management evidence from compliance change logs.
+     *
+     * @param string $period The audit period identifier
+     *
+     * @return array<string, mixed>
+     */
+    public function collectChangeLogEvidence(string $period): array
+    {
+        [$startDate, $endDate] = $this->parsePeriodDates($period);
+
+        $changes = ComplianceChangeLog::where('created_at', '>=', $startDate)
+            ->where('created_at', '<=', $endDate)
+            ->get();
+
+        $byType = $changes->groupBy('change_type')->map(function (Collection $typeChanges) {
+            return [
+                'count'   => $typeChanges->count(),
+                'changes' => $typeChanges->map(function (ComplianceChangeLog $change) {
+                    return [
+                        'id'               => $change->id,
+                        'description'      => $change->description,
+                        'changed_by'       => $change->changed_by,
+                        'environment'      => $change->environment,
+                        'ticket_reference' => $change->ticket_reference,
+                        'created_at'       => $change->created_at?->toIso8601String(),
+                    ];
+                })->toArray(),
+            ];
+        })->toArray();
+
+        return [
+            'period'        => $period,
+            'total_changes' => $changes->count(),
+            'by_type'       => $byType,
+            'environments'  => $changes->unique('environment')->pluck('environment')->filter()->values()->toArray(),
+            'collected_at'  => now()->toIso8601String(),
+        ];
+    }
+
+    /**
+     * Generate a SHA-256 integrity hash for evidence data.
+     *
+     * @param array<string, mixed> $data
+     */
+    public function generateIntegrityHash(array $data): string
+    {
+        return hash('sha256', json_encode($data));
+    }
+
+    /**
+     * Store evidence with an integrity hash.
+     *
+     * @param string               $type   Evidence type identifier
+     * @param string               $period Audit period
+     * @param array<string, mixed> $data   Evidence data payload
+     *
+     * @return array<string, mixed>
+     */
+    private function storeEvidence(string $type, string $period, array $data): array
+    {
+        $integrityHash = $this->generateIntegrityHash($data);
+
+        $evidence = ComplianceEvidence::create([
+            'evidence_type'  => $type,
+            'period'         => $period,
+            'data'           => $data,
+            'integrity_hash' => $integrityHash,
+            'collected_by'   => auth()->user()?->name ?? 'system',
+            'metadata'       => [
+                'version'      => '1.0',
+                'collector'    => static::class,
+                'collected_at' => now()->toIso8601String(),
+            ],
+        ]);
+
+        return [
+            'id'             => $evidence->id,
+            'type'           => $type,
+            'period'         => $period,
+            'integrity_hash' => $integrityHash,
+            'record_count'   => is_countable($data) ? count($data) : 0,
+            'collected_at'   => $evidence->created_at?->toIso8601String(),
+        ];
+    }
+
+    /**
+     * Parse a period string into start and end Carbon dates.
+     *
+     * Supports formats: 'YYYY-QN' (quarterly) and 'YYYY-MM' (monthly).
+     *
+     * @param string $period
+     *
+     * @return array{0: Carbon, 1: Carbon}
+     */
+    private function parsePeriodDates(string $period): array
+    {
+        if (preg_match('/^(\d{4})-Q(\d)$/', $period, $matches)) {
+            $year = (int) $matches[1];
+            $quarter = (int) $matches[2];
+            $startMonth = ($quarter - 1) * 3 + 1;
+
+            $startDate = Carbon::create($year, $startMonth, 1)->startOfDay();
+            $endDate = $startDate->copy()->addMonths(3)->subSecond();
+
+            return [$startDate, $endDate];
+        }
+
+        if (preg_match('/^(\d{4})-(\d{2})$/', $period, $matches)) {
+            $startDate = Carbon::create((int) $matches[1], (int) $matches[2], 1)->startOfDay();
+            $endDate = $startDate->copy()->endOfMonth();
+
+            return [$startDate, $endDate];
+        }
+
+        $reviewDays = (int) config('compliance-certification.soc2.review_period', 90);
+        $endDate = Carbon::now();
+        $startDate = $endDate->copy()->subDays($reviewDays);
+
+        return [$startDate, $endDate];
+    }
+
+    /**
+     * Return realistic simulated evidence data for demo mode.
+     *
+     * @param string $period
+     *
+     * @return array<string, mixed>
+     */
+    private function getDemoEvidence(string $period): array
+    {
+        $now = now()->toIso8601String();
+
+        return [
+            'access' => [
+                'id'             => 'demo-access-' . md5($period),
+                'type'           => 'access',
+                'period'         => $period,
+                'integrity_hash' => hash('sha256', 'demo-access-' . $period),
+                'record_count'   => 1247,
+                'collected_at'   => $now,
+                'data'           => [
+                    'period'       => $period,
+                    'total_events' => 1247,
+                    'unique_users' => 23,
+                    'by_user'      => [
+                        'admin-001'    => ['action_count' => 312, 'actions' => ['login' => 45, 'view' => 198, 'update' => 69]],
+                        'analyst-002'  => ['action_count' => 189, 'actions' => ['login' => 31, 'view' => 142, 'export' => 16]],
+                        'operator-003' => ['action_count' => 156, 'actions' => ['login' => 28, 'view' => 95, 'update' => 33]],
+                    ],
+                    'by_action' => [
+                        'login'  => 284,
+                        'view'   => 623,
+                        'update' => 198,
+                        'create' => 87,
+                        'delete' => 12,
+                        'export' => 43,
+                    ],
+                ],
+            ],
+            'config' => [
+                'id'             => 'demo-config-' . md5($period),
+                'type'           => 'config_snapshot',
+                'period'         => $period,
+                'integrity_hash' => hash('sha256', 'demo-config-' . $period),
+                'record_count'   => 16,
+                'collected_at'   => $now,
+                'data'           => [
+                    'app_debug'        => false,
+                    'app_env'          => 'production',
+                    'session_lifetime' => 120,
+                    'session_driver'   => 'redis',
+                    'session_encrypt'  => true,
+                    'auth_defaults'    => ['guard' => 'web', 'passwords' => 'users'],
+                    'hashing_driver'   => 'bcrypt',
+                    'collected_at'     => $now,
+                ],
+            ],
+            'change_management' => [
+                'id'             => 'demo-changes-' . md5($period),
+                'type'           => 'change_management',
+                'period'         => $period,
+                'integrity_hash' => hash('sha256', 'demo-changes-' . $period),
+                'record_count'   => 34,
+                'collected_at'   => $now,
+                'data'           => [
+                    'period'        => $period,
+                    'total_changes' => 34,
+                    'by_type'       => [
+                        'deployment'     => ['count' => 12],
+                        'configuration'  => ['count' => 8],
+                        'access_change'  => ['count' => 6],
+                        'infrastructure' => ['count' => 5],
+                        'policy_update'  => ['count' => 3],
+                    ],
+                    'environments' => ['production', 'staging'],
+                ],
+            ],
+        ];
+    }
+}

--- a/app/Domain/Compliance/Services/Certification/IncidentResponseService.php
+++ b/app/Domain/Compliance/Services/Certification/IncidentResponseService.php
@@ -1,0 +1,289 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Compliance\Services\Certification;
+
+use App\Domain\Compliance\Models\SecurityIncident;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * SOC 2 Incident Response Service.
+ *
+ * Manages the full lifecycle of security incidents: creation, investigation,
+ * resolution, postmortem generation, and statistical reporting for SOC 2
+ * Trust Services Criteria (CC7.2, CC7.3, CC7.4, CC7.5).
+ */
+class IncidentResponseService
+{
+    /**
+     * Create a new security incident.
+     *
+     * @param array<string, mixed> $data Incident data (title, description, severity, affected_systems, reported_by, assigned_to, metadata)
+     */
+    public function createIncident(array $data): SecurityIncident
+    {
+        $incident = SecurityIncident::create([
+            'title'       => $data['title'],
+            'description' => $data['description'],
+            'severity'    => $data['severity'] ?? 'medium',
+            'status'      => 'open',
+            'timeline'    => [
+                [
+                    'timestamp' => now()->toIso8601String(),
+                    'action'    => 'incident_created',
+                    'actor'     => $data['reported_by'] ?? auth()->user()?->name ?? 'system',
+                    'notes'     => 'Incident reported and opened for investigation.',
+                ],
+            ],
+            'resolution'       => null,
+            'affected_systems' => $data['affected_systems'] ?? [],
+            'reported_by'      => $data['reported_by'] ?? auth()->user()?->name ?? 'system',
+            'assigned_to'      => $data['assigned_to'] ?? null,
+            'detected_at'      => $data['detected_at'] ?? now(),
+            'resolved_at'      => null,
+            'postmortem'       => null,
+            'metadata'         => $data['metadata'] ?? [],
+        ]);
+
+        Log::info('Security incident created', [
+            'id'          => $incident->id,
+            'title'       => $incident->title,
+            'severity'    => $incident->severity,
+            'reported_by' => $incident->reported_by,
+        ]);
+
+        return $incident;
+    }
+
+    /**
+     * Update an existing security incident and append a timeline entry.
+     *
+     * @param string               $id   Incident UUID
+     * @param array<string, mixed> $data Fields to update
+     */
+    public function updateIncident(string $id, array $data): SecurityIncident
+    {
+        $incident = SecurityIncident::findOrFail($id);
+
+        $updatableFields = [
+            'title', 'description', 'severity', 'status',
+            'affected_systems', 'assigned_to', 'metadata',
+        ];
+
+        $updateData = array_intersect_key($data, array_flip($updatableFields));
+        $incident->update($updateData);
+
+        $changedFields = array_keys($updateData);
+        $incident->addTimelineEntry(
+            'incident_updated',
+            auth()->user()?->name ?? 'system',
+            'Updated fields: ' . implode(', ', $changedFields)
+        );
+
+        Log::info('Security incident updated', [
+            'id'             => $incident->id,
+            'updated_fields' => $changedFields,
+        ]);
+
+        return $incident->fresh();
+    }
+
+    /**
+     * Resolve a security incident.
+     *
+     * @param string $id         Incident UUID
+     * @param string $resolution Description of the resolution
+     */
+    public function resolveIncident(string $id, string $resolution): SecurityIncident
+    {
+        $incident = SecurityIncident::findOrFail($id);
+
+        $incident->update([
+            'status'      => 'resolved',
+            'resolution'  => $resolution,
+            'resolved_at' => now(),
+        ]);
+
+        $incident->addTimelineEntry(
+            'incident_resolved',
+            auth()->user()?->name ?? 'system',
+            $resolution
+        );
+
+        Log::info('Security incident resolved', [
+            'id'                    => $incident->id,
+            'title'                 => $incident->title,
+            'resolution_time_hours' => $incident->detected_at
+                ? $incident->detected_at->diffInHours(now())
+                : null,
+        ]);
+
+        return $incident->fresh();
+    }
+
+    /**
+     * Retrieve incidents with optional status and severity filters.
+     *
+     * @param string|null $status   Filter by status (open, investigating, mitigating, resolved, closed)
+     * @param string|null $severity Filter by severity (low, medium, high, critical)
+     *
+     * @return Collection<int, SecurityIncident>
+     */
+    public function getIncidents(?string $status = null, ?string $severity = null): Collection
+    {
+        $query = SecurityIncident::query();
+
+        if ($status !== null) {
+            $query->where('status', $status);
+        }
+
+        if ($severity !== null) {
+            $query->forSeverity($severity);
+        }
+
+        return $query->orderBy('created_at', 'desc')->get();
+    }
+
+    /**
+     * Get all currently open incidents (open, investigating, or mitigating).
+     *
+     * @return Collection<int, SecurityIncident>
+     */
+    public function getOpenIncidents(): Collection
+    {
+        return SecurityIncident::open()
+            ->orderBy('created_at', 'desc')
+            ->get();
+    }
+
+    /**
+     * Generate a postmortem report for a resolved incident.
+     *
+     * @param string $id Incident UUID
+     *
+     * @return array<string, mixed>
+     */
+    public function generatePostmortem(string $id): array
+    {
+        $incident = SecurityIncident::findOrFail($id);
+
+        $resolutionTimeHours = null;
+        if ($incident->detected_at && $incident->resolved_at) {
+            $resolutionTimeHours = round($incident->detected_at->diffInHours($incident->resolved_at), 2);
+        }
+
+        $postmortem = [
+            'incident_id'      => $incident->id,
+            'title'            => $incident->title,
+            'severity'         => $incident->severity,
+            'status'           => $incident->status,
+            'generated_at'     => now()->toIso8601String(),
+            'incident_summary' => [
+                'description'           => $incident->description,
+                'detected_at'           => $incident->detected_at?->toIso8601String(),
+                'resolved_at'           => $incident->resolved_at?->toIso8601String(),
+                'resolution_time_hours' => $resolutionTimeHours,
+                'reported_by'           => $incident->reported_by,
+                'assigned_to'           => $incident->assigned_to,
+            ],
+            'affected_systems' => $incident->affected_systems ?? [],
+            'timeline'         => $incident->timeline ?? [],
+            'resolution'       => $incident->resolution,
+            'root_cause'       => $incident->postmortem['root_cause'] ?? 'Root cause analysis pending.',
+            'lessons_learned'  => $incident->postmortem['lessons_learned'] ?? [
+                'Detection: Review monitoring thresholds and alerting rules.',
+                'Response: Evaluate incident response procedures for improvement.',
+                'Prevention: Identify and implement measures to prevent recurrence.',
+            ],
+            'action_items'      => $incident->postmortem['action_items'] ?? [],
+            'impact_assessment' => [
+                'affected_system_count' => count($incident->affected_systems ?? []),
+                'severity'              => $incident->severity,
+                'was_data_compromised'  => $incident->metadata['data_compromised'] ?? false,
+                'customer_impact'       => $incident->metadata['customer_impact'] ?? 'Assessment pending.',
+            ],
+        ];
+
+        // Persist the postmortem on the incident record
+        $incident->update(['postmortem' => $postmortem]);
+
+        Log::info('Postmortem generated for security incident', [
+            'id'    => $incident->id,
+            'title' => $incident->title,
+        ]);
+
+        return $postmortem;
+    }
+
+    /**
+     * Get incident statistics: counts by severity, status, and average resolution time.
+     *
+     * @return array<string, mixed>
+     */
+    public function getIncidentStatistics(): array
+    {
+        $incidents = SecurityIncident::all();
+
+        $bySeverity = $incidents->groupBy('severity')->map->count()->toArray();
+        $byStatus = $incidents->groupBy('status')->map->count()->toArray();
+
+        $resolvedIncidents = $incidents->filter(function (SecurityIncident $incident) {
+            return $incident->detected_at !== null && $incident->resolved_at !== null;
+        });
+
+        $avgResolutionHours = null;
+        if ($resolvedIncidents->isNotEmpty()) {
+            $totalHours = $resolvedIncidents->sum(function (SecurityIncident $incident) {
+                return $incident->detected_at->diffInHours($incident->resolved_at);
+            });
+            $avgResolutionHours = round($totalHours / $resolvedIncidents->count(), 2);
+        }
+
+        return [
+            'generated_at'                  => now()->toIso8601String(),
+            'total_incidents'               => $incidents->count(),
+            'open_incidents'                => $incidents->filter(fn (SecurityIncident $i) => ! $i->isResolved())->count(),
+            'resolved_incidents'            => $resolvedIncidents->count(),
+            'by_severity'                   => $bySeverity,
+            'by_status'                     => $byStatus,
+            'average_resolution_time_hours' => $avgResolutionHours,
+            'critical_open'                 => $incidents
+                ->where('severity', 'critical')
+                ->filter(fn (SecurityIncident $i) => ! $i->isResolved())
+                ->count(),
+            'mttr_by_severity' => $this->calculateMttrBySeverity($incidents),
+        ];
+    }
+
+    /**
+     * Calculate Mean Time To Resolve (MTTR) grouped by severity.
+     *
+     * @param Collection<int, SecurityIncident> $incidents
+     *
+     * @return array<string, float|null>
+     */
+    private function calculateMttrBySeverity(Collection $incidents): array
+    {
+        $severities = ['low', 'medium', 'high', 'critical'];
+        $mttr = [];
+
+        foreach ($severities as $severity) {
+            $resolved = $incidents->where('severity', $severity)->filter(function (SecurityIncident $incident) {
+                return $incident->detected_at !== null && $incident->resolved_at !== null;
+            });
+
+            if ($resolved->isNotEmpty()) {
+                $totalHours = $resolved->sum(function (SecurityIncident $incident) {
+                    return $incident->detected_at->diffInHours($incident->resolved_at);
+                });
+                $mttr[$severity] = round($totalHours / $resolved->count(), 2);
+            } else {
+                $mttr[$severity] = null;
+            }
+        }
+
+        return $mttr;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `EvidenceCollectionService` for SOC 2 audit evidence collection (access logs, config snapshots, change management) with SHA-256 integrity hashing and demo mode support
- Add `AccessReviewService` for privileged user auditing, permission matrix generation, stale account detection, and dormant Sanctum token identification
- Add `ChangeManagementService` for compliance change logging, period-based reporting with ticket coverage metrics, and deployment tracking
- Add `IncidentResponseService` for full security incident lifecycle (create, update, resolve) with timeline tracking, postmortem generation, and MTTR statistics by severity

## Test plan
- [ ] Verify PHP syntax passes: `php -l app/Domain/Compliance/Services/Certification/*.php`
- [ ] Verify code style passes: `./vendor/bin/php-cs-fixer fix --dry-run app/Domain/Compliance/Services/Certification/`
- [ ] Verify demo mode returns simulated data for EvidenceCollectionService and AccessReviewService
- [ ] Verify evidence integrity hashes match SHA-256 of stored data
- [ ] Verify incident timeline entries are appended correctly on create/update/resolve
- [ ] Verify change report ticket coverage percentage calculation
- [ ] Verify stale account detection respects the 90-day inactivity threshold
- [ ] Verify dormant token detection queries personal_access_tokens table correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)