### PR TITLE
chore: v3.5.0 release — CHANGELOG, version bump, OpenAPI spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to the FinAegis Core Banking Platform will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0] - 2026-02-12
+
+### Added
+
+#### SOC 2 Type II Preparation (Phase 1, PRs #511-#512)
+- `EvidenceCollectionService` — automated SOC 2 evidence collection with config snapshots and integrity hashing
+- `AccessReviewService` — periodic access review automation with demo mode
+- `IncidentResponseService` — security incident lifecycle management (create, update, resolve, postmortem)
+- `SecurityIncident` model with status tracking and resolution workflow
+- `Soc2DashboardController` with SOC 2 readiness overview API endpoints
+- `soc2:evidence-collect` and `soc2:access-review` artisan commands
+- `compliance-certification.php` config for SOC 2, PCI DSS, multi-region, and GDPR settings
+
+#### PCI DSS Readiness (Phase 2, PR #513)
+- `DataClassificationService` — data classification with sensitivity levels (public/internal/confidential/restricted)
+- `EncryptionVerificationService` — verification suite for at-rest, in-transit, key strength, and algorithm compliance
+- `KeyRotationService` — key rotation tracking, scheduling, and automated rotation with dry-run mode
+- `DataClassification` and `KeyRotationSchedule` models with tenant awareness
+- `pci:classify-data`, `pci:verify-encryption`, `pci:rotate-keys` artisan commands
+- 3 migrations for data classifications and key rotation schedules
+
+#### Multi-Region Deployment (Phase 3, PR #514)
+- `DataResidencyService` — data residency enforcement with region-to-disk mapping and compliance verification
+- `RegionAwareStorageService` — region-aware storage with disk selection and access verification
+- `GeoRoutingController` — geo-routing API endpoints for nearest region, latency probing, and failover
+- `DataTransferLog` model for cross-region transfer audit trail
+- `multi-region.php` config for region definitions, storage mapping, and geo-routing settings
+- 2 migrations for data transfer logs and geo-routing config
+
+#### GDPR Enhanced Compliance (Phase 4, PR #515)
+- `BreachNotificationService` — GDPR Articles 33/34 breach reporting with 72-hour deadline tracking
+- `ConsentManagementService` — granular consent management with immutable audit trail and coverage statistics
+- `DataProcessingRegisterService` — Article 30 Records of Processing Activities (ROPA) with completeness checking
+- `DataRetentionService` — automated retention policy enforcement (delete/archive/anonymize) with dry-run mode
+- `DpiaService` — Data Protection Impact Assessments (Article 35) with risk scoring and approval workflow
+- 5 models: `ConsentRecord`, `DataBreach`, `DataProtectionAssessment`, `ProcessingActivity`, `RetentionPolicy`
+- 6 event-sourcing events: `BreachDetected`, `BreachAuthorityNotified`, `BreachSubjectsNotified`, `ConsentRecorded`, `ConsentRevoked`, `RetentionPolicyEnforced`
+- `GdprEnhancedController` with 14 API endpoints under `/compliance/gdpr/v2/`
+- `gdpr:breach-check`, `gdpr:retention-enforce`, `gdpr:register-export` artisan commands
+- 5 migrations for processing activities, assessments, breaches, consents, and retention policies
+
+### Fixed
+- Duplicate `uses(Tests\TestCase::class)` declarations in Certification test directory (Pest.php global binding conflict)
+- `SecurityAuditServiceTest` check count updated from 8 to 10 to match current security check inventory
+
 ## [3.4.0] - 2026-02-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,8 @@ git status && git branch --show-current
 ### Version Status
 | Version | Status | Key Changes |
 |---------|--------|-------------|
+| v3.5.0 | ✅ Released | Compliance Certification: SOC 2 Type II, PCI DSS readiness, multi-region deployment, GDPR enhanced (ROPA, DPIA, breach notification, consent v2, retention) |
+| v3.4.0 | ✅ Released | API Maturity & DX: API versioning, tier-aware rate limiting, SDK generation, OpenAPI annotations (143+ endpoints) |
 | v3.3.0 | ✅ Released | Event Store Optimization & Observability: Event replay/rebuild/stats/cleanup commands, observability dashboards, structured logging, deep health checks, event archival/compaction |
 | v3.2.0 | ✅ Released | Production Readiness & Plugin Architecture: Module manifests, enable/disable, modular routes, module admin API/UI, k6 load tests, query performance middleware, open-source templates |
 | v3.1.0 | ✅ Released | Consolidation, Documentation & UI Completeness: Swagger annotations, 7 feature pages, 15 Filament admin resources, 4 user-facing views, developer portal update |

--- a/app/Http/Controllers/Api/Documentation/OpenApiDoc.php
+++ b/app/Http/Controllers/Api/Documentation/OpenApiDoc.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers\Api\Documentation;
 /**
  * @OA\Info(
  *     title="FinAegis Core Banking API",
- *     version="3.4.0",
+ *     version="3.5.0",
  *     description="Open Source Core Banking as a Service - A modern, scalable, and secure core banking platform built with Laravel 12, featuring 41 DDD domains, event sourcing, CQRS, cross-chain bridges, DeFi protocol integration, privacy-preserving identity, RegTech compliance, Banking-as-a-Service, and AI-powered analytics.",
  *
  * @OA\Contact(

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -11,7 +11,7 @@
             "name": "Apache 2.0",
             "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
         },
-        "version": "3.4.0"
+        "version": "3.5.0"
     },
     "servers": [
         {


### PR DESCRIPTION
## Summary

- CHANGELOG.md updated with v3.5.0 release notes covering all 4 phases
- OpenAPI version bumped from 3.4.0 to 3.5.0
- CLAUDE.md version table updated with v3.4.0 and v3.5.0
- OpenAPI spec regenerated

## v3.5.0 Phases (all merged)

| Phase | PR | Theme |
|-------|-----|-------|
| 1 | #512 | SOC 2 Type II — evidence collection, access reviews, incident response |
| 2 | #513 | PCI DSS — data classification, encryption verification, key rotation |
| 3 | #514 | Multi-Region — data residency, region-aware storage, geo-routing |
| 4 | #515 | GDPR — Article 30 ROPA, DPIA, breach notification, consent v2, retention |

🤖 Generated with [Claude Code](https://claude.com/claude-code)