### PR TITLE
fix: resolve axios CVE-2025 — upgrade to 1.13.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@tailwindcss/forms": "^0.5.7",
                 "@tailwindcss/typography": "^0.5.19",
                 "autoprefixer": "^10.4.16",
-                "axios": "^1.11.0",
+                "axios": "^1.13.5",
                 "laravel-vite-plugin": "^1.0",
                 "postcss": "^8.5.6",
                 "tailwindcss": "^3.4.0",
@@ -1044,17 +1044,6 @@
                 "axios": "1.12.2"
             }
         },
-        "node_modules/@ledgerhq/cryptoassets-evm-signatures/node_modules/axios": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-            "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
-                "proxy-from-env": "^1.1.0"
-            }
-        },
         "node_modules/@ledgerhq/devices": {
             "version": "8.7.0",
             "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-8.7.0.tgz",
@@ -1121,17 +1110,6 @@
                 "axios": "1.12.2",
                 "bignumber.js": "^9.1.2",
                 "semver": "^7.3.5"
-            }
-        },
-        "node_modules/@ledgerhq/hw-app-eth/node_modules/axios": {
-            "version": "1.12.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-            "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
-                "proxy-from-env": "^1.1.0"
             }
         },
         "node_modules/@ledgerhq/hw-transport": {
@@ -3216,13 +3194,13 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-            "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+            "version": "1.13.5",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+            "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
             "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.4",
+                "follow-redirects": "^1.15.11",
+                "form-data": "^4.0.5",
                 "proxy-from-env": "^1.1.0"
             }
         },
@@ -4293,9 +4271,9 @@
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.9",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-            "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+            "version": "1.15.11",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
             "funding": [
                 {
                     "type": "individual",
@@ -4345,9 +4323,9 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -22,10 +22,13 @@
         "@tailwindcss/forms": "^0.5.7",
         "@tailwindcss/typography": "^0.5.19",
         "autoprefixer": "^10.4.16",
-        "axios": "^1.11.0",
+        "axios": "^1.13.5",
         "laravel-vite-plugin": "^1.0",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.0",
         "vite": "^6.4.1"
+    },
+    "overrides": {
+        "axios": "^1.13.5"
     }
 }


### PR DESCRIPTION
## Summary
- Upgrades axios from 1.13.2 to 1.13.5 (fixes Dependabot alert #44, HIGH severity)
- Adds npm `overrides` to force all transitive axios dependencies to ^1.13.5
- Elliptic alert #42 (LOW) has no available patch — upstream @ledgerhq dependency

## Test plan
- [ ] npm audit shows no axios vulnerabilities
- [ ] npm ls axios shows all instances at 1.13.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)