### PR TITLE
docs: update README and ARCHITECTURAL_ROADMAP for v5.0.0

### DIFF
--- a/docs/ARCHITECTURAL_ROADMAP.md
+++ b/docs/ARCHITECTURAL_ROADMAP.md
@@ -17,7 +17,7 @@ Transform FinAegis into the **premier open source core banking platform** that:
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
-│                     FINAEGIS CORE BANKING PLATFORM (v3.0.0)              │
+│                     FINAEGIS CORE BANKING PLATFORM (v5.0.0)              │
 ├─────────────────────────────────────────────────────────────────────────┤
 │  CORE BANKING                                                            │
 │  ┌────────────┐  ┌────────────┐  ┌────────────┐  ┌────────────┐        │
@@ -74,7 +74,7 @@ Transform FinAegis into the **premier open source core banking platform** that:
 | **BaaS** | FinancialInstitution (Partner APIs, SDKs, Widgets, Billing, Marketplace) | Mature |
 | **Supporting** | User, Contact, Newsletter, Webhook, Activity, Batch, CGO, Shared | Complete |
 
-### Key Metrics (as of v3.0.0)
+### Key Metrics (as of v5.0.0)
 
 | Metric | Value |
 |--------|-------|
@@ -83,7 +83,9 @@ Transform FinAegis into the **premier open source core banking platform** that:
 | Controllers | 167 |
 | API Routes | 1,150+ |
 | PHPStan Level | **8** |
-| Test Files | 500+ |
+| Test Files | 775+ |
+| GraphQL Domains | 14 |
+| GraphQL Schema Files | 17 |
 
 ---
 
@@ -171,25 +173,30 @@ Transform FinAegis into the **premier open source core banking platform** that:
 - Multi-chain portfolio tracking
 - Cross-chain yield optimization
 
+### Completed Improvements (v4.0.0-v5.0.0)
+
+#### Event Store v2 (v4.0.0) -- COMPLETED
+- Domain-specific routing (33 domains) with configurable event tables
+- Upcasting pipeline for event schema evolution
+- Migration tooling for seamless event store upgrades
+
+#### GraphQL API (v4.0.0-v4.3.0) -- COMPLETED
+- Schema-first approach with Lighthouse PHP
+- 14 domains exposed via GraphQL (Fraud, Banking, Mobile, TrustCert, and more)
+- Real-time subscriptions for live data
+- DataLoaders for N+1 query prevention
+
+#### Plugin Marketplace (v4.0.0) -- COMPLETED
+- Plugin manager and loader architecture
+- Sandbox execution environment for plugin isolation
+- Security scanner for plugin vetting
+
+#### Event Streaming (v5.0.0) -- COMPLETED
+- Redis Streams publisher/consumer for real-time event distribution
+- Live dashboard with 5 metrics endpoints
+- Multi-channel notification system (email, push, in-app, webhook, SMS)
+
 ### Planned Improvements
