### PR TITLE
chore: update Blade views for v5.0.0 (GraphQL API + Event Streaming)

### DIFF
--- a/resources/views/developers/api-docs.blade.php
+++ b/resources/views/developers/api-docs.blade.php
@@ -43,6 +43,8 @@
                     <a href="#mobile-payment" class="text-violet-600 hover:text-violet-800">Mobile Payment</a>
                     <a href="#partner-baas" class="text-rose-600 hover:text-rose-800">Partner BaaS</a>
                     <a href="#ai" class="text-gray-600 hover:text-gray-900">AI</a>
+                    <a href="#graphql" class="text-sky-600 hover:text-sky-800">GraphQL</a>
+                    <a href="#event-streaming" class="text-lime-600 hover:text-lime-800">Event Streaming</a>
                     <a href="#webhooks" class="text-gray-600 hover:text-gray-900">Webhooks</a>
                     <a href="#errors" class="text-gray-600 hover:text-gray-900">Errors</a>
                 </nav>
@@ -1241,6 +1243,173 @@ curl -H "Authorization: Bearer your_api_key" \
                             </div>
                         </div>
                     </section>
+
+                    <!-- GraphQL API -->
+                    <section id="graphql" class="mb-16">
+                        <h2 class="text-3xl font-bold text-gray-900 mb-8">GraphQL API</h2>
+
+                        <div class="prose prose-lg max-w-none mb-8">
+                            <p>Schema-first GraphQL API powered by Lighthouse PHP. Provides queries, mutations, and subscriptions across 14 domain schemas with DataLoader-optimized resolvers and WebSocket-based real-time subscriptions.</p>
+                            <p class="text-sm text-gray-500">14 domain schemas &middot; Queries, Mutations, Subscriptions</p>
+                        </div>
+
+                        <div class="space-y-8">
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">Execute GraphQL Query / Mutation</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
+                                        <span class="ml-2 font-mono text-sm">/graphql</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Execute a GraphQL query or mutation against the unified schema. Supports all 14 domain schemas including Account, Exchange, Wallet, Compliance, CrossChain, DeFi, and more.</p>
+                                <x-code-block language="bash">
+curl -X POST \
+  -H "Authorization: Bearer your_api_key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "{ accounts(first: 10) { data { id name currency balance { available total } } } }"
+  }' \
+  https://api.finaegis.org/graphql
+                                </x-code-block>
+
+                                <h4 class="font-semibold mb-2 mt-6">Example Query:</h4>
+                                <x-code-block language="graphql">
+query {
+  accounts(first: 10) {
+    data {
+      id
+      name
+      currency
+      balance {
+        available
+        total
+      }
+    }
+    paginatorInfo {
+      total
+      currentPage
+      lastPage
+    }
+  }
+}
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">GraphQL Playground</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
+                                        <span class="ml-2 font-mono text-sm">/graphql-playground</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Interactive GraphQL explorer with schema introspection, auto-complete, and query history. Use this to explore available types, queries, mutations, and subscriptions.</p>
+                                <x-code-block language="bash">
+# Open in your browser
+https://api.finaegis.org/graphql-playground
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6 bg-sky-50 border-sky-200">
+                                <h3 class="text-xl font-semibold mb-4">Available Subscriptions</h3>
+                                <p class="text-gray-600 mb-4">Real-time WebSocket subscriptions are available for the following events:</p>
+                                <ul class="list-disc list-inside text-gray-600 space-y-1">
+                                    <li><code class="bg-gray-100 px-1">accountUpdated(id: ID!)</code> - Account balance and status changes</li>
+                                    <li><code class="bg-gray-100 px-1">transactionCreated(accountId: ID!)</code> - New transactions on an account</li>
+                                    <li><code class="bg-gray-100 px-1">transferCompleted(id: ID!)</code> - Transfer completion notifications</li>
+                                    <li><code class="bg-gray-100 px-1">orderMatched(pair: String!)</code> - Exchange order match events</li>
+                                </ul>
+                            </div>
+                        </div>
+                    </section>
+
+                    <!-- Event Streaming & Live Dashboard -->
+                    <section id="event-streaming" class="mb-16">
+                        <h2 class="text-3xl font-bold text-gray-900 mb-8">Event Streaming & Live Dashboard</h2>
+
+                        <div class="prose prose-lg max-w-none mb-8">
+                            <p>Real-time event streaming via Redis Streams with a live metrics dashboard. Monitor system health, domain status, event throughput, stream connectivity, and projector lag across all event-sourced domains.</p>
+                            <p class="text-sm text-gray-500">5 endpoints &middot; Redis Streams &middot; Real-time Metrics</p>
+                        </div>
+
+                        <div class="space-y-8">
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">System Metrics</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
+                                        <span class="ml-2 font-mono text-sm">/v1/live-dashboard/metrics</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Retrieve aggregated system metrics including event counts, processing rates, error rates, and uptime statistics.</p>
+                                <x-code-block language="bash">
+curl -H "Authorization: Bearer your_api_key" \
+     https://api.finaegis.org/v1/live-dashboard/metrics
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">Domain Health</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
+                                        <span class="ml-2 font-mono text-sm">/v1/live-dashboard/domain-health</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Get health status for each event-sourced domain including event store connectivity, projector status, and recent error counts.</p>
+                                <x-code-block language="bash">
+curl -H "Authorization: Bearer your_api_key" \
+     https://api.finaegis.org/v1/live-dashboard/domain-health
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">Event Throughput</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
+                                        <span class="ml-2 font-mono text-sm">/v1/live-dashboard/event-throughput</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Monitor real-time event throughput rates per domain and aggregate, including events per second and processing latency.</p>
+                                <x-code-block language="bash">
+curl -H "Authorization: Bearer your_api_key" \
+     https://api.finaegis.org/v1/live-dashboard/event-throughput
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">Stream Status</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
+                                        <span class="ml-2 font-mono text-sm">/v1/live-dashboard/stream-status</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Check Redis Streams connectivity, consumer group status, pending message counts, and stream memory usage.</p>
+                                <x-code-block language="bash">
+curl -H "Authorization: Bearer your_api_key" \
+     https://api.finaegis.org/v1/live-dashboard/stream-status
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">Projector Lag</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
+                                        <span class="ml-2 font-mono text-sm">/v1/live-dashboard/projector-lag</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Monitor projector lag across all event-sourced domains showing how far behind each read model projector is from the latest events.</p>
+                                <x-code-block language="bash">
+curl -H "Authorization: Bearer your_api_key" \
+     https://api.finaegis.org/v1/live-dashboard/projector-lag
+                                </x-code-block>
+                            </div>
+                        </div>
+                    </section>
                 </div>
 
                 <!-- Sidebar -->
