### PR TITLE
feat: v4.1.0 — GraphQL Expansion + Platform Hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to the FinAegis Core Banking Platform will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.0] - 2026-02-13
+
+### Added
+
+#### GraphQL Expansion — 6 New Domains
+- Treasury domain: `AssetAllocation` type, `portfolio`/`portfolios` queries, `createPortfolio`/`rebalancePortfolio` mutations
+- Payment domain: `PaymentTransaction` type, `payment`/`payments` queries, `initiatePayment` mutation
+- Lending domain: `LoanApplication` type, `loanApplication`/`loanApplications` queries, `applyForLoan`/`approveLoan` mutations
+- Stablecoin domain: `StablecoinReserve` type, `stablecoinReserve`/`stablecoinReserves` queries, `mintStablecoin`/`redeemStablecoin` mutations
+- CrossChain domain: `BridgeTransaction` type, `bridgeTransaction`/`bridgeTransactions` queries, `initiateBridgeTransfer` mutation
+- DeFi domain: `DeFiPosition` type, `defiPosition`/`defiPositions` queries, `openPosition`/`closePosition` mutations
+
+#### Event Replay Filtering Enhancement
+- Added `--event-type` filter option to `event:replay` command for replaying specific event classes
+- Added `--aggregate-id` filter option to `event:replay` command for replaying specific aggregates
+- Selective replay support without full domain replay
+
+#### Projector Health Monitoring
+- `ProjectorHealthService` — track all registered projectors, detect stale/failed status
+- `projector:health` Artisan command with `--domain` and `--stale-only` options
+- REST endpoint at `/api/monitoring/projector-health` with cached status
+- Stale projector detection endpoint at `/api/monitoring/projector-health/stale`
+
+#### Integration Tests
+- 6 GraphQL domain integration tests (Treasury, Payment, Lending, Stablecoin, CrossChain, DeFi)
+- Event replay filter unit tests
+- Projector health service unit tests
+
+---
+
 ## [4.0.0] - 2026-02-13
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ git status && git branch --show-current
 ### Version Status
 | Version | Status | Key Changes |
 |---------|--------|-------------|
+| v4.1.0 | ✅ Released | GraphQL Expansion: 6 new domains (Treasury, Payment, Lending, Stablecoin, CrossChain, DeFi), event replay filtering, projector health monitoring |
 | v4.0.0 | ✅ Released | Architecture Evolution: Event Store v2 (domain routing, migration tooling, upcasting), GraphQL API (lighthouse-php, 4 domains, subscriptions, DataLoaders), Plugin Marketplace (manager, sandbox, security scanner) |
 | v3.5.0 | ✅ Released | Compliance Certification: SOC 2 Type II, PCI DSS readiness, multi-region deployment, GDPR enhanced (ROPA, DPIA, breach notification, consent v2, retention) |
 | v3.4.0 | ✅ Released | API Maturity & DX: API versioning, tier-aware rate limiting, SDK generation, OpenAPI annotations (143+ endpoints) |

