### PR TITLE
chore: v5.1.3 release — Mobile API Compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to the FinAegis Core Banking Platform will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.3] - 2026-02-17
+
+### Fixed
+- `POST /api/v1/relayer/account` required `owner_address` — unusable during mobile onboarding when user has no wallet; now optional with server-side derivation from authenticated user
+- Register endpoint response inconsistency — returned flat `{ message, user: {subset}, access_token }` instead of standard `{ success, data: { user, access_token, token_type, expires_in } }` envelope; now matches login format with full User model
+- Passkey authenticate response missing `user` object and `expires_in` — mobile had incomplete session data after passkey auth
+- `TransactionRateLimitMiddleware` crashed (500) on relayer endpoints — `incrementCounters()` lacked null-coalesce fallback for unknown transaction types like `relayer`
+
+### Added
+- `POST /api/auth/refresh` — token refresh endpoint (route existed but method was missing); revokes current token and issues a new one
+- `POST /api/auth/logout-all` — revoke all tokens across all devices (route existed but method was missing)
+- `expires_in` field in register and passkey auth responses for consistent token lifetime visibility
+
+---
+
 ## [5.1.2] - 2026-02-16
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ git status && git branch --show-current
 ### Version Status
 | Version | Status | Key Changes |
 |---------|--------|-------------|
+| v5.1.3 | ✅ Released | Mobile API Compat: optional `owner_address` for smart account onboarding, auth response standardization, token refresh/logout-all endpoints, rate limiter 500 fix |
 | v5.1.2 | ✅ Released | Production Landing Page Fix: standalone pre-compiled CSS for `/app` (CSP-compliant, Vite-independent) |
 | v5.1.1 | ✅ Released | Mobile App Landing Page: `/app` teaser with email signup, feature showcase, flaky Azure HSM test fix |
 | v5.1.0 | ✅ Released | Mobile API Completeness: 21 mobile endpoints (Privacy, Commerce, Card, Wallet, Mobile), GraphQL 33-domain full coverage, blockchain address models, CI hardening, axios CVE fix |

--- a/docs/06-DEVELOPMENT/CLAUDE.md
+++ b/docs/06-DEVELOPMENT/CLAUDE.md
@@ -2145,6 +2145,6 @@ $user->assignRole('customer_business');
 
 ---
 
-**Last Updated**: 2026-02-16
-**Version**: 5.1.2
-**Status**: Production Ready - v5.1.2 with Production Landing Page Fix, Mobile App Landing Page, Mobile API Completeness, GraphQL 33-Domain Coverage, Event Streaming, Live Dashboard
+**Last Updated**: 2026-02-17
+**Version**: 5.1.3
+**Status**: Production Ready - v5.1.3 with Mobile API Compatibility, Token Refresh, Smart Account Onboarding, Auth Standardization

--- a/docs/ARCHITECTURAL_ROADMAP.md
+++ b/docs/ARCHITECTURAL_ROADMAP.md
@@ -17,7 +17,7 @@ Transform FinAegis into the **premier open source core banking platform** that:
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
-│                     FINAEGIS CORE BANKING PLATFORM (v5.1.2)              │
+│                     FINAEGIS CORE BANKING PLATFORM (v5.1.3)              │
 ├─────────────────────────────────────────────────────────────────────────┤
 │  CORE BANKING                                                            │
 │  ┌────────────┐  ┌────────────┐  ┌────────────┐  ┌────────────┐        │
@@ -74,7 +74,7 @@ Transform FinAegis into the **premier open source core banking platform** that:
 | **BaaS** | FinancialInstitution (Partner APIs, SDKs, Widgets, Billing, Marketplace) | Mature |
 | **Supporting** | User, Contact, Newsletter, Webhook, Activity, Batch, Cgo, Shared | Complete |
 
-### Key Metrics (as of v5.1.2)
+### Key Metrics (as of v5.1.3)
 
 | Metric | Value |
 |--------|-------|
@@ -273,10 +273,10 @@ The FinAegis platform has evolved from a core banking prototype to a comprehensi
 8. **Banking-as-a-Service** - Partner APIs, SDK generation, embeddable widgets
 9. **AI Framework** - MCP tools, NLP queries, ML anomaly detection
 