@@ -1257,7 +1426,7 @@ curl -H "Authorization: Bearer your_api_key" \
                         </div>
 
                         <div class="bg-white border rounded-lg p-6 mb-8">
-                            <h3 class="text-lg font-semibold mb-4">v2.0 - v3.0 API Areas</h3>
+                            <h3 class="text-lg font-semibold mb-4">Platform API Areas</h3>
                             <ul class="space-y-2 text-sm">
                                 <li><a href="#crosschain" class="text-cyan-600 hover:text-cyan-800 flex justify-between"><span>CrossChain</span><span class="text-gray-400">7 routes</span></a></li>
                                 <li><a href="#defi" class="text-emerald-600 hover:text-emerald-800 flex justify-between"><span>DeFi</span><span class="text-gray-400">8 routes</span></a></li>
@@ -1265,6 +1434,8 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <li><a href="#mobile-payment" class="text-violet-600 hover:text-violet-800 flex justify-between"><span>Mobile Payment</span><span class="text-gray-400">25+ routes</span></a></li>
                                 <li><a href="#partner-baas" class="text-rose-600 hover:text-rose-800 flex justify-between"><span>Partner BaaS</span><span class="text-gray-400">24 routes</span></a></li>
                                 <li><a href="#ai" class="text-gray-600 hover:text-gray-800 flex justify-between"><span>AI Query</span><span class="text-gray-400">2 routes</span></a></li>
+                                <li><a href="#graphql" class="text-sky-600 hover:text-sky-800 flex justify-between"><span>GraphQL</span><span class="text-gray-400">14 domains</span></a></li>
+                                <li><a href="#event-streaming" class="text-lime-600 hover:text-lime-800 flex justify-between"><span>Event Streaming</span><span class="text-gray-400">5 endpoints</span></a></li>
                             </ul>
                         </div>
 

--- a/resources/views/developers/index.blade.php
+++ b/resources/views/developers/index.blade.php
@@ -140,7 +140,7 @@
                 <div class="text-center">
                     <div class="inline-flex items-center px-4 py-2 bg-white/10 backdrop-blur-sm rounded-full text-sm mb-6">
                         <span class="w-2 h-2 bg-green-400 rounded-full mr-2 animate-pulse"></span>
-                        <span>v3.0 Documentation -- 41 Domains, 1,150+ Routes</span>
+                        <span>v5.0 Documentation -- 41 Domains, 1,189+ Routes, GraphQL + REST</span>
                     </div>
                     <h1 class="text-5xl md:text-7xl font-bold mb-6 bg-clip-text text-transparent bg-gradient-to-r from-white to-blue-200">
                         Built for Developers
@@ -180,8 +180,8 @@
                     <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                     </svg>