--- a/app/Console/Commands/ProjectorHealthCheckCommand.php
+++ b/app/Console/Commands/ProjectorHealthCheckCommand.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Monitoring\Services\ProjectorHealthService;
+use Illuminate\Console\Command;
+
+class ProjectorHealthCheckCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'projector:health
+                            {--domain= : Filter projectors by domain}
+                            {--stale-only : Show only stale/failed projectors}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Check health status of all registered projectors';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(ProjectorHealthService $healthService): int
+    {
+        $status = $healthService->getAllProjectorStatus();
+        $domain = $this->option('domain');
+        $staleOnly = (bool) $this->option('stale-only');
+
+        $projectors = collect($status['projectors']);
+
+        if ($domain) {
+            $projectors = $projectors->filter(
+                fn (array $p) => strtolower($p['domain']) === strtolower($domain)
+            );
+        }
+
+        if ($staleOnly) {
+            $projectors = $projectors->filter(
+                fn (array $p) => in_array($p['status'], ['stale', 'failed'], true)
+            );
+        }
+
+        $this->info("Projector Health Check — {$status['checked_at']}");
+        $this->newLine();
+
+        $this->table(
+            ['Projector', 'Domain', 'Status', 'Lag', 'Last Processed'],
+            $projectors->map(fn (array $p) => [
+                $p['name'],
+                $p['domain'],
+                $this->formatStatus($p['status']),
+                $p['lag'],
+                $p['last_processed_at'] ?? 'Never',
+            ])->toArray()
+        );
+
+        $this->newLine();
+        $this->info("Total: {$status['total_projectors']} | Healthy: {$status['healthy']} | Stale: {$status['stale']} | Failed: {$status['failed']}");
+
+        if ($status['failed'] > 0) {
+            return Command::FAILURE;
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function formatStatus(string $status): string
+    {
+        return match ($status) {
+            'healthy' => '<fg=green>healthy</>',
+            'stale'   => '<fg=yellow>stale</>',
+            'failed'  => '<fg=red>failed</>',
+            default   => $status,
+        };
+    }
+}

--- a/app/Domain/Monitoring/Services/ProjectorHealthService.php
+++ b/app/Domain/Monitoring/Services/ProjectorHealthService.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Monitoring\Services;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Spatie\EventSourcing\Facades\Projectionist;
+
+class ProjectorHealthService
+{
+    private const CACHE_KEY = 'projector_health_status';
+
+    private const CACHE_TTL = 300; // 5 minutes
+
+    /**
+     * Get health status for all registered projectors.
+     *
+     * @return array<string, mixed>
+     */
+    public function getAllProjectorStatus(): array
+    {
+        $projectors = Projectionist::getProjectors();
+        $statuses = [];
+
+        foreach ($projectors as $projector) {
+            $statuses[] = $this->getProjectorStatus($projector);
+        }
+
+        return [
+            'total_projectors' => count($statuses),
+            'healthy'          => collect($statuses)->where('status', 'healthy')->count(),
+            'stale'            => collect($statuses)->where('status', 'stale')->count(),
+            'failed'           => collect($statuses)->where('status', 'failed')->count(),
+            'projectors'       => $statuses,
+            'checked_at'       => now()->toIso8601String(),
+        ];
+    }
+
+    /**
+     * Get health status for a single projector.
+     *
+     * @return array<string, mixed>
+     */
+    public function getProjectorStatus(object $projector): array
+    {
+        $className = $projector::class;
+        $lastProcessedAt = $this->getLastProcessedAt($className);
+        $lag = $this->calculateLag($className);
+        $status = $this->determineStatus($lastProcessedAt, $lag);
+
+        return [
+            'class'             => $className,
+            'name'              => class_basename($className),
+            'status'            => $status,
+            'last_processed_at' => $lastProcessedAt?->toIso8601String(),
+            'lag'               => $lag,
+            'domain'            => $this->extractDomain($className),
+        ];
+    }
+
+    /**
+     * Get cached health status or refresh.
+     *
+     * @return array<string, mixed>
+     */
+    public function getCachedStatus(): array
+    {
+        return Cache::remember(self::CACHE_KEY, self::CACHE_TTL, function () {
+            return $this->getAllProjectorStatus();
+        });
+    }
+
+    /**
+     * Detect stale projectors (no activity for > 1 hour with pending events).
+     *
+     * @return Collection<int, array<string, mixed>>
+     */
+    public function detectStaleProjectors(): Collection
+    {
+        $status = $this->getAllProjectorStatus();
+
+        return collect($status['projectors'])->filter(
+            fn (array $p) => $p['status'] === 'stale' || $p['status'] === 'failed'
+        )->values();
+    }
+
+    /**
+     * Get the last time a projector processed an event.
+     */
+    private function getLastProcessedAt(string $projectorClass): ?\Illuminate\Support\Carbon
+    {
+        $record = DB::table('projector_statuses')
+            ->where('projector_name', $projectorClass)
+            ->first();
+
+        if (! $record) {
+            return null;
+        }
+
+        return \Illuminate\Support\Carbon::parse($record->updated_at);
+    }
+
+    /**
+     * Calculate the number of unprocessed events for a projector.
+     */
+    private function calculateLag(string $projectorClass): int
+    {
+        $lastProcessedId = DB::table('projector_statuses')
+            ->where('projector_name', $projectorClass)
+            ->value('last_processed_event_id');
+
+        if ($lastProcessedId === null) {
+            return 0;
+        }
+
+        return (int) DB::table('stored_events')
+            ->where('id', '>', $lastProcessedId)
+            ->count();
+    }
+
+    /**
+     * Determine projector health status.
+     */
+    private function determineStatus(?\Illuminate\Support\Carbon $lastProcessedAt, int $lag): string
+    {
+        if ($lastProcessedAt === null) {
+            return 'unknown';
+        }
+
+        $minutesSinceLastActivity = $lastProcessedAt->diffInMinutes(now());
+
+        if ($lag > 1000) {
+            return 'failed';
+        }
+
+        if ($minutesSinceLastActivity > 60 && $lag > 0) {
+            return 'stale';
+        }
+
+        return 'healthy';
+    }
+
+    /**
+     * Extract domain name from projector class.
+     */
+    private function extractDomain(string $className): string
+    {
+        if (preg_match('/App\\\\Domain\\\\([^\\\\]+)\\\\/', $className, $matches)) {
+            return $matches[1];
+        }
+
+        return 'Unknown';
+    }
+}

--- a/app/GraphQL/Mutations/CrossChain/InitiateBridgeTransferMutation.php
+++ b/app/GraphQL/Mutations/CrossChain/InitiateBridgeTransferMutation.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Mutations\CrossChain;
+
+use App\Domain\CrossChain\Models\BridgeTransaction;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Support\Facades\Auth;
+
+class InitiateBridgeTransferMutation
+{
+    /**
+     * @param  array<string, mixed>  $args
+     */
+    public function __invoke(mixed $rootValue, array $args): BridgeTransaction
+    {
+        $user = Auth::user();
+
+        if (! $user) {
+            throw new AuthenticationException('Unauthenticated.');
+        }
+
+        return BridgeTransaction::create([
+            'user_id'           => $user->id,
+            'source_chain'      => $args['source_chain'],
+            'dest_chain'        => $args['dest_chain'],
+            'token'             => $args['token'],
+            'amount'            => $args['amount'],
+            'recipient_address' => $args['recipient_address'],
+            'provider'          => $args['provider'] ?? 'wormhole',
+            'status'            => 'pending',
+        ]);
+    }
+}

--- a/app/GraphQL/Mutations/DeFi/ClosePositionMutation.php
+++ b/app/GraphQL/Mutations/DeFi/ClosePositionMutation.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Mutations\DeFi;
+
+use App\Domain\DeFi\Models\DeFiPosition;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\Auth;
+
+class ClosePositionMutation
+{
+    /**
+     * @param  array<string, mixed>  $args
+     */
+    public function __invoke(mixed $rootValue, array $args): DeFiPosition
+    {
+        $user = Auth::user();
+
+        if (! $user) {
+            throw new AuthenticationException('Unauthenticated.');
+        }
+
+        /** @var DeFiPosition|null $position */
+        $position = DeFiPosition::query()->find($args['position_id']);
+
+        if (! $position) {
+            throw new ModelNotFoundException('DeFi position not found.');
+        }
+
+        $position->update([
+            'status'    => 'closed',
+            'closed_at' => now(),
+        ]);
+
+        return $position->fresh() ?? $position;
+    }
+}

--- a/app/GraphQL/Mutations/DeFi/OpenPositionMutation.php
+++ b/app/GraphQL/Mutations/DeFi/OpenPositionMutation.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Mutations\DeFi;
+
+use App\Domain\DeFi\Models\DeFiPosition;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Support\Facades\Auth;
+
+class OpenPositionMutation
+{
+    /**
+     * @param  array<string, mixed>  $args
+     */
+    public function __invoke(mixed $rootValue, array $args): DeFiPosition
+    {
+        $user = Auth::user();
+
+        if (! $user) {
+            throw new AuthenticationException('Unauthenticated.');
+        }
+
+        return DeFiPosition::create([
+            'user_id'   => $user->id,
+            'protocol'  => $args['protocol'],
+            'type'      => $args['type'],
+            'chain'     => $args['chain'],
+            'asset'     => $args['asset'],
+            'amount'    => $args['amount'],
+            'status'    => 'active',
+            'opened_at' => now(),
+        ]);
+    }
+}

--- a/app/GraphQL/Mutations/Lending/ApplyForLoanMutation.php
+++ b/app/GraphQL/Mutations/Lending/ApplyForLoanMutation.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Mutations\Lending;
+
+use App\Domain\Lending\Models\LoanApplication;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Support\Facades\Auth;
+
+class ApplyForLoanMutation
+{
+    /**
+     * @param  array<string, mixed>  $args
+     */
+    public function __invoke(mixed $rootValue, array $args): LoanApplication
+    {
+        $user = Auth::user();
+
+        if (! $user) {
+            throw new AuthenticationException('Unauthenticated.');
+        }
+
+        return LoanApplication::create([
+            'borrower_id'      => (string) $user->id,
+            'requested_amount' => $args['requested_amount'],
+            'term_months'      => $args['term_months'],
+            'purpose'          => $args['purpose'],
+            'status'           => 'submitted',
+            'submitted_at'     => now(),
+        ]);
+    }
+}

--- a/app/GraphQL/Mutations/Lending/ApproveLoanMutation.php
+++ b/app/GraphQL/Mutations/Lending/ApproveLoanMutation.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Mutations\Lending;
+
+use App\Domain\Lending\Models\LoanApplication;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\Auth;
+
+class ApproveLoanMutation
+{
+    /**
+     * @param  array<string, mixed>  $args
+     */
+    public function __invoke(mixed $rootValue, array $args): LoanApplication
+    {
+        $user = Auth::user();
+
+        if (! $user) {
+            throw new AuthenticationException('Unauthenticated.');
+        }
+
+        /** @var LoanApplication|null $application */
+        $application = LoanApplication::query()->find($args['id']);
+
+        if (! $application) {
+            throw new ModelNotFoundException('Loan application not found.');
+        }
+
+        $application->update([
+            'status'          => 'approved',
+            'approved_amount' => $args['approved_amount'],
+            'interest_rate'   => $args['interest_rate'],
+            'approved_by'     => (string) $user->id,
+            'approved_at'     => now(),
+        ]);
+
+        return $application->fresh() ?? $application;
+    }
+}

--- a/app/GraphQL/Mutations/Payment/InitiatePaymentMutation.php
+++ b/app/GraphQL/Mutations/Payment/InitiatePaymentMutation.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Mutations\Payment;
+
+use App\Domain\Payment\Models\PaymentTransaction;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+
+class InitiatePaymentMutation
+{
+    /**
+     * @param  array<string, mixed>  $args
+     */
+    public function __invoke(mixed $rootValue, array $args): PaymentTransaction
+    {
+        $user = Auth::user();
+
+        if (! $user) {
+            throw new AuthenticationException('Unauthenticated.');
+        }
+
+        return PaymentTransaction::create([
+            'aggregate_uuid' => Str::uuid()->toString(),
+            'account_uuid'   => $args['account_uuid'],
+            'type'           => $args['type'],
+            'status'         => 'pending',
+            'amount'         => $args['amount'],
+            'currency'       => $args['currency'],
+            'payment_method' => $args['payment_method'] ?? null,
+            'reference'      => $args['reference'] ?? Str::uuid()->toString(),
+            'initiated_at'   => now(),
+        ]);
+    }
+}

--- a/app/GraphQL/Mutations/Stablecoin/MintStablecoinMutation.php
+++ b/app/GraphQL/Mutations/Stablecoin/MintStablecoinMutation.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Mutations\Stablecoin;
+
+use App\Domain\Stablecoin\Models\StablecoinReserve;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+
+class MintStablecoinMutation
+{
+    /**
+     * @param  array<string, mixed>  $args
+     */
+    public function __invoke(mixed $rootValue, array $args): StablecoinReserve
+    {
+        $user = Auth::user();
+
+        if (! $user) {
+            throw new AuthenticationException('Unauthenticated.');
+        }
+
+        return StablecoinReserve::create([
+            'reserve_id'      => Str::uuid()->toString(),
+            'pool_id'         => $args['pool_id'],
+            'stablecoin_code' => $args['stablecoin_code'],
+            'asset_code'      => $args['stablecoin_code'],
+            'amount'          => $args['amount'],
+            'value_usd'       => $args['amount'],
+            'custodian_type'  => 'internal',
+            'status'          => 'active',
+        ]);
+    }
+}

--- a/app/GraphQL/Mutations/Stablecoin/RedeemStablecoinMutation.php
+++ b/app/GraphQL/Mutations/Stablecoin/RedeemStablecoinMutation.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Mutations\Stablecoin;
+
+use App\Domain\Stablecoin\Models\StablecoinReserve;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\Auth;
+use InvalidArgumentException;
+
+class RedeemStablecoinMutation
+{
+    /**
+     * @param  array<string, mixed>  $args
+     */
+    public function __invoke(mixed $rootValue, array $args): StablecoinReserve
+    {
+        $user = Auth::user();
+
+        if (! $user) {
+            throw new AuthenticationException('Unauthenticated.');
+        }
+
+        $reserve = StablecoinReserve::where('reserve_id', $args['reserve_id'])->first();
+
+        if (! $reserve) {
+            throw new ModelNotFoundException('Stablecoin reserve not found.');
+        }
+
+        $currentAmount = (float) $reserve->amount;
+        $redeemAmount = (float) $args['amount'];
+
+        if ($redeemAmount > $currentAmount) {
+            throw new InvalidArgumentException('Redeem amount exceeds available reserve.');
+        }
+
+        $newAmount = number_format($currentAmount - $redeemAmount, 18, '.', '');
+        $reserve->update([
+            'amount'    => $newAmount,
+            'value_usd' => $newAmount,
+        ]);
+
+        return $reserve->fresh() ?? $reserve;
+    }
+}

--- a/app/GraphQL/Mutations/Treasury/CreatePortfolioMutation.php
+++ b/app/GraphQL/Mutations/Treasury/CreatePortfolioMutation.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Mutations\Treasury;
+
+use App\Domain\Treasury\Models\AssetAllocation;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+
+class CreatePortfolioMutation
+{
+    /**
+     * @param  array<string, mixed>  $args
+     */
+    public function __invoke(mixed $rootValue, array $args): AssetAllocation
+    {
+        $user = Auth::user();
+
+        if (! $user) {
+            throw new AuthenticationException('Unauthenticated.');
+        }
+
+        return AssetAllocation::create([
+            'portfolio_id'   => Str::uuid()->toString(),
+            'asset_class'    => $args['asset_class'],
+            'target_weight'  => $args['target_weight'],
+            'current_weight' => 0,
+            'drift'          => 0,
+            'target_amount'  => $args['target_amount'] ?? null,
+            'current_amount' => 0,
+        ]);
+    }
+}

--- a/app/GraphQL/Mutations/Treasury/RebalancePortfolioMutation.php
+++ b/app/GraphQL/Mutations/Treasury/RebalancePortfolioMutation.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Mutations\Treasury;
+
+use App\Domain\Treasury\Models\AssetAllocation;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\Auth;
+
+class RebalancePortfolioMutation
+{
+    /**
+     * @param  array<string, mixed>  $args
+     */
+    public function __invoke(mixed $rootValue, array $args): AssetAllocation
+    {
+        $user = Auth::user();
+
+        if (! $user) {
+            throw new AuthenticationException('Unauthenticated.');
+        }
+
+        $allocation = AssetAllocation::where('portfolio_id', $args['portfolio_id'])->first();
+
+        if (! $allocation) {
+            throw new ModelNotFoundException('Portfolio allocation not found.');
+        }
+
+        $threshold = $args['threshold'] ?? 5.0;
+        $drift = (float) $allocation->drift;
+
+        if (abs($drift) > $threshold) {
+            $allocation->update([
+                'current_weight' => $allocation->target_weight,
+                'drift'          => 0,
+                'current_amount' => $allocation->target_amount,
+            ]);
+        }
+
+        return $allocation->fresh() ?? $allocation;
+    }
+}

--- a/app/GraphQL/Queries/CrossChain/BridgeTransferQuery.php
+++ b/app/GraphQL/Queries/CrossChain/BridgeTransferQuery.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Queries\CrossChain;
+
+use App\Domain\CrossChain\Models\BridgeTransaction;
+use Illuminate\Database\Eloquent\Builder;
+
+class BridgeTransferQuery
+{
+    /**
+     * @param  array<string, mixed>  $args
+     */
+    public function __invoke(mixed $rootValue, array $args): Builder
+    {
+        return BridgeTransaction::query()->orderBy('created_at', 'desc');
+    }
+}

--- a/app/GraphQL/Queries/DeFi/DeFiPositionQuery.php
+++ b/app/GraphQL/Queries/DeFi/DeFiPositionQuery.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Queries\DeFi;
+
+use App\Domain\DeFi\Models\DeFiPosition;
+use Illuminate\Database\Eloquent\Builder;
+
+class DeFiPositionQuery
+{
+    /**
+     * @param  array<string, mixed>  $args
+     */
+    public function __invoke(mixed $rootValue, array $args): Builder
+    {
+        return DeFiPosition::query()->orderBy('created_at', 'desc');
+    }
+}

--- a/app/GraphQL/Queries/Lending/LoanApplicationQuery.php
+++ b/app/GraphQL/Queries/Lending/LoanApplicationQuery.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Queries\Lending;
+
+use App\Domain\Lending\Models\LoanApplication;
+use Illuminate\Database\Eloquent\Builder;
+
+class LoanApplicationQuery
+{
+    /**
+     * @param  array<string, mixed>  $args
+     */
+    public function __invoke(mixed $rootValue, array $args): Builder
+    {
+        return LoanApplication::query()->orderBy('created_at', 'desc');
+    }
+}

--- a/app/GraphQL/Queries/Payment/PaymentQuery.php
+++ b/app/GraphQL/Queries/Payment/PaymentQuery.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Queries\Payment;
+
+use App\Domain\Payment\Models\PaymentTransaction;
+use Illuminate\Database\Eloquent\Builder;
+
+class PaymentQuery
+{
+    /**
+     * @param  array<string, mixed>  $args
+     */
+    public function __invoke(mixed $rootValue, array $args): Builder
+    {
+        return PaymentTransaction::query()->orderBy('created_at', 'desc');
+    }
+}

--- a/app/GraphQL/Queries/Stablecoin/StablecoinReserveQuery.php
+++ b/app/GraphQL/Queries/Stablecoin/StablecoinReserveQuery.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Queries\Stablecoin;
+
+use App\Domain\Stablecoin\Models\StablecoinReserve;
+use Illuminate\Database\Eloquent\Builder;
+
+class StablecoinReserveQuery
+{
+    /**
+     * @param  array<string, mixed>  $args
+     */
+    public function __invoke(mixed $rootValue, array $args): Builder
+    {
+        return StablecoinReserve::query()->orderBy('created_at', 'desc');
+    }
+}

--- a/app/GraphQL/Queries/Treasury/PortfolioQuery.php
+++ b/app/GraphQL/Queries/Treasury/PortfolioQuery.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Queries\Treasury;
+
+use App\Domain\Treasury\Models\AssetAllocation;
+use Illuminate\Database\Eloquent\Builder;
+
+class PortfolioQuery
+{
+    /**
+     * @param  array<string, mixed>  $args
+     */
+    public function __invoke(mixed $rootValue, array $args): Builder
+    {
+        return AssetAllocation::query()->orderBy('created_at', 'desc');
+    }
+}

--- a/app/Http/Controllers/Api/Documentation/OpenApiDoc.php
+++ b/app/Http/Controllers/Api/Documentation/OpenApiDoc.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers\Api\Documentation;
 /**
  * @OA\Info(
  *     title="FinAegis Core Banking API",
- *     version="4.0.0",
+ *     version="4.1.0",
  *     description="Open Source Core Banking as a Service - A modern, scalable, and secure core banking platform built with Laravel 12, featuring 41 DDD domains, event sourcing, CQRS, cross-chain bridges, DeFi protocol integration, privacy-preserving identity, RegTech compliance, Banking-as-a-Service, and AI-powered analytics.",
  *
  * @OA\Contact(

--- a/app/Http/Controllers/Api/ProjectorHealthController.php
+++ b/app/Http/Controllers/Api/ProjectorHealthController.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Domain\Monitoring\Services\ProjectorHealthService;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+
+class ProjectorHealthController extends Controller
+{
+    public function __construct(
+        private readonly ProjectorHealthService $healthService
+    ) {
+    }
+
+    /**
+     * Get projector health status.
+     *
+     * @OA\Get(
+     *     path="/api/monitoring/projector-health",
+     *     summary="Get projector health status",
+     *     tags={"Monitoring"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Projector health status",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="total_projectors", type="integer"),
+     *             @OA\Property(property="healthy", type="integer"),
+     *             @OA\Property(property="stale", type="integer"),
+     *             @OA\Property(property="failed", type="integer"),
+     *             @OA\Property(property="checked_at", type="string", format="date-time")
+     *         )
+     *     )
+     * )
+     */
+    public function index(): JsonResponse
+    {
+        $status = $this->healthService->getCachedStatus();
+
+        return response()->json($status);
+    }
+
+    /**
+     * Get stale projectors only.
+     *
+     * @OA\Get(
+     *     path="/api/monitoring/projector-health/stale",
+     *     summary="Get stale projectors",
+     *     tags={"Monitoring"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="List of stale projectors"
+     *     )
+     * )
+     */
+    public function stale(): JsonResponse
+    {
+        $staleProjectors = $this->healthService->detectStaleProjectors();
+
+        return response()->json([
+            'stale_projectors' => $staleProjectors,
+            'count'            => $staleProjectors->count(),
+        ]);
+    }
+}

