### PR TITLE
fix: remove redundant dump-autoload in CI workflows

### DIFF
--- a/.github/workflows/01-code-quality.yml
+++ b/.github/workflows/01-code-quality.yml
@@ -55,10 +55,9 @@ jobs:
           
       - name: Install Dependencies
         run: |
-          # No database service in this job — skip post-install scripts (package:discover)
-          # that boot Laravel and attempt DB connections. Static analysis only needs vendor files.
+          # No database service in this job — skip all scripts (package:discover boots Laravel
+          # and attempts DB connections). Static analysis only needs vendor files + autoloader.
           composer install --prefer-dist --no-progress --optimize-autoloader --no-scripts
-          composer dump-autoload --optimize
         
       - name: Run PHP Code Sniffer
         run: vendor/bin/phpcs

--- a/.github/workflows/02-security-scan.yml
+++ b/.github/workflows/02-security-scan.yml
@@ -55,9 +55,9 @@ jobs:
           
       - name: Install Dependencies
         run: |
-          # No database service in this job — skip post-install scripts (package:discover)
+          # No database service in this job — skip all scripts (package:discover boots Laravel).
+          # Security audit only needs composer metadata, not a running app.
           composer install --prefer-dist --no-progress --no-dev --no-scripts
-          composer dump-autoload --optimize
         
       - name: Run Security Audit (Production Dependencies)
         id: audit-prod


### PR DESCRIPTION
## Summary
Remove `composer dump-autoload --optimize` from Code Quality and Security Scan CI workflows. Even though `composer install --no-scripts` was added in PR #554, `dump-autoload` triggers `post-autoload-dump` scripts (including `package:discover`) which boots Laravel and fails without a database.

The `--optimize-autoloader` flag on `composer install` already handles autoloader optimization, making `dump-autoload` redundant.

## Test plan
- [x] Code Quality job only needs vendor files for phpstan/phpcs/php-cs-fixer
- [x] Security audit only needs composer metadata for `composer audit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)