-**v5.1.2 Focus**: Production landing page CSS fix — standalone pre-compiled Tailwind CSS for `/app`, CSP-compliant and Vite-independent.
+**v5.1.3 Focus**: Mobile API compatibility — optional smart account onboarding, auth response standardization, token refresh & logout-all endpoints.
 
 ---
 
-*Document Version: 5.1.2*
-*Last Updated: February 16, 2026*
+*Document Version: 5.1.3*
+*Last Updated: February 17, 2026*
 *Author: Architecture Review*

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,11 +96,12 @@ Welcome to the FinAegis documentation. This guide will help you understand, use,
 
 ## Platform Status
 
-- **Version**: 5.1.2 (Production Landing Page Fix)
+- **Version**: 5.1.3 (Mobile API Compatibility)
 - **Status**: Demonstration Prototype
-- **Last Updated**: February 16, 2026
+- **Last Updated**: February 17, 2026
 
-### Current Release Features (v5.1.2)
+### Current Release Features (v5.1.3)
+- **v5.1.3**: Mobile API compat — optional `owner_address` for smart account onboarding, auth response standardization, token refresh & logout-all endpoints, rate limiter fix
 - **v5.1.2**: Production CSS fix for `/app` landing page — standalone pre-compiled Tailwind CSS (CSP-compliant, Vite-independent)
 - **v5.1.1**: Mobile app landing page (`/app`) with email signup, flaky Azure HSM test fix
 - **v5.1.0**: 21 mobile API endpoints, GraphQL 33-domain full coverage, blockchain address models, CI hardening

--- a/docs/VERSION_ROADMAP.md
+++ b/docs/VERSION_ROADMAP.md
@@ -1832,6 +1832,24 @@ After 18 releases (v1.1.0 → v3.0.0), the platform has grown to 41 domains, 266
 
 ---
 
+## v5.1.3 — Mobile API Compatibility ✅ COMPLETED
+
+**Released**: February 17, 2026
+**Theme**: Mobile Onboarding Fixes, Auth Response Standardization, Token Refresh
+
+### Delivered
+
+| Feature | Status | Description |
+|---------|--------|-------------|
+| Optional `owner_address` | ✅ | `POST /api/v1/relayer/account` no longer requires `owner_address` — derives deterministic address from authenticated user during onboarding |
+| Auth response standardization | ✅ | Register endpoint now returns standard `{ success, data }` envelope with full User model, matching login format |
+| Token refresh endpoint | ✅ | `POST /api/auth/refresh` implemented — revokes current token, issues new one with fresh expiration |
+| Logout-all endpoint | ✅ | `POST /api/auth/logout-all` implemented — revokes all tokens across all devices |
+| Passkey auth response | ✅ | `authenticate` now returns `user` object and `expires_in` for consistent mobile session handling |
+| Rate limiter crash fix | ✅ | `TransactionRateLimitMiddleware.incrementCounters()` no longer crashes on unknown transaction types (`relayer`) |
+
+---
+
 ## v5.1.2 — Production Landing Page Fix ✅ COMPLETED
 
 **Released**: February 16, 2026
@@ -1849,6 +1867,6 @@ The `/app` landing page rendered correctly locally but broke in production becau
 
 ---
 
-*Document Version: 5.1.2*
+*Document Version: 5.1.3*
 *Created: January 11, 2026*
-*Updated: February 16, 2026 (v5.1.2 Production Landing Page Fix released)*
+*Updated: February 17, 2026 (v5.1.3 Mobile API Compatibility released)*


### PR DESCRIPTION
## Summary

- Version bump and release notes for v5.1.3
- Documents all fixes from PR #587 (already merged to main)

## Changes in v5.1.3

- **Smart account onboarding**: `owner_address` now optional — server derives address for new users
- **Auth response standardization**: Register returns same `{ success, data }` envelope as login with full User model
- **Token refresh**: `POST /api/auth/refresh` implemented (revoke + reissue)
- **Logout-all**: `POST /api/auth/logout-all` implemented (revoke all device tokens)
- **Passkey auth**: Response now includes `user` and `expires_in`
- **Rate limiter fix**: No more 500 on relayer endpoints

## Files Updated

CHANGELOG.md, CLAUDE.md, docs/README.md, docs/VERSION_ROADMAP.md, docs/ARCHITECTURAL_ROADMAP.md, docs/06-DEVELOPMENT/CLAUDE.md

## Test plan

- [x] Docs-only change — no code changes
- [x] All code changes already merged and CI-verified in PR #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)