--- a/docs/VERSION_ROADMAP.md
+++ b/docs/VERSION_ROADMAP.md
@@ -1113,6 +1113,7 @@ main ─────────●─────────●─────
 | **v3.4.0** | API Maturity & DX | API versioning, rate limiting per tier, SDK auto-generation, OpenAPI 100% | ✅ Released 2026-02-12 |
 | **v3.5.0** | Compliance Certification | SOC 2, PCI DSS, multi-region, GDPR tooling | ✅ Released 2026-02-12 |
 | **v4.0.0** | Architecture Evolution | Event Store v2, GraphQL API, Plugin Marketplace | ✅ Released 2026-02-13 |
+| **v4.1.0** | GraphQL Expansion | 6 new GraphQL domains (Treasury, Payment, Lending, Stablecoin, CrossChain, DeFi), event replay filters, projector health monitoring | ✅ Released 2026-02-13 |
 
 ---
 
@@ -1688,7 +1689,30 @@ After 18 releases (v1.1.0 → v3.0.0), the platform has grown to 41 domains, 266
 
 ---
 
-*Document Version: 4.0.0*
+## v4.1.0 — GraphQL Expansion + Platform Hardening ✅ COMPLETED
+
+**Released**: February 13, 2026
+**Theme**: GraphQL Coverage Expansion, Event Replay Filtering, Projector Health Monitoring
+
+### Delivered
+
+| Feature | Status | Description |
+|---------|--------|-------------|
+| GraphQL — Treasury Domain | ✅ | AssetAllocation type, portfolio queries, createPortfolio/rebalancePortfolio mutations |
+| GraphQL — Payment Domain | ✅ | PaymentTransaction type, payment queries, initiatePayment mutation |
+| GraphQL — Lending Domain | ✅ | LoanApplication type, loan queries, applyForLoan/approveLoan mutations |
+| GraphQL — Stablecoin Domain | ✅ | StablecoinReserve type, reserve queries, mintStablecoin/redeemStablecoin mutations |
+| GraphQL — CrossChain Domain | ✅ | BridgeTransaction type, bridge queries, initiateBridgeTransfer mutation |
+| GraphQL — DeFi Domain | ✅ | DeFiPosition type, position queries, openPosition/closePosition mutations |
+| Event Replay Filtering | ✅ | --event-type and --aggregate-id filter options for selective replay |
+| Projector Health Monitoring | ✅ | ProjectorHealthService, projector:health command, REST endpoint |
+| Integration Tests | ✅ | 8 test files covering all new GraphQL domains, event replay, projector health |
+
+**GraphQL Coverage**: 10/41 domains (up from 4/41 in v4.0.0)
+
+---
+
+*Document Version: 4.1.0*
 *Created: January 11, 2026*
