### PR TITLE
fix: resolve PHPCS code quality violations

### DIFF
--- a/app/Console/Commands/PluginCreateCommand.php
+++ b/app/Console/Commands/PluginCreateCommand.php
@@ -19,8 +19,10 @@ class PluginCreateCommand extends Command
         $name = $this->argument('name');
 
         $namePattern = '/^[a-zA-Z0-9_-]+$/';
-        if (! is_string($vendor) || ! preg_match($namePattern, $vendor)
-            || ! is_string($name) || ! preg_match($namePattern, $name)) {
+        if (
+            ! is_string($vendor) || ! preg_match($namePattern, $vendor)
+            || ! is_string($name) || ! preg_match($namePattern, $name)
+        ) {
             $this->error('Vendor and name must contain only alphanumeric characters, hyphens, and underscores.');
 
             return self::FAILURE;

--- a/app/Domain/Compliance/Services/Certification/DataResidencyService.php
+++ b/app/Domain/Compliance/Services/Certification/DataResidencyService.php
@@ -73,8 +73,10 @@ class DataResidencyService
         $isAllowed = false;
 
         foreach ($allowedPairs as $pair) {
-            if (($pair[0] === $fromRegion && $pair[1] === $toRegion)
-                || ($pair[0] === $toRegion && $pair[1] === $fromRegion)) {
+            if (
+                ($pair[0] === $fromRegion && $pair[1] === $toRegion)
+                || ($pair[0] === $toRegion && $pair[1] === $fromRegion)
+            ) {
                 $isAllowed = true;
                 break;
             }

--- a/app/Http/Controllers/PayseraDepositController.php
+++ b/app/Http/Controllers/PayseraDepositController.php
@@ -12,7 +12,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
-use Illuminate\Validation\ValidationException;
 
 /**
  * Controller for Paysera deposit operations.

--- a/app/Http/Middleware/GraphQLQueryCostMiddleware.php
+++ b/app/Http/Middleware/GraphQLQueryCostMiddleware.php
@@ -95,10 +95,12 @@ class GraphQLQueryCostMiddleware
         $lines = preg_split('/\R/', $query) ?: [];
         foreach ($lines as $line) {
             $trimmed = trim($line);
-            if (! empty($trimmed) && ! str_starts_with($trimmed, '{') && ! str_starts_with($trimmed, '}')
+            if (
+                ! empty($trimmed) && ! str_starts_with($trimmed, '{') && ! str_starts_with($trimmed, '}')
                 && ! str_starts_with($trimmed, '#') && ! str_starts_with($trimmed, 'query')
                 && ! str_starts_with($trimmed, 'mutation') && ! str_starts_with($trimmed, 'subscription')
-                && ! str_starts_with($trimmed, '$') && ! str_starts_with($trimmed, '...')) {
+                && ! str_starts_with($trimmed, '$') && ! str_starts_with($trimmed, '...')
+            ) {
                 $fieldCount++;
             }
         }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -31,4 +31,7 @@
     
     <!-- Exclude bootstrap/cache -->
     <exclude-pattern>bootstrap/cache/</exclude-pattern>
+
+    <!-- Exclude non-PHP files (k6 JavaScript tests) -->
+    <exclude-pattern>tests/k6/</exclude-pattern>
 </ruleset>

--- a/tests/Unit/Notifications/NotificationServiceTest.php
+++ b/tests/Unit/Notifications/NotificationServiceTest.php
@@ -14,7 +14,8 @@ describe('NotificationService', function () {
         $service = new NotificationService();
         expect($service->hasChannel('email'))->toBeFalse();
 
-        $service->registerChannel('email', function () {});
+        $service->registerChannel('email', function () {
+        });
         expect($service->hasChannel('email'))->toBeTrue();
         expect($service->getRegisteredChannels())->toContain('email');
     });


### PR DESCRIPTION
## Summary
- Convert named test classes to anonymous classes via factory functions in `EventUpcastingTest` (fixes PSR-1 namespace/class-per-file violations)
- Fix multi-line control structure formatting in `PluginCreateCommand`, `DataResidencyService`, and `GraphQLQueryCostMiddleware`
- Fix closing brace formatting in `NotificationServiceTest`
- Remove unused `ValidationException` import in `PayseraDepositController`
- Exclude k6 JavaScript test files from PHPCS scanning in `phpcs.xml`

## Test plan
- [x] `phpcs` passes with 0 errors across entire codebase
- [x] `php-cs-fixer fix --dry-run` reports 0 fixable files
- [x] All 13 EventUpcastingTest tests pass
- [x] All 8 NotificationServiceTest tests pass
- [x] PHPStan reports no errors on modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)