### PR TITLE
fix: resolve CI migration FK types and composer.lock sync

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "54e37552fbd6a4b4b911aef828db9400",
+    "content-hash": "c12fc36112087ec5d17d386903e74341",
     "packages": [
         {
             "name": "amphp/amp",
@@ -2018,6 +2018,7 @@
                 "issues": "https://github.com/doctrine/annotations/issues",
                 "source": "https://github.com/doctrine/annotations/tree/2.0.2"
             },
+            "abandoned": true,
             "time": "2024-09-05T10:17:24+00:00"
         },
         {
@@ -4375,12 +4376,12 @@
             "version": "1.0.34",
             "source": {
                 "type": "git",
-                "url": "https://github.com/laravel-workflow/laravel-workflow.git",
+                "url": "https://github.com/durable-workflow/workflow.git",
                 "reference": "a0d3ff623dbda9faf546df92d58536f16e0feab8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel-workflow/laravel-workflow/zipball/a0d3ff623dbda9faf546df92d58536f16e0feab8",
+                "url": "https://api.github.com/repos/durable-workflow/workflow/zipball/a0d3ff623dbda9faf546df92d58536f16e0feab8",
                 "reference": "a0d3ff623dbda9faf546df92d58536f16e0feab8",
                 "shasum": ""
             },
@@ -4421,8 +4422,8 @@
             ],
             "description": "Durable workflow engine that allows users to write long running persistent distributed workflows (orchestrations) in PHP powered by Laravel queues.",
             "support": {
-                "issues": "https://github.com/laravel-workflow/laravel-workflow/issues",
-                "source": "https://github.com/laravel-workflow/laravel-workflow/tree/1.0.34"
+                "issues": "https://github.com/durable-workflow/workflow/issues",
+                "source": "https://github.com/durable-workflow/workflow/tree/1.0.34"
             },
             "time": "2025-04-12T21:54:08+00:00"
         },
@@ -4431,12 +4432,12 @@
             "version": "1.0.12",
             "source": {
                 "type": "git",
-                "url": "https://github.com/laravel-workflow/waterline.git",
+                "url": "https://github.com/durable-workflow/waterline.git",
                 "reference": "bb1df3896a10816e12d0c9499b84979695d650f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel-workflow/waterline/zipball/bb1df3896a10816e12d0c9499b84979695d650f2",
+                "url": "https://api.github.com/repos/durable-workflow/waterline/zipball/bb1df3896a10816e12d0c9499b84979695d650f2",
                 "reference": "bb1df3896a10816e12d0c9499b84979695d650f2",
                 "shasum": ""
             },
@@ -4481,8 +4482,8 @@
             ],
             "description": "An elegant UI for monitoring Laravel Workflows.",
             "support": {
-                "issues": "https://github.com/laravel-workflow/waterline/issues",
-                "source": "https://github.com/laravel-workflow/waterline/tree/1.0.12"
+                "issues": "https://github.com/durable-workflow/waterline/issues",
+                "source": "https://github.com/durable-workflow/waterline/tree/1.0.12"
             },
             "time": "2025-03-16T22:54:21+00:00"
         },
@@ -21284,7 +21285,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.3",
+        "php": "^8.4",
         "ext-gmp": "*",
         "ext-intl": "*",
         "ext-mbstring": "*",

--- a/database/migrations/2025_06_01_000001_create_bridge_transactions_table.php
+++ b/database/migrations/2025_06_01_000001_create_bridge_transactions_table.php
@@ -9,7 +9,7 @@ return new class () extends Migration {
     {
         Schema::create('bridge_transactions', function (Blueprint $table) {
             $table->uuid('id')->primary();
-            $table->foreignUuid('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
             $table->string('source_chain');
             $table->string('dest_chain');
             $table->string('token');

--- a/database/migrations/2025_06_01_000002_create_defi_positions_table.php
+++ b/database/migrations/2025_06_01_000002_create_defi_positions_table.php
@@ -9,7 +9,7 @@ return new class () extends Migration {
     {
         Schema::create('defi_positions', function (Blueprint $table) {
             $table->uuid('id')->primary();
-            $table->foreignUuid('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
             $table->string('protocol');
             $table->string('type');
             $table->string('status')->default('active');

--- a/database/migrations/2025_06_01_000003_create_certificates_table.php
+++ b/database/migrations/2025_06_01_000003_create_certificates_table.php
@@ -9,7 +9,7 @@ return new class () extends Migration {
     {
         Schema::create('certificates', function (Blueprint $table) {
             $table->uuid('id')->primary();
-            $table->foreignUuid('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
             $table->string('subject');
             $table->string('issuer_type');
             $table->string('status')->default('pending');


### PR DESCRIPTION
## Summary
- Fix `foreignUuid` → `foreignId` for `user_id` column in 3 migrations (`bridge_transactions`, `defi_positions`, `certificates`) — MySQL enforces FK type compatibility and `users.id` is `bigint`, not UUID
- Sync `composer.lock` with `composer.json` to fix Code Quality CI step

## Test plan
- [x] Full test suite: 7,396 passed, 0 failures locally
- [x] Migration FK fix resolves `SQLSTATE[HY000]: General error: 3780 Referencing column 'user_id' and referenced column 'id' ... are incompatible` in MySQL CI
- [x] `composer.lock` sync resolves "lock file is not up to date" Code Quality failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)