-*Updated: February 13, 2026 (v4.0.0 Architecture Evolution released)*
-*Next Review: v4.1.0 Planning*
+*Updated: February 13, 2026 (v4.1.0 GraphQL Expansion released)*
+*Next Review: v4.2.0 Planning*

--- a/graphql/crosschain.graphql
+++ b/graphql/crosschain.graphql
@@ -1,0 +1,50 @@
+type BridgeTransaction @model(class: "App\\Domain\\CrossChain\\Models\\BridgeTransaction") {
+    id: ID!
+    user_id: Int
+    source_chain: String!
+    dest_chain: String!
+    token: String!
+    amount: Float!
+    provider: String
+    status: String!
+    sender_address: String
+    recipient_address: String
+    source_tx_hash: String
+    dest_tx_hash: String
+    fee_amount: Float
+    fee_currency: String
+    completed_at: DateTime
+    created_at: DateTime!
+    updated_at: DateTime!
+}
+
+input InitiateBridgeTransferInput {
+    source_chain: String!
+    dest_chain: String!
+    token: String!
+    amount: Float!
+    recipient_address: String!
+    provider: String
+}
+
+extend type Query {
+    bridgeTransaction(id: ID! @eq): BridgeTransaction
+        @find
+        @guard(with: ["sanctum"])
+
+    bridgeTransactions(
+        page: Int @rules(apply: ["integer", "min:1"])
+        first: Int @rules(apply: ["integer", "min:1", "max:100"])
+        status: String @where(operator: "=")
+        source_chain: String @where(operator: "=")
+        dest_chain: String @where(operator: "=")
+    ): [BridgeTransaction!]!
+        @paginate(defaultCount: 15, model: "App\\Domain\\CrossChain\\Models\\BridgeTransaction")
+        @guard(with: ["sanctum"])
+}
+
+extend type Mutation {
+    initiateBridgeTransfer(input: InitiateBridgeTransferInput! @spread): BridgeTransaction!
+        @guard(with: ["sanctum"])
+        @field(resolver: "App\\GraphQL\\Mutations\\CrossChain\\InitiateBridgeTransferMutation")
+}

--- a/graphql/defi.graphql
+++ b/graphql/defi.graphql
@@ -1,0 +1,56 @@
+type DeFiPosition @model(class: "App\\Domain\\DeFi\\Models\\DeFiPosition") {
+    id: ID!
+    user_id: Int
+    protocol: String!
+    type: String!
+    status: String!
+    chain: String!
+    asset: String!
+    amount: Float!
+    value_usd: Float
+    apy: Float
+    health_factor: Float
+    opened_at: DateTime
+    closed_at: DateTime
+    created_at: DateTime!
+    updated_at: DateTime!
+}
+
+input OpenPositionInput {
+    protocol: String!
+    type: String!
+    chain: String!
+    asset: String!
+    amount: Float!
+}
+
+input ClosePositionInput {
+    position_id: ID!
+}
+
+extend type Query {
+    defiPosition(id: ID! @eq): DeFiPosition
+        @find
+        @guard(with: ["sanctum"])
+
+    defiPositions(
+        page: Int @rules(apply: ["integer", "min:1"])
+        first: Int @rules(apply: ["integer", "min:1", "max:100"])
+        status: String @where(operator: "=")
+        protocol: String @where(operator: "=")
+        chain: String @where(operator: "=")
+        type: String @where(operator: "=")
+    ): [DeFiPosition!]!
+        @paginate(defaultCount: 15, model: "App\\Domain\\DeFi\\Models\\DeFiPosition")
+        @guard(with: ["sanctum"])
+}
+
+extend type Mutation {
+    openPosition(input: OpenPositionInput! @spread): DeFiPosition!
+        @guard(with: ["sanctum"])
+        @field(resolver: "App\\GraphQL\\Mutations\\DeFi\\OpenPositionMutation")
+
+    closePosition(input: ClosePositionInput! @spread): DeFiPosition!
+        @guard(with: ["sanctum"])
+        @field(resolver: "App\\GraphQL\\Mutations\\DeFi\\ClosePositionMutation")
+}

