### PR TITLE
feat: Multi-region deployment — data residency, region-aware storage, geo-routing (v3.5.0)

### DIFF
--- a/app/Console/Commands/DataResidencyStatusCommand.php
+++ b/app/Console/Commands/DataResidencyStatusCommand.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Compliance\Services\Certification\DataResidencyService;
+use App\Domain\Compliance\Services\Certification\GeoRoutingService;
+use App\Domain\Compliance\Services\Certification\RegionAwareStorageService;
+use Illuminate\Console\Command;
+
+class DataResidencyStatusCommand extends Command
+{
+    protected $signature = 'data-residency:status
+        {--region= : Filter by specific region}
+        {--tenant= : Filter by specific tenant}
+        {--format=text : Output format (text, json)}
+        {--verify-storage : Verify regional storage access}';
+
+    protected $description = 'Show data residency status and configuration';
+
+    public function handle(
+        DataResidencyService $residencyService,
+        GeoRoutingService $geoRoutingService,
+        RegionAwareStorageService $storageService,
+    ): int {
+        $format = $this->option('format');
+
+        $this->info('Data Residency Status');
+        $this->info('=====================');
+        $this->newLine();
+
+        // Residency status
+        $status = $residencyService->getResidencyStatus();
+        $results = ['residency' => $status];
+
+        if ($format === 'text') {
+            $enabledColor = $status['enabled'] ? 'green' : 'yellow';
+            $this->line("  Enabled: <fg={$enabledColor}>" . ($status['enabled'] ? 'Yes' : 'No') . '</>');
+            $this->line("  Default region: {$status['default_region']}");
+            $this->line('  Available regions: ' . implode(', ', $status['available_regions']));
+            $this->line("  Tenant mappings: {$status['tenant_mappings']}");
+            $this->line("  Transfers (30d): {$status['transfers_last_30d']}");
+            $this->line("  Cross-region (30d): {$status['cross_region_transfers_last_30d']}");
+            $this->newLine();
+
+            if (! empty($status['region_distribution'])) {
+                $this->info('Region Distribution:');
+                foreach ($status['region_distribution'] as $region => $count) {
+                    $this->line("  {$region}: {$count} tenants");
+                }
+                $this->newLine();
+            }
+        }
+
+        // Routing configuration
+        $routingConfig = $geoRoutingService->getRoutingConfig();
+        $results['routing'] = $routingConfig;
+
+        if ($format === 'text') {
+            $this->info('Routing Configuration:');
+            $this->line('  Resolution order: ' . implode(' -> ', $routingConfig['resolution_order']));
+            $this->newLine();
+        }
+
+        // Optional storage verification
+        if ($this->option('verify-storage')) {
+            $this->info('Verifying Regional Storage Access...');
+            $storageResults = $storageService->verifyStorageAccess();
+            $results['storage'] = $storageResults;
+
+            if ($format === 'text') {
+                foreach ($storageResults as $region => $result) {
+                    $color = $result['accessible'] ? 'green' : 'red';
+                    $status = $result['accessible'] ? 'OK' : 'FAIL';
+                    $this->line("  {$region} ({$result['disk']}): <fg={$color}>{$status}</>");
+                }
+                $this->newLine();
+            }
+        }
+
+        // Tenant-specific info
+        $tenant = $this->option('tenant');
+        if ($tenant) {
+            $tenantRegion = $residencyService->getRegionForTenant($tenant);
+            $tenantRegions = $residencyService->getTenantRegions($tenant);
+            $results['tenant'] = [
+                'tenant_id'      => $tenant,
+                'primary_region' => $tenantRegion,
+                'all_regions'    => $tenantRegions->pluck('region')->toArray(),
+            ];
+
+            if ($format === 'text') {
+                $this->info("Tenant {$tenant}:");
+                $this->line("  Primary region: {$tenantRegion}");
+                $this->line('  All regions: ' . $tenantRegions->pluck('region')->implode(', '));
+                $this->newLine();
+            }
+        }
+
+        if ($format === 'json') {
+            $this->line((string) json_encode($results, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        }
+
+        $this->info('Data residency status complete.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Domain/Compliance/Models/DataTransferLog.php
+++ b/app/Domain/Compliance/Models/DataTransferLog.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Compliance\Models;
+
+use App\Domain\Shared\Traits\UsesTenantConnection;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class DataTransferLog extends Model
+{
+    use UsesTenantConnection;
+    use HasFactory;
+    use HasUuids;
+
+    protected $table = 'data_transfer_logs';
+
+    protected $fillable = [
+        'tenant_id',
+        'from_region',
+        'to_region',
+        'data_type',
+        'reason',
+        'approved_by',
+        'status',
+        'user_uuid',
+        'metadata',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'metadata' => 'array',
+        ];
+    }
+
+    /**
+     * @param  \Illuminate\Database\Eloquent\Builder<static>  $query
+     * @return \Illuminate\Database\Eloquent\Builder<static>
+     */
+    public function scopeFromRegion($query, string $region)
+    {
+        return $query->where('from_region', $region);
+    }
+
+    /**
+     * @param  \Illuminate\Database\Eloquent\Builder<static>  $query
+     * @return \Illuminate\Database\Eloquent\Builder<static>
+     */
+    public function scopeToRegion($query, string $region)
+    {
+        return $query->where('to_region', $region);
+    }
+
+    /**
+     * @param  \Illuminate\Database\Eloquent\Builder<static>  $query
+     * @return \Illuminate\Database\Eloquent\Builder<static>
+     */
+    public function scopeCrossRegion($query)
+    {
+        return $query->whereColumn('from_region', '!=', 'to_region');
+    }
+
+    public function isCrossRegion(): bool
+    {
+        return $this->from_region !== $this->to_region;
+    }
+}

--- a/app/Domain/Compliance/Models/TenantRegionMapping.php
+++ b/app/Domain/Compliance/Models/TenantRegionMapping.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Compliance\Models;
+
+use App\Domain\Shared\Traits\UsesTenantConnection;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property Carbon|null $effective_from
+ * @property Carbon|null $effective_until
+ */
+class TenantRegionMapping extends Model
+{
+    use UsesTenantConnection;
+    use HasFactory;
+    use HasUuids;
+
+    protected $table = 'tenant_region_mappings';
+
+    protected $fillable = [
+        'tenant_id',
+        'region',
+        'is_primary',
+        'effective_from',
+        'effective_until',
+        'metadata',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'is_primary'      => 'boolean',
+            'effective_from'  => 'datetime',
+            'effective_until' => 'datetime',
+            'metadata'        => 'array',
+        ];
+    }
+
+    /**
+     * @param  \Illuminate\Database\Eloquent\Builder<static>  $query
+     * @return \Illuminate\Database\Eloquent\Builder<static>
+     */
+    public function scopeForTenant($query, string $tenantId)
+    {
+        return $query->where('tenant_id', $tenantId);
+    }
+
+    /**
+     * @param  \Illuminate\Database\Eloquent\Builder<static>  $query
+     * @return \Illuminate\Database\Eloquent\Builder<static>
+     */
+    public function scopePrimary($query)
+    {
+        return $query->where('is_primary', true);
+    }
+
+    /**
+     * @param  \Illuminate\Database\Eloquent\Builder<static>  $query
+     * @return \Illuminate\Database\Eloquent\Builder<static>
+     */
+    public function scopeActive($query)
+    {
+        return $query->where(function ($q) {
+            $q->whereNull('effective_until')
+                ->orWhere('effective_until', '>', now());
+        })->where(function ($q) {
+            $q->whereNull('effective_from')
+                ->orWhere('effective_from', '<=', now());
+        });
+    }
+
+    /**
+     * @param  \Illuminate\Database\Eloquent\Builder<static>  $query
+     * @return \Illuminate\Database\Eloquent\Builder<static>
+     */
+    public function scopeForRegion($query, string $region)
+    {
+        return $query->where('region', $region);
+    }
+
+    public function isActive(): bool
+    {
+        $now = now();
+
+        if ($this->effective_from && $this->effective_from->isFuture()) {
+            return false;
+        }
+        if ($this->effective_until && $this->effective_until->isPast()) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/app/Domain/Compliance/Routes/api.php
+++ b/app/Domain/Compliance/Routes/api.php
@@ -66,6 +66,12 @@ Route::middleware('auth:sanctum', 'check.token.expiration')->prefix('compliance'
         Route::get('/pci/key-rotation', [ComplianceCertificationController::class, 'getKeyRotationStatus']);
         Route::post('/pci/key-rotation/rotate', [ComplianceCertificationController::class, 'rotateKey']);
         Route::get('/pci/network-segmentation', [ComplianceCertificationController::class, 'getNetworkSegmentation']);
+
+        // Data Residency endpoints
+        Route::get('/data-residency/status', [ComplianceCertificationController::class, 'getResidencyStatus']);
+        Route::get('/data-residency/transfers', [ComplianceCertificationController::class, 'getTransferLogs']);
+        Route::post('/data-residency/transfers', [ComplianceCertificationController::class, 'logTransfer']);
+        Route::get('/data-residency/routing', [ComplianceCertificationController::class, 'getRoutingConfig']);
     });
 
     // GDPR endpoints

--- a/app/Domain/Compliance/Services/Certification/DataResidencyService.php
+++ b/app/Domain/Compliance/Services/Certification/DataResidencyService.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Compliance\Services\Certification;
+
+use App\Domain\Compliance\Models\DataTransferLog;
+use App\Domain\Compliance\Models\TenantRegionMapping;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Log;
+
+class DataResidencyService
+{
+    /**
+     * Get the region for a given tenant.
+     */
+    public function getRegionForTenant(string $tenantId): string
+    {
+        $mapping = TenantRegionMapping::forTenant($tenantId)
+            ->primary()
+            ->active()
+            ->first();
+
+        if ($mapping) {
+            return $mapping->region;
+        }
+
+        return Config::get('compliance-certification.data_residency.default_region', 'EU');
+    }
+
+    /**
+     * Set the region for a tenant.
+     */
+    public function setTenantRegion(string $tenantId, string $region, bool $isPrimary = true): TenantRegionMapping
+    {
+        if ($isPrimary) {
+            TenantRegionMapping::forTenant($tenantId)
+                ->primary()
+                ->update(['is_primary' => false]);
+        }
+
+        return TenantRegionMapping::updateOrCreate(
+            ['tenant_id' => $tenantId, 'region' => $region],
+            [
+                'is_primary'     => $isPrimary,
+                'effective_from' => now(),
+            ],
+        );
+    }
+
+    /**
+     * Get all region mappings for a tenant.
+     *
+     * @return Collection<int, TenantRegionMapping>
+     */
+    public function getTenantRegions(string $tenantId): Collection
+    {
+        return TenantRegionMapping::forTenant($tenantId)->active()->get();
+    }
+
+    /**
+     * Validate a cross-region data transfer.
+     *
+     * @return array<string, mixed>
+     */
+    public function validateTransfer(string $fromRegion, string $toRegion, string $dataType): array
+    {
+        $config = Config::get('compliance-certification.data_residency.cross_region_transfer', []);
+        $requireApproval = $config['require_approval'] ?? true;
+
+        $allowedPairs = $config['allowed_pairs'] ?? [];
+        $isAllowed = false;
+
+        foreach ($allowedPairs as $pair) {
+            if (($pair[0] === $fromRegion && $pair[1] === $toRegion)
+                || ($pair[0] === $toRegion && $pair[1] === $fromRegion)) {
+                $isAllowed = true;
+                break;
+            }
+        }
+
+        return [
+            'from_region'       => $fromRegion,
+            'to_region'         => $toRegion,
+            'data_type'         => $dataType,
+            'allowed'           => $isAllowed,
+            'requires_approval' => $requireApproval,
+            'is_cross_region'   => $fromRegion !== $toRegion,
+        ];
+    }
+
+    /**
+     * Log a data transfer event.
+     */
+    public function logTransfer(
+        string $fromRegion,
+        string $toRegion,
+        string $dataType,
+        ?string $reason = null,
+        ?string $approvedBy = null,
+        ?string $userUuid = null,
+    ): DataTransferLog {
+        $validation = $this->validateTransfer($fromRegion, $toRegion, $dataType);
+
+        $status = 'logged';
+        if ($validation['requires_approval'] && ! $approvedBy) {
+            $status = 'pending_approval';
+        } elseif (! $validation['allowed']) {
+            $status = 'denied';
+        }
+
+        $log = DataTransferLog::create([
+            'from_region' => $fromRegion,
+            'to_region'   => $toRegion,
+            'data_type'   => $dataType,
+            'reason'      => $reason,
+            'approved_by' => $approvedBy,
+            'status'      => $status,
+            'user_uuid'   => $userUuid,
+            'metadata'    => $validation,
+        ]);
+
+        Log::info('Data transfer logged', [
+            'from'      => $fromRegion,
+            'to'        => $toRegion,
+            'data_type' => $dataType,
+            'status'    => $status,
+        ]);
+
+        return $log;
+    }
+
+    /**
+     * Get transfer logs with optional filters.
+     *
+     * @return Collection<int, DataTransferLog>
+     */
+    public function getTransferLogs(?string $fromRegion = null, ?string $toRegion = null): Collection
+    {
+        $query = DataTransferLog::query();
+
+        if ($fromRegion) {
+            $query->fromRegion($fromRegion);
+        }
+        if ($toRegion) {
+            $query->toRegion($toRegion);
+        }
+
+        return $query->orderByDesc('created_at')->limit(100)->get();
+    }
+
+    /**
+     * Get data residency status overview.
+     *
+     * @return array<string, mixed>
+     */
+    public function getResidencyStatus(): array
+    {
+        $enabled = Config::get('compliance-certification.data_residency.enabled', false);
+        $regions = Config::get('compliance-certification.data_residency.regions', []);
+        $defaultRegion = Config::get('compliance-certification.data_residency.default_region', 'EU');
+
+        $tenantMappings = TenantRegionMapping::active()->get();
+        $transferCount = DataTransferLog::where('created_at', '>=', now()->subDays(30))->count();
+        $crossRegionCount = DataTransferLog::crossRegion()
+            ->where('created_at', '>=', now()->subDays(30))
+            ->count();
+
+        return [
+            'enabled'                         => $enabled,
+            'default_region'                  => $defaultRegion,
+            'available_regions'               => array_keys($regions),
+            'tenant_mappings'                 => $tenantMappings->count(),
+            'region_distribution'             => $tenantMappings->groupBy('region')->map->count()->toArray(),
+            'transfers_last_30d'              => $transferCount,
+            'cross_region_transfers_last_30d' => $crossRegionCount,
+            'generated_at'                    => now()->toIso8601String(),
+        ];
+    }
+
+    /**
+     * Get demo residency status.
+     *
+     * @return array<string, mixed>
+     */
+    public function getDemoStatus(): array
+    {
+        return [
+            'enabled'             => true,
+            'default_region'      => 'EU',
+            'available_regions'   => ['EU', 'US', 'APAC', 'UK'],
+            'tenant_mappings'     => 12,
+            'region_distribution' => [
+                'EU'   => 5,
+                'US'   => 4,
+                'APAC' => 2,
+                'UK'   => 1,
+            ],
+            'transfers_last_30d'              => 847,
+            'cross_region_transfers_last_30d' => 23,
+            'generated_at'                    => now()->toIso8601String(),
+        ];
+    }
+}

--- a/app/Domain/Compliance/Services/Certification/GeoRoutingService.php
+++ b/app/Domain/Compliance/Services/Certification/GeoRoutingService.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Compliance\Services\Certification;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
+
+class GeoRoutingService
+{
+    /**
+     * Resolve region from request context.
+     */
+    public function resolveRegion(Request $request): string
+    {
+        // 1. Check explicit header
+        $headerRegion = $request->header('X-Data-Region');
+        if ($headerRegion && $this->isValidRegion($headerRegion)) {
+            return strtoupper($headerRegion);
+        }
+
+        // 2. Check query parameter
+        $queryRegion = $request->query('region');
+        if ($queryRegion && $this->isValidRegion($queryRegion)) {
+            return strtoupper($queryRegion);
+        }
+
+        // 3. Try to resolve from IP geolocation (simplified)
+        $ipRegion = $this->resolveFromIp($request->ip());
+        if ($ipRegion) {
+            return $ipRegion;
+        }
+
+        // 4. Fall back to default
+        return Config::get('compliance-certification.data_residency.default_region', 'EU');
+    }
+
+    /**
+     * Check if a region code is valid.
+     */
+    public function isValidRegion(string $region): bool
+    {
+        $regions = Config::get('compliance-certification.data_residency.regions', []);
+
+        return isset($regions[strtoupper($region)]);
+    }
+
+    /**
+     * Get all available regions.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public function getAvailableRegions(): array
+    {
+        return Config::get('compliance-certification.data_residency.regions', []);
+    }
+
+    /**
+     * Get region configuration.
+     *
+     * @return array<string, mixed>|null
+     */
+    public function getRegionConfig(string $region): ?array
+    {
+        $regions = Config::get('compliance-certification.data_residency.regions', []);
+
+        return $regions[strtoupper($region)] ?? null;
+    }
+
+    /**
+     * Resolve region from IP address (simplified mapping).
+     * In production, integrate MaxMind GeoIP2 or AWS CloudFront geo headers.
+     */
+    private function resolveFromIp(?string $ip): ?string
+    {
+        if (! $ip) {
+            return null;
+        }
+
+        // Private/loopback ranges — cannot resolve
+        $privateRanges = ['10.', '127.', '192.168.', '172.'];
+
+        foreach ($privateRanges as $prefix) {
+            if (str_starts_with($ip, $prefix)) {
+                return null;
+            }
+        }
+
+        // Simplified continent-level mapping for demo purposes
+        // In production, use MaxMind GeoIP2 or similar service
+        $regionPrefixes = Config::get('compliance-certification.data_residency.ip_region_map', []);
+
+        foreach ($regionPrefixes as $prefix => $region) {
+            if (str_starts_with($ip, (string) $prefix)) {
+                return $region;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get routing configuration summary.
+     *
+     * @return array<string, mixed>
+     */
+    public function getRoutingConfig(): array
+    {
+        $regions = $this->getAvailableRegions();
+        $enabled = Config::get('compliance-certification.data_residency.enabled', false);
+
+        return [
+            'enabled'           => $enabled,
+            'available_regions' => array_keys($regions),
+            'default_region'    => Config::get('compliance-certification.data_residency.default_region', 'EU'),
+            'region_details'    => collect($regions)->map(function ($config, $code) {
+                return [
+                    'code'         => $code,
+                    'display_name' => $config['display_name'] ?? $code,
+                    'storage_disk' => $config['storage_disk'] ?? 'local',
+                    'timezone'     => $config['timezone'] ?? 'UTC',
+                ];
+            })->values()->toArray(),
+            'resolution_order' => [
+                'X-Data-Region header',
+                'region query parameter',
+                'IP geolocation',
+                'Default region',
+            ],
+        ];
+    }
+}

--- a/app/Domain/Compliance/Services/Certification/RegionAwareStorageService.php
+++ b/app/Domain/Compliance/Services/Certification/RegionAwareStorageService.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Compliance\Services\Certification;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Storage;
+use Throwable;
+
+class RegionAwareStorageService
+{
+    /**
+     * Get the appropriate storage disk for a region.
+     */
+    public function getDiskForRegion(string $region): string
+    {
+        $regions = Config::get('compliance-certification.data_residency.regions', []);
+        $regionConfig = $regions[strtoupper($region)] ?? $regions[strtolower($region)] ?? null;
+
+        if ($regionConfig && isset($regionConfig['storage_disk'])) {
+            return $regionConfig['storage_disk'];
+        }
+
+        return Config::get('filesystems.default', 'local');
+    }
+
+    /**
+     * Get the storage instance for a region.
+     */
+    public function getStorageForRegion(string $region): \Illuminate\Contracts\Filesystem\Filesystem
+    {
+        return Storage::disk($this->getDiskForRegion($region));
+    }
+
+    /**
+     * Store a file in the region-appropriate storage.
+     */
+    public function storeInRegion(string $region, string $path, string $contents): bool
+    {
+        return $this->getStorageForRegion($region)->put($path, $contents);
+    }
+
+    /**
+     * Get a file from region-appropriate storage.
+     */
+    public function getFromRegion(string $region, string $path): ?string
+    {
+        return $this->getStorageForRegion($region)->get($path);
+    }
+
+    /**
+     * Check if a file exists in region-appropriate storage.
+     */
+    public function existsInRegion(string $region, string $path): bool
+    {
+        return $this->getStorageForRegion($region)->exists($path);
+    }
+
+    /**
+     * Delete a file from region-appropriate storage.
+     */
+    public function deleteFromRegion(string $region, string $path): bool
+    {
+        return $this->getStorageForRegion($region)->delete($path);
+    }
+
+    /**
+     * Get all configured regional storage disks.
+     *
+     * @return array<string, string>
+     */
+    public function getRegionalDisks(): array
+    {
+        $regions = Config::get('compliance-certification.data_residency.regions', []);
+        $disks = [];
+
+        foreach ($regions as $regionCode => $config) {
+            $disks[$regionCode] = $config['storage_disk'] ?? 'local';
+        }
+
+        return $disks;
+    }
+
+    /**
+     * Verify all regional storage disks are accessible.
+     *
+     * @return array<string, mixed>
+     */
+    public function verifyStorageAccess(): array
+    {
+        $disks = $this->getRegionalDisks();
+        $results = [];
+
+        foreach ($disks as $region => $diskName) {
+            try {
+                $disk = Storage::disk($diskName);
+                $testPath = ".compliance-storage-test-{$region}";
+                $disk->put($testPath, 'test');
+                $disk->delete($testPath);
+                $results[$region] = [
+                    'disk'       => $diskName,
+                    'accessible' => true,
+                ];
+            } catch (Throwable $e) {
+                $results[$region] = [
+                    'disk'       => $diskName,
+                    'accessible' => false,
+                    'error'      => $e->getMessage(),
+                ];
+            }
+        }
+
+        return $results;
+    }
+}

--- a/app/Http/Middleware/DataResidencyMiddleware.php
+++ b/app/Http/Middleware/DataResidencyMiddleware.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Domain\Compliance\Services\Certification\GeoRoutingService;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+
+class DataResidencyMiddleware
+{
+    public function __construct(
+        private readonly GeoRoutingService $geoRoutingService,
+    ) {
+    }
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! Config::get('compliance-certification.data_residency.enabled', false)) {
+            return $next($request);
+        }
+
+        $region = $this->geoRoutingService->resolveRegion($request);
+
+        // Set region in request attributes for downstream use
+        $request->attributes->set('data_region', $region);
+
+        $response = $next($request);
+
+        // Add region header to response
+        $response->headers->set('X-Data-Region', $region);
+
+        // Log cross-region access if configured
+        $userRegion = $request->header('X-User-Region');
+        if ($userRegion && strtoupper($userRegion) !== $region) {
+            Log::info('Cross-region access detected', [
+                'user_region' => strtoupper($userRegion),
+                'data_region' => $region,
+                'path'        => $request->path(),
+                'ip'          => $request->ip(),
+            ]);
+        }
+
+        return $response;
+    }
+}

--- a/config/database.php
+++ b/config/database.php
@@ -195,6 +195,84 @@ return [
             // 'trust_server_certificate' => env('DB_TRUST_SERVER_CERTIFICATE', 'false'),
         ],
 
+        /*
+        |----------------------------------------------------------------------
+        | Regional Read Replicas (v3.5.0 — Multi-Region Data Residency)
+        |----------------------------------------------------------------------
+        |
+        | Read-only replicas for region-local queries. Used by
+        | DataResidencyService when cross-region read optimization is enabled.
+        |
+        */
+
+        'replica-eu' => [
+            'driver'         => 'mariadb',
+            'host'           => env('DB_REPLICA_EU_HOST', '127.0.0.1'),
+            'port'           => env('DB_REPLICA_EU_PORT', '3306'),
+            'database'       => env('DB_REPLICA_EU_DATABASE', 'finaegis'),
+            'username'       => env('DB_REPLICA_EU_USERNAME', 'root'),
+            'password'       => env('DB_REPLICA_EU_PASSWORD', ''),
+            'charset'        => env('DB_CHARSET', 'utf8mb4'),
+            'collation'      => env('DB_COLLATION', 'utf8mb4_unicode_ci'),
+            'prefix'         => '',
+            'prefix_indexes' => true,
+            'strict'         => true,
+            'options'        => extension_loaded('pdo_mysql') ? array_filter([
+                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+            ]) : [],
+        ],
+
+        'replica-us' => [
+            'driver'         => 'mariadb',
+            'host'           => env('DB_REPLICA_US_HOST', '127.0.0.1'),
+            'port'           => env('DB_REPLICA_US_PORT', '3306'),
+            'database'       => env('DB_REPLICA_US_DATABASE', 'finaegis'),
+            'username'       => env('DB_REPLICA_US_USERNAME', 'root'),
+            'password'       => env('DB_REPLICA_US_PASSWORD', ''),
+            'charset'        => env('DB_CHARSET', 'utf8mb4'),
+            'collation'      => env('DB_COLLATION', 'utf8mb4_unicode_ci'),
+            'prefix'         => '',
+            'prefix_indexes' => true,
+            'strict'         => true,
+            'options'        => extension_loaded('pdo_mysql') ? array_filter([
+                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+            ]) : [],
+        ],
+
+        'replica-apac' => [
+            'driver'         => 'mariadb',
+            'host'           => env('DB_REPLICA_APAC_HOST', '127.0.0.1'),
+            'port'           => env('DB_REPLICA_APAC_PORT', '3306'),
+            'database'       => env('DB_REPLICA_APAC_DATABASE', 'finaegis'),
+            'username'       => env('DB_REPLICA_APAC_USERNAME', 'root'),
+            'password'       => env('DB_REPLICA_APAC_PASSWORD', ''),
+            'charset'        => env('DB_CHARSET', 'utf8mb4'),
+            'collation'      => env('DB_COLLATION', 'utf8mb4_unicode_ci'),
+            'prefix'         => '',
+            'prefix_indexes' => true,
+            'strict'         => true,
+            'options'        => extension_loaded('pdo_mysql') ? array_filter([
+                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+            ]) : [],
+        ],
+
+        'replica-uk' => [
+            'driver'         => 'mariadb',
+            'host'           => env('DB_REPLICA_UK_HOST', '127.0.0.1'),
+            'port'           => env('DB_REPLICA_UK_PORT', '3306'),
+            'database'       => env('DB_REPLICA_UK_DATABASE', 'finaegis'),
+            'username'       => env('DB_REPLICA_UK_USERNAME', 'root'),
+            'password'       => env('DB_REPLICA_UK_PASSWORD', ''),
+            'charset'        => env('DB_CHARSET', 'utf8mb4'),
+            'collation'      => env('DB_COLLATION', 'utf8mb4_unicode_ci'),
+            'prefix'         => '',
+            'prefix_indexes' => true,
+            'strict'         => true,
+            'options'        => extension_loaded('pdo_mysql') ? array_filter([
+                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+            ]) : [],
+        ],
+
     ],
 
     /*

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -56,6 +56,64 @@ return [
             'throw'                   => false,
         ],
 
+        /*
+        |----------------------------------------------------------------------
+        | Regional S3 Disks (v3.5.0 — Multi-Region Data Residency)
+        |----------------------------------------------------------------------
+        |
+        | Region-specific S3 buckets for data residency compliance.
+        | Each region stores data in the corresponding AWS region.
+        |
+        */
+
+        's3-eu' => [
+            'driver'                  => 's3',
+            'key'                     => env('AWS_ACCESS_KEY_ID'),
+            'secret'                  => env('AWS_SECRET_ACCESS_KEY'),
+            'region'                  => env('AWS_S3_EU_REGION', 'eu-west-1'),
+            'bucket'                  => env('AWS_S3_EU_BUCKET', 'finaegis-eu'),
+            'url'                     => env('AWS_S3_EU_URL'),
+            'endpoint'                => env('AWS_S3_EU_ENDPOINT'),
+            'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
+            'throw'                   => false,
+        ],
+
+        's3-us' => [
+            'driver'                  => 's3',
+            'key'                     => env('AWS_ACCESS_KEY_ID'),
+            'secret'                  => env('AWS_SECRET_ACCESS_KEY'),
+            'region'                  => env('AWS_S3_US_REGION', 'us-east-1'),
+            'bucket'                  => env('AWS_S3_US_BUCKET', 'finaegis-us'),
+            'url'                     => env('AWS_S3_US_URL'),
+            'endpoint'                => env('AWS_S3_US_ENDPOINT'),
+            'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
+            'throw'                   => false,
+        ],
+
+        's3-apac' => [
+            'driver'                  => 's3',
+            'key'                     => env('AWS_ACCESS_KEY_ID'),
+            'secret'                  => env('AWS_SECRET_ACCESS_KEY'),
+            'region'                  => env('AWS_S3_APAC_REGION', 'ap-southeast-1'),
+            'bucket'                  => env('AWS_S3_APAC_BUCKET', 'finaegis-apac'),
+            'url'                     => env('AWS_S3_APAC_URL'),
+            'endpoint'                => env('AWS_S3_APAC_ENDPOINT'),
+            'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
+            'throw'                   => false,
+        ],
+
+        's3-uk' => [
+            'driver'                  => 's3',
+            'key'                     => env('AWS_ACCESS_KEY_ID'),
+            'secret'                  => env('AWS_SECRET_ACCESS_KEY'),
+            'region'                  => env('AWS_S3_UK_REGION', 'eu-west-2'),
+            'bucket'                  => env('AWS_S3_UK_BUCKET', 'finaegis-uk'),
+            'url'                     => env('AWS_S3_UK_URL'),
+            'endpoint'                => env('AWS_S3_UK_ENDPOINT'),
+            'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
+            'throw'                   => false,
+        ],
+
     ],
 
     /*

--- a/database/migrations/2026_02_12_000006_create_data_transfer_logs_table.php
+++ b/database/migrations/2026_02_12_000006_create_data_transfer_logs_table.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('data_transfer_logs', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('tenant_id')->nullable()->index();
+            $table->string('from_region')->index();
+            $table->string('to_region')->index();
+            $table->string('data_type');
+            $table->text('reason')->nullable();
+            $table->string('approved_by')->nullable();
+            $table->string('status')->default('logged')->index(); // logged, approved, denied
+            $table->string('user_uuid')->nullable()->index();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+
+            $table->index(['from_region', 'to_region']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('data_transfer_logs');
+    }
+};

--- a/database/migrations/2026_02_12_000007_create_tenant_region_mappings_table.php
+++ b/database/migrations/2026_02_12_000007_create_tenant_region_mappings_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('tenant_region_mappings', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('tenant_id')->index();
+            $table->string('region')->index();
+            $table->boolean('is_primary')->default(false);
+            $table->timestamp('effective_from')->nullable();
+            $table->timestamp('effective_until')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+
+            $table->unique(['tenant_id', 'region']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tenant_region_mappings');
+    }
+};

--- a/tests/Domain/Compliance/Certification/DataResidencyServiceTest.php
+++ b/tests/Domain/Compliance/Certification/DataResidencyServiceTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Compliance\Models\DataTransferLog;
+use App\Domain\Compliance\Services\Certification\DataResidencyService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(Tests\TestCase::class, RefreshDatabase::class);
+
+describe('DataResidencyService', function () {
+    it('returns default region when no mapping exists', function () {
+        $service = new DataResidencyService();
+        $region = $service->getRegionForTenant('nonexistent-tenant');
+
+        expect($region)->toBe('EU');
+    });
+
+    it('sets and retrieves tenant region', function () {
+        $service = new DataResidencyService();
+        $service->setTenantRegion('test-tenant', 'US');
+
+        $region = $service->getRegionForTenant('test-tenant');
+
+        expect($region)->toBe('US');
+    });
+
+    it('validates cross-region transfers', function () {
+        $service = new DataResidencyService();
+        $result = $service->validateTransfer('EU', 'US', 'personal_data');
+
+        expect($result)->toHaveKey('from_region')
+            ->and($result['from_region'])->toBe('EU')
+            ->and($result['to_region'])->toBe('US')
+            ->and($result['is_cross_region'])->toBeTrue();
+    });
+
+    it('logs data transfers', function () {
+        $service = new DataResidencyService();
+        $log = $service->logTransfer('EU', 'US', 'personal_data', 'Business requirement');
+
+        expect($log)->toBeInstanceOf(DataTransferLog::class)
+            ->and($log->from_region)->toBe('EU')
+            ->and($log->to_region)->toBe('US')
+            ->and($log->data_type)->toBe('personal_data');
+    });
+
+    it('returns residency status', function () {
+        $service = new DataResidencyService();
+        $status = $service->getResidencyStatus();
+
+        expect($status)->toHaveKey('enabled')
+            ->and($status)->toHaveKey('default_region')
+            ->and($status)->toHaveKey('available_regions');
+    });
+
+    it('returns demo status', function () {
+        $service = new DataResidencyService();
+        $status = $service->getDemoStatus();
+
+        expect($status['enabled'])->toBeTrue()
+            ->and($status['available_regions'])->toContain('EU', 'US')
+            ->and($status['tenant_mappings'])->toBe(12);
+    });
+});

--- a/tests/Domain/Compliance/Certification/RegionAwareStorageServiceTest.php
+++ b/tests/Domain/Compliance/Certification/RegionAwareStorageServiceTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Compliance\Services\Certification\RegionAwareStorageService;
+
+uses(Tests\TestCase::class);
+
+describe('RegionAwareStorageService', function () {
+    it('returns disk for configured region', function () {
+        $service = new RegionAwareStorageService();
+        $disk = $service->getDiskForRegion('EU');
+
+        expect($disk)->toBeString();
+    });
+
+    it('returns default disk for unknown region', function () {
+        $service = new RegionAwareStorageService();
+        $disk = $service->getDiskForRegion('UNKNOWN');
+
+        expect($disk)->toBe(config('filesystems.default', 'local'));
+    });
+
+    it('lists all regional disks', function () {
+        $service = new RegionAwareStorageService();
+        $disks = $service->getRegionalDisks();
+
+        expect($disks)->toBeArray();
+    });
+
+    it('verifies storage access', function () {
+        $service = new RegionAwareStorageService();
+        $results = $service->verifyStorageAccess();
+
+        expect($results)->toBeArray();
+        foreach ($results as $region => $result) {
+            expect($result)->toHaveKey('disk')
+                ->and($result)->toHaveKey('accessible');
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- Add **DataResidencyService** for tenant-to-region mapping, cross-region transfer validation and logging
- Add **RegionAwareStorageService** routing file storage to region-specific S3 buckets (EU, US, APAC, UK)
- Add **GeoRoutingService** resolving user region from headers, query params, or IP
- Add **DataResidencyMiddleware** (config-gated) that sets `X-Data-Region` header and logs cross-region access
- Add `data-residency:status` Artisan command with `--region`, `--tenant`, `--verify-storage` options
- Add 4 regional S3 disks and 4 regional DB read replicas to config
- Add 4 data-residency API endpoints under `/compliance/certification/data-residency/`
- Add 2 Eloquent models: `DataTransferLog`, `TenantRegionMapping` with UUID PKs and tenant isolation
- Add 2 migration files for the new tables

**Phase 3 of 6** for v3.5.0 Compliance Certification Readiness.

## New Files (11)
- 2 migrations (`data_transfer_logs`, `tenant_region_mappings`)
- 2 models (`DataTransferLog`, `TenantRegionMapping`)
- 3 services (`DataResidencyService`, `RegionAwareStorageService`, `GeoRoutingService`)
- 1 middleware (`DataResidencyMiddleware`)
- 1 command (`DataResidencyStatusCommand`)
- 2 tests (`DataResidencyServiceTest`, `RegionAwareStorageServiceTest`)

## Modified Files (4)
- `ComplianceCertificationController` — 4 new data-residency endpoints
- `Compliance Routes/api.php` — 4 data-residency routes
- `config/filesystems.php` — 4 regional S3 disks
- `config/database.php` — 4 regional read replicas

## Test plan
- [ ] Verify migrations create tables correctly
- [ ] Verify `data-residency:status` command runs without errors
- [ ] Verify middleware only activates when `DATA_RESIDENCY_ENABLED=true`
- [ ] Verify API endpoints return expected JSON structures
- [ ] Run `./vendor/bin/pest tests/Domain/Compliance/Certification/DataResidencyServiceTest.php`
- [ ] Run `./vendor/bin/pest tests/Domain/Compliance/Certification/RegionAwareStorageServiceTest.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)