### PR TITLE
chore: v5.1.2 release — Production Landing Page Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the FinAegis Core Banking Platform will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.2] - 2026-02-16
+
+### Fixed
+- Production landing page CSS broken — `public/build/` is gitignored so Vite-compiled CSS missed `/app` page classes; replaced `@vite()` with pre-compiled standalone Tailwind CSS (`public/css/app-landing.css`) generated via Tailwind CLI
+- CSP violation blocking Tailwind CDN — initial CDN fix was rejected by Content Security Policy `script-src`; resolved by self-hosting pre-compiled CSS (no external scripts needed)
+
+---
+
 ## [5.1.1] - 2026-02-16
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ git status && git branch --show-current
 ### Version Status
 | Version | Status | Key Changes |
 |---------|--------|-------------|
+| v5.1.2 | ✅ Released | Production Landing Page Fix: standalone pre-compiled CSS for `/app` (CSP-compliant, Vite-independent) |
 | v5.1.1 | ✅ Released | Mobile App Landing Page: `/app` teaser with email signup, feature showcase, flaky Azure HSM test fix |
 | v5.1.0 | ✅ Released | Mobile API Completeness: 21 mobile endpoints (Privacy, Commerce, Card, Wallet, Mobile), GraphQL 33-domain full coverage, blockchain address models, CI hardening, axios CVE fix |
 | v5.0.1 | ✅ Released | Platform Hardening: GraphQL CQRS alignment (21 mutations), OpenAPI 100% coverage (52 controllers), Plugin Marketplace UI, PHP 8.4 CI, 97 test conversions, documentation refresh |

--- a/docs/06-DEVELOPMENT/CLAUDE.md
+++ b/docs/06-DEVELOPMENT/CLAUDE.md
@@ -2146,5 +2146,5 @@ $user->assignRole('customer_business');
 ---
 
 **Last Updated**: 2026-02-16
-**Version**: 5.1.1
-**Status**: Production Ready - v5.1.1 with Mobile App Landing Page, Mobile API Completeness, GraphQL 33-Domain Coverage, Event Streaming, Live Dashboard
+**Version**: 5.1.2
+**Status**: Production Ready - v5.1.2 with Production Landing Page Fix, Mobile App Landing Page, Mobile API Completeness, GraphQL 33-Domain Coverage, Event Streaming, Live Dashboard

--- a/docs/ARCHITECTURAL_ROADMAP.md
+++ b/docs/ARCHITECTURAL_ROADMAP.md
@@ -17,7 +17,7 @@ Transform FinAegis into the **premier open source core banking platform** that:
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
-│                     FINAEGIS CORE BANKING PLATFORM (v5.1.1)              │
+│                     FINAEGIS CORE BANKING PLATFORM (v5.1.2)              │
 ├─────────────────────────────────────────────────────────────────────────┤
 │  CORE BANKING                                                            │
 │  ┌────────────┐  ┌────────────┐  ┌────────────┐  ┌────────────┐        │
@@ -74,7 +74,7 @@ Transform FinAegis into the **premier open source core banking platform** that:
 | **BaaS** | FinancialInstitution (Partner APIs, SDKs, Widgets, Billing, Marketplace) | Mature |
 | **Supporting** | User, Contact, Newsletter, Webhook, Activity, Batch, Cgo, Shared | Complete |
 
-### Key Metrics (as of v5.1.1)
+### Key Metrics (as of v5.1.2)
 
 | Metric | Value |
 |--------|-------|
@@ -273,10 +273,10 @@ The FinAegis platform has evolved from a core banking prototype to a comprehensi
 8. **Banking-as-a-Service** - Partner APIs, SDK generation, embeddable widgets
 9. **AI Framework** - MCP tools, NLP queries, ML anomaly detection
 
-**v5.1.1 Focus**: Mobile App Landing Page — teaser page at `/app` with email signup and feature showcase, plus CI test stability fix.
+**v5.1.2 Focus**: Production landing page CSS fix — standalone pre-compiled Tailwind CSS for `/app`, CSP-compliant and Vite-independent.
 
 ---
 
-*Document Version: 5.1.1*
+*Document Version: 5.1.2*
 *Last Updated: February 16, 2026*
 *Author: Architecture Review*

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,11 +96,12 @@ Welcome to the FinAegis documentation. This guide will help you understand, use,
 
 ## Platform Status
 
-- **Version**: 5.1.1 (Mobile App Landing Page)
+- **Version**: 5.1.2 (Production Landing Page Fix)
 - **Status**: Demonstration Prototype
 - **Last Updated**: February 16, 2026
 
-### Current Release Features (v5.1.1)
+### Current Release Features (v5.1.2)
+- **v5.1.2**: Production CSS fix for `/app` landing page — standalone pre-compiled Tailwind CSS (CSP-compliant, Vite-independent)
 - **v5.1.1**: Mobile app landing page (`/app`) with email signup, flaky Azure HSM test fix
 - **v5.1.0**: 21 mobile API endpoints, GraphQL 33-domain full coverage, blockchain address models, CI hardening
 - **Event Streaming**: Redis Streams publisher/consumer for real-time event distribution

--- a/docs/VERSION_ROADMAP.md
+++ b/docs/VERSION_ROADMAP.md
@@ -1120,6 +1120,7 @@ main ─────────●─────────●─────
 | **v5.0.1** | Platform Hardening | GraphQL CQRS alignment (21 mutations), OpenAPI 100%, Plugin Marketplace UI, PHP 8.4 CI, 97 test conversions, doc refresh | ✅ Released 2026-02-13 |
 | **v5.1.0** | Mobile API Completeness | 21 mobile endpoints, GraphQL 33-domain full coverage, blockchain models, CI hardening, axios CVE fix | ✅ Released 2026-02-16 |
 | **v5.1.1** | Mobile App Landing Page | Landing page at `/app` with email signup, flaky Azure HSM test fix | ✅ Released 2026-02-16 |
+| **v5.1.2** | Production Landing Page Fix | Standalone pre-compiled CSS for `/app` (CSP-compliant, Vite-independent) | ✅ Released 2026-02-16 |
 
 ---
 
@@ -1831,6 +1832,23 @@ After 18 releases (v1.1.0 → v3.0.0), the platform has grown to 41 domains, 266
 
 ---
 
-*Document Version: 5.1.1*
+## v5.1.2 — Production Landing Page Fix ✅ COMPLETED
+
+**Released**: February 16, 2026
+**Theme**: Production CSS Fix, CSP Compliance
+
+### Delivered
+
+| Feature | Status | Description |
+|---------|--------|-------------|
+| Standalone Tailwind CSS | ✅ | Pre-compiled `public/css/app-landing.css` via Tailwind CLI — no Vite dependency |
+| CSP Compliance | ✅ | Self-hosted CSS instead of CDN script — no CSP `script-src` changes needed |
+
+### Root Cause
+The `/app` landing page rendered correctly locally but broke in production because `public/build/` is gitignored. The Vite-compiled CSS on production was built before `app.blade.php` existed, so Tailwind purged all its utility classes. Initial CDN fix was blocked by Content Security Policy. Final solution: pre-compiled standalone CSS committed to git.
+
+---
+
+*Document Version: 5.1.2*
 *Created: January 11, 2026*
-*Updated: February 16, 2026 (v5.1.1 Mobile App Landing Page released)*
+*Updated: February 16, 2026 (v5.1.2 Production Landing Page Fix released)*


### PR DESCRIPTION
## Summary
- **v5.1.2 patch release** for production landing page CSS fixes
- Standalone pre-compiled Tailwind CSS for `/app` (CSP-compliant, Vite-independent)
- Version bumps in CHANGELOG, CLAUDE.md, docs/README.md, docs/ARCHITECTURAL_ROADMAP.md, docs/VERSION_ROADMAP.md, docs/06-DEVELOPMENT/CLAUDE.md

## Changes Since v5.1.1
- PR #566: Made `/app` landing page standalone from Vite build pipeline
- PR #567: Replaced CDN approach with pre-compiled standalone CSS to fix CSP violation

## Test plan
- [ ] Verify CHANGELOG entry is correct
- [ ] Verify version numbers consistent across all docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)