--- a/graphql/lending.graphql
+++ b/graphql/lending.graphql
@@ -1,0 +1,55 @@
+type LoanApplication @model(class: "App\\Domain\\Lending\\Models\\LoanApplication") {
+    id: ID!
+    borrower_id: String
+    requested_amount: Float!
+    term_months: Int
+    purpose: String
+    status: String!
+    credit_score: Int
+    risk_rating: String
+    default_probability: Float
+    approved_amount: Float
+    interest_rate: Float
+    approved_by: String
+    approved_at: DateTime
+    rejected_at: DateTime
+    submitted_at: DateTime
+    created_at: DateTime!
+    updated_at: DateTime!
+}
+
+input ApplyForLoanInput {
+    requested_amount: Float!
+    term_months: Int!
+    purpose: String!
+}
+
+input ApproveLoanInput {
+    id: ID!
+    approved_amount: Float!
+    interest_rate: Float!
+}
+
+extend type Query {
+    loanApplication(id: ID! @eq): LoanApplication
+        @find
+        @guard(with: ["sanctum"])
+
+    loanApplications(
+        page: Int @rules(apply: ["integer", "min:1"])
+        first: Int @rules(apply: ["integer", "min:1", "max:100"])
+        status: String @where(operator: "=")
+    ): [LoanApplication!]!
+        @paginate(defaultCount: 15, model: "App\\Domain\\Lending\\Models\\LoanApplication")
+        @guard(with: ["sanctum"])
+}
+
+extend type Mutation {
+    applyForLoan(input: ApplyForLoanInput! @spread): LoanApplication!
+        @guard(with: ["sanctum"])
+        @field(resolver: "App\\GraphQL\\Mutations\\Lending\\ApplyForLoanMutation")
+
+    approveLoan(input: ApproveLoanInput! @spread): LoanApplication!
+        @guard(with: ["sanctum"])
+        @field(resolver: "App\\GraphQL\\Mutations\\Lending\\ApproveLoanMutation")
+}

