### PR TITLE
fix: make /app landing page standalone from Vite build

### DIFF
--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -18,7 +18,19 @@
     <link rel="preconnect" href="https://fonts.bunny.net">
     <link href="https://fonts.bunny.net/css?family=inter:300,400,500,600,700,800&display=swap" rel="stylesheet" />
 
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
+    {{-- Standalone Tailwind — this page must work without the Vite build pipeline --}}
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+    tailwind.config = {
+        theme: {
+            extend: {
+                fontFamily: {
+                    sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+                },
+            },
+        },
+    }
+    </script>
 
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-X65KH9NFMY"></script>


### PR DESCRIPTION
## Summary

- Fixes broken layout on https://finaegis.org/app — all text overlapping, fonts incorrect, no layout styles

## Root Cause

`public/build/` is gitignored. The production Vite build (`app-B8VHGObv.css`) was compiled **before** `app.blade.php` existed, so Tailwind purged all utility classes unique to this page. Result: zero layout styles on production.

## Fix

Replace `@vite(['resources/css/app.css', 'resources/js/app.js'])` with Tailwind CDN + inline config:

```html
<script src="https://cdn.tailwindcss.com"></script>
<script>
tailwind.config = {
    theme: { extend: { fontFamily: { sans: ['Inter', ...] } } }
}
</script>
```

The landing page is now fully self-contained and works without any build step.

## Test plan

- [x] `php artisan view:cache` — templates compile
- [x] `curl /app` — returns HTTP 200
- [x] HTML output contains CDN script, no Vite references
- [ ] Manual: verify https://finaegis.org/app renders correctly after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)