### PR TITLE
feat: Plugin Marketplace sandboxing & API — permissions, security, admin (v4.0.0)

### DIFF
--- a/app/Domain/Shared/Models/PluginReview.php
+++ b/app/Domain/Shared/Models/PluginReview.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Shared\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PluginReview extends Model
+{
+    use HasUuids;
+
+    protected $fillable = [
+        'plugin_id',
+        'reviewer_id',
+        'status',
+        'security_score',
+        'notes',
+        'scan_results',
+        'reviewed_at',
+    ];
+
+    protected $casts = [
+        'scan_results' => 'array',
+        'security_score' => 'integer',
+        'reviewed_at' => 'datetime',
+    ];
+
+    public function plugin(): BelongsTo
+    {
+        return $this->belongsTo(Plugin::class);
+    }
+
+    public function isApproved(): bool
+    {
+        return $this->status === 'approved';
+    }
+
+    public function isRejected(): bool
+    {
+        return $this->status === 'rejected';
+    }
+
+    public function isPending(): bool
+    {
+        return $this->status === 'pending';
+    }
+}

--- a/app/Filament/Resources/PluginResource.php
+++ b/app/Filament/Resources/PluginResource.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Domain\Shared\Models\Plugin;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class PluginResource extends Resource
+{
+    protected static ?string $model = Plugin::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-puzzle-piece';
+
+    protected static ?string $navigationGroup = 'System';
+
+    protected static ?string $navigationLabel = 'Plugins';
+
+    protected static ?int $navigationSort = 50;
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('vendor')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('version')
+                    ->sortable(),
+                Tables\Columns\BadgeColumn::make('status')
+                    ->colors([
+                        'success' => 'active',
+                        'warning' => 'inactive',
+                        'danger' => 'failed',
+                    ]),
+                Tables\Columns\IconColumn::make('is_system')
+                    ->boolean()
+                    ->label('System'),
+                Tables\Columns\TextColumn::make('installed_at')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')
+                    ->options([
+                        'active' => 'Active',
+                        'inactive' => 'Inactive',
+                        'failed' => 'Failed',
+                    ]),
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => \App\Filament\Resources\PluginResource\Pages\ListPlugins::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Resources/PluginResource/Pages/ListPlugins.php
+++ b/app/Filament/Resources/PluginResource/Pages/ListPlugins.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\PluginResource\Pages;
+
+use App\Filament\Resources\PluginResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListPlugins extends ListRecords
+{
+    protected static string $resource = PluginResource::class;
+}

--- a/app/Http/Controllers/Api/PluginMarketplaceController.php
+++ b/app/Http/Controllers/Api/PluginMarketplaceController.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Domain\Shared\Models\Plugin;
+use App\Http\Controllers\Controller;
+use App\Infrastructure\Plugins\PluginManager;
+use App\Infrastructure\Plugins\PluginManifest;
+use App\Infrastructure\Plugins\PluginSecurityScanner;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class PluginMarketplaceController extends Controller
+{
+    public function __construct(
+        private readonly PluginManager $pluginManager,
+        private readonly PluginSecurityScanner $securityScanner,
+    ) {}
+
+    /**
+     * List all installed plugins.
+     */
+    public function index(): JsonResponse
+    {
+        $plugins = $this->pluginManager->list();
+
+        return response()->json([
+            'data' => $plugins->map(fn (Plugin $p) => [
+                'id' => $p->id,
+                'vendor' => $p->vendor,
+                'name' => $p->name,
+                'full_name' => $p->getFullName(),
+                'version' => $p->version,
+                'display_name' => $p->display_name,
+                'description' => $p->description,
+                'status' => $p->status,
+                'is_system' => $p->is_system,
+                'permissions' => $p->permissions,
+                'installed_at' => $p->installed_at?->toIso8601String(),
+            ]),
+            'meta' => [
+                'total' => $plugins->count(),
+                'active' => $plugins->where('status', 'active')->count(),
+            ],
+        ]);
+    }
+
+    /**
+     * Show a specific plugin.
+     */
+    public function show(string $id): JsonResponse
+    {
+        $plugin = Plugin::findOrFail($id);
+
+        return response()->json([
+            'data' => [
+                'id' => $plugin->id,
+                'vendor' => $plugin->vendor,
+                'name' => $plugin->name,
+                'full_name' => $plugin->getFullName(),
+                'version' => $plugin->version,
+                'display_name' => $plugin->display_name,
+                'description' => $plugin->description,
+                'author' => $plugin->author,
+                'license' => $plugin->license,
+                'homepage' => $plugin->homepage,
+                'status' => $plugin->status,
+                'is_system' => $plugin->is_system,
+                'permissions' => $plugin->permissions,
+                'dependencies' => $plugin->dependencies,
+                'metadata' => $plugin->metadata,
+                'installed_at' => $plugin->installed_at?->toIso8601String(),
+                'activated_at' => $plugin->activated_at?->toIso8601String(),
+                'last_updated_at' => $plugin->last_updated_at?->toIso8601String(),
+            ],
+        ]);
+    }
+
+    /**
+     * Enable a plugin.
+     */
+    public function enable(string $id): JsonResponse
+    {
+        $plugin = Plugin::findOrFail($id);
+        $result = $this->pluginManager->enable($plugin->vendor, $plugin->name);
+
+        return response()->json($result, $result['success'] ? 200 : 422);
+    }
+
+    /**
+     * Disable a plugin.
+     */
+    public function disable(string $id): JsonResponse
+    {
+        $plugin = Plugin::findOrFail($id);
+        $result = $this->pluginManager->disable($plugin->vendor, $plugin->name);
+
+        return response()->json($result, $result['success'] ? 200 : 422);
+    }
+
+    /**
+     * Remove a plugin.
+     */
+    public function destroy(string $id): JsonResponse
+    {
+        $plugin = Plugin::findOrFail($id);
+        $result = $this->pluginManager->remove($plugin->vendor, $plugin->name);
+
+        return response()->json($result, $result['success'] ? 200 : 422);
+    }
+
+    /**
+     * Scan a plugin for security issues.
+     */
+    public function scan(string $id): JsonResponse
+    {
+        $plugin = Plugin::findOrFail($id);
+        $result = $this->securityScanner->scan($plugin->path);
+
+        return response()->json([
+            'plugin' => $plugin->getFullName(),
+            'safe' => $result['safe'],
+            'issues' => $result['issues'],
+            'summary' => $this->securityScanner->summarize($result['issues']),
+        ]);
+    }
+
+    /**
+     * Discover new plugins from the filesystem.
+     */
+    public function discover(): JsonResponse
+    {
+        $result = $this->pluginManager->discover();
+
+        return response()->json([
+            'discovered' => $result['discovered'],
+            'new' => $result['new'],
+        ]);
+    }
+}

--- a/app/Infrastructure/Plugins/PluginPermissions.php
+++ b/app/Infrastructure/Plugins/PluginPermissions.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Plugins;
+
+class PluginPermissions
+{
+    public const DATABASE_READ = 'database:read';
+    public const DATABASE_WRITE = 'database:write';
+    public const API_INTERNAL = 'api:internal';
+    public const API_EXTERNAL = 'api:external';
+    public const EVENTS_LISTEN = 'events:listen';
+    public const EVENTS_DISPATCH = 'events:dispatch';
+    public const QUEUE_DISPATCH = 'queue:dispatch';
+    public const CACHE_READ = 'cache:read';
+    public const CACHE_WRITE = 'cache:write';
+    public const FILESYSTEM_READ = 'filesystem:read';
+    public const FILESYSTEM_WRITE = 'filesystem:write';
+    public const CONFIG_READ = 'config:read';
+
+    /**
+     * @var array<string, string>
+     */
+    private static array $descriptions = [
+        'database:read' => 'Read access to database tables',
+        'database:write' => 'Write access to database tables',
+        'api:internal' => 'Access to internal API endpoints',
+        'api:external' => 'Make outbound HTTP requests',
+        'events:listen' => 'Listen to application events',
+        'events:dispatch' => 'Dispatch application events',
+        'queue:dispatch' => 'Dispatch jobs to queues',
+        'cache:read' => 'Read from application cache',
+        'cache:write' => 'Write to application cache',
+        'filesystem:read' => 'Read files from storage',
+        'filesystem:write' => 'Write files to storage',
+        'config:read' => 'Read application configuration',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    private static array $categories = [
+        'database:read' => 'Data Access',
+        'database:write' => 'Data Access',
+        'api:internal' => 'API',
+        'api:external' => 'API',
+        'events:listen' => 'Events',
+        'events:dispatch' => 'Events',
+        'queue:dispatch' => 'Queue',
+        'cache:read' => 'Cache',
+        'cache:write' => 'Cache',
+        'filesystem:read' => 'Storage',
+        'filesystem:write' => 'Storage',
+        'config:read' => 'Configuration',
+    ];
+
+    /**
+     * Get all available permissions.
+     *
+     * @return array<string>
+     */
+    public static function all(): array
+    {
+        return array_keys(self::$descriptions);
+    }
+
+    /**
+     * Check if a permission string is valid.
+     */
+    public static function isValid(string $permission): bool
+    {
+        return isset(self::$descriptions[$permission]);
+    }
+
+    /**
+     * Get the description for a permission.
+     */
+    public static function describe(string $permission): string
+    {
+        return self::$descriptions[$permission] ?? 'Unknown permission';
+    }
+
+    /**
+     * Get the category for a permission.
+     */
+    public static function category(string $permission): string
+    {
+        return self::$categories[$permission] ?? 'Other';
+    }
+
+    /**
+     * Validate a list of requested permissions.
+     *
+     * @param  array<string>  $permissions
+     * @return array{valid: bool, invalid: array<string>}
+     */
+    public static function validate(array $permissions): array
+    {
+        $invalid = array_filter($permissions, fn ($p) => ! self::isValid($p));
+
+        return [
+            'valid' => empty($invalid),
+            'invalid' => array_values($invalid),
+        ];
+    }
+
+    /**
+     * Get permissions grouped by category.
+     *
+     * @return array<string, array<string>>
+     */
+    public static function grouped(): array
+    {
+        $grouped = [];
+        foreach (self::$categories as $permission => $category) {
+            $grouped[$category][] = $permission;
+        }
+        return $grouped;
+    }
+}

--- a/app/Infrastructure/Plugins/PluginSandbox.php
+++ b/app/Infrastructure/Plugins/PluginSandbox.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Plugins;
+
+use App\Domain\Shared\Models\Plugin;
+
+class PluginSandbox
+{
+    /**
+     * Check if a plugin has a specific permission.
+     */
+    public function hasPermission(Plugin $plugin, string $permission): bool
+    {
+        if (! config('plugins.sandbox.enabled', true)) {
+            return true;
+        }
+
+        return $plugin->hasPermission($permission);
+    }
+
+    /**
+     * Enforce that a plugin has the required permission.
+     *
+     * @throws \RuntimeException
+     */
+    public function enforce(Plugin $plugin, string $permission): void
+    {
+        if (! $this->hasPermission($plugin, $permission)) {
+            throw new \RuntimeException(
+                "Plugin {$plugin->getFullName()} does not have permission: {$permission}"
+            );
+        }
+    }
+
+    /**
+     * Check if a plugin can access a specific resource.
+     *
+     * @param  array<string>  $requiredPermissions
+     */
+    public function canAccess(Plugin $plugin, array $requiredPermissions): bool
+    {
+        foreach ($requiredPermissions as $permission) {
+            if (! $this->hasPermission($plugin, $permission)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the permissions that a plugin is missing.
+     *
+     * @param  array<string>  $requiredPermissions
+     * @return array<string>
+     */
+    public function getMissingPermissions(Plugin $plugin, array $requiredPermissions): array
+    {
+        return array_filter(
+            $requiredPermissions,
+            fn ($p) => ! $this->hasPermission($plugin, $p),
+        );
+    }
+
+    /**
+     * Validate that a plugin only uses declared permissions.
+     *
+     * @return array{valid: bool, undeclared: array<string>}
+     */
+    public function validatePermissions(Plugin $plugin): array
+    {
+        $declared = $plugin->permissions ?? [];
+        $validation = PluginPermissions::validate($declared);
+
+        return [
+            'valid' => $validation['valid'],
+            'undeclared' => $validation['invalid'],
+        ];
+    }
+}

--- a/app/Infrastructure/Plugins/PluginSecurityScanner.php
+++ b/app/Infrastructure/Plugins/PluginSecurityScanner.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Plugins;
+
+use Illuminate\Support\Facades\File;
+
+class PluginSecurityScanner
+{
+    /**
+     * Dangerous patterns to detect in plugin code.
+     *
+     * @var array<string, string>
+     */
+    private array $patterns = [
+        'eval' => '/\beval\s*\(/i',
+        'exec' => '/\bexec\s*\(/i',
+        'shell_exec' => '/\bshell_exec\s*\(/i',
+        'system' => '/\bsystem\s*\(/i',
+        'passthru' => '/\bpassthru\s*\(/i',
+        'proc_open' => '/\bproc_open\s*\(/i',
+        'popen' => '/\bpopen\s*\(/i',
+        'backtick' => '/`[^`]+`/',
+        'raw_sql' => '/\bDB::raw\s*\(/i',
+        'raw_query' => '/\bDB::statement\s*\(/i',
+        'file_get_contents' => '/\bfile_get_contents\s*\(\s*[\'"]https?:/i',
+        'curl' => '/\bcurl_exec\s*\(/i',
+        'unserialize' => '/\bunserialize\s*\(/i',
+        'base64_decode_exec' => '/\bbase64_decode\s*\(.*\beval\b/i',
+        'env_access' => '/\benv\s*\(\s*[\'"][A-Z_]*(?:KEY|SECRET|PASSWORD|TOKEN)/i',
+    ];
+
+    /**
+     * Scan a plugin directory for security issues.
+     *
+     * @return array{safe: bool, issues: array<array{file: string, line: int, type: string, code: string}>}
+     */
+    public function scan(string $pluginPath): array
+    {
+        $issues = [];
+
+        if (! File::isDirectory($pluginPath)) {
+            return ['safe' => true, 'issues' => []];
+        }
+
+        $files = File::allFiles($pluginPath);
+
+        foreach ($files as $file) {
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $content = $file->getContents();
+            $lines = explode("\n", $content);
+
+            foreach ($lines as $lineNumber => $line) {
+                foreach ($this->patterns as $type => $pattern) {
+                    if (preg_match($pattern, $line)) {
+                        $issues[] = [
+                            'file' => $file->getRelativePathname(),
+                            'line' => $lineNumber + 1,
+                            'type' => $type,
+                            'code' => trim($line),
+                        ];
+                    }
+                }
+            }
+        }
+
+        return [
+            'safe' => empty($issues),
+            'issues' => $issues,
+        ];
+    }
+
+    /**
+     * Get a summary of scan results.
+     *
+     * @param  array<array{file: string, line: int, type: string, code: string}>  $issues
+     * @return array<string, int>
+     */
+    public function summarize(array $issues): array
+    {
+        $summary = [];
+        foreach ($issues as $issue) {
+            $type = $issue['type'];
+            $summary[$type] = ($summary[$type] ?? 0) + 1;
+        }
+        return $summary;
+    }
+
+    /**
+     * Get the severity level for an issue type.
+     */
+    public function getSeverity(string $type): string
+    {
+        $critical = ['eval', 'exec', 'shell_exec', 'system', 'passthru', 'proc_open', 'popen', 'backtick'];
+        $high = ['raw_sql', 'raw_query', 'unserialize', 'base64_decode_exec', 'env_access'];
+        $medium = ['file_get_contents', 'curl'];
+
+        if (in_array($type, $critical, true)) {
+            return 'critical';
+        }
+        if (in_array($type, $high, true)) {
+            return 'high';
+        }
+        if (in_array($type, $medium, true)) {
+            return 'medium';
+        }
+        return 'low';
+    }
+}

--- a/database/migrations/2026_02_13_000003_create_plugin_reviews_table.php
+++ b/database/migrations/2026_02_13_000003_create_plugin_reviews_table.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('plugin_reviews', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('plugin_id');
+            $table->unsignedBigInteger('reviewer_id')->nullable();
+            $table->string('status')->default('pending'); // pending, approved, rejected
+            $table->integer('security_score')->nullable();
+            $table->text('notes')->nullable();
+            $table->json('scan_results')->nullable();
+            $table->timestamp('reviewed_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('plugin_id')->references('id')->on('plugins')->onDelete('cascade');
+            $table->index('status');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('plugin_reviews');
+    }
+};

--- a/tests/Unit/Plugins/PluginSandboxTest.php
+++ b/tests/Unit/Plugins/PluginSandboxTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Shared\Models\Plugin;
+use App\Infrastructure\Plugins\PluginPermissions;
+use App\Infrastructure\Plugins\PluginSandbox;
+
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+describe('PluginSandbox', function () {
+    it('allows access with declared permissions', function () {
+        $plugin = Plugin::create([
+            'vendor' => 'finaegis',
+            'name' => 'test',
+            'version' => '1.0.0',
+            'status' => 'active',
+            'path' => '/plugins/finaegis/test',
+            'permissions' => ['database:read', 'cache:read'],
+        ]);
+
+        $sandbox = new PluginSandbox();
+
+        expect($sandbox->hasPermission($plugin, 'database:read'))->toBeTrue();
+        expect($sandbox->hasPermission($plugin, 'cache:read'))->toBeTrue();
+    });
+
+    it('denies access without declared permissions', function () {
+        $plugin = Plugin::create([
+            'vendor' => 'finaegis',
+            'name' => 'restricted',
+            'version' => '1.0.0',
+            'status' => 'active',
+            'path' => '/plugins/finaegis/restricted',
+            'permissions' => ['database:read'],
+        ]);
+
+        $sandbox = new PluginSandbox();
+
+        expect($sandbox->hasPermission($plugin, 'database:write'))->toBeFalse();
+        expect($sandbox->hasPermission($plugin, 'api:external'))->toBeFalse();
+    });
+
+    it('throws on enforce without permission', function () {
+        $plugin = Plugin::create([
+            'vendor' => 'finaegis',
+            'name' => 'enforced',
+            'version' => '1.0.0',
+            'status' => 'active',
+            'path' => '/plugins/finaegis/enforced',
+            'permissions' => [],
+        ]);
+
+        $sandbox = new PluginSandbox();
+
+        expect(fn () => $sandbox->enforce($plugin, 'database:write'))
+            ->toThrow(\RuntimeException::class);
+    });
+
+    it('checks multiple permissions with canAccess', function () {
+        $plugin = Plugin::create([
+            'vendor' => 'finaegis',
+            'name' => 'multi-perm',
+            'version' => '1.0.0',
+            'status' => 'active',
+            'path' => '/plugins/finaegis/multi-perm',
+            'permissions' => ['database:read', 'cache:read', 'events:listen'],
+        ]);
+
+        $sandbox = new PluginSandbox();
+
+        expect($sandbox->canAccess($plugin, ['database:read', 'cache:read']))->toBeTrue();
+        expect($sandbox->canAccess($plugin, ['database:read', 'api:external']))->toBeFalse();
+    });
+
+    it('reports missing permissions', function () {
+        $plugin = Plugin::create([
+            'vendor' => 'finaegis',
+            'name' => 'missing-perms',
+            'version' => '1.0.0',
+            'status' => 'active',
+            'path' => '/plugins/finaegis/missing-perms',
+            'permissions' => ['database:read'],
+        ]);
+
+        $sandbox = new PluginSandbox();
+
+        $missing = $sandbox->getMissingPermissions($plugin, [
+            'database:read',
+            'database:write',
+            'api:external',
+        ]);
+
+        expect($missing)->toContain('database:write');
+        expect($missing)->toContain('api:external');
+        expect($missing)->not->toContain('database:read');
+    });
+});
+
+describe('PluginPermissions', function () {
+    it('lists all permissions', function () {
+        $all = PluginPermissions::all();
+        expect($all)->toContain('database:read');
+        expect($all)->toContain('api:external');
+        expect(count($all))->toBeGreaterThanOrEqual(12);
+    });
+
+    it('validates permissions', function () {
+        $result = PluginPermissions::validate(['database:read', 'invalid:perm']);
+        expect($result['valid'])->toBeFalse();
+        expect($result['invalid'])->toContain('invalid:perm');
+    });
+
+    it('groups permissions by category', function () {
+        $grouped = PluginPermissions::grouped();
+        expect($grouped)->toHaveKey('Data Access');
+        expect($grouped)->toHaveKey('API');
+        expect($grouped['Data Access'])->toContain('database:read');
+    });
+});

--- a/tests/Unit/Plugins/PluginSecurityScannerTest.php
+++ b/tests/Unit/Plugins/PluginSecurityScannerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Infrastructure\Plugins\PluginSecurityScanner;
+use Illuminate\Support\Facades\File;
+
+uses(Tests\TestCase::class);
+
+describe('PluginSecurityScanner', function () {
+    it('detects dangerous function calls', function () {
+        $testDir = sys_get_temp_dir() . '/plugin-scan-test-' . uniqid();
+        File::makeDirectory($testDir, 0755, true);
+        File::put("{$testDir}/dangerous.php", <<<'PHP'
+<?php
+$result = eval('return 1;');
+exec('ls -la');
+shell_exec('whoami');
+PHP);
+
+        $scanner = new PluginSecurityScanner();
+        $result = $scanner->scan($testDir);
+
+        expect($result['safe'])->toBeFalse();
+        expect($result['issues'])->toHaveCount(3);
+
+        $types = array_column($result['issues'], 'type');
+        expect($types)->toContain('eval');
+        expect($types)->toContain('exec');
+        expect($types)->toContain('shell_exec');
+
+        File::deleteDirectory($testDir);
+    });
+
+    it('passes clean plugin code', function () {
+        $testDir = sys_get_temp_dir() . '/plugin-scan-clean-' . uniqid();
+        File::makeDirectory($testDir, 0755, true);
+        File::put("{$testDir}/clean.php", <<<'PHP'
+<?php
+namespace TestPlugin;
+
+class CleanService
+{
+    public function calculate(int $a, int $b): int
+    {
+        return $a + $b;
+    }
+}
+PHP);
+
+        $scanner = new PluginSecurityScanner();
+        $result = $scanner->scan($testDir);
+
+        expect($result['safe'])->toBeTrue();
+        expect($result['issues'])->toBeEmpty();
+
+        File::deleteDirectory($testDir);
+    });
+
+    it('classifies severity correctly', function () {
+        $scanner = new PluginSecurityScanner();
+
+        expect($scanner->getSeverity('eval'))->toBe('critical');
+        expect($scanner->getSeverity('exec'))->toBe('critical');
+        expect($scanner->getSeverity('raw_sql'))->toBe('high');
+        expect($scanner->getSeverity('env_access'))->toBe('high');
+        expect($scanner->getSeverity('file_get_contents'))->toBe('medium');
+        expect($scanner->getSeverity('unknown'))->toBe('low');
+    });
+
+    it('summarizes scan results', function () {
+        $scanner = new PluginSecurityScanner();
+
+        $issues = [
+            ['file' => 'a.php', 'line' => 1, 'type' => 'eval', 'code' => 'eval()'],
+            ['file' => 'b.php', 'line' => 2, 'type' => 'eval', 'code' => 'eval()'],
+            ['file' => 'c.php', 'line' => 3, 'type' => 'exec', 'code' => 'exec()'],
+        ];
+
+        $summary = $scanner->summarize($issues);
+
+        expect($summary['eval'])->toBe(2);
+        expect($summary['exec'])->toBe(1);
+    });
+
+    it('handles non-existent directory gracefully', function () {
+        $scanner = new PluginSecurityScanner();
+        $result = $scanner->scan('/non/existent/path');
+
+        expect($result['safe'])->toBeTrue();
+        expect($result['issues'])->toBeEmpty();
+    });
+});


### PR DESCRIPTION
## Summary
- Add permission system (12 categories) with runtime sandbox enforcement
- Add static security scanner detecting 15 dangerous code patterns
- REST API for plugin management (list, show, enable, disable, remove, scan, discover)
- Filament admin panel for plugin oversight
- PluginReview model for security review tracking

## Test plan
- [x] 5 PluginSandbox tests (allow, deny, enforce, multi-perm, missing)
- [x] 3 PluginPermissions tests (list, validate, group)
- [x] 5 PluginSecurityScanner tests (detect, clean, severity, summarize, non-existent)
- [x] All 28 plugin tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)