--- a/graphql/payment.graphql
+++ b/graphql/payment.graphql
@@ -1,0 +1,51 @@
+type PaymentTransaction @model(class: "App\\Domain\\Payment\\Models\\PaymentTransaction") {
+    id: ID!
+    aggregate_uuid: String
+    account_uuid: String
+    type: String
+    status: String!
+    amount: Float!
+    currency: String!
+    reference: String
+    external_reference: String
+    transaction_id: String
+    payment_method: String
+    payment_method_type: String
+    initiated_at: DateTime
+    completed_at: DateTime
+    failed_at: DateTime
+    failed_reason: String
+    created_at: DateTime!
+    updated_at: DateTime!
+}
+
+input InitiatePaymentInput {
+    account_uuid: String!
+    amount: Float!
+    currency: String!
+    type: String!
+    payment_method: String
+    reference: String
+}
+
+extend type Query {
+    payment(id: ID! @eq): PaymentTransaction
+        @find
+        @guard(with: ["sanctum"])
+
+    payments(
+        page: Int @rules(apply: ["integer", "min:1"])
+        first: Int @rules(apply: ["integer", "min:1", "max:100"])
+        status: String @where(operator: "=")
+        currency: String @where(operator: "=")
+        type: String @where(operator: "=")
+    ): [PaymentTransaction!]!
+        @paginate(defaultCount: 15, model: "App\\Domain\\Payment\\Models\\PaymentTransaction")
+        @guard(with: ["sanctum"])
+}
+
+extend type Mutation {
+    initiatePayment(input: InitiatePaymentInput! @spread): PaymentTransaction!
+        @guard(with: ["sanctum"])
+        @field(resolver: "App\\GraphQL\\Mutations\\Payment\\InitiatePaymentMutation")
+}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -9,5 +9,11 @@ scalar DateTime @scalar(class: "Nuwave\\Lighthouse\\Schema\\Types\\Scalars\\Date
 #import wallet.graphql
 #import exchange.graphql
 #import compliance.graphql
+#import treasury.graphql
+#import payment.graphql
+#import lending.graphql
+#import stablecoin.graphql
+#import crosschain.graphql
+#import defi.graphql
 # Subscriptions require SubscriptionServiceProvider registration and a broadcast driver.
 # Uncomment after configuring: #import subscriptions.graphql

--- a/graphql/stablecoin.graphql
+++ b/graphql/stablecoin.graphql
@@ -1,0 +1,56 @@
+type StablecoinReserve @model(class: "App\\Domain\\Stablecoin\\Models\\StablecoinReserve") {
+    id: ID!
+    reserve_id: String!
+    pool_id: String!
+    stablecoin_code: String!
+    asset_code: String!
+    amount: Float!
+    value_usd: Float!
+    allocation_percentage: Float
+    custodian_id: String
+    custodian_name: String
+    custodian_type: String!
+    wallet_address: String
+    last_verified_at: DateTime
+    verification_source: String
+    status: String!
+    created_at: DateTime!
+    updated_at: DateTime!
+}
+
+input MintStablecoinInput {
+    stablecoin_code: String!
+    amount: Float!
+    pool_id: String!
+}
+
+input RedeemStablecoinInput {
+    reserve_id: String!
+    amount: Float!
+}
+
+extend type Query {
+    stablecoinReserve(id: ID! @eq): StablecoinReserve
+        @find
+        @guard(with: ["sanctum"])
+
+    stablecoinReserves(
+        page: Int @rules(apply: ["integer", "min:1"])
+        first: Int @rules(apply: ["integer", "min:1", "max:100"])
+        stablecoin_code: String @where(operator: "=")
+        status: String @where(operator: "=")
+        pool_id: String @where(operator: "=")
+    ): [StablecoinReserve!]!
+        @paginate(defaultCount: 15, model: "App\\Domain\\Stablecoin\\Models\\StablecoinReserve")
+        @guard(with: ["sanctum"])
+}
+
+extend type Mutation {
+    mintStablecoin(input: MintStablecoinInput! @spread): StablecoinReserve!
+        @guard(with: ["sanctum"])
+        @field(resolver: "App\\GraphQL\\Mutations\\Stablecoin\\MintStablecoinMutation")
+
+    redeemStablecoin(input: RedeemStablecoinInput! @spread): StablecoinReserve!
+        @guard(with: ["sanctum"])
+        @field(resolver: "App\\GraphQL\\Mutations\\Stablecoin\\RedeemStablecoinMutation")
+}

--- a/graphql/treasury.graphql
+++ b/graphql/treasury.graphql
@@ -1,0 +1,48 @@
+type AssetAllocation @model(class: "App\\Domain\\Treasury\\Models\\AssetAllocation") {
+    id: ID!
+    portfolio_id: String
+    asset_class: String!
+    target_weight: Float!
+    current_weight: Float!
+    drift: Float!
+    target_amount: Float
+    current_amount: Float
+    created_at: DateTime!
+    updated_at: DateTime!
+}
+
+input CreatePortfolioInput {
+    asset_class: String!
+    target_weight: Float!
+    target_amount: Float
+}
+
+input RebalancePortfolioInput {
+    portfolio_id: String!
+    threshold: Float
+}
+
+extend type Query {
+    portfolio(id: ID! @eq): AssetAllocation
+        @find
+        @guard(with: ["sanctum"])
+
+    portfolios(
+        page: Int @rules(apply: ["integer", "min:1"])
+        first: Int @rules(apply: ["integer", "min:1", "max:100"])
+        asset_class: String @where(operator: "=")
+        portfolio_id: String @where(operator: "=")
+    ): [AssetAllocation!]!
+        @paginate(defaultCount: 15, model: "App\\Domain\\Treasury\\Models\\AssetAllocation")
+        @guard(with: ["sanctum"])
+}
+
+extend type Mutation {
+    createPortfolio(input: CreatePortfolioInput! @spread): AssetAllocation!
+        @guard(with: ["sanctum"])
+        @field(resolver: "App\\GraphQL\\Mutations\\Treasury\\CreatePortfolioMutation")
+
+    rebalancePortfolio(input: RebalancePortfolioInput! @spread): AssetAllocation!
+        @guard(with: ["sanctum"])
+        @field(resolver: "App\\GraphQL\\Mutations\\Treasury\\RebalancePortfolioMutation")
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -183,6 +183,9 @@ Route::prefix('monitoring')->middleware(['auth:sanctum', 'check.token.expiration
     Route::get('/alerts', [App\Http\Controllers\Api\MonitoringController::class, 'alerts']);
     Route::put('/alerts/{alertId}/acknowledge', [App\Http\Controllers\Api\MonitoringController::class, 'acknowledgeAlert']);
 
+    Route::get('/projector-health', [App\Http\Controllers\Api\ProjectorHealthController::class, 'index']);
+    Route::get('/projector-health/stale', [App\Http\Controllers\Api\ProjectorHealthController::class, 'stale']);
+
     Route::middleware('is_admin')->group(function () {
         Route::post('/workflow/start', [App\Http\Controllers\Api\MonitoringController::class, 'startWorkflow']);
         Route::post('/workflow/stop', [App\Http\Controllers\Api\MonitoringController::class, 'stopWorkflow']);

--- a/tests/Integration/GraphQL/CrossChainGraphQLTest.php
+++ b/tests/Integration/GraphQL/CrossChainGraphQLTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\CrossChain\Models\BridgeTransaction;
+use App\Models\User;
+
+uses(Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+describe('GraphQL CrossChain API', function () {
+    it('returns unauthorized without authentication', function () {
+        $response = $this->postJson('/graphql', [
+            'query' => '{ bridgeTransaction(id: "test") { id status } }',
+        ]);
+
+        $response->assertOk();
+        expect($response->json())->toHaveKey('errors');
+    });
+
+    it('queries bridge transaction by id with authentication', function () {
+        $user = User::factory()->create();
+        $tx = BridgeTransaction::create([
+            'user_id'           => $user->id,
+            'source_chain'      => 'ethereum',
+            'dest_chain'        => 'polygon',
+            'token'             => 'USDC',
+            'amount'            => '1000.000000000000000000',
+            'provider'          => 'wormhole',
+            'status'            => 'pending',
+            'recipient_address' => '0x1234567890abcdef1234567890abcdef12345678',
+        ]);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/graphql', [
+                'query' => '
+                    query ($id: ID!) {
+                        bridgeTransaction(id: $id) {
+                            id
+                            source_chain
+                            dest_chain
+                            token
+                            status
+                        }
+                    }
+                ',
+                'variables' => ['id' => $tx->id],
+            ]);
+
+        $response->assertOk();
+        $data = $response->json('data.bridgeTransaction');
+        expect($data['token'])->toBe('USDC');
+        expect($data['status'])->toBe('pending');
+    });
+
+    it('paginates bridge transactions', function () {
+        $user = User::factory()->create();
+        for ($i = 0; $i < 3; $i++) {
+            BridgeTransaction::create([
+                'user_id'           => $user->id,
+                'source_chain'      => 'ethereum',
+                'dest_chain'        => 'polygon',
+                'token'             => 'ETH',
+                'amount'            => (string) (1 + $i),
+                'provider'          => 'wormhole',
+                'status'            => 'pending',
+                'recipient_address' => '0xabcdef',
+            ]);
+        }
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/graphql', [
+                'query' => '
+                    {
+                        bridgeTransactions(first: 10, page: 1) {
+                            data {
+                                id
+                                source_chain
+                                dest_chain
+                                status
+                            }
+                            paginatorInfo {
+                                total
+                            }
+                        }
+                    }
+                ',
+            ]);
+
+        $response->assertOk();
+        $data = $response->json('data.bridgeTransactions');
+        expect($data['data'])->toBeArray();
+        expect($data['paginatorInfo']['total'])->toBeGreaterThanOrEqual(3);
+    });
+
+    it('initiates bridge transfer via mutation', function () {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/graphql', [
+                'query' => '
+                    mutation ($input: InitiateBridgeTransferInput!) {
+                        initiateBridgeTransfer(input: $input) {
+                            id
+                            source_chain
+                            dest_chain
+                            token
+                            status
+                        }
+                    }
+                ',
+                'variables' => [
+                    'input' => [
+                        'source_chain'      => 'ethereum',
+                        'dest_chain'        => 'arbitrum',
+                        'token'             => 'USDC',
+                        'amount'            => 5000.0,
+                        'recipient_address' => '0xabcdef1234567890abcdef1234567890abcdef12',
+                    ],
+                ],
+            ]);
+
+        $response->assertOk();
+        $json = $response->json();
+        expect($json)->not->toHaveKey('errors');
+        $data = $response->json('data.initiateBridgeTransfer');
+        expect($data['status'])->toBe('pending');
+        expect($data['token'])->toBe('USDC');
+    });
+});

--- a/tests/Integration/GraphQL/DeFiGraphQLTest.php
+++ b/tests/Integration/GraphQL/DeFiGraphQLTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\DeFi\Models\DeFiPosition;
+use App\Models\User;
+
+uses(Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+describe('GraphQL DeFi API', function () {
+    it('returns unauthorized without authentication', function () {
+        $response = $this->postJson('/graphql', [
+            'query' => '{ defiPosition(id: "test") { id status } }',
+        ]);
+
+        $response->assertOk();
+        expect($response->json())->toHaveKey('errors');
+    });
+
+    it('queries defi position by id with authentication', function () {
+        $user = User::factory()->create();
+        $position = DeFiPosition::create([
+            'user_id'   => $user->id,
+            'protocol'  => 'uniswap',
+            'type'      => 'liquidity',
+            'status'    => 'active',
+            'chain'     => 'ethereum',
+            'asset'     => 'ETH/USDC',
+            'amount'    => '10.000000000000000000',
+            'value_usd' => 25000.00,
+            'apy'       => 5.25,
+            'opened_at' => now(),
+        ]);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/graphql', [
+                'query' => '
+                    query ($id: ID!) {
+                        defiPosition(id: $id) {
+                            id
+                            protocol
+                            type
+                            status
+                            asset
+                        }
+                    }
+                ',
+                'variables' => ['id' => $position->id],
+            ]);
+
+        $response->assertOk();
+        $data = $response->json('data.defiPosition');
+        expect($data['protocol'])->toBe('uniswap');
+        expect($data['status'])->toBe('active');
+    });
+
+    it('paginates defi positions', function () {
+        $user = User::factory()->create();
+        for ($i = 0; $i < 3; $i++) {
+            DeFiPosition::create([
+                'user_id'   => $user->id,
+                'protocol'  => 'aave',
+                'type'      => 'lending',
+                'status'    => 'active',
+                'chain'     => 'ethereum',
+                'asset'     => 'USDC',
+                'amount'    => (string) (1000 * ($i + 1)),
+                'opened_at' => now(),
+            ]);
+        }
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/graphql', [
+                'query' => '
+                    {
+                        defiPositions(first: 10, page: 1) {
+                            data {
+                                id
+                                protocol
+                                status
+                            }
+                            paginatorInfo {
+                                total
+                            }
+                        }
+                    }
+                ',
+            ]);
+
+        $response->assertOk();
+        $data = $response->json('data.defiPositions');
+        expect($data['data'])->toBeArray();
+        expect($data['paginatorInfo']['total'])->toBeGreaterThanOrEqual(3);
+    });
+
+    it('opens a defi position via mutation', function () {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/graphql', [
+                'query' => '
+                    mutation ($input: OpenPositionInput!) {
+                        openPosition(input: $input) {
+                            id
+                            protocol
+                            type
+                            status
+                            asset
+                        }
+                    }
+                ',
+                'variables' => [
+                    'input' => [
+                        'protocol' => 'aave',
+                        'type'     => 'lending',
+                        'chain'    => 'ethereum',
+                        'asset'    => 'DAI',
+                        'amount'   => 10000.0,
+                    ],
+                ],
+            ]);
+
+        $response->assertOk();
+        $json = $response->json();
+        expect($json)->not->toHaveKey('errors');
+        $data = $response->json('data.openPosition');
+        expect($data['status'])->toBe('active');
+        expect($data['protocol'])->toBe('aave');
+    });
+});

