### PR TITLE
feat: Event Store v2 foundation — domain table routing (v4.0.0 Phase 1)

### DIFF
--- a/app/Domain/Monitoring/Services/EventPartitioningService.php
+++ b/app/Domain/Monitoring/Services/EventPartitioningService.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Monitoring\Services;
+
+use App\Domain\Shared\EventSourcing\EventRouterInterface;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Manages domain-based event store partitioning.
+ *
+ * Provides utilities for inspecting, validating, and reporting on
+ * the distribution of events across domain-specific tables.
+ */
+class EventPartitioningService
+{
+    public function __construct(
+        private readonly EventRouterInterface $eventRouter,
+    ) {}
+
+    /**
+     * Get partitioning status for all domains.
+     *
+     * @return array<string, array{table: string, exists: bool, count: int}>
+     */
+    public function getPartitioningStatus(): array
+    {
+        $status = [];
+        $map = $this->eventRouter->getDomainTableMap();
+
+        foreach ($map as $domain => $table) {
+            $exists = Schema::hasTable($table);
+            $count = $exists ? DB::table($table)->count() : 0;
+
+            $status[$domain] = [
+                'table'  => $table,
+                'exists' => $exists,
+                'count'  => $count,
+            ];
+        }
+
+        // Also include the default fallback table
+        $defaultTable = $this->eventRouter->getDefaultTable();
+        $defaultExists = Schema::hasTable($defaultTable);
+        $status['_default'] = [
+            'table'  => $defaultTable,
+            'exists' => $defaultExists,
+            'count'  => $defaultExists ? DB::table($defaultTable)->count() : 0,
+        ];
+
+        return $status;
+    }
+
+    /**
+     * Verify that all required domain event tables exist.
+     *
+     * @return array{missing: string[], existing: string[]}
+     */
+    public function verifyTables(): array
+    {
+        $missing = [];
+        $existing = [];
+
+        foreach ($this->eventRouter->getDomainTableMap() as $domain => $table) {
+            if (Schema::hasTable($table)) {
+                $existing[] = $table;
+            } else {
+                $missing[] = $table;
+            }
+        }
+
+        return [
+            'missing'  => $missing,
+            'existing' => $existing,
+        ];
+    }
+
+    /**
+     * Get event distribution across all tables.
+     *
+     * @return array{total: int, per_table: array<string, int>, per_domain: array<string, int>}
+     */
+    public function getEventDistribution(): array
+    {
+        $perTable = [];
+        $perDomain = [];
+        $total = 0;
+
+        foreach ($this->eventRouter->getDomainTableMap() as $domain => $table) {
+            if (Schema::hasTable($table)) {
+                $count = DB::table($table)->count();
+                $perTable[$table] = ($perTable[$table] ?? 0) + $count;
+                $perDomain[$domain] = $count;
+                $total += $count;
+            }
+        }
+
+        $defaultTable = $this->eventRouter->getDefaultTable();
+        if (Schema::hasTable($defaultTable)) {
+            $defaultCount = DB::table($defaultTable)->count();
+            $perTable[$defaultTable] = $defaultCount;
+            $total += $defaultCount;
+        }
+
+        return [
+            'total'      => $total,
+            'per_table'  => $perTable,
+            'per_domain' => $perDomain,
+        ];
+    }
+
+    /**
+     * Check if domain partitioning is active.
+     */
+    public function isPartitioningActive(): bool
+    {
+        return config('event-store.partitioning.strategy') === 'domain';
+    }
+
+    /**
+     * Get the routing configuration summary.
+     *
+     * @return array{strategy: string, domains: int, default_table: string, tables: string[]}
+     */
+    public function getRoutingConfig(): array
+    {
+        $map = $this->eventRouter->getDomainTableMap();
+
+        return [
+            'strategy'      => (string) config('event-store.partitioning.strategy', 'none'),
+            'domains'       => count($map),
+            'default_table' => $this->eventRouter->getDefaultTable(),
+            'tables'        => array_unique(array_values($map)),
+        ];
+    }
+}

