### PR TITLE
chore: v5.1.1 release — Mobile App Landing Page & CI Test Stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the FinAegis Core Banking Platform will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.1] - 2026-02-16
+
+### Added
+- Mobile app landing page at `/app` — futuristic dark-theme teaser page with email signup, feature cards (stablecoin payments, transaction shielding, Super KYC), Shamir's Secret Sharing explainer, platform architecture section, FAQ, and App Store/Google Play badges (Coming Soon)
+
+### Fixed
+- Flaky Azure HSM OAuth token caching test in CI — race condition with parallel Redis cache; replaced `Cache::get()` assertion with `Http::assertSent()` + `Http::assertSentCount()` to avoid shared mutable state
+
+---
+
 ## [5.1.0] - 2026-02-16
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ git status && git branch --show-current
 ### Version Status
 | Version | Status | Key Changes |
 |---------|--------|-------------|
+| v5.1.1 | ✅ Released | Mobile App Landing Page: `/app` teaser with email signup, feature showcase, flaky Azure HSM test fix |
 | v5.1.0 | ✅ Released | Mobile API Completeness: 21 mobile endpoints (Privacy, Commerce, Card, Wallet, Mobile), GraphQL 33-domain full coverage, blockchain address models, CI hardening, axios CVE fix |
 | v5.0.1 | ✅ Released | Platform Hardening: GraphQL CQRS alignment (21 mutations), OpenAPI 100% coverage (52 controllers), Plugin Marketplace UI, PHP 8.4 CI, 97 test conversions, documentation refresh |
 | v5.0.0 | ✅ Released | Streaming Architecture (MAJOR): Event streaming (Redis Streams publisher/consumer), live dashboard (5 metrics endpoints), notification system (5 channels), API gateway middleware |

--- a/docs/06-DEVELOPMENT/CLAUDE.md
+++ b/docs/06-DEVELOPMENT/CLAUDE.md
@@ -2146,5 +2146,5 @@ $user->assignRole('customer_business');
 ---
 
 **Last Updated**: 2026-02-16
-**Version**: 5.1.0
-**Status**: Production Ready - v5.1.0 with Mobile API Completeness, GraphQL 33-Domain Coverage, Event Streaming, Live Dashboard
+**Version**: 5.1.1
+**Status**: Production Ready - v5.1.1 with Mobile App Landing Page, Mobile API Completeness, GraphQL 33-Domain Coverage, Event Streaming, Live Dashboard

--- a/docs/ARCHITECTURAL_ROADMAP.md
+++ b/docs/ARCHITECTURAL_ROADMAP.md
@@ -17,7 +17,7 @@ Transform FinAegis into the **premier open source core banking platform** that:
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
-│                     FINAEGIS CORE BANKING PLATFORM (v5.1.0)              │
+│                     FINAEGIS CORE BANKING PLATFORM (v5.1.1)              │
 ├─────────────────────────────────────────────────────────────────────────┤
 │  CORE BANKING                                                            │
 │  ┌────────────┐  ┌────────────┐  ┌────────────┐  ┌────────────┐        │
@@ -74,7 +74,7 @@ Transform FinAegis into the **premier open source core banking platform** that:
 | **BaaS** | FinancialInstitution (Partner APIs, SDKs, Widgets, Billing, Marketplace) | Mature |
 | **Supporting** | User, Contact, Newsletter, Webhook, Activity, Batch, Cgo, Shared | Complete |
 
-### Key Metrics (as of v5.1.0)
+### Key Metrics (as of v5.1.1)
 
 | Metric | Value |
 |--------|-------|
@@ -273,10 +273,10 @@ The FinAegis platform has evolved from a core banking prototype to a comprehensi
 8. **Banking-as-a-Service** - Partner APIs, SDK generation, embeddable widgets
 9. **AI Framework** - MCP tools, NLP queries, ML anomaly detection
 
-**v5.1.0 Focus**: Mobile API Completeness — 21 mobile endpoints, GraphQL 33-domain full coverage, blockchain address models, CI/CD hardening.
+**v5.1.1 Focus**: Mobile App Landing Page — teaser page at `/app` with email signup and feature showcase, plus CI test stability fix.
 
 ---
 
-*Document Version: 5.1.0*
+*Document Version: 5.1.1*
 *Last Updated: February 16, 2026*
 *Author: Architecture Review*

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,11 +96,12 @@ Welcome to the FinAegis documentation. This guide will help you understand, use,
 
 ## Platform Status
 
-- **Version**: 5.1.0 (Mobile API Completeness)
+- **Version**: 5.1.1 (Mobile App Landing Page)
 - **Status**: Demonstration Prototype
 - **Last Updated**: February 16, 2026
 
-### Current Release Features (v5.1.0)
+### Current Release Features (v5.1.1)
+- **v5.1.1**: Mobile app landing page (`/app`) with email signup, flaky Azure HSM test fix
 - **v5.1.0**: 21 mobile API endpoints, GraphQL 33-domain full coverage, blockchain address models, CI hardening
 - **Event Streaming**: Redis Streams publisher/consumer for real-time event distribution
 - **Live Dashboard**: 5 metrics endpoints for real-time platform monitoring

--- a/docs/VERSION_ROADMAP.md
+++ b/docs/VERSION_ROADMAP.md
@@ -1119,6 +1119,7 @@ main ─────────●─────────●─────
 | **v5.0.0** | Streaming Architecture | Event streaming (Redis Streams), live dashboard, notification system, API gateway, GraphQL schema expansion (33 domains) | ✅ Released 2026-02-13 |
 | **v5.0.1** | Platform Hardening | GraphQL CQRS alignment (21 mutations), OpenAPI 100%, Plugin Marketplace UI, PHP 8.4 CI, 97 test conversions, doc refresh | ✅ Released 2026-02-13 |
 | **v5.1.0** | Mobile API Completeness | 21 mobile endpoints, GraphQL 33-domain full coverage, blockchain models, CI hardening, axios CVE fix | ✅ Released 2026-02-16 |
+| **v5.1.1** | Mobile App Landing Page | Landing page at `/app` with email signup, flaky Azure HSM test fix | ✅ Released 2026-02-16 |
 
 ---
 
@@ -1816,6 +1817,20 @@ After 18 releases (v1.1.0 → v3.0.0), the platform has grown to 41 domains, 266
 
 ---
 
-*Document Version: 5.1.0*
+## v5.1.1 — Mobile App Landing Page ✅ COMPLETED
+
+**Released**: February 16, 2026
+**Theme**: Mobile App Teaser, CI Test Stability
+
+### Delivered
+
+| Feature | Status | Description |
+|---------|--------|-------------|
+| Mobile App Landing Page | ✅ | Futuristic dark-theme page at `/app` with email signup, feature cards, Shamir's SSS explainer, platform architecture section, FAQ |
+| Azure HSM Test Fix | ✅ | Resolved flaky OAuth token caching test — race condition with parallel Redis in CI |
+
+---
+
+*Document Version: 5.1.1*
 *Created: January 11, 2026*
-*Updated: February 16, 2026 (v5.1.0 Mobile API Completeness released)*
+*Updated: February 16, 2026 (v5.1.1 Mobile App Landing Page released)*


### PR DESCRIPTION
## Summary

- Version bump to v5.1.1 across all documentation and configuration files
- CHANGELOG entry for the two changes since v5.1.0

## Changes in v5.1.1

| PR | Type | Description |
|----|------|-------------|
| #563 | feat | Mobile app landing page at `/app` — dark-theme teaser with email signup, feature cards, FAQ |
| #564 | fix | Flaky Azure HSM OAuth token caching test — Redis race condition in parallel CI |

## Files Updated

- `CHANGELOG.md` — new v5.1.1 section
- `CLAUDE.md` — version table
- `docs/README.md` — platform status
- `docs/ARCHITECTURAL_ROADMAP.md` — version refs
- `docs/VERSION_ROADMAP.md` — version table + v5.1.1 section
- `docs/06-DEVELOPMENT/CLAUDE.md` — footer version

## Test plan

- [x] No PHP changes — docs only
- [x] Pre-commit check passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)