--- a/tests/Integration/GraphQL/LendingGraphQLTest.php
+++ b/tests/Integration/GraphQL/LendingGraphQLTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Lending\Models\LoanApplication;
+use App\Models\User;
+
+uses(Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+describe('GraphQL Lending API', function () {
+    it('returns unauthorized without authentication', function () {
+        $response = $this->postJson('/graphql', [
+            'query' => '{ loanApplication(id: "test") { id status } }',
+        ]);
+
+        $response->assertOk();
+        expect($response->json())->toHaveKey('errors');
+    });
+
+    it('queries loan application by id with authentication', function () {
+        $user = User::factory()->create();
+        $application = LoanApplication::create([
+            'borrower_id'      => (string) $user->id,
+            'requested_amount' => 50000.00,
+            'term_months'      => 12,
+            'purpose'          => 'Business expansion',
+            'status'           => 'submitted',
+            'submitted_at'     => now(),
+        ]);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/graphql', [
+                'query' => '
+                    query ($id: ID!) {
+                        loanApplication(id: $id) {
+                            id
+                            status
+                            requested_amount
+                            purpose
+                        }
+                    }
+                ',
+                'variables' => ['id' => $application->id],
+            ]);
+
+        $response->assertOk();
+        $data = $response->json('data.loanApplication');
+        expect($data['status'])->toBe('submitted');
+        expect($data['purpose'])->toBe('Business expansion');
+    });
+
+    it('paginates loan applications', function () {
+        $user = User::factory()->create();
+        for ($i = 0; $i < 3; $i++) {
+            LoanApplication::create([
+                'borrower_id'      => (string) $user->id,
+                'requested_amount' => 10000 + ($i * 5000),
+                'term_months'      => 12,
+                'purpose'          => "Loan purpose {$i}",
+                'status'           => 'submitted',
+            ]);
+        }
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/graphql', [
+                'query' => '
+                    {
+                        loanApplications(first: 10, page: 1) {
+                            data {
+                                id
+                                status
+                                requested_amount
+                            }
+                            paginatorInfo {
+                                total
+                            }
+                        }
+                    }
+                ',
+            ]);
+
+        $response->assertOk();
+        $data = $response->json('data.loanApplications');
+        expect($data['data'])->toBeArray();
+        expect($data['paginatorInfo']['total'])->toBeGreaterThanOrEqual(3);
+    });
+
+    it('applies for a loan via mutation', function () {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/graphql', [
+                'query' => '
+                    mutation ($input: ApplyForLoanInput!) {
+                        applyForLoan(input: $input) {
+                            id
+                            status
+                            requested_amount
+                            purpose
+                        }
+                    }
+                ',
+                'variables' => [
+                    'input' => [
+                        'requested_amount' => 75000.0,
+                        'term_months'      => 24,
+                        'purpose'          => 'Equipment purchase',
+                    ],
+                ],
+            ]);
+
+        $response->assertOk();
+        $json = $response->json();
+        expect($json)->not->toHaveKey('errors');
+        $data = $response->json('data.applyForLoan');
+        expect($data['status'])->toBe('submitted');
+        expect($data['purpose'])->toBe('Equipment purchase');
+    });
+});

--- a/tests/Integration/GraphQL/PaymentGraphQLTest.php
+++ b/tests/Integration/GraphQL/PaymentGraphQLTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Payment\Models\PaymentTransaction;
+use App\Models\User;
+use Illuminate\Support\Str;
+
+uses(Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+describe('GraphQL Payment API', function () {
+    it('returns unauthorized without authentication', function () {
+        $response = $this->postJson('/graphql', [
+            'query' => '{ payment(id: 1) { id status } }',
+        ]);
+
+        $response->assertOk();
+        expect($response->json())->toHaveKey('errors');
+    });
+
+    it('queries payment by id with authentication', function () {
+        $user = User::factory()->create();
+        $payment = PaymentTransaction::create([
+            'aggregate_uuid' => Str::uuid()->toString(),
+            'account_uuid'   => Str::uuid()->toString(),
+            'type'           => 'deposit',
+            'status'         => 'pending',
+            'amount'         => 10000,
+            'currency'       => 'USD',
+            'reference'      => 'REF-001',
+            'initiated_at'   => now(),
+        ]);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/graphql', [
+                'query' => '
+                    query ($id: ID!) {
+                        payment(id: $id) {
+                            id
+                            status
+                            amount
+                            currency
+                        }
+                    }
+                ',
+                'variables' => ['id' => $payment->id],
+            ]);
+
+        $response->assertOk();
+        $data = $response->json('data.payment');
+        expect($data['status'])->toBe('pending');
+        expect($data['currency'])->toBe('USD');
+    });
+
+    it('paginates payments', function () {
+        $user = User::factory()->create();
+        for ($i = 0; $i < 3; $i++) {
+            PaymentTransaction::create([
+                'aggregate_uuid' => Str::uuid()->toString(),
+                'account_uuid'   => Str::uuid()->toString(),
+                'type'           => 'deposit',
+                'status'         => 'pending',
+                'amount'         => 5000 + $i,
+                'currency'       => 'USD',
+            ]);
+        }
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/graphql', [
+                'query' => '
+                    {
+                        payments(first: 10, page: 1) {
+                            data {
+                                id
+                                status
+                                amount
+                            }
+                            paginatorInfo {
+                                total
+                            }
+                        }
+                    }
+                ',
+            ]);
+
+        $response->assertOk();
+        $data = $response->json('data.payments');
+        expect($data['data'])->toBeArray();
+        expect($data['paginatorInfo']['total'])->toBeGreaterThanOrEqual(3);
+    });
+
+    it('initiates a payment via mutation', function () {
+        $user = User::factory()->create();
+        $accountUuid = Str::uuid()->toString();
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/graphql', [
+                'query' => '
+                    mutation ($input: InitiatePaymentInput!) {
+                        initiatePayment(input: $input) {
+                            id
+                            status
+                            amount
+                            currency
+                            type
+                        }
+                    }
+                ',
+                'variables' => [
+                    'input' => [
+                        'account_uuid' => $accountUuid,
+                        'amount'       => 25000.0,
+                        'currency'     => 'EUR',
+                        'type'         => 'withdrawal',
+                    ],
+                ],
+            ]);
+
+        $response->assertOk();
+        $json = $response->json();
+        expect($json)->not->toHaveKey('errors');
+        $data = $response->json('data.initiatePayment');
+        expect($data['status'])->toBe('pending');
+        expect($data['currency'])->toBe('EUR');
+    });
+});

--- a/tests/Integration/GraphQL/StablecoinGraphQLTest.php
+++ b/tests/Integration/GraphQL/StablecoinGraphQLTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Stablecoin\Models\StablecoinReserve;
+use App\Models\User;
+use Illuminate\Support\Str;
+
+uses(Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+describe('GraphQL Stablecoin API', function () {
+    it('returns unauthorized without authentication', function () {
+        $response = $this->postJson('/graphql', [
+            'query' => '{ stablecoinReserve(id: 1) { id status } }',
+        ]);
+
+        $response->assertOk();
+        expect($response->json())->toHaveKey('errors');
+    });
+
+    it('queries stablecoin reserve by id with authentication', function () {
+        $user = User::factory()->create();
+        $reserve = StablecoinReserve::create([
+            'reserve_id'      => Str::uuid()->toString(),
+            'pool_id'         => 'pool-1',
+            'stablecoin_code' => 'USDC',
+            'asset_code'      => 'USD',
+            'amount'          => '1000000.000000000000000000',
+            'value_usd'       => '1000000.00000000',
+            'custodian_type'  => 'bank',
+            'status'          => 'active',
+        ]);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/graphql', [
+                'query' => '
+                    query ($id: ID!) {
+                        stablecoinReserve(id: $id) {
+                            id
+                            stablecoin_code
+                            status
+                            amount
+                        }
+                    }
+                ',
+                'variables' => ['id' => $reserve->id],
+            ]);
+
+        $response->assertOk();
+        $data = $response->json('data.stablecoinReserve');
+        expect($data['stablecoin_code'])->toBe('USDC');
+        expect($data['status'])->toBe('active');
+    });
+
+    it('paginates stablecoin reserves', function () {
+        $user = User::factory()->create();
+        for ($i = 0; $i < 3; $i++) {
+            StablecoinReserve::create([
+                'reserve_id'      => Str::uuid()->toString(),
+                'pool_id'         => 'pool-' . $i,
+                'stablecoin_code' => 'USDC',
+                'asset_code'      => 'USD',
+                'amount'          => '100000.000000000000000000',
+                'value_usd'       => '100000.00000000',
+                'custodian_type'  => 'bank',
+                'status'          => 'active',
+            ]);
+        }
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/graphql', [
+                'query' => '
+                    {
+                        stablecoinReserves(first: 10, page: 1) {
+                            data {
+                                id
+                                stablecoin_code
+                                status
+                            }
+                            paginatorInfo {
+                                total
+                            }
+                        }
+                    }
+                ',
+            ]);
+
+        $response->assertOk();
+        $data = $response->json('data.stablecoinReserves');
+        expect($data['data'])->toBeArray();
+        expect($data['paginatorInfo']['total'])->toBeGreaterThanOrEqual(3);
+    });
+
+    it('mints stablecoin via mutation', function () {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/graphql', [
+                'query' => '
+                    mutation ($input: MintStablecoinInput!) {
+                        mintStablecoin(input: $input) {
+                            id
+                            stablecoin_code
+                            status
+                            amount
+                        }
+                    }
+                ',
+                'variables' => [
+                    'input' => [
+                        'stablecoin_code' => 'USDT',
+                        'amount'          => 500000.0,
+                        'pool_id'         => 'pool-mint-1',
+                    ],
+                ],
+            ]);
+
+        $response->assertOk();
+        $json = $response->json();
+        expect($json)->not->toHaveKey('errors');
+        $data = $response->json('data.mintStablecoin');
+        expect($data['stablecoin_code'])->toBe('USDT');
+        expect($data['status'])->toBe('active');
+    });
+});

--- a/tests/Integration/GraphQL/TreasuryGraphQLTest.php
+++ b/tests/Integration/GraphQL/TreasuryGraphQLTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Treasury\Models\AssetAllocation;
+use App\Models\User;
+
+uses(Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+describe('GraphQL Treasury API', function () {
+    it('returns unauthorized without authentication', function () {
+        $response = $this->postJson('/graphql', [
+            'query' => '{ portfolio(id: 1) { id asset_class } }',
+        ]);
+
+        $response->assertOk();
+        expect($response->json())->toHaveKey('errors');
+    });
+
+    it('queries portfolio by id with authentication', function () {
+        $user = User::factory()->create();
+        $allocation = AssetAllocation::create([
+            'portfolio_id'   => 'test-portfolio-1',
+            'asset_class'    => 'equities',
+            'target_weight'  => 60.0,
+            'current_weight' => 55.0,
+            'drift'          => -5.0,
+            'target_amount'  => 60000.00,
+            'current_amount' => 55000.00,
+        ]);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/graphql', [
+                'query' => '
+                    query ($id: ID!) {
+                        portfolio(id: $id) {
+                            id
+                            asset_class
+                            target_weight
+                            current_weight
+                            drift
+                        }
+                    }
+                ',
+                'variables' => ['id' => $allocation->id],
+            ]);
+
+        $response->assertOk();
+        $data = $response->json('data.portfolio');
+        expect($data['asset_class'])->toBe('equities');
+    });
+
+    it('paginates portfolios', function () {
+        $user = User::factory()->create();
+        for ($i = 0; $i < 3; $i++) {
+            AssetAllocation::create([
+                'portfolio_id'   => 'portfolio-' . $i,
+                'asset_class'    => 'asset_' . $i,
+                'target_weight'  => 30.0,
+                'current_weight' => 28.0,
+                'drift'          => -2.0,
+            ]);
+        }
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/graphql', [
+                'query' => '
+                    {
+                        portfolios(first: 10, page: 1) {
+                            data {
+                                id
+                                asset_class
+                                target_weight
+                            }
+                            paginatorInfo {
+                                total
+                            }
+                        }
+                    }
+                ',
+            ]);
+
+        $response->assertOk();
+        $data = $response->json('data.portfolios');
+        expect($data['data'])->toBeArray();
+        expect($data['paginatorInfo']['total'])->toBeGreaterThanOrEqual(3);
+    });
+
+    it('creates a portfolio via mutation', function () {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/graphql', [
+                'query' => '
+                    mutation ($input: CreatePortfolioInput!) {
+                        createPortfolio(input: $input) {
+                            id
+                            asset_class
+                            target_weight
+                        }
+                    }
+                ',
+                'variables' => [
+                    'input' => [
+                        'asset_class'   => 'fixed_income',
+                        'target_weight' => 40.0,
+                    ],
+                ],
+            ]);
+
+        $response->assertOk();
+        $json = $response->json();
+        expect($json)->not->toHaveKey('errors');
+        $data = $response->json('data.createPortfolio');
+        expect($data['asset_class'])->toBe('fixed_income');
+    });
+});

--- a/tests/Unit/EventSourcing/EventReplayFilterTest.php
+++ b/tests/Unit/EventSourcing/EventReplayFilterTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+describe('EventReplayCommand Filters', function () {
+    it('has event-type filter option in signature', function () {
+        $command = new App\Console\Commands\EventReplayCommand();
+        $definition = $command->getDefinition();
+
+        expect($definition->hasOption('event-type'))->toBeTrue();
+        expect($definition->getOption('event-type')->getDescription())
+            ->toContain('event classes');
+    });
+
+    it('has aggregate-id filter option in signature', function () {
+        $command = new App\Console\Commands\EventReplayCommand();
+        $definition = $command->getDefinition();
+
+        expect($definition->hasOption('aggregate-id'))->toBeTrue();
+        expect($definition->getOption('aggregate-id')->getDescription())
+            ->toContain('aggregate UUID');
+    });
+
+    it('retains existing filter options', function () {
+        $command = new App\Console\Commands\EventReplayCommand();
+        $definition = $command->getDefinition();
+
+        expect($definition->hasOption('domain'))->toBeTrue();
+        expect($definition->hasOption('projector'))->toBeTrue();
+        expect($definition->hasOption('from'))->toBeTrue();
+        expect($definition->hasOption('to'))->toBeTrue();
+        expect($definition->hasOption('dry-run'))->toBeTrue();
+    });
+});

--- a/tests/Unit/Monitoring/ProjectorHealthTest.php
+++ b/tests/Unit/Monitoring/ProjectorHealthTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Monitoring\Services\ProjectorHealthService;
+
+describe('ProjectorHealthService', function () {
+    it('can be instantiated', function () {
+        $service = new ProjectorHealthService();
+
+        expect($service)->toBeInstanceOf(ProjectorHealthService::class);
+    });
+
+    it('returns health status structure', function () {
+        $service = new ProjectorHealthService();
+        $status = $service->getAllProjectorStatus();
+
+        expect($status)->toHaveKeys([
+            'total_projectors',
+            'healthy',
+            'stale',
+            'failed',
+            'projectors',
+            'checked_at',
+        ]);
+        expect($status['projectors'])->toBeArray();
+    });
+
+    it('detects stale projectors returns collection', function () {
+        $service = new ProjectorHealthService();
+        $stale = $service->detectStaleProjectors();
+
+        expect($stale)->toBeInstanceOf(Illuminate\Support\Collection::class);
+    });
+});
+
+describe('ProjectorHealthCheckCommand', function () {
+    it('has correct command signature', function () {
+        $command = new App\Console\Commands\ProjectorHealthCheckCommand();
+        $definition = $command->getDefinition();
+
+        expect($definition->hasOption('domain'))->toBeTrue();
+        expect($definition->hasOption('stale-only'))->toBeTrue();
+    });
+});


### PR DESCRIPTION
## Summary
- **GraphQL expansion** from 4 to 10 domains: Treasury, Payment, Lending, Stablecoin, CrossChain, DeFi — each with schema types, queries (single + paginated), and mutations
- **Event replay filtering**: `--event-type` and `--aggregate-id` options for selective event replay instead of full domain replay
- **Projector health monitoring**: `ProjectorHealthService`, `projector:health` Artisan command, and REST endpoint at `/api/monitoring/projector-health`
- **8 new test files** covering all GraphQL domains, event replay filters, and projector health

### New Files (40)
| Category | Files |
|----------|-------|
| GraphQL Schemas | `graphql/{treasury,payment,lending,stablecoin,crosschain,defi}.graphql` |
| Query Resolvers | 6 query classes in `app/GraphQL/Queries/{Treasury,Payment,Lending,Stablecoin,CrossChain,DeFi}/` |
| Mutation Resolvers | 10 mutation classes in `app/GraphQL/Mutations/{Treasury,Payment,Lending,Stablecoin,CrossChain,DeFi}/` |
| Monitoring | `ProjectorHealthService`, `ProjectorHealthCheckCommand`, `ProjectorHealthController` |
| Tests | 6 GraphQL integration tests, 1 event replay filter test, 1 projector health test |

### Modified Files
- `graphql/schema.graphql` — imports for 6 new domains
- `app/Console/Commands/EventReplayCommand.php` — `--event-type` and `--aggregate-id` filters
- `routes/api.php` — projector health endpoints
- `CHANGELOG.md`, `CLAUDE.md`, `docs/VERSION_ROADMAP.md`, `OpenApiDoc.php` — version bump

## Test plan
- [ ] Run `./vendor/bin/pest --parallel` — all tests pass
- [ ] Run `XDEBUG_MODE=off vendor/bin/phpstan analyse --memory-limit=2G` — no new errors
- [ ] Verify GraphQL schema loads at `/graphql` endpoint
- [ ] Verify `php artisan projector:health` command works
- [ ] Verify new mutations work with sanctum auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)