### PR TITLE
fix: upgrade CI pipeline to PHP 8.4

### DIFF
--- a/.github/workflows/01-code-quality.yml
+++ b/.github/workflows/01-code-quality.yml
@@ -6,7 +6,7 @@ on:
       php-version:
         description: 'PHP version to use'
         required: false
-        default: '8.3'
+        default: '8.4'
         type: string
     secrets:
       CODECOV_TOKEN:

--- a/.github/workflows/02-security-scan.yml
+++ b/.github/workflows/02-security-scan.yml
@@ -6,7 +6,7 @@ on:
       php-version:
         description: 'PHP version to use'
         required: false
-        default: '8.3'
+        default: '8.4'
         type: string
     secrets:
       GITLEAKS_LICENSE:

--- a/.github/workflows/03-test-suite.yml
+++ b/.github/workflows/03-test-suite.yml
@@ -6,7 +6,7 @@ on:
       php-version:
         description: 'PHP version to use'
         required: false
-        default: '8.3'
+        default: '8.4'
         type: string
       node-version:
         description: 'Node.js version to use'

--- a/.github/workflows/04-security-tests.yml
+++ b/.github/workflows/04-security-tests.yml
@@ -6,7 +6,7 @@ on:
       php-version:
         description: 'PHP version to use'
         required: false
-        default: '8.3'
+        default: '8.4'
         type: string
 
 env:

--- a/.github/workflows/05-performance.yml
+++ b/.github/workflows/05-performance.yml
@@ -6,7 +6,7 @@ on:
       php-version:
         description: 'PHP version to use'
         required: false
-        default: '8.3'
+        default: '8.4'
         type: string
 
 env:

--- a/.github/workflows/behat-tests.yml
+++ b/.github/workflows/behat-tests.yml
@@ -14,11 +14,11 @@ on:
       php-version:
         description: 'PHP version to use'
         required: false
-        default: '8.3'
+        default: '8.4'
         type: string
 
 env:
-  PHP_VERSION: ${{ inputs.php-version || '8.3' }}
+  PHP_VERSION: ${{ inputs.php-version || '8.4' }}
 
 jobs:
   behat:

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -14,7 +14,7 @@ on:
         default: false
 
 env:
-  PHP_VERSION: '8.3'
+  PHP_VERSION: '8.4'
   NODE_VERSION: '20'
 
 permissions:
@@ -32,14 +32,14 @@ jobs:
     name: Code Quality
     uses: ./.github/workflows/01-code-quality.yml
     with:
-      php-version: '8.3'
+      php-version: '8.4'
     secrets: inherit
 
   security-scan:
     name: Security Scan
     uses: ./.github/workflows/02-security-scan.yml
     with:
-      php-version: '8.3'
+      php-version: '8.4'
     secrets: inherit
 
   build-assets:
@@ -54,7 +54,7 @@ jobs:
     name: Test Suite
     uses: ./.github/workflows/03-test-suite.yml
     with:
-      php-version: '8.3'
+      php-version: '8.4'
       node-version: '20'
     secrets: inherit
 
@@ -64,7 +64,7 @@ jobs:
     needs: [security-scan]
     uses: ./.github/workflows/04-security-tests.yml
     with:
-      php-version: '8.3'
+      php-version: '8.4'
     secrets: inherit
 
   # Phase 4: Performance Tests (Run in parallel - no blocking dependencies)
@@ -72,7 +72,7 @@ jobs:
     name: Performance Tests
     uses: ./.github/workflows/05-performance.yml
     with:
-      php-version: '8.3'
+      php-version: '8.4'
     secrets: inherit
 
   # Final Phase: Status Check (No commenting)

--- a/.github/workflows/database-operations.yml
+++ b/.github/workflows/database-operations.yml
@@ -38,7 +38,7 @@ on:
         type: string
 
 env:
-  PHP_VERSION: '8.3'
+  PHP_VERSION: '8.4'
 
 permissions:
   contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ on:
         default: false
 
 env:
-  PHP_VERSION: '8.3'
+  PHP_VERSION: '8.4'
   NODE_VERSION: '20'
 
 permissions:

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -17,7 +17,7 @@ on:
       - '.github/workflows/slow-tests.yml'
 
 env:
-  PHP_VERSION: '8.3'
+  PHP_VERSION: '8.4'
   NODE_VERSION: '20'
   COMPOSER_PROCESS_TIMEOUT: 0
   COMPOSER_NO_INTERACTION: 1

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^8.3",
+        "php": "^8.4",
         "ext-gmp": "*",
         "ext-intl": "*",
         "ext-mbstring": "*",


### PR DESCRIPTION
## Summary
- Update all 10 GitHub Actions workflow files from PHP 8.3 to PHP 8.4
- Update composer.json `require.php` from `^8.3` to `^8.4`
- Aligns CI with documented platform requirements (README, docs say PHP 8.4+)

## Test plan
- [x] No PHP 8.3-specific code in the codebase
- [x] All workflow files updated consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)