-                    <span class="font-medium">v3.0 Released:</span>
-                    <span class="ml-2">41 DDD domains, 1,150+ API routes including CrossChain, DeFi, RegTech, and Partner BaaS endpoints.</span>
+                    <span class="font-medium">v5.0 Released:</span>
+                    <span class="ml-2">41 DDD domains, 1,189+ API routes with GraphQL API (14 domains), Event Streaming, Plugin Marketplace, CrossChain, DeFi, RegTech, and Partner BaaS.</span>
                 </div>
             </div>
         </section>
@@ -551,6 +551,45 @@
                                 </div>
                                 <p class="text-gray-600 text-sm mb-3">Natural language transaction queries and AI-powered financial insights via the intelligent query interface.</p>
                                 <span class="text-gray-600 text-sm font-medium group-hover:text-gray-800">View endpoints &rarr;</span>
+                            </div>
+                        </a>
+
+                        <!-- GraphQL API -->
+                        <a href="{{ route('developers.show', 'api-docs') }}#graphql" class="group block">
+                            <div class="bg-white rounded-xl border border-gray-200 p-6 hover:shadow-lg transition-all hover:-translate-y-1 h-full">
+                                <div class="flex items-center mb-3">
+                                    <div class="w-10 h-10 bg-gradient-to-br from-sky-500 to-blue-600 rounded-lg flex items-center justify-center text-white mr-3">
+                                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v3m0 12v3m9-9h-3M6 12H3m15.364-6.364l-2.121 2.121M8.757 15.243l-2.121 2.121m12.728 0l-2.121-2.121M8.757 8.757L6.636 6.636"></path>
+                                        </svg>
+                                    </div>
+                                    <div>
+                                        <h4 class="text-lg font-semibold text-gray-900">GraphQL API</h4>
+                                        <span class="text-xs text-gray-500">14 domains</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 text-sm mb-3">Schema-first GraphQL via Lighthouse PHP with queries, mutations, subscriptions, and DataLoaders across 14 domain schemas.</p>
+                                <span class="text-sky-600 text-sm font-medium group-hover:text-sky-700">View endpoints &rarr;</span>
+                            </div>
+                        </a>
+
+                        <!-- Event Streaming -->
+                        <a href="{{ route('developers.show', 'api-docs') }}#event-streaming" class="group block">
+                            <div class="bg-white rounded-xl border border-gray-200 p-6 hover:shadow-lg transition-all hover:-translate-y-1 h-full">
+                                <div class="flex items-center mb-3">
+                                    <div class="w-10 h-10 bg-gradient-to-br from-lime-500 to-green-600 rounded-lg flex items-center justify-center text-white mr-3">
+                                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.348 14.651a3.75 3.75 0 010-5.303m5.304 0a3.75 3.75 0 010 5.303m-7.425 2.122a6.75 6.75 0 010-9.546m9.546 0a6.75 6.75 0 010 9.546M5.106 18.894c-3.808-3.808-3.808-9.98 0-13.789m13.788 0c3.808 3.808 3.808 9.981 0 13.79M12 12h.008v.007H12V12zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z"></path>
+                                        </svg>
+                                    </div>
+                                    <div>
+                                        <h4 class="text-lg font-semibold text-gray-900">Event Streaming</h4>
+                                        <span class="text-xs text-gray-500">5 endpoints</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 text-sm mb-3">Redis Streams-based event publishing, consumer groups, live metrics dashboard with projector lag and throughput monitoring.</p>
+                                <span class="text-lime-600 text-sm font-medium group-hover:text-lime-700">View endpoints &rarr;</span>
                             </div>
                         </a>
 


### PR DESCRIPTION
## Summary
- Update `developers/index.blade.php` hero badge and status alert from v3.0 to v5.0 with 1,189+ routes and GraphQL + REST
- Add **GraphQL API** (14 domains, sky/blue theme) and **Event Streaming** (5 endpoints, lime/green theme) cards to the developer API overview grid
- Update `developers/api-docs.blade.php` with new navigation links, sidebar entries (renamed heading to "Platform API Areas"), and full documentation sections for GraphQL API and Event Streaming Live Dashboard
- No changes needed in `welcome.blade.php` (no version references found)

## Test plan
- [ ] Visit `/developers` and verify the hero badge shows "v5.0 Documentation -- 41 Domains, 1,189+ Routes, GraphQL + REST"
- [ ] Verify the status alert shows "v5.0 Released:" with updated description
- [ ] Verify GraphQL API and Event Streaming cards appear in the API overview grid with correct colors and links
- [ ] Visit `/developers/api-docs` and verify GraphQL and Event Streaming nav links appear in the top navigation
- [ ] Verify sidebar heading reads "Platform API Areas" with GraphQL and Event Streaming entries
- [ ] Verify the GraphQL API section includes POST /graphql, GET /graphql-playground, and subscriptions info
- [ ] Verify the Event Streaming section includes all 5 live-dashboard endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)