--- a/app/Domain/Shared/EventSourcing/EventRouter.php
+++ b/app/Domain/Shared/EventSourcing/EventRouter.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Shared\EventSourcing;
+
+/**
+ * Routes events to domain-specific tables by namespace.
+ *
+ * Extracts the domain name from event class namespaces (App\Domain\{Domain}\Events\...)
+ * and maps them to dedicated event storage tables. Falls back to `stored_events`
+ * for unmapped domains.
+ */
+class EventRouter implements EventRouterInterface
+{
+    /** @var array<string, string> */
+    private array $domainTableMap;
+
+    private string $defaultTable;
+
+    /**
+     * @param array<string, string> $domainTableMap Domain => table name mapping
+     * @param string $defaultTable Fallback table for unmapped domains
+     */
+    public function __construct(
+        array $domainTableMap = [],
+        string $defaultTable = 'stored_events',
+    ) {
+        $this->domainTableMap = $domainTableMap ?: $this->getDefaultDomainTableMap();
+        $this->defaultTable = $defaultTable;
+    }
+
+    public function resolveTableForEvent(string $eventClass): string
+    {
+        $domain = $this->extractDomain($eventClass);
+
+        return $this->resolveTableForDomain($domain);
+    }
+
+    public function resolveTableForDomain(string $domain): string
+    {
+        return $this->domainTableMap[$domain] ?? $this->defaultTable;
+    }
+
+    public function extractDomain(string $eventClass): string
+    {
+        // Match App\Domain\{Domain}\... pattern
+        if (preg_match('/^App\\\\Domain\\\\([^\\\\]+)\\\\/', $eventClass, $matches)) {
+            return $matches[1];
+        }
+
+        return 'Unknown';
+    }
+
+    public function getDomainTableMap(): array
+    {
+        return $this->domainTableMap;
+    }
+
+    public function getDefaultTable(): string
+    {
+        return $this->defaultTable;
+    }
+
+    /**
+     * Default domain-to-table mapping.
+     *
+     * Each domain gets a dedicated `{domain}_events` table.
+     * This activates the domain-specific event tables that exist
+     * but were previously unused (all events went to `stored_events`).
+     *
+     * @return array<string, string>
+     */
+    private function getDefaultDomainTableMap(): array
+    {
+        return [
+            'Account'       => 'account_events',
+            'AgentProtocol' => 'agent_protocol_events',
+            'AI'            => 'ai_events',
+            'Asset'         => 'asset_events',
+            'Batch'         => 'batch_events',
+            'Cgo'           => 'cgo_events',
+            'Compliance'    => 'compliance_events',
+            'Exchange'      => 'exchange_events',
+            'Lending'       => 'lending_events',
+            'Mobile'        => 'mobile_events',
+            'Monitoring'    => 'monitoring_events',
+            'Payment'       => 'payment_events',
+            'Performance'   => 'performance_events',
+            'Product'       => 'product_events',
+            'Stablecoin'    => 'stablecoin_events',
+            'Treasury'      => 'treasury_events',
+            'User'          => 'user_events',
+            'Wallet'        => 'wallet_events',
+            'CrossChain'    => 'cross_chain_events',
+            'DeFi'          => 'defi_events',
+            'Privacy'       => 'privacy_events',
+        ];
+    }
+}

--- a/app/Domain/Shared/EventSourcing/EventRouterInterface.php
+++ b/app/Domain/Shared/EventSourcing/EventRouterInterface.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Shared\EventSourcing;
+
+/**
+ * Routes events to domain-specific tables based on event namespace.
+ *
+ * This interface defines the contract for resolving which database table
+ * should store events for a given domain or event class.
+ */
+interface EventRouterInterface
+{
+    /**
+     * Resolve the event table name for a given event class.
+     *
+     * @param class-string $eventClass The fully-qualified event class name
+     * @return string The table name where the event should be stored
+     */
+    public function resolveTableForEvent(string $eventClass): string;
+
+    /**
+     * Resolve the event table name for a given domain.
+     *
+     * @param string $domain The domain name (e.g., 'Account', 'Exchange')
+     * @return string The table name for the domain's events
+     */
+    public function resolveTableForDomain(string $domain): string;
+
+    /**
+     * Extract the domain name from an event class namespace.
+     *
+     * @param class-string $eventClass The fully-qualified event class name
+     * @return string The domain name extracted from the namespace
+     */
+    public function extractDomain(string $eventClass): string;
+
+    /**
+     * Get the complete domain-to-table mapping.
+     *
+     * @return array<string, string> Domain name => table name
+     */
+    public function getDomainTableMap(): array;
+
+    /**
+     * Get the default fallback table name.
+     */
+    public function getDefaultTable(): string;
+}

