### PR TITLE
fix: add prototype disclaimers to partner/bank pages

### DIFF
--- a/resources/views/features/bank-integration.blade.php
+++ b/resources/views/features/bank-integration.blade.php
@@ -47,6 +47,29 @@
         </div>
     </section>
 
+    <!-- Prototype Disclaimer -->
+    <section class="py-8 bg-amber-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="bg-white rounded-lg shadow p-6 border-l-4 border-amber-400">
+                <div class="flex items-start">
+                    <div class="flex-shrink-0">
+                        <svg class="w-6 h-6 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
+                        </svg>
+                    </div>
+                    <div class="ml-3">
+                        <h3 class="text-lg font-semibold text-gray-900">Prototype Implementation Notice</h3>
+                        <p class="mt-2 text-gray-600">
+                            The bank integrations on this page are <strong>reference implementations</strong> demonstrating how production
+                            banking connectors would function. These are not live bank connections. Actual integrations with financial
+                            institutions require separate commercial agreements and regulatory approvals.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
     <!-- Partner Banks -->
     <section class="py-20 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/resources/views/partners.blade.php
+++ b/resources/views/partners.blade.php
@@ -14,6 +14,30 @@
             </div>
         </div>
 
+        <!-- Prototype Disclaimer -->
+        <div class="py-8 bg-amber-50">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                <div class="bg-white rounded-lg shadow p-6 border-l-4 border-amber-400">
+                    <div class="flex items-start">
+                        <div class="flex-shrink-0">
+                            <svg class="w-6 h-6 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
+                            </svg>
+                        </div>
+                        <div class="ml-3">
+                            <h3 class="text-lg font-semibold text-gray-900">Prototype Implementation Notice</h3>
+                            <p class="mt-2 text-gray-600">
+                                The banking integrations shown on this page demonstrate the platform's <strong>multi-bank architecture capabilities</strong>.
+                                The bank connectors (Paysera, Deutsche Bank, Santander, Revolut, N26) are reference implementations showing how
+                                production banking integrations would work. Actual bank partnerships require separate commercial agreements.
+                                Deposit protection figures illustrate the theoretical benefit of multi-bank distribution.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <!-- Partner Banks Section -->
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
             <div class="text-center mb-16">


### PR DESCRIPTION
## Summary
- Added amber warning disclaimer banners to `partners.blade.php` and `features/bank-integration.blade.php`
- Both pages previously presented bank connectors (Paysera, Deutsche Bank, Santander, Revolut, N26) as operational partnerships, which is misleading for a prototype
- Disclaimer styling matches the existing "Project Under Active Development" pattern from `security.blade.php` (amber/yellow border-left card with warning icon)

## Details
- **partners.blade.php**: Disclaimer placed between the hero header and the "Trusted Banking Partners" grid. Clarifies that connectors are reference implementations and deposit protection figures are theoretical.
- **features/bank-integration.blade.php**: Disclaimer placed between the hero section and the partner banks grid. Clarifies these are not live bank connections and require commercial agreements.

## Notes
- Layout inconsistency observed: `partners.blade.php` uses `<x-guest-layout>` while `bank-integration.blade.php` uses `@extends('layouts.public')`. Not addressed here as it would be a larger refactor.
- No existing content was removed or modified — only disclaimer banners were inserted.

## Test plan
- [ ] Verify `partners.blade.php` renders the amber disclaimer banner below the hero section
- [ ] Verify `features/bank-integration.blade.php` renders the amber disclaimer banner below the hero section
- [ ] Confirm disclaimer styling matches the pattern on the security page
- [ ] Confirm no existing page content was altered

🤖 Generated with [Claude Code](https://claude.com/claude-code)