### PR TITLE
chore: v5.0.1 release — platform hardening + documentation refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to the FinAegis Core Banking Platform will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.0.1] - 2026-02-13
+
+### Added
+
+#### GraphQL Schema Expansion — 10 New Domains (24 total)
+- Privacy, RegTech, Governance, Asset, KeyManagement, Relayer, Banking, Commerce, Custodian, AI domain schemas
+- 16 new query resolvers and 31 new mutation resolvers
+- All 21 GraphQL mutations refactored to use CQRS WorkflowStub/Service patterns instead of direct Eloquent
+
+#### Plugin Marketplace Admin UI
+- Filament admin page with search/filter, enable/disable/scan actions, stats bar, security scan results
+
+#### OpenAPI Annotations — 100% Controller Coverage
+- `@OA` docblocks added to 52 remaining controllers (143+ total annotated endpoints)
+
+### Changed
+
+#### CI/CD — PHP 8.4 Upgrade
+- All 10 GitHub Actions workflow files updated from PHP 8.3 to PHP 8.4
+- `composer.json` minimum PHP requirement bumped to `^8.4`
+
+#### Test Suite Quality
+- 97 structural test files converted from `class_exists()`/`method_exists()` stubs to ReflectionClass-based behavioral assertions
+
+#### Documentation Refresh
+- `docs/01-VISION/ROADMAP.md` rewritten for v5.0.0 (41 domains, current capabilities)
+- `docs/06-DEVELOPMENT/DOMAIN_MANAGEMENT.md` updated from 29 to 41 domains with categorized registry
+- `docs/02-ARCHITECTURE/ARCHITECTURE.md` updated to v5.0 (24 GraphQL domains, streaming, plugins)
+- `docs/ARCHITECTURAL_ROADMAP.md` GraphQL metrics updated to 24 domains
+- `docs/VERSION_ROADMAP.md` v5.0.0 GraphQL expansion documented
+- `docs/README.md` GraphQL count corrected to 24 domains
+- `docs/IMPLEMENTATION_PLAN.md` marked as historical (v1.x era)
+- `docs/BACKEND_UPGRADE_PLAN_v2.4.md` marked as COMPLETED
+- `docs/MOBILE_APP_SPECIFICATION.md` version context added
+- `docs/06-DEVELOPMENT/CLAUDE.md` updated to v5.0.0 with new domain entries
+- GraphQL domain count corrected from 14 to 24 across 12 files (23 occurrences)
+
+#### Website Updates
+- Stablecoins & Treasury sub-products changed from "COMING SOON" to "Available"
+- SDK version references updated from v3.0.0 to v5.0.0 across all packages
+- Feature pages updated to reflect v5.0.0 implementation reality
+- Prototype disclaimers added to partner and bank integration pages
+- Blade views updated with accurate stats and status badges
+
+### Fixed
+- Serena memory files updated with correct GraphQL domain counts and lists
+
+---
+
 ## [5.0.0] - 2026-02-13
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ git status && git branch --show-current
 ### Version Status
 | Version | Status | Key Changes |
 |---------|--------|-------------|
+| v5.0.1 | ✅ Released | Platform Hardening: GraphQL CQRS alignment (21 mutations), OpenAPI 100% coverage (52 controllers), Plugin Marketplace UI, PHP 8.4 CI, 97 test conversions, documentation refresh |
 | v5.0.0 | ✅ Released | Streaming Architecture (MAJOR): Event streaming (Redis Streams publisher/consumer), live dashboard (5 metrics endpoints), notification system (5 channels), API gateway middleware |
 | v4.3.0 | ✅ Released | Developer Experience: 4 new GraphQL domains (Fraud, Mobile, MobilePayment, TrustCert), dashboard widget plugin, CLI commands (schema-check, plugin-verify, domain-status), GraphQL rate limiting + query cost analysis |
 | v4.2.0 | ✅ Released | Real-time Platform: GraphQL subscriptions (4 new), plugin hook system (17 hooks), webhook-notifier + audit-exporter plugins, core domain mutations (8 new) |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FinAegis Core Banking Platform
 
 [![CI Pipeline](https://github.com/finaegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml/badge.svg)](https://github.com/finaegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml)
-[![Version](https://img.shields.io/badge/version-5.0.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.0.1-blue.svg)](CHANGELOG.md)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![PHP Version](https://img.shields.io/badge/php-%3E%3D8.4-8892BF.svg)](https://php.net/)
 [![Laravel Version](https://img.shields.io/badge/Laravel-12.x-FF2D20.svg)](https://laravel.com/)

--- a/docs/VERSION_ROADMAP.md
+++ b/docs/VERSION_ROADMAP.md
@@ -1776,6 +1776,25 @@ After 18 releases (v1.1.0 → v3.0.0), the platform has grown to 41 domains, 266
 
 ---
 
-*Document Version: 5.0.0*
+## v5.0.1 — Platform Hardening + Documentation Refresh ✅ COMPLETED
+
+**Released**: February 13, 2026
+**Theme**: GraphQL CQRS Alignment, OpenAPI Coverage, DX Improvements, Documentation Accuracy
+
+### Delivered
+
+| Feature | Status | Description |
+|---------|--------|-------------|
+| GraphQL CQRS Alignment | ✅ | All 21 GraphQL mutations refactored from direct Eloquent to WorkflowStub/Service patterns |
+| OpenAPI 100% Coverage | ✅ | `@OA` annotations added to 52 remaining controllers (143+ total endpoints) |
+| Plugin Marketplace UI | ✅ | Filament admin page with search, filter, enable/disable, security scan |
+| PHP 8.4 CI Upgrade | ✅ | 10 workflow files + composer.json updated from PHP 8.3 to 8.4 |
+| Structural Test Conversion | ✅ | 97 test files converted from class_exists stubs to ReflectionClass assertions |
+| Documentation Refresh | ✅ | 12+ docs files updated, GraphQL count 14→24 across 23 occurrences |
+| Website Updates | ✅ | Sub-products, SDKs, feature pages, prototype disclaimers |
+
+---
+
+*Document Version: 5.0.1*
 *Created: January 11, 2026*
-*Updated: February 13, 2026 (v5.0.0 Streaming Architecture released)*
+*Updated: February 13, 2026 (v5.0.1 Platform Hardening released)*


### PR DESCRIPTION
## Summary
- v5.0.1 patch release covering PRs #533-#544
- CHANGELOG updated with all v5.0.1 changes
- README version badge bumped to v5.0.1
- VERSION_ROADMAP.md updated with v5.0.1 entry
- CLAUDE.md version table updated

## Changes in v5.0.1
- **GraphQL CQRS Alignment**: All 21 mutations refactored to WorkflowStub/Service patterns
- **GraphQL Schema Expansion**: 10 new domain schemas (24 total)
- **OpenAPI 100% Coverage**: 52 controllers annotated (143+ total endpoints)
- **Plugin Marketplace UI**: Filament admin page with search, filter, scan
- **PHP 8.4 CI Upgrade**: 10 workflow files + composer.json
- **97 Test Conversions**: Structural stubs → ReflectionClass assertions
- **Documentation Refresh**: 12+ docs files, GraphQL count 14→24 (23 occurrences)
- **Website Updates**: Sub-products, SDKs, feature pages, prototype disclaimers

## Test plan
- [ ] Verify CHANGELOG entry is accurate
- [ ] Verify version badge renders correctly
- [ ] Verify VERSION_ROADMAP entry is complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)