--- a/config/event-store.php
+++ b/config/event-store.php
@@ -55,7 +55,26 @@ return [
     |
     */
     'partitioning' => [
-        'strategy' => env('EVENT_STORE_PARTITION_STRATEGY', 'none'),
+        'strategy' => env('EVENT_STORE_PARTITION_STRATEGY', 'domain'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Event Routing Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Controls how events are routed to domain-specific tables.
+    | The default_table is used for events from unmapped domains.
+    | The domain_tables map overrides the built-in defaults in EventRouter.
+    |
+    */
+    'routing' => [
+        'default_table' => env('EVENT_STORE_DEFAULT_TABLE', 'stored_events'),
+
+        // Override domain-to-table mappings (leave empty to use defaults)
+        'domain_tables' => [
+            // 'Account' => 'custom_account_events',
+        ],
     ],
 
     /*

--- a/tests/Integration/EventSourcing/DomainTableRoutingTest.php
+++ b/tests/Integration/EventSourcing/DomainTableRoutingTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Monitoring\Services\EventPartitioningService;
+use App\Domain\Monitoring\Services\EventStoreService;
+use App\Domain\Shared\EventSourcing\EventRouter;
+use App\Domain\Shared\EventSourcing\EventRouterInterface;
+
+uses(Tests\TestCase::class);
+
+describe('Domain Table Routing Integration', function () {
+    it('registers EventRouter in the container', function () {
+        $router = app(EventRouterInterface::class);
+
+        expect($router)->toBeInstanceOf(EventRouter::class);
+    });
+
+    it('EventStoreService resolves tables via router when partitioning is domain', function () {
+        config(['event-store.partitioning.strategy' => 'domain']);
+
+        $router = app(EventRouterInterface::class);
+        $service = new EventStoreService($router);
+        $map = $service->getDomainTableMap();
+
+        expect($map['Account']['event_table'])->toBe('account_events');
+        expect($map['Exchange']['event_table'])->toBe('exchange_events');
+        expect($map['Wallet']['event_table'])->toBe('wallet_events');
+    });
+
+    it('EventStoreService falls back to stored_events when partitioning is none', function () {
+        config(['event-store.partitioning.strategy' => 'none']);
+
+        $router = app(EventRouterInterface::class);
+        $service = new EventStoreService($router);
+        $map = $service->getDomainTableMap();
+
+        expect($map['Account']['event_table'])->toBe('stored_events');
+        expect($map['Exchange']['event_table'])->toBe('stored_events');
+    });
+
+    it('EventPartitioningService reports routing config', function () {
+        config(['event-store.partitioning.strategy' => 'domain']);
+
+        $router = app(EventRouterInterface::class);
+        $service = new EventPartitioningService($router);
+        $config = $service->getRoutingConfig();
+
+        expect($config['strategy'])->toBe('domain');
+        expect($config['domains'])->toBeGreaterThan(15);
+        expect($config['default_table'])->toBe('stored_events');
+    });
+
+    it('EventPartitioningService detects active partitioning', function () {
+        config(['event-store.partitioning.strategy' => 'domain']);
+        $router = app(EventRouterInterface::class);
+        $service = new EventPartitioningService($router);
+        expect($service->isPartitioningActive())->toBeTrue();
+
+        config(['event-store.partitioning.strategy' => 'none']);
+        expect($service->isPartitioningActive())->toBeFalse();
+    });
+
+    it('preserves snapshot table associations', function () {
+        config(['event-store.partitioning.strategy' => 'domain']);
+
+        $router = app(EventRouterInterface::class);
+        $service = new EventStoreService($router);
+        $map = $service->getDomainTableMap();
+
+        expect($map['Account']['snapshot_table'])->toBe('transaction_snapshots');
+        expect($map['Treasury']['snapshot_table'])->toBe('treasury_snapshots');
+        expect($map['Compliance']['snapshot_table'])->toBe('compliance_snapshots');
+        expect($map['Exchange']['snapshot_table'])->toBeNull();
+    });
+
+    it('resolves event table for domain via EventStoreService', function () {
+        config(['event-store.partitioning.strategy' => 'domain']);
+
+        $router = app(EventRouterInterface::class);
+        $service = new EventStoreService($router);
+
+        expect($service->resolveEventTable('Account'))->toBe('account_events');
+        expect($service->resolveEventTable('Wallet'))->toBe('wallet_events');
+    });
+});

--- a/tests/Unit/EventSourcing/EventRouterTest.php
+++ b/tests/Unit/EventSourcing/EventRouterTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Shared\EventSourcing\EventRouter;
+
+describe('EventRouter', function () {
+    it('resolves table for known domain event class', function () {
+        $router = new EventRouter();
+
+        $table = $router->resolveTableForEvent('App\\Domain\\Account\\Events\\MoneyAdded');
+
+        expect($table)->toBe('account_events');
+    });
+
+    it('resolves table for Exchange domain', function () {
+        $router = new EventRouter();
+
+        $table = $router->resolveTableForEvent('App\\Domain\\Exchange\\Events\\OrderPlaced');
+
+        expect($table)->toBe('exchange_events');
+    });
+
+    it('falls back to stored_events for unknown domain', function () {
+        $router = new EventRouter();
+
+        $table = $router->resolveTableForEvent('App\\Domain\\UnknownDomain\\Events\\SomeEvent');
+
+        expect($table)->toBe('stored_events');
+    });
+
+    it('falls back to stored_events for non-domain event class', function () {
+        $router = new EventRouter();
+
+        $table = $router->resolveTableForEvent('Spatie\\EventSourcing\\Events\\SomeEvent');
+
+        expect($table)->toBe('stored_events');
+    });
+
+    it('extracts domain from event class namespace', function () {
+        $router = new EventRouter();
+
+        expect($router->extractDomain('App\\Domain\\Account\\Events\\MoneyAdded'))->toBe('Account');
+        expect($router->extractDomain('App\\Domain\\Compliance\\Events\\AlertCreated'))->toBe('Compliance');
+        expect($router->extractDomain('App\\Domain\\Treasury\\Events\\Portfolio\\PortfolioCreated'))->toBe('Treasury');
+        expect($router->extractDomain('Spatie\\EventSourcing\\Events\\SomeEvent'))->toBe('Unknown');
+    });
+
+    it('resolves table for domain name directly', function () {
+        $router = new EventRouter();
+
+        expect($router->resolveTableForDomain('Account'))->toBe('account_events');
+        expect($router->resolveTableForDomain('Wallet'))->toBe('wallet_events');
+        expect($router->resolveTableForDomain('Compliance'))->toBe('compliance_events');
+        expect($router->resolveTableForDomain('UnknownDomain'))->toBe('stored_events');
+    });
+
+    it('returns complete domain table map', function () {
+        $router = new EventRouter();
+
+        $map = $router->getDomainTableMap();
+
+        expect($map)->toBeArray();
+        expect($map)->toHaveKey('Account');
+        expect($map)->toHaveKey('Exchange');
+        expect($map)->toHaveKey('Wallet');
+        expect($map)->toHaveKey('Treasury');
+        expect($map['Account'])->toBe('account_events');
+    });
+
+    it('returns default table name', function () {
+        $router = new EventRouter();
+
+        expect($router->getDefaultTable())->toBe('stored_events');
+    });
+
+    it('accepts custom domain table map', function () {
+        $router = new EventRouter(
+            domainTableMap: ['CustomDomain' => 'custom_events'],
+            defaultTable: 'fallback_events',
+        );
+
+        expect($router->resolveTableForDomain('CustomDomain'))->toBe('custom_events');
+        expect($router->resolveTableForDomain('Other'))->toBe('fallback_events');
+        expect($router->getDefaultTable())->toBe('fallback_events');
+    });
+
+    it('maps all core domains', function () {
+        $router = new EventRouter();
+        $map = $router->getDomainTableMap();
+
+        $expectedDomains = [
+            'Account', 'AgentProtocol', 'AI', 'Asset', 'Batch', 'Cgo',
+            'Compliance', 'Exchange', 'Lending', 'Mobile', 'Monitoring',
+            'Payment', 'Performance', 'Product', 'Stablecoin', 'Treasury',
+            'User', 'Wallet', 'CrossChain', 'DeFi', 'Privacy',
+        ];
+
+        foreach ($expectedDomains as $domain) {
+            expect($map)->toHaveKey($domain);
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- Activate domain-specific event tables by introducing EventRouter that maps event namespaces to dedicated tables
- Previously all 446+ events went to single `stored_events` table; now each of 21 domains routes to its own table (e.g., `account_events`, `exchange_events`)
- Add EventPartitioningService for monitoring partition status and distribution

## Changes
- `EventRouterInterface` + `EventRouter`: namespace-to-table routing with fallback
- `EventPartitioningService`: partition status, table verification, event distribution
- Updated `EventStoreService` to use EventRouter when domain partitioning is active
- Updated `config/event-store.php`: new routing config, default strategy set to `domain`
- Registered EventRouter singleton in Infrastructure DomainServiceProvider

## Test plan
- [x] 10 unit tests for EventRouter (namespace extraction, domain mapping, fallback, custom config)
- [x] 7 integration tests for domain table routing (container binding, table resolution, fallback, config)
- [x] All 17 new tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)