### PR TITLE
feat: SOC 2 Type II preparation — evidence collection, access reviews, incident response (v3.5.0)

### DIFF
--- a/app/Console/Commands/ComplianceAccessReviewCommand.php
+++ b/app/Console/Commands/ComplianceAccessReviewCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Compliance\Services\Certification\AccessReviewService;
+use Illuminate\Console\Command;
+use Throwable;
+
+class ComplianceAccessReviewCommand extends Command
+{
+    protected $signature = 'compliance:access-review
+        {--format=text : Output format (json, text)}
+        {--export : Export to file}';
+
+    protected $description = 'Run a SOC 2 access review and report on privileged users, permissions, and stale accounts';
+
+    public function handle(AccessReviewService $service): int
+    {
+        $format = (string) $this->option('format');
+        $export = (bool) $this->option('export');
+
+        $this->info('Running access review...');
+
+        try {
+            $report = $service->runAccessReview();
+            $summary = $report['summary'] ?? $report;
+
+            if ($format === 'json') {
+                $output = json_encode($report, JSON_PRETTY_PRINT);
+                $this->line($output);
+
+                if ($export) {
+                    $path = storage_path('app/compliance/access-review-' . date('Y-m-d') . '.json');
+                    if (! is_dir(dirname($path))) {
+                        mkdir(dirname($path), 0755, true);
+                    }
+                    file_put_contents($path, $output);
+                    $this->info("Exported to: {$path}");
+                }
+            } else {
+                $this->info('Privileged Users: ' . ($summary['privileged_user_count'] ?? 0));
+                $this->info('Total Roles: ' . ($summary['total_roles'] ?? 0));
+                $this->info('Stale Accounts: ' . ($summary['stale_account_count'] ?? 0));
+                $this->info('Dormant Tokens: ' . ($summary['dormant_token_count'] ?? 0));
+
+                if (! empty($report['recommendations'])) {
+                    $this->warn('Recommendations:');
+                    foreach ($report['recommendations'] as $rec) {
+                        $this->line("  - {$rec}");
+                    }
+                }
+            }
+
+            return self::SUCCESS;
+        } catch (Throwable $e) {
+            $this->error("Access review failed: {$e->getMessage()}");
+
+            return self::FAILURE;
+        }
+    }
+}

--- a/app/Console/Commands/ComplianceEvidenceCollectCommand.php
+++ b/app/Console/Commands/ComplianceEvidenceCollectCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Compliance\Services\Certification\EvidenceCollectionService;
+use Illuminate\Console\Command;
+use Throwable;
+
+class ComplianceEvidenceCollectCommand extends Command
+{
+    protected $signature = 'compliance:collect-evidence
+        {--period=quarterly : Evidence collection period (quarterly, monthly, annual)}
+        {--type=all : Evidence type to collect (all, access_logs, config_snapshot, change_log)}
+        {--format=json : Output format (json, text)}
+        {--dry-run : Preview without saving}';
+
+    protected $description = 'Collect SOC 2 compliance evidence for the specified period';
+
+    public function handle(EvidenceCollectionService $service): int
+    {
+        $period = (string) $this->option('period');
+        $type = (string) $this->option('type');
+        $format = (string) $this->option('format');
+        $dryRun = (bool) $this->option('dry-run');
+
+        $this->info("Collecting {$type} evidence for period: {$period}...");
+
+        if ($dryRun) {
+            $this->warn('DRY RUN — no records will be saved.');
+        }
+
+        try {
+            $evidence = $service->collectEvidence($period, $type);
+
+            if ($format === 'json') {
+                $this->line(json_encode($evidence, JSON_PRETTY_PRINT));
+            } else {
+                $this->info('Evidence collected successfully.');
+                $this->table(
+                    ['Type', 'Records', 'Integrity Hash'],
+                    collect($evidence)->map(fn ($item) => [
+                        $item['evidence_type'] ?? 'unknown',
+                        is_array($item['data'] ?? null) ? count($item['data']) : 1,
+                        substr($item['integrity_hash'] ?? '', 0, 16) . '...',
+                    ])->toArray()
+                );
+            }
+
+            return self::SUCCESS;
+        } catch (Throwable $e) {
+            $this->error("Evidence collection failed: {$e->getMessage()}");
+
+            return self::FAILURE;
+        }
+    }
+}

--- a/app/Console/Commands/ComplianceIncidentCommand.php
+++ b/app/Console/Commands/ComplianceIncidentCommand.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Compliance\Services\Certification\IncidentResponseService;
+use Illuminate\Console\Command;
+use Throwable;
+
+class ComplianceIncidentCommand extends Command
+{
+    protected $signature = 'compliance:incident
+        {action : Action to perform (list, create, resolve, postmortem, stats)}
+        {--id= : Incident ID for resolve/postmortem actions}
+        {--severity= : Severity level for create (critical, high, medium, low)}
+        {--title= : Incident title for create}
+        {--description= : Incident description for create}
+        {--resolution= : Resolution text for resolve action}';
+
+    protected $description = 'Manage security incidents for SOC 2 compliance';
+
+    public function handle(IncidentResponseService $service): int
+    {
+        $action = (string) $this->argument('action');
+
+        try {
+            return match ($action) {
+                'list'       => $this->listIncidents($service),
+                'create'     => $this->createIncident($service),
+                'resolve'    => $this->resolveIncident($service),
+                'postmortem' => $this->showPostmortem($service),
+                'stats'      => $this->showStatistics($service),
+                default      => $this->invalidAction($action),
+            };
+        } catch (Throwable $e) {
+            $this->error("Incident command failed: {$e->getMessage()}");
+
+            return self::FAILURE;
+        }
+    }
+
+    private function listIncidents(IncidentResponseService $service): int
+    {
+        $incidents = $service->getOpenIncidents();
+
+        if ($incidents->isEmpty()) {
+            $this->info('No open incidents.');
+
+            return self::SUCCESS;
+        }
+
+        $this->table(
+            ['ID', 'Title', 'Severity', 'Status', 'Detected At'],
+            $incidents->map(fn ($i) => [
+                substr((string) $i->id, 0, 8) . '...',
+                $i->title,
+                $i->severity,
+                $i->status,
+                $i->detected_at?->format('Y-m-d H:i') ?? 'N/A',
+            ])->toArray()
+        );
+
+        return self::SUCCESS;
+    }
+
+    private function createIncident(IncidentResponseService $service): int
+    {
+        $title = $this->option('title');
+        $severity = $this->option('severity');
+
+        if (! $title || ! $severity) {
+            $this->error('--title and --severity are required for create action.');
+
+            return self::FAILURE;
+        }
+
+        $incident = $service->createIncident([
+            'title'       => $title,
+            'description' => $this->option('description') ?? $title,
+            'severity'    => $severity,
+        ]);
+
+        $this->info("Incident created: {$incident->id}");
+
+        return self::SUCCESS;
+    }
+
+    private function resolveIncident(IncidentResponseService $service): int
+    {
+        $id = $this->option('id');
+        $resolution = $this->option('resolution');
+
+        if (! $id || ! $resolution) {
+            $this->error('--id and --resolution are required for resolve action.');
+
+            return self::FAILURE;
+        }
+
+        $service->resolveIncident($id, $resolution);
+        $this->info("Incident {$id} resolved.");
+
+        return self::SUCCESS;
+    }
+
+    private function showPostmortem(IncidentResponseService $service): int
+    {
+        $id = $this->option('id');
+
+        if (! $id) {
+            $this->error('--id is required for postmortem action.');
+
+            return self::FAILURE;
+        }
+
+        $postmortem = $service->generatePostmortem($id);
+        $this->line(json_encode($postmortem, JSON_PRETTY_PRINT));
+
+        return self::SUCCESS;
+    }
+
+    private function showStatistics(IncidentResponseService $service): int
+    {
+        $stats = $service->getIncidentStatistics();
+        $this->line(json_encode($stats, JSON_PRETTY_PRINT));
+
+        return self::SUCCESS;
+    }
+
+    private function invalidAction(string $action): int
+    {
+        $this->error("Invalid action: {$action}. Use: list, create, resolve, postmortem, stats");
+
+        return self::FAILURE;
+    }
+}

--- a/app/Domain/Compliance/Models/ComplianceChangeLog.php
+++ b/app/Domain/Compliance/Models/ComplianceChangeLog.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Compliance\Models;
+
+use App\Domain\Shared\Traits\UsesTenantConnection;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ComplianceChangeLog extends Model
+{
+    use UsesTenantConnection;
+    use HasFactory;
+    use HasUuids;
+
+    protected $table = 'compliance_change_logs';
+
+    protected $fillable = [
+        'tenant_id',
+        'change_type',
+        'description',
+        'old_values',
+        'new_values',
+        'changed_by',
+        'environment',
+        'ticket_reference',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'old_values' => 'array',
+        'new_values' => 'array',
+        'metadata'   => 'array',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function scopeForType($query, string $type)
+    {
+        return $query->where('change_type', $type);
+    }
+
+    public function scopeForEnvironment($query, string $environment)
+    {
+        return $query->where('environment', $environment);
+    }
+}

--- a/app/Domain/Compliance/Models/ComplianceEvidence.php
+++ b/app/Domain/Compliance/Models/ComplianceEvidence.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Compliance\Models;
+
+use App\Domain\Shared\Traits\UsesTenantConnection;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ComplianceEvidence extends Model
+{
+    use UsesTenantConnection;
+    use HasFactory;
+    use HasUuids;
+
+    protected $table = 'compliance_evidence';
+
+    protected $fillable = [
+        'tenant_id',
+        'evidence_type',
+        'period',
+        'data',
+        'integrity_hash',
+        'collected_by',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'data'       => 'array',
+        'metadata'   => 'array',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function scopeForType($query, string $type)
+    {
+        return $query->where('evidence_type', $type);
+    }
+
+    public function scopeForPeriod($query, string $period)
+    {
+        return $query->where('period', $period);
+    }
+
+    public function verifyIntegrity(): bool
+    {
+        return hash('sha256', json_encode($this->data)) === $this->integrity_hash;
+    }
+}

--- a/app/Domain/Compliance/Models/SecurityIncident.php
+++ b/app/Domain/Compliance/Models/SecurityIncident.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Compliance\Models;
+
+use App\Domain\Shared\Traits\UsesTenantConnection;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SecurityIncident extends Model
+{
+    use UsesTenantConnection;
+    use HasFactory;
+    use HasUuids;
+
+    protected $table = 'security_incidents';
+
+    protected $fillable = [
+        'tenant_id',
+        'title',
+        'description',
+        'severity',
+        'status',
+        'timeline',
+        'resolution',
+        'affected_systems',
+        'reported_by',
+        'assigned_to',
+        'detected_at',
+        'resolved_at',
+        'postmortem',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'timeline'         => 'array',
+        'affected_systems' => 'array',
+        'postmortem'       => 'array',
+        'metadata'         => 'array',
+        'detected_at'      => 'datetime',
+        'resolved_at'      => 'datetime',
+        'created_at'       => 'datetime',
+        'updated_at'       => 'datetime',
+    ];
+
+    public function scopeOpen($query)
+    {
+        return $query->whereIn('status', ['open', 'investigating', 'mitigating']);
+    }
+
+    public function scopeForSeverity($query, string $severity)
+    {
+        return $query->where('severity', $severity);
+    }
+
+    public function isResolved(): bool
+    {
+        return in_array($this->status, ['resolved', 'closed']);
+    }
+
+    public function addTimelineEntry(string $action, ?string $actor = null, ?string $notes = null): void
+    {
+        $timeline = $this->timeline ?? [];
+        $timeline[] = [
+            'timestamp' => now()->toIso8601String(),
+            'action'    => $action,
+            'actor'     => $actor,
+            'notes'     => $notes,
+        ];
+        $this->update(['timeline' => $timeline]);
+    }
+}

--- a/app/Domain/Compliance/Routes/api.php
+++ b/app/Domain/Compliance/Routes/api.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Http\Controllers\Api\ComplianceAlertController;
 use App\Http\Controllers\Api\ComplianceCaseController;
+use App\Http\Controllers\Api\ComplianceCertificationController;
 use App\Http\Controllers\Api\GdprController;
 use App\Http\Controllers\Api\KycController;
 use Illuminate\Support\Facades\Route;
@@ -45,6 +46,19 @@ Route::middleware('auth:sanctum', 'check.token.expiration')->prefix('compliance'
         Route::post('/submit', [KycController::class, 'submit']);
         Route::post('/documents', [KycController::class, 'upload']);
         Route::get('/documents/{documentId}/download', [KycController::class, 'downloadDocument']);
+    });
+
+    // Compliance Certification (SOC 2, PCI DSS)
+    Route::prefix('certification')->group(function () {
+        Route::get('/evidence', [ComplianceCertificationController::class, 'getEvidence']);
+        Route::post('/evidence/collect', [ComplianceCertificationController::class, 'collectEvidence']);
+        Route::get('/access-review', [ComplianceCertificationController::class, 'getAccessReview']);
+        Route::get('/access-review/privileged-users', [ComplianceCertificationController::class, 'getPrivilegedUsers']);
+        Route::get('/incidents', [ComplianceCertificationController::class, 'getIncidents']);
+        Route::post('/incidents', [ComplianceCertificationController::class, 'createIncident']);
+        Route::put('/incidents/{id}', [ComplianceCertificationController::class, 'updateIncident']);
+        Route::post('/incidents/{id}/resolve', [ComplianceCertificationController::class, 'resolveIncident']);
+        Route::get('/incidents/{id}/postmortem', [ComplianceCertificationController::class, 'getPostmortem']);
     });
 
     // GDPR endpoints

--- a/app/Http/Controllers/Api/ComplianceCertificationController.php
+++ b/app/Http/Controllers/Api/ComplianceCertificationController.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Domain\Compliance\Services\Certification\AccessReviewService;
+use App\Domain\Compliance\Services\Certification\EvidenceCollectionService;
+use App\Domain\Compliance\Services\Certification\IncidentResponseService;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Throwable;
+
+class ComplianceCertificationController extends Controller
+{
+    public function __construct(
+        private readonly EvidenceCollectionService $evidenceService,
+        private readonly AccessReviewService $accessReviewService,
+        private readonly IncidentResponseService $incidentResponseService,
+    ) {
+    }
+
+    /**
+     * Get SOC 2 compliance evidence.
+     */
+    public function getEvidence(Request $request): JsonResponse
+    {
+        try {
+            $evidence = $this->evidenceService->getEvidence(
+                $request->query('period'),
+                $request->query('type'),
+            );
+
+            return response()->json([
+                'data' => $evidence,
+            ]);
+        } catch (Throwable $e) {
+            return response()->json([
+                'error'   => 'Failed to retrieve evidence',
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    /**
+     * Collect SOC 2 compliance evidence for a given period.
+     */
+    public function collectEvidence(Request $request): JsonResponse
+    {
+        try {
+            $validated = $request->validate([
+                'period' => ['required', 'string'],
+                'type'   => ['sometimes', 'string'],
+            ]);
+
+            $result = $this->evidenceService->collectEvidence(
+                $validated['period'],
+                $validated['type'] ?? 'all',
+            );
+
+            return response()->json([
+                'message' => 'Evidence collection initiated successfully',
+                'data'    => $result,
+            ], 201);
+        } catch (Throwable $e) {
+            return response()->json([
+                'error'   => 'Failed to collect evidence',
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    /**
+     * Get access review report.
+     */
+    public function getAccessReview(): JsonResponse
+    {
+        try {
+            $report = $this->accessReviewService->generateReviewReport();
+
+            return response()->json([
+                'data' => $report,
+            ]);
+        } catch (Throwable $e) {
+            return response()->json([
+                'error'   => 'Failed to generate access review report',
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    /**
+     * Get list of privileged users.
+     */
+    public function getPrivilegedUsers(): JsonResponse
+    {
+        try {
+            $users = $this->accessReviewService->getPrivilegedUsers();
+
+            return response()->json([
+                'data' => $users->toArray(),
+            ]);
+        } catch (Throwable $e) {
+            return response()->json([
+                'error'   => 'Failed to retrieve privileged users',
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    /**
+     * Get incidents with optional status and severity filters.
+     */
+    public function getIncidents(Request $request): JsonResponse
+    {
+        try {
+            $incidents = $this->incidentResponseService->getIncidents(
+                $request->query('status'),
+                $request->query('severity'),
+            );
+
+            return response()->json([
+                'data' => $incidents,
+            ]);
+        } catch (Throwable $e) {
+            return response()->json([
+                'error'   => 'Failed to retrieve incidents',
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    /**
+     * Create a new incident.
+     */
+    public function createIncident(Request $request): JsonResponse
+    {
+        try {
+            $validated = $request->validate([
+                'title'            => ['required', 'string'],
+                'description'      => ['required', 'string'],
+                'severity'         => ['required', 'in:critical,high,medium,low'],
+                'affected_systems' => ['nullable', 'array'],
+            ]);
+
+            $incident = $this->incidentResponseService->createIncident($validated);
+
+            return response()->json([
+                'message' => 'Incident created successfully',
+                'data'    => $incident,
+            ], 201);
+        } catch (Throwable $e) {
+            return response()->json([
+                'error'   => 'Failed to create incident',
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    /**
+     * Update an existing incident.
+     */
+    public function updateIncident(Request $request, string $id): JsonResponse
+    {
+        try {
+            $validated = $request->validate([
+                'title'            => ['sometimes', 'string'],
+                'description'      => ['sometimes', 'string'],
+                'severity'         => ['sometimes', 'in:critical,high,medium,low'],
+                'status'           => ['sometimes', 'string'],
+                'affected_systems' => ['sometimes', 'array'],
+            ]);
+
+            $incident = $this->incidentResponseService->updateIncident($id, $validated);
+
+            return response()->json([
+                'message' => 'Incident updated successfully',
+                'data'    => $incident,
+            ]);
+        } catch (Throwable $e) {
+            return response()->json([
+                'error'   => 'Failed to update incident',
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    /**
+     * Resolve an incident.
+     */
+    public function resolveIncident(Request $request, string $id): JsonResponse
+    {
+        try {
+            $validated = $request->validate([
+                'resolution' => ['required', 'string'],
+            ]);
+
+            $incident = $this->incidentResponseService->resolveIncident($id, $validated['resolution']);
+
+            return response()->json([
+                'message' => 'Incident resolved successfully',
+                'data'    => $incident,
+            ]);
+        } catch (Throwable $e) {
+            return response()->json([
+                'error'   => 'Failed to resolve incident',
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    /**
+     * Get incident postmortem report.
+     */
+    public function getPostmortem(string $id): JsonResponse
+    {
+        try {
+            $postmortem = $this->incidentResponseService->generatePostmortem($id);
+
+            return response()->json([
+                'data' => $postmortem,
+            ]);
+        } catch (Throwable $e) {
+            return response()->json([
+                'error'   => 'Failed to generate postmortem',
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+}

--- a/config/compliance-certification.php
+++ b/config/compliance-certification.php
@@ -1,0 +1,334 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Compliance Certification Configuration (v3.5.0)
+    |--------------------------------------------------------------------------
+    |
+    | Master configuration for compliance certification across SOC 2 Type II,
+    | PCI DSS, data residency, GDPR, and security scanning. Each section
+    | governs a distinct compliance domain and its operational parameters.
+    |
+    */
+
+    /*
+    |--------------------------------------------------------------------------
+    | SOC 2 Type II Settings
+    |--------------------------------------------------------------------------
+    |
+    | Service Organization Control 2 Type II audit configuration. Controls
+    | evidence collection, review cadence, and privileged access governance.
+    |
+    */
+
+    'soc2' => [
+        // When enabled, SOC 2 checks run in demonstration mode (no real audit trail)
+        'demo_mode' => env('SOC2_DEMO_MODE', true),
+
+        // Number of days to retain audit evidence artifacts
+        'evidence_retention_days' => (int) env('SOC2_EVIDENCE_RETENTION_DAYS', 365),
+
+        // Periodic review cadence: daily, weekly, monthly, quarterly, annually
+        'review_period' => env('SOC2_REVIEW_PERIOD', 'quarterly'),
+
+        // Roles considered privileged for SOC 2 access-control trust criteria
+        'privileged_roles' => [
+            'super_admin',
+            'compliance_officer',
+            'security_admin',
+            'database_admin',
+            'infrastructure_admin',
+        ],
+
+        // Trust service criteria to evaluate
+        'trust_criteria' => [
+            'security',
+            'availability',
+            'processing_integrity',
+            'confidentiality',
+            'privacy',
+        ],
+
+        // Continuous monitoring toggle
+        'continuous_monitoring' => env('SOC2_CONTINUOUS_MONITORING', true),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | PCI DSS Settings
+    |--------------------------------------------------------------------------
+    |
+    | Payment Card Industry Data Security Standard configuration. Manages
+    | data classification, cryptographic key rotation, and network controls.
+    |
+    */
+
+    'pci_dss' => [
+        // Data classification levels ordered from least to most sensitive
+        'classification_levels' => [
+            'public' => [
+                'label'             => 'Public',
+                'encryption'        => false,
+                'access_logging'    => false,
+                'retention_days'    => null,
+            ],
+            'internal' => [
+                'label'             => 'Internal',
+                'encryption'        => false,
+                'access_logging'    => true,
+                'retention_days'    => 730, // 2 years
+            ],
+            'confidential' => [
+                'label'             => 'Confidential',
+                'encryption'        => true,
+                'access_logging'    => true,
+                'retention_days'    => 365,
+            ],
+            'restricted' => [
+                'label'             => 'Restricted',
+                'encryption'        => true,
+                'access_logging'    => true,
+                'retention_days'    => 90,
+            ],
+        ],
+
+        // Cryptographic key rotation policy
+        'key_rotation' => [
+            'interval_days' => (int) env('PCI_KEY_ROTATION_INTERVAL_DAYS', 90),
+            'auto_rotate'   => env('PCI_KEY_AUTO_ROTATE', true),
+            'algorithm'     => env('PCI_KEY_ALGORITHM', 'AES-256-GCM'),
+            'notify_before_days' => (int) env('PCI_KEY_ROTATION_NOTIFY_DAYS', 14),
+        ],
+
+        // Network segmentation controls
+        'network_segmentation' => [
+            'enabled'     => env('PCI_NETWORK_SEGMENTATION_ENABLED', true),
+            'cde_network' => env('PCI_CDE_NETWORK', '10.0.1.0/24'), // Cardholder data environment
+            'dmz_network' => env('PCI_DMZ_NETWORK', '10.0.2.0/24'),
+            'internal_network' => env('PCI_INTERNAL_NETWORK', '10.0.3.0/24'),
+            'firewall_rules_path' => env('PCI_FIREWALL_RULES_PATH', storage_path('compliance/pci/firewall-rules.json')),
+            'verify_segmentation' => env('PCI_VERIFY_SEGMENTATION', true),
+        ],
+
+        // PCI DSS compliance level (1-4)
+        'compliance_level' => (int) env('PCI_COMPLIANCE_LEVEL', 1),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Data Residency (Multi-Region)
+    |--------------------------------------------------------------------------
+    |
+    | Controls where data is stored geographically to meet sovereignty
+    | requirements. Each region specifies its storage backend, database
+    | connection, and timezone for audit timestamps.
+    |
+    */
+
+    'data_residency' => [
+        'enabled' => env('DATA_RESIDENCY_ENABLED', false),
+
+        // Available data residency regions
+        'regions' => [
+            'EU' => [
+                'display_name'  => 'European Union',
+                'storage_disk'  => env('DATA_RESIDENCY_EU_DISK', 'eu-s3'),
+                'db_connection' => env('DATA_RESIDENCY_EU_DB', 'mysql-eu'),
+                'timezone'      => 'Europe/Frankfurt',
+            ],
+            'US' => [
+                'display_name'  => 'United States',
+                'storage_disk'  => env('DATA_RESIDENCY_US_DISK', 'us-s3'),
+                'db_connection' => env('DATA_RESIDENCY_US_DB', 'mysql-us'),
+                'timezone'      => 'America/New_York',
+            ],
+            'APAC' => [
+                'display_name'  => 'Asia-Pacific',
+                'storage_disk'  => env('DATA_RESIDENCY_APAC_DISK', 'apac-s3'),
+                'db_connection' => env('DATA_RESIDENCY_APAC_DB', 'mysql-apac'),
+                'timezone'      => 'Asia/Singapore',
+            ],
+            'UK' => [
+                'display_name'  => 'United Kingdom',
+                'storage_disk'  => env('DATA_RESIDENCY_UK_DISK', 'uk-s3'),
+                'db_connection' => env('DATA_RESIDENCY_UK_DB', 'mysql-uk'),
+                'timezone'      => 'Europe/London',
+            ],
+        ],
+
+        // Fallback region when no region is specified or matched
+        'default_region' => env('DATA_RESIDENCY_DEFAULT_REGION', 'EU'),
+
+        // Cross-region data transfer controls
+        'cross_region_transfer' => [
+            'require_approval' => env('DATA_RESIDENCY_REQUIRE_TRANSFER_APPROVAL', true),
+            'log_transfers'    => env('DATA_RESIDENCY_LOG_TRANSFERS', true),
+            'allowed_pairs'    => [
+                // Pairs of regions that may transfer data between each other
+                ['EU', 'UK'],
+                ['US', 'APAC'],
+            ],
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | GDPR Settings
+    |--------------------------------------------------------------------------
+    |
+    | General Data Protection Regulation configuration. Governs breach
+    | notification timelines, consent management, data retention defaults,
+    | and the format for data-subject register exports.
+    |
+    */
+
+    'gdpr' => [
+        // Maximum hours allowed to notify the supervisory authority after a breach
+        'breach_notification_deadline_hours' => (int) env('GDPR_BREACH_NOTIFICATION_HOURS', 72),
+
+        // Consent purposes that require explicit opt-in from data subjects
+        'consent_purposes' => [
+            'marketing_emails' => [
+                'label'       => 'Marketing Communications',
+                'description' => 'Receive promotional emails and product updates',
+                'required'    => false,
+            ],
+            'analytics' => [
+                'label'       => 'Analytics & Tracking',
+                'description' => 'Allow usage analytics to improve our services',
+                'required'    => false,
+            ],
+            'third_party_sharing' => [
+                'label'       => 'Third-Party Data Sharing',
+                'description' => 'Share anonymized data with trusted partners',
+                'required'    => false,
+            ],
+            'transaction_processing' => [
+                'label'       => 'Transaction Processing',
+                'description' => 'Process financial transactions on your behalf',
+                'required'    => true,
+            ],
+            'kyc_aml' => [
+                'label'       => 'KYC/AML Verification',
+                'description' => 'Verify identity for regulatory compliance',
+                'required'    => true,
+            ],
+        ],
+
+        // Default data retention periods by data category (in days)
+        'retention_defaults' => [
+            'personal_data'     => (int) env('GDPR_RETENTION_PERSONAL_DAYS', 1095),      // 3 years
+            'transaction_data'  => (int) env('GDPR_RETENTION_TRANSACTION_DAYS', 2555),    // 7 years
+            'audit_logs'        => (int) env('GDPR_RETENTION_AUDIT_DAYS', 2555),          // 7 years
+            'session_data'      => (int) env('GDPR_RETENTION_SESSION_DAYS', 90),
+            'consent_records'   => (int) env('GDPR_RETENTION_CONSENT_DAYS', 1825),        // 5 years
+            'marketing_data'    => (int) env('GDPR_RETENTION_MARKETING_DAYS', 365),
+        ],
+
+        // Format for ROPA (Records of Processing Activities) and DSAR exports
+        'register_export_format' => env('GDPR_EXPORT_FORMAT', 'json'),
+
+        // Data subject request handling
+        'dsar_response_days' => (int) env('GDPR_DSAR_RESPONSE_DAYS', 30),
+
+        // Data Protection Officer contact
+        'dpo_email' => env('GDPR_DPO_EMAIL', 'dpo@finaegis.org'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Security Scanning
+    |--------------------------------------------------------------------------
+    |
+    | Configuration for automated security scanning pipelines including SAST,
+    | DAST, container image scanning, dependency auditing, and scheduling.
+    |
+    */
+
+    'scanning' => [
+        // Static Application Security Testing (SAST)
+        'sast' => [
+            'enabled' => env('SCANNING_SAST_ENABLED', true),
+
+            // PHP functions considered unsafe — flagged during static analysis
+            'unsafe_functions' => [
+                'eval',
+                'exec',
+                'passthru',
+                'shell_exec',
+                'system',
+                'proc_open',
+                'popen',
+                'assert',
+                'preg_replace',  // with /e modifier
+                'create_function',
+                'call_user_func',
+                'call_user_func_array',
+                'unserialize',
+                'extract',
+                'parse_str',
+            ],
+
+            // Paths to include in SAST scanning
+            'include_paths' => [
+                'app/',
+                'config/',
+                'routes/',
+                'database/',
+            ],
+
+            // Paths to exclude from SAST scanning
+            'exclude_paths' => [
+                'vendor/',
+                'node_modules/',
+                'storage/',
+            ],
+        ],
+
+        // Dynamic Application Security Testing (DAST)
+        'dast' => [
+            'enabled'    => env('SCANNING_DAST_ENABLED', true),
+            'target_url' => env('SCANNING_DAST_TARGET_URL', 'http://localhost:8000'),
+            'profile'    => env('SCANNING_DAST_PROFILE', 'full'), // full, api-only, quick
+            'auth_token' => env('SCANNING_DAST_AUTH_TOKEN'),
+            'max_duration_minutes' => (int) env('SCANNING_DAST_MAX_DURATION', 120),
+        ],
+
+        // Container image scanning
+        'container' => [
+            'enabled'         => env('SCANNING_CONTAINER_ENABLED', true),
+            'dockerfile_path' => env('SCANNING_CONTAINER_DOCKERFILE', 'Dockerfile'),
+            'severity_threshold' => env('SCANNING_CONTAINER_SEVERITY', 'high'), // low, medium, high, critical
+            'registries'      => [
+                env('SCANNING_CONTAINER_REGISTRY', 'ghcr.io/finaegis'),
+            ],
+        ],
+
+        // Dependency / Software Composition Analysis (SCA)
+        'dependency' => [
+            'enabled'    => env('SCANNING_DEPENDENCY_ENABLED', true),
+            'auto_audit' => env('SCANNING_DEPENDENCY_AUTO_AUDIT', true),
+            'lock_files' => [
+                'composer.lock',
+                'package-lock.json',
+            ],
+            'vulnerability_db' => env('SCANNING_VULN_DB', 'https://github.com/advisories'),
+            'fail_on_severity' => env('SCANNING_DEPENDENCY_FAIL_SEVERITY', 'high'), // low, medium, high, critical
+        ],
+
+        // Scan scheduling
+        'scheduling' => [
+            'frequency'   => env('SCANNING_FREQUENCY', 'weekly'), // daily, weekly, biweekly, monthly
+            'day_of_week' => env('SCANNING_DAY_OF_WEEK', 'sunday'),
+            'time'        => env('SCANNING_TIME', '02:00'),
+            'timezone'    => env('SCANNING_TIMEZONE', 'UTC'),
+            'notify_on_findings' => env('SCANNING_NOTIFY_ON_FINDINGS', true),
+            'notification_channels' => ['email', 'slack'],
+        ],
+    ],
+
+];

--- a/database/migrations/2026_02_12_000001_create_compliance_evidence_table.php
+++ b/database/migrations/2026_02_12_000001_create_compliance_evidence_table.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('compliance_evidence', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('tenant_id')->nullable()->index();
+            $table->string('evidence_type')->index(); // access_logs, config_snapshot, change_log, deployment_record
+            $table->string('period')->index(); // e.g. 'Q1-2026', '2026-01'
+            $table->json('data');
+            $table->string('integrity_hash', 64); // SHA-256
+            $table->string('collected_by')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+            $table->index(['evidence_type', 'period']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('compliance_evidence');
+    }
+};

--- a/database/migrations/2026_02_12_000002_create_compliance_change_logs_table.php
+++ b/database/migrations/2026_02_12_000002_create_compliance_change_logs_table.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('compliance_change_logs', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('tenant_id')->nullable()->index();
+            $table->string('change_type')->index(); // deployment, config_change, infrastructure, policy
+            $table->text('description');
+            $table->json('old_values')->nullable();
+            $table->json('new_values')->nullable();
+            $table->string('changed_by')->nullable();
+            $table->string('environment')->default('production');
+            $table->string('ticket_reference')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('compliance_change_logs');
+    }
+};

--- a/database/migrations/2026_02_12_000003_create_security_incidents_table.php
+++ b/database/migrations/2026_02_12_000003_create_security_incidents_table.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('security_incidents', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('tenant_id')->nullable()->index();
+            $table->string('title');
+            $table->text('description');
+            $table->string('severity')->index(); // critical, high, medium, low
+            $table->string('status')->default('open')->index(); // open, investigating, mitigating, resolved, closed
+            $table->json('timeline')->nullable(); // array of {timestamp, action, actor, notes}
+            $table->text('resolution')->nullable();
+            $table->json('affected_systems')->nullable();
+            $table->string('reported_by')->nullable();
+            $table->string('assigned_to')->nullable();
+            $table->timestamp('detected_at')->nullable();
+            $table->timestamp('resolved_at')->nullable();
+            $table->json('postmortem')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('security_incidents');
+    }
+};

--- a/tests/Domain/Compliance/Certification/AccessReviewServiceTest.php
+++ b/tests/Domain/Compliance/Certification/AccessReviewServiceTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Compliance\Services\Certification\AccessReviewService;
+
+describe('AccessReviewService', function () {
+    beforeEach(function () {
+        $this->service = new AccessReviewService();
+        config(['compliance-certification.soc2.demo_mode' => true]);
+    });
+
+    it('generates access review report in demo mode', function () {
+        $report = $this->service->runAccessReview();
+
+        expect($report)->toBeArray()
+            ->and($report)->toHaveKey('summary')
+            ->and($report['summary'])->toHaveKey('privileged_user_count')
+            ->and($report['summary'])->toHaveKey('total_roles')
+            ->and($report['summary'])->toHaveKey('stale_account_count')
+            ->and($report['summary'])->toHaveKey('dormant_token_count');
+    });
+
+    it('runs full access review in demo mode', function () {
+        $result = $this->service->runAccessReview();
+
+        expect($result)->toBeArray()
+            ->and($result)->toHaveKey('privileged_users')
+            ->and($result)->toHaveKey('permission_matrix')
+            ->and($result)->toHaveKey('stale_accounts')
+            ->and($result)->toHaveKey('dormant_tokens')
+            ->and($result)->toHaveKey('recommendations');
+    });
+
+    it('returns permission matrix in demo mode', function () {
+        $result = $this->service->runAccessReview();
+        $matrix = $result['permission_matrix'];
+
+        expect($matrix)->toBeArray()
+            ->and($matrix)->not->toBeEmpty();
+    });
+});

--- a/tests/Domain/Compliance/Certification/EvidenceCollectionServiceTest.php
+++ b/tests/Domain/Compliance/Certification/EvidenceCollectionServiceTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Compliance\Services\Certification\EvidenceCollectionService;
+
+describe('EvidenceCollectionService', function () {
+    beforeEach(function () {
+        $this->service = new EvidenceCollectionService();
+        config(['compliance-certification.soc2.demo_mode' => true]);
+    });
+
+    it('collects evidence for a period in demo mode', function () {
+        $evidence = $this->service->collectEvidence('Q1-2026');
+
+        expect($evidence)->toBeArray()
+            ->and($evidence)->not->toBeEmpty();
+    });
+
+    it('collects evidence with specific type filter', function () {
+        $evidence = $this->service->collectEvidence('Q1-2026', 'access_logs');
+
+        expect($evidence)->toBeArray();
+    });
+
+    it('generates SHA-256 integrity hash', function () {
+        $data = ['test' => 'data', 'key' => 'value'];
+        $hash = $this->service->generateIntegrityHash($data);
+
+        expect($hash)->toBeString()
+            ->and(strlen($hash))->toBe(64)
+            ->and($hash)->toBe(hash('sha256', json_encode($data)));
+    });
+
+    it('returns consistent hashes for same data', function () {
+        $data = ['foo' => 'bar'];
+        $hash1 = $this->service->generateIntegrityHash($data);
+        $hash2 = $this->service->generateIntegrityHash($data);
+
+        expect($hash1)->toBe($hash2);
+    });
+
+    it('collects config snapshot evidence', function () {
+        $evidence = $this->service->collectEvidence('Q1-2026', 'config_snapshot');
+
+        expect($evidence)->toBeArray();
+    });
+});

--- a/tests/Domain/Compliance/Certification/IncidentResponseServiceTest.php
+++ b/tests/Domain/Compliance/Certification/IncidentResponseServiceTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Compliance\Models\SecurityIncident;
+use App\Domain\Compliance\Services\Certification\IncidentResponseService;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+describe('IncidentResponseService', function () {
+    beforeEach(function () {
+        $this->service = new IncidentResponseService();
+    });
+
+    it('creates a new security incident', function () {
+        $incident = $this->service->createIncident([
+            'title' => 'Test Incident',
+            'description' => 'A test security incident',
+            'severity' => 'medium',
+        ]);
+
+        expect($incident)->toBeInstanceOf(SecurityIncident::class)
+            ->and($incident->title)->toBe('Test Incident')
+            ->and($incident->severity)->toBe('medium')
+            ->and($incident->status)->toBe('open')
+            ->and($incident->timeline)->toBeArray()
+            ->and($incident->timeline)->not->toBeEmpty();
+    });
+
+    it('resolves an incident', function () {
+        $incident = $this->service->createIncident([
+            'title' => 'Resolve Test',
+            'description' => 'Incident to resolve',
+            'severity' => 'low',
+        ]);
+
+        $resolved = $this->service->resolveIncident($incident->id, 'Issue was a false positive');
+
+        expect($resolved->status)->toBe('resolved')
+            ->and($resolved->resolution)->toBe('Issue was a false positive')
+            ->and($resolved->resolved_at)->not->toBeNull();
+    });
+
+    it('updates an incident', function () {
+        $incident = $this->service->createIncident([
+            'title' => 'Update Test',
+            'description' => 'Original description',
+            'severity' => 'high',
+        ]);
+
+        $updated = $this->service->updateIncident($incident->id, [
+            'status' => 'investigating',
+            'assigned_to' => 'security-team',
+        ]);
+
+        expect($updated->status)->toBe('investigating')
+            ->and($updated->assigned_to)->toBe('security-team');
+    });
+
+    it('generates incident statistics', function () {
+        $this->service->createIncident([
+            'title' => 'Stats Test 1',
+            'description' => 'Test',
+            'severity' => 'high',
+        ]);
+        $this->service->createIncident([
+            'title' => 'Stats Test 2',
+            'description' => 'Test',
+            'severity' => 'low',
+        ]);
+
+        $stats = $this->service->getIncidentStatistics();
+
+        expect($stats)->toBeArray()
+            ->and($stats)->toHaveKey('total_incidents')
+            ->and($stats['total_incidents'])->toBeGreaterThanOrEqual(2);
+    });
+
+    it('generates postmortem for resolved incident', function () {
+        $incident = $this->service->createIncident([
+            'title' => 'Postmortem Test',
+            'description' => 'Incident for postmortem',
+            'severity' => 'critical',
+            'affected_systems' => ['api', 'database'],
+        ]);
+        $this->service->resolveIncident($incident->id, 'Root cause identified and patched');
+
+        $postmortem = $this->service->generatePostmortem($incident->id);
+
+        expect($postmortem)->toBeArray()
+            ->and($postmortem)->toHaveKey('incident_id')
+            ->and($postmortem)->toHaveKey('title')
+            ->and($postmortem)->toHaveKey('resolution');
+    });
+
+    it('retrieves open incidents only', function () {
+        $this->service->createIncident([
+            'title' => 'Open One',
+            'description' => 'Test',
+            'severity' => 'medium',
+        ]);
+        $incident2 = $this->service->createIncident([
+            'title' => 'Will Close',
+            'description' => 'Test',
+            'severity' => 'low',
+        ]);
+        $this->service->resolveIncident($incident2->id, 'Resolved');
+
+        $open = $this->service->getOpenIncidents();
+
+        expect($open->where('title', 'Open One'))->not->toBeEmpty()
+            ->and($open->where('title', 'Will Close'))->toBeEmpty();
+    });
+});

--- a/tests/Integration/Compliance/ComplianceCertificationTest.php
+++ b/tests/Integration/Compliance/ComplianceCertificationTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+uses(TestCase::class);
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+describe('Compliance Certification Artisan Commands', function () {
+    it('runs evidence collection command', function () {
+        config(['compliance-certification.soc2.demo_mode' => true]);
+
+        $exitCode = Artisan::call('compliance:collect-evidence', [
+            '--period' => 'quarterly',
+            '--format' => 'json',
+        ]);
+
+        expect($exitCode)->toBe(0);
+    });
+
+    it('runs access review command', function () {
+        config(['compliance-certification.soc2.demo_mode' => true]);
+
+        $exitCode = Artisan::call('compliance:access-review', [
+            '--format' => 'json',
+        ]);
+
+        expect($exitCode)->toBe(0);
+    });
+
+    it('runs incident stats command', function () {
+        $exitCode = Artisan::call('compliance:incident', [
+            'action' => 'stats',
+        ]);
+
+        expect($exitCode)->toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary
- Add `compliance-certification.php` master config with soc2, pci_dss, data_residency, gdpr, scanning sections
- Add 3 Eloquent models: `ComplianceEvidence`, `ComplianceChangeLog`, `SecurityIncident` with UUID PKs and tenant isolation
- Add 3 database migrations for compliance evidence, change logs, and security incidents tables
- Add `ComplianceCertificationController` with 9 REST endpoints for SOC 2 compliance
- Add 3 Artisan commands: `compliance:collect-evidence`, `compliance:access-review`, `compliance:incident`
- Add certification route group under `api/compliance/certification/`
- Add Pest PHP unit tests for EvidenceCollectionService, AccessReviewService, IncidentResponseService
- Add integration tests for Artisan command execution

## Test plan
- [ ] Verify migrations run successfully
- [ ] Verify all 9 certification API endpoints respond correctly
- [ ] Verify Artisan commands execute with demo mode
- [ ] Verify models use UsesTenantConnection trait
- [ ] Run `./vendor/bin/pest tests/Domain/Compliance/Certification/ tests/Integration/Compliance/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)