-
-#### Event Store Optimization
-```php
-// Current: Single event store per domain
-exchange_events, lending_events, wallet_events...
-
-// Proposed: Unified event store with domain partitioning
-CREATE TABLE domain_events (
-    id BIGINT PRIMARY KEY,
-    domain VARCHAR(50) INDEX,
-    aggregate_uuid UUID INDEX,
-    aggregate_type VARCHAR(100),
-    event_class VARCHAR(255),
-    event_properties JSON,
-    meta_data JSON,
-    created_at TIMESTAMP INDEX
-) PARTITION BY LIST (domain);
-```
 
 #### CQRS Enhancement
 ```php
@@ -256,17 +263,20 @@ interface CachingQueryBus extends QueryBus
 
 The FinAegis platform has evolved from a core banking prototype to a comprehensive financial infrastructure platform spanning 41 domains. Key capabilities now include:
 
-1. **Cross-Chain & DeFi** - Bridge protocols, DEX aggregation, multi-chain portfolio
-2. **Privacy & Identity** - ZK-KYC, Merkle trees, Soulbound tokens, Verifiable Credentials
-3. **Mobile Payments** - Payment intents, passkeys, ERC-4337 gas abstraction
-4. **RegTech** - MiFID II, MiCA, Travel Rule, multi-jurisdiction adapters
-5. **Banking-as-a-Service** - Partner APIs, SDK generation, embeddable widgets
-6. **AI Framework** - MCP tools, NLP queries, ML anomaly detection
+1. **GraphQL API** - Schema-first Lighthouse PHP across 14 domains with subscriptions and DataLoaders
+2. **Event Streaming** - Redis Streams publisher/consumer, live dashboard, multi-channel notifications
+3. **Plugin Marketplace** - Plugin manager, sandbox execution, security scanning
+4. **Cross-Chain & DeFi** - Bridge protocols, DEX aggregation, multi-chain portfolio
+5. **Privacy & Identity** - ZK-KYC, Merkle trees, Soulbound tokens, Verifiable Credentials
+6. **Mobile Payments** - Payment intents, passkeys, ERC-4337 gas abstraction
+7. **RegTech** - MiFID II, MiCA, Travel Rule, multi-jurisdiction adapters
+8. **Banking-as-a-Service** - Partner APIs, SDK generation, embeddable widgets
+9. **AI Framework** - MCP tools, NLP queries, ML anomaly detection
 
-**v3.1.0 Focus**: Consolidation — documentation, admin UI coverage (15 new Filament resources), user-facing UI, and Swagger completeness.
+**v5.0.0 Focus**: Streaming Architecture — Redis Streams event distribution, live dashboard metrics, multi-channel notification system, and API gateway middleware.
 
 ---
 
-*Document Version: 3.1.0*
-*Last Updated: February 11, 2026*
+*Document Version: 5.0.0*
+*Last Updated: February 13, 2026*
 *Author: Architecture Review*

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,8 @@ Welcome to the FinAegis documentation. This guide will help you understand, use,
 - [BIAN API](04-API/BIAN_API_DOCUMENTATION.md) - Banking industry standard
 - [Webhook Integration](04-API/WEBHOOK_INTEGRATION.md) - Event notifications
 - [CQRS Implementation](04-API/CQRS_IMPLEMENTATION.md) - Command/Query separation
+- [GraphQL API](../graphql-playground) - GraphQL API (14 domains)
+- [Event Streaming](../config/event-streaming.php) - Event Streaming configuration
 
 ### User Guides
 - [Getting Started](05-USER-GUIDES/GETTING-STARTED.md) - First steps
@@ -94,18 +96,28 @@ Welcome to the FinAegis documentation. This guide will help you understand, use,
 
 ## Platform Status
 
-- **Version**: 2.7.0 (Mobile Payment API & Enhanced Authentication)
+- **Version**: 5.0.0 (Streaming Architecture (MAJOR))
 - **Status**: Demonstration Prototype
-- **Last Updated**: February 8, 2026
+- **Last Updated**: February 13, 2026
 
-### Current Release Features (v2.7.0)
-- **MobilePayment Domain**: Payment Intent lifecycle, receipt generation, activity feed, network status
-- **Authentication**: WebAuthn/Passkey challenge-response with ECDSA P-256 verification
-- **P2P Transfers**: Address validation (Solana/Tron), ENS/SNS name resolution, fee quotes
-- **TrustCert**: Certificate details and PDF export for mobile consumption
-- **Security**: Response shape alignment, race condition fixes, idempotency support
+### Current Release Features (v5.0.0)
+- **Event Streaming**: Redis Streams publisher/consumer for real-time event distribution
+- **Live Dashboard**: 5 metrics endpoints for real-time platform monitoring
+- **Multi-Channel Notification System**: Email, push, in-app, webhook, SMS notification channels
+- **API Gateway Middleware**: Request ID tracing, timing headers for observability
 
 ### Previous Releases
+- v4.3.0: Developer Experience (GraphQL Fraud/Banking/Mobile/TrustCert, CLI commands, security hardening)
+- v4.2.0: Real-time Platform (GraphQL subscriptions, plugin hook system, webhook/audit plugins)
+- v4.1.0: GraphQL Expansion (6 new domains, event replay filtering, projector health monitoring)
+- v4.0.0: Architecture Evolution (Event Store v2, GraphQL API foundation, Plugin Marketplace)
+- v3.5.0: Compliance Certification (SOC 2, PCI DSS, multi-region, GDPR enhanced)
+- v3.4.0: API Maturity & DX (API versioning, rate limiting, SDK generation, OpenAPI)
+- v3.3.0: Event Store Optimization & Observability
+- v3.2.0: Production Readiness & Plugin Architecture
+- v3.1.0: Consolidation & Documentation
+- v3.0.0: Cross-Chain & DeFi
+- v2.8.0-v2.9.0: AI, RegTech, BaaS, ML Fraud Detection
 - v2.6.0: Privacy Layer & ERC-4337 (Merkle Trees, Smart Accounts, Gas Station, UserOp Signing)
 - v2.5.0: Mobile App Launch (Expo/React Native, separate repository)
 - v2.4.0: Privacy & Identity (Key Management, ZK-KYC, Commerce, TrustCert)


### PR DESCRIPTION
## Summary
- Updated `docs/README.md` Platform Status to v5.0.0 (Streaming Architecture), added v2.8.0-v4.3.0 release history, added GraphQL API and Event Streaming to API Reference section
- Updated `docs/ARCHITECTURAL_ROADMAP.md` ASCII diagram to v5.0.0, updated Key Metrics (Test Files 775+, GraphQL Domains 14, GraphQL Schema Files 17), added Completed Improvements section (Event Store v2, GraphQL API, Plugin Marketplace, Event Streaming), updated Conclusion and Document Version to 5.0.0

## Test plan
- [x] Verify docs/README.md Platform Status section shows v5.0.0
- [x] Verify docs/README.md Previous Releases includes v2.8.0 through v4.3.0
- [x] Verify docs/README.md API Reference includes GraphQL and Event Streaming entries
- [x] Verify docs/ARCHITECTURAL_ROADMAP.md header shows v5.0.0
- [x] Verify Key Metrics table includes GraphQL rows
- [x] Verify Completed Improvements section lists Event Store v2, GraphQL API, Plugin Marketplace, Event Streaming
- [x] Verify Conclusion mentions GraphQL, Event Streaming, and Plugin Marketplace
- [x] Verify Document Version is 5.0.0 and date is February 13, 2026

🤖 Generated with [Claude Code](https://claude.com/claude-code)