### PR TITLE
chore: v5.1.0 release — Mobile API Completeness & GraphQL Full Coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,54 @@ All notable changes to the FinAegis Core Banking Platform will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.0] - 2026-02-16
+
+### Added
+
+#### Mobile API Completeness — 21 New Endpoints
+- 11 privacy endpoints: shielded balances, total balance, transactions, shield/unshield/transfer, viewing key, proof of innocence (generate + verify), SRS URL/status
+- 4 commerce endpoints: merchant detail, payment request detail/cancel, recent payments
+- 3 card issuance endpoints: create card, card detail, card transactions
+- 2 mobile endpoints: app status (public), bulk device removal
+- 1 wallet endpoint: transaction quote with recipient validation
+- 7 new feature test files with 42 tests covering all new endpoints
+
+#### GraphQL 33-Domain Full Coverage
+- 9 remaining domain schemas and resolvers added (completing 33-domain coverage)
+- 14-domain GraphQL integration test suite
+
+#### Blockchain Address Models
+- `BlockchainAddress` and `BlockchainTransaction` Eloquent models with UUID support
+- `blockchain_addresses` and `blockchain_address_transactions` migration
+- `BlockchainWalletController` for address/transaction management
+
+### Changed
+
+#### Test Quality
+- 97 ReflectionClass-based structural tests converted to behavioral assertions
+- 9 pre-existing test failures resolved across event commands, GraphQL mutations, and projector health
+- Azure Key Vault HSM test hardened with `Http::preventStrayRequests()` and explicit URL schemes
+
+#### CI/CD Hardening
+- k6 load test step made non-blocking in CI pipeline
+- Per-scenario k6 thresholds for CI environment
+- PHPStan Laravel bootstrap restored for CI
+- PHPCS code quality violations resolved across codebase
+- Composer autoload redundancy removed
+
+### Fixed
+- PHPStan generic types for `BlockchainAddress`/`BlockchainTransaction` BelongsTo relationships
+- MariaDB timestamp compatibility in 4 migration files
+- Swagger/OpenAPI documentation regenerated with all new endpoints
+- axios CVE-2025-27152 resolved (upgrade to 1.13.5)
+- Migration foreign key type mismatches and composer.lock sync
+- Documentation accuracy: version references, domain counts, stale metrics
+
+### Security
+- axios upgraded to 1.13.5 to resolve CVE (npm overrides)
+
+---
+
 ## [5.0.1] - 2026-02-13
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ git status && git branch --show-current
 ### Version Status
 | Version | Status | Key Changes |
 |---------|--------|-------------|
+| v5.1.0 | ✅ Released | Mobile API Completeness: 21 mobile endpoints (Privacy, Commerce, Card, Wallet, Mobile), GraphQL 33-domain full coverage, blockchain address models, CI hardening, axios CVE fix |
 | v5.0.1 | ✅ Released | Platform Hardening: GraphQL CQRS alignment (21 mutations), OpenAPI 100% coverage (52 controllers), Plugin Marketplace UI, PHP 8.4 CI, 97 test conversions, documentation refresh |
 | v5.0.0 | ✅ Released | Streaming Architecture (MAJOR): Event streaming (Redis Streams publisher/consumer), live dashboard (5 metrics endpoints), notification system (5 channels), API gateway middleware |
 | v4.3.0 | ✅ Released | Developer Experience: 4 new GraphQL domains (Fraud, Mobile, MobilePayment, TrustCert), dashboard widget plugin, CLI commands (schema-check, plugin-verify, domain-status), GraphQL rate limiting + query cost analysis |

--- a/docs/06-DEVELOPMENT/CLAUDE.md
+++ b/docs/06-DEVELOPMENT/CLAUDE.md
@@ -442,7 +442,7 @@ ActivityStub::make(ValidateLiquidityActivity::class)
 - **Projectors**: Build read models from events (`AccountProjector`, `TurnoverProjector`, `TransactionProjector`, `AssetTransactionProjector`, `AssetTransferProjector`, `ExchangeRateProjector`)
 - **Reactors**: Handle side effects (`SnapshotTransactionsReactor`, `SnapshotTransfersReactor`)
 
-### GraphQL API (v4.0.0-v5.0.1)
+### GraphQL API (v4.0.0-v5.1.0)
 The platform provides a GraphQL API via Lighthouse PHP alongside the REST API:
 - **33 domain schemas**: Account, AgentProtocol, AI, Asset, Banking, Basket, Batch, CardIssuance, Cgo, Commerce, Compliance, CrossChain, Custodian, DeFi, Exchange, FinancialInstitution, Fraud, Governance, KeyManagement, Lending, Mobile, MobilePayment, Payment, Privacy, Product, RegTech, Regulatory, Relayer, Stablecoin, Treasury, TrustCert, User, Wallet
 - **Schema files**: `graphql/*.graphql`
@@ -2145,6 +2145,6 @@ $user->assignRole('customer_business');
 
 ---
 
-**Last Updated**: 2026-02-13
-**Version**: 5.0.1
-**Status**: Production Ready - v5.0.1 with Event Streaming, Live Dashboard, GraphQL API, Plugin Marketplace
+**Last Updated**: 2026-02-16
+**Version**: 5.1.0
+**Status**: Production Ready - v5.1.0 with Mobile API Completeness, GraphQL 33-Domain Coverage, Event Streaming, Live Dashboard

--- a/docs/ARCHITECTURAL_ROADMAP.md
+++ b/docs/ARCHITECTURAL_ROADMAP.md
@@ -17,7 +17,7 @@ Transform FinAegis into the **premier open source core banking platform** that:
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
-│                     FINAEGIS CORE BANKING PLATFORM (v5.0.1)              │
+│                     FINAEGIS CORE BANKING PLATFORM (v5.1.0)              │
 ├─────────────────────────────────────────────────────────────────────────┤
 │  CORE BANKING                                                            │
 │  ┌────────────┐  ┌────────────┐  ┌────────────┐  ┌────────────┐        │
@@ -74,7 +74,7 @@ Transform FinAegis into the **premier open source core banking platform** that:
 | **BaaS** | FinancialInstitution (Partner APIs, SDKs, Widgets, Billing, Marketplace) | Mature |
 | **Supporting** | User, Contact, Newsletter, Webhook, Activity, Batch, Cgo, Shared | Complete |
 
-### Key Metrics (as of v5.0.1)
+### Key Metrics (as of v5.1.0)
 
 | Metric | Value |
 |--------|-------|
@@ -273,10 +273,10 @@ The FinAegis platform has evolved from a core banking prototype to a comprehensi
 8. **Banking-as-a-Service** - Partner APIs, SDK generation, embeddable widgets
 9. **AI Framework** - MCP tools, NLP queries, ML anomaly detection
 
-**v5.0.1 Focus**: Streaming Architecture — Redis Streams event distribution, live dashboard metrics, multi-channel notification system, and API gateway middleware.
+**v5.1.0 Focus**: Mobile API Completeness — 21 mobile endpoints, GraphQL 33-domain full coverage, blockchain address models, CI/CD hardening.
 
 ---
 
-*Document Version: 5.0.1*
-*Last Updated: February 13, 2026*
+*Document Version: 5.1.0*
+*Last Updated: February 16, 2026*
 *Author: Architecture Review*

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,12 +96,12 @@ Welcome to the FinAegis documentation. This guide will help you understand, use,
 
 ## Platform Status
 
-- **Version**: 5.0.1 (Platform Hardening)
+- **Version**: 5.1.0 (Mobile API Completeness)
 - **Status**: Demonstration Prototype
-- **Last Updated**: February 13, 2026
+- **Last Updated**: February 16, 2026
 
-### Current Release Features (v5.0.1)
-- **v5.0.1**: GraphQL CQRS alignment, OpenAPI 100% coverage, Plugin Marketplace UI, PHP 8.4, documentation refresh
+### Current Release Features (v5.1.0)
+- **v5.1.0**: 21 mobile API endpoints, GraphQL 33-domain full coverage, blockchain address models, CI hardening
 - **Event Streaming**: Redis Streams publisher/consumer for real-time event distribution
 - **Live Dashboard**: 5 metrics endpoints for real-time platform monitoring
 - **Multi-Channel Notification System**: Email, push, in-app, webhook, SMS notification channels

--- a/docs/VERSION_ROADMAP.md
+++ b/docs/VERSION_ROADMAP.md
@@ -1118,6 +1118,7 @@ main ─────────●─────────●─────
 | **v4.3.0** | Developer Experience | 4 new GraphQL domains, dashboard widget plugin, CLI commands, GraphQL security hardening | ✅ Released 2026-02-13 |
 | **v5.0.0** | Streaming Architecture | Event streaming (Redis Streams), live dashboard, notification system, API gateway, GraphQL schema expansion (33 domains) | ✅ Released 2026-02-13 |
 | **v5.0.1** | Platform Hardening | GraphQL CQRS alignment (21 mutations), OpenAPI 100%, Plugin Marketplace UI, PHP 8.4 CI, 97 test conversions, doc refresh | ✅ Released 2026-02-13 |
+| **v5.1.0** | Mobile API Completeness | 21 mobile endpoints, GraphQL 33-domain full coverage, blockchain models, CI hardening, axios CVE fix | ✅ Released 2026-02-16 |
 
 ---
 
@@ -1796,6 +1797,25 @@ After 18 releases (v1.1.0 → v3.0.0), the platform has grown to 41 domains, 266
 
 ---
 
-*Document Version: 5.0.1*
+## v5.1.0 — Mobile API Completeness & GraphQL Full Coverage ✅ COMPLETED
+
+**Released**: February 16, 2026
+**Theme**: Mobile Integration Readiness, GraphQL 33-Domain Coverage, CI/CD Hardening
+
+### Delivered
+
+| Feature | Status | Description |
+|---------|--------|-------------|
+| Mobile API Endpoints | ✅ | 21 missing endpoints across Privacy (11), Commerce (4), Card Issuance (3), Mobile (2), Wallet (1) |
+| GraphQL Full Coverage | ✅ | 9 remaining domain schemas added, completing 33-domain coverage |
+| GraphQL Integration Tests | ✅ | 14-domain integration test suite |
+| Blockchain Models | ✅ | BlockchainAddress/Transaction Eloquent models with UUID, migration, controller |
+| Test Quality | ✅ | 42 new feature tests, 9 pre-existing failures fixed, behavioral test conversions |
+| CI Hardening | ✅ | k6 non-blocking, per-scenario thresholds, PHPStan bootstrap, PHPCS fixes |
+| Security | ✅ | axios CVE fix, PHPStan generic types, MariaDB timestamp fixes |
+
+---
+
+*Document Version: 5.1.0*
 *Created: January 11, 2026*
-*Updated: February 13, 2026 (v5.0.1 Platform Hardening released)*
+*Updated: February 16, 2026 (v5.1.0 Mobile API Completeness released)*


### PR DESCRIPTION
## Summary
- CHANGELOG.md updated with v5.1.0 entry
- Version bumped from 5.0.1 to 5.1.0 across 6 documentation files
- VERSION_ROADMAP.md updated with v5.1.0 section and summary row
- Serena memory updated with release details

## What's in v5.1.0

### Added
- **21 mobile API endpoints**: Privacy (11), Commerce (4), Card Issuance (3), Mobile (2), Wallet (1)
- **GraphQL 33-domain full coverage**: 9 remaining domain schemas + 14-domain integration tests
- **Blockchain address models**: BlockchainAddress/Transaction with UUID support

### Changed
- 97 structural tests converted to behavioral assertions
- 9 pre-existing test failures resolved
- CI hardened: k6 non-blocking, PHPStan bootstrap, PHPCS fixes

### Fixed
- PHPStan generic types for blockchain model relationships
- MariaDB timestamp compatibility in migrations
- axios CVE-2025-27152 (upgrade to 1.13.5)

## Test plan
- [ ] CI pipeline passes (docs-only changes, no code impact)
- [ ] Version references consistent across all files

🤖 Generated with [Claude Code](https://claude.com/claude-code)