### PR TITLE
fix: Mobile API compat — auth responses, smart account onboarding, token refresh

### DIFF
--- a/app/Http/Controllers/Api/Auth/PasskeyController.php
+++ b/app/Http/Controllers/Api/Auth/PasskeyController.php
@@ -111,8 +111,10 @@ class PasskeyController extends Controller
      *     @OA\Response(response=200, description="Authentication successful", @OA\JsonContent(
      *         @OA\Property(property="success", type="boolean", example=true),
      *         @OA\Property(property="data", type="object",
+     *             @OA\Property(property="user", type="object"),
      *             @OA\Property(property="access_token", type="string"),
      *             @OA\Property(property="token_type", type="string", example="Bearer"),
+     *             @OA\Property(property="expires_in", type="integer", nullable=true, example=86400),
      *             @OA\Property(property="expires_at", type="string", format="date-time")
      *         )
      *     )),
@@ -169,8 +171,10 @@ class PasskeyController extends Controller
         return response()->json([
             'success' => true,
             'data'    => [
+                'user'         => $device->user,
                 'access_token' => $result['token'],
                 'token_type'   => 'Bearer',
+                'expires_in'   => config('sanctum.expiration') ? config('sanctum.expiration') * 60 : null,
                 'expires_at'   => $result['expires_at']->toIso8601String(),
             ],
         ]);

--- a/app/Http/Controllers/Api/Auth/RegisterController.php
+++ b/app/Http/Controllers/Api/Auth/RegisterController.php
@@ -50,17 +50,22 @@ class RegisterController extends Controller
      *
      * @OA\JsonContent(
      *
-     * @OA\Property(property="message",               type="string", example="User registered successfully"),
+     * @OA\Property(property="success",               type="boolean", example=true),
      * @OA\Property(
-     *                 property="user",
+     *                 property="data",
      *                 type="object",
+     * @OA\Property(
+     *                     property="user",
+     *                     type="object",
      * @OA\Property(property="id",                    type="integer", example=1),
      * @OA\Property(property="name",                  type="string", example="John Doe"),
      * @OA\Property(property="email",                 type="string", example="john@example.com"),
      * @OA\Property(property="email_verified_at",     type="string", nullable=true, example=null)
-     *             ),
+     *                 ),
      * @OA\Property(property="access_token",          type="string", example="1|aBcDeFgHiJkLmNoPqRsTuVwXyZ..."),
-     * @OA\Property(property="token_type",            type="string", example="Bearer")
+     * @OA\Property(property="token_type",            type="string", example="Bearer"),
+     * @OA\Property(property="expires_in",            type="integer", nullable=true, example=86400, description="Token expiration time in seconds")
+     *             )
      *         )
      *     ),
      *
@@ -116,15 +121,13 @@ class RegisterController extends Controller
 
         return response()->json(
             [
-                'message' => 'User registered successfully',
-                'user'    => [
-                    'id'                => $user->id,
-                    'name'              => $user->name,
-                    'email'             => $user->email,
-                    'email_verified_at' => $user->email_verified_at,
+                'success' => true,
+                'data'    => [
+                    'user'         => $user,
+                    'access_token' => $token,
+                    'token_type'   => 'Bearer',
+                    'expires_in'   => config('sanctum.expiration') ? config('sanctum.expiration') * 60 : null,
                 ],
-                'access_token' => $token,
-                'token_type'   => 'Bearer',
             ],
             201
         );

--- a/app/Http/Middleware/TransactionRateLimitMiddleware.php
+++ b/app/Http/Middleware/TransactionRateLimitMiddleware.php
@@ -289,7 +289,7 @@ class TransactionRateLimitMiddleware
      */
     private function incrementCounters(int $userId, string $transactionType, Request $request): void
     {
-        $config = self::TRANSACTION_LIMITS[$transactionType];
+        $config = self::TRANSACTION_LIMITS[$transactionType] ?? self::TRANSACTION_LIMITS['transfer'];
 
         // Increment hourly counter
         $hourlyKey = "tx_rate_limit:{$userId}:{$transactionType}:hourly";

--- a/phpstan-baseline-level8.neon
+++ b/phpstan-baseline-level8.neon
@@ -3957,7 +3957,7 @@ parameters:
 		-
 			message: '#^Cannot access property \$expires_at on Laravel\\Sanctum\\PersonalAccessToken\|null\.$#'
 			identifier: property.nonObject
-			count: 3
+			count: 4
 			path: tests/Feature/Security/TokenExpirationTest.php
 
 		-

--- a/tests/Feature/Api/Auth/RegisterControllerTest.php
+++ b/tests/Feature/Api/Auth/RegisterControllerTest.php
@@ -21,16 +21,19 @@ class RegisterControllerTest extends ControllerTestCase
 
         $response->assertStatus(201)
             ->assertJsonStructure([
-                'message',
-                'user' => [
-                    'id',
-                    'name',
-                    'email',
-                    'email_verified_at',
+                'success',
+                'data' => [
+                    'user' => [
+                        'id',
+                        'name',
+                        'email',
+                    ],
+                    'access_token',
+                    'token_type',
+                    'expires_in',
                 ],
-                'access_token',
-                'token_type',
-            ]);
+            ])
+            ->assertJsonPath('success', true);
 
         $this->assertDatabaseHas('users', [
             'name'  => 'John Doe',
@@ -100,7 +103,7 @@ class RegisterControllerTest extends ControllerTestCase
         ]);
 
         $response->assertStatus(201);
-        $token = $response->json('access_token');
+        $token = $response->json('data.access_token');
         $this->assertNotEmpty($token);
 
         // Test that the token works

--- a/tests/Feature/Http/Controllers/Api/Auth/RegisterControllerTest.php
+++ b/tests/Feature/Http/Controllers/Api/Auth/RegisterControllerTest.php
@@ -21,27 +21,24 @@ class RegisterControllerTest extends ControllerTestCase
 
         $response->assertStatus(201)
             ->assertJsonStructure([
-                'message',
-                'user' => [
-                    'id',
-                    'name',
-                    'email',
-                    'email_verified_at',
+                'success',
+                'data' => [
+                    'user' => [
+                        'id',
+                        'name',
+                        'email',
+                    ],
+                    'access_token',
+                    'token_type',
+                    'expires_in',
                 ],
-                'access_token',
-                'token_type',
             ])
-            ->assertJson([
-                'message' => 'User registered successfully',
-                'user'    => [
-                    'name'              => 'John Doe',
-                    'email'             => 'john@example.com',
-                    'email_verified_at' => null,
-                ],
-                'token_type' => 'Bearer',
-            ]);
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.user.name', 'John Doe')
+            ->assertJsonPath('data.user.email', 'john@example.com')
+            ->assertJsonPath('data.token_type', 'Bearer');
 
-        $this->assertNotEmpty($response->json('access_token'));
+        $this->assertNotEmpty($response->json('data.access_token'));
 
         // Verify user was created
         $this->assertDatabaseHas('users', [
@@ -219,7 +216,7 @@ class RegisterControllerTest extends ControllerTestCase
         ]);
 
         $response->assertStatus(201)
-            ->assertJsonPath('user.email_verified_at', null);
+            ->assertJsonPath('data.user.email_verified_at', null);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- **SmartAccountController**: `owner_address` is now optional in `POST /api/v1/relayer/account`. When omitted, a deterministic address is derived from the authenticated user — enabling initial account creation during onboarding before the user has a wallet.
- **Auth response standardization**: `RegisterController` now returns the standard `{ success, data: { user, access_token, token_type, expires_in } }` envelope with the full User model (matching `LoginController`). `PasskeyController.authenticate` now includes `user` and `expires_in`.
- **Token refresh**: `LoginController.refresh()` and `logoutAll()` methods implemented (routes existed but methods were missing). Refresh revokes the current token and issues a new one.
- **500 fix on relayer endpoints**: `TransactionRateLimitMiddleware.incrementCounters()` crashed on unknown transaction types like `relayer` — now uses the same fallback as `handle()`.

## Files Changed

| File | Change |
|------|--------|
| `SmartAccountController.php` | `owner_address` nullable, `deriveOwnerAddress()` helper |
| `RegisterController.php` | Response standardized to `{ success, data }` envelope |
| `LoginController.php` | Added `refresh()` and `logoutAll()` methods |
| `PasskeyController.php` | Added `user` and `expires_in` to authenticate response |
| `TransactionRateLimitMiddleware.php` | Null-coalesce fallback in `incrementCounters()` |
| `phpstan-baseline-level8.neon` | Updated baseline count for new test assertion |
| `RegisterControllerTest.php` (x2) | Updated assertions for new response format |
| `SmartAccountControllerTest.php` | Added tests for no-owner-address flow |
| `TokenExpirationTest.php` | Implemented `test_token_refresh_maintains_scopes` (was skipped) |
| `ConcurrentSessionTest.php` | Implemented `test_logout_all_revokes_all_sessions` (was skipped) |

## Test plan

- [x] All 50 auth/relayer tests pass
- [x] All 15 security tests pass (2 previously-skipped tests now enabled)
- [x] Full suite: 3320 passed, 0 regressions
- [x] PHPStan clean, PHPCS/CS-Fixer clean
- [ ] Verify mobile app onboarding flow creates smart account without owner_address
- [ ] Verify mobile app handles new register response format
- [ ] Verify token refresh flow works end-to-end from mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)