### PR TITLE
feat: Implement refresh token mechanism for mobile auth

### DIFF
--- a/app/Domain/Mobile/Services/PasskeyAuthenticationService.php
+++ b/app/Domain/Mobile/Services/PasskeyAuthenticationService.php
@@ -49,7 +49,7 @@ class PasskeyAuthenticationService
      * @param  string  $authenticatorData  The authenticator data (base64url)
      * @param  string  $clientDataJSON  The client data JSON (base64url)
      * @param  string  $signature  The signature from the authenticator (base64url)
-     * @return array{token: string, expires_at: \Carbon\Carbon, session_id: string}|null
+     * @return array{access_token: string, refresh_token: string, expires_at: \Carbon\Carbon, session_id: string}|null
      *
      * @throws BiometricBlockedException If the device is temporarily blocked
      */
@@ -176,7 +176,7 @@ class PasskeyAuthenticationService
                 if (! $user) {
                     throw new RuntimeException('User not found for device');
                 }
-                $plainToken = $this->createTokenWithScopes($user, 'mobile-passkey');
+                $tokenPair = $this->createTokenPair($user, 'mobile-passkey');
 
                 $device->update(['last_active_at' => now()]);
 
@@ -187,9 +187,10 @@ class PasskeyAuthenticationService
                 ]);
 
                 return [
-                    'token'      => $plainToken,
-                    'expires_at' => $session->expires_at,
-                    'session_id' => $session->id,
+                    'access_token'  => $tokenPair['access_token'],
+                    'refresh_token' => $tokenPair['refresh_token'],
+                    'expires_at'    => $session->expires_at,
+                    'session_id'    => $session->id,
                 ];
             });
         } catch (BiometricBlockedException $e) {

--- a/app/Http/Controllers/Api/Auth/PasskeyController.php
+++ b/app/Http/Controllers/Api/Auth/PasskeyController.php
@@ -171,11 +171,13 @@ class PasskeyController extends Controller
         return response()->json([
             'success' => true,
             'data'    => [
-                'user'         => $device->user,
-                'access_token' => $result['token'],
-                'token_type'   => 'Bearer',
-                'expires_in'   => config('sanctum.expiration') ? config('sanctum.expiration') * 60 : null,
-                'expires_at'   => $result['expires_at']->toIso8601String(),
+                'user'               => $device->user,
+                'access_token'       => $result['access_token'],
+                'refresh_token'      => $result['refresh_token'],
+                'token_type'         => 'Bearer',
+                'expires_in'         => config('sanctum.expiration') ? (int) config('sanctum.expiration') * 60 : null,
+                'refresh_expires_in' => config('sanctum.refresh_token_expiration') ? (int) config('sanctum.refresh_token_expiration') * 60 : null,
+                'expires_at'         => $result['expires_at']->toIso8601String(),
             ],
         ]);
     }

--- a/app/Http/Controllers/Api/Auth/RegisterController.php
+++ b/app/Http/Controllers/Api/Auth/RegisterController.php
@@ -116,17 +116,19 @@ class RegisterController extends Controller
             ]
         );
 
-        // Create a personal access token for the user with appropriate scopes
-        $token = $this->createTokenWithScopes($user, 'api-token');
+        // Create access/refresh token pair
+        $tokenPair = $this->createTokenPair($user, 'api-token');
 
         return response()->json(
             [
                 'success' => true,
                 'data'    => [
-                    'user'         => $user,
-                    'access_token' => $token,
-                    'token_type'   => 'Bearer',
-                    'expires_in'   => config('sanctum.expiration') ? config('sanctum.expiration') * 60 : null,
+                    'user'               => $user,
+                    'access_token'       => $tokenPair['access_token'],
+                    'refresh_token'      => $tokenPair['refresh_token'],
+                    'token_type'         => 'Bearer',
+                    'expires_in'         => $tokenPair['expires_in'],
+                    'refresh_expires_in' => $tokenPair['refresh_expires_in'],
                 ],
             ],
             201

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -50,6 +50,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Refresh Token Expiration Minutes
+    |--------------------------------------------------------------------------
+    |
+    | This value controls the number of minutes until a refresh token will be
+    | considered expired. Refresh tokens are long-lived tokens used to obtain
+    | new access tokens after they expire.
+    |
+    */
+
+    'refresh_token_expiration' => env('SANCTUM_REFRESH_TOKEN_EXPIRATION', 43200), // 30 days
+
+    /*
+    |--------------------------------------------------------------------------
     | Token Prefix
     |--------------------------------------------------------------------------
     |

--- a/routes/api-v2.php
+++ b/routes/api-v2.php
@@ -27,11 +27,13 @@ Route::prefix('auth')->middleware('api.rate_limit:auth')->group(function () {
     Route::post('/register', [App\Http\Controllers\Api\Auth\RegisterController::class, 'register']);
     Route::post('/login', [App\Http\Controllers\Api\Auth\LoginController::class, 'login']);
 
+    // Token refresh (public — accepts refresh token in body or Authorization header)
+    Route::post('/refresh', [App\Http\Controllers\Api\Auth\LoginController::class, 'refresh'])->middleware('throttle:20,1');
+
     // Protected auth endpoints
     Route::middleware(['auth:sanctum', 'check.token.expiration'])->group(function () {
         Route::post('/logout', [App\Http\Controllers\Api\Auth\LoginController::class, 'logout']);
         Route::post('/logout-all', [App\Http\Controllers\Api\Auth\LoginController::class, 'logoutAll']);
-        Route::post('/refresh', [App\Http\Controllers\Api\Auth\LoginController::class, 'refresh']);
         Route::get('/user', [App\Http\Controllers\Api\Auth\LoginController::class, 'user']);
         Route::post('/change-password', [App\Http\Controllers\Api\Auth\PasswordController::class, 'changePassword']);
     });

--- a/routes/api.php
+++ b/routes/api.php
@@ -79,6 +79,9 @@ Route::prefix('auth')->middleware('api.rate_limit:auth')->group(function () {
     Route::post('/register', [RegisterController::class, 'register']);
     Route::post('/login', [LoginController::class, 'login']);
 
+    // Token refresh (public — accepts refresh token in body or Authorization header)
+    Route::post('/refresh', [LoginController::class, 'refresh'])->middleware('throttle:20,1');
+
     // Password reset endpoints (public)
     Route::post('/forgot-password', [PasswordResetController::class, 'forgotPassword']);
     Route::post('/reset-password', [PasswordResetController::class, 'resetPassword']);
@@ -96,7 +99,6 @@ Route::prefix('auth')->middleware('api.rate_limit:auth')->group(function () {
     Route::middleware(['auth:sanctum', 'check.token.expiration'])->group(function () {
         Route::post('/logout', [LoginController::class, 'logout']);
         Route::post('/logout-all', [LoginController::class, 'logoutAll']);
-        Route::post('/refresh', [LoginController::class, 'refresh']);
         Route::get('/user', [LoginController::class, 'user']);
         Route::get('/me', [LoginController::class, 'user'])->name('api.auth.me');
         Route::post('/delete-account', AccountDeletionController::class)->name('api.auth.delete-account');

--- a/tests/Feature/Api/Auth/RegisterControllerTest.php
+++ b/tests/Feature/Api/Auth/RegisterControllerTest.php
@@ -29,8 +29,10 @@ class RegisterControllerTest extends ControllerTestCase
                         'email',
                     ],
                     'access_token',
+                    'refresh_token',
                     'token_type',
                     'expires_in',
+                    'refresh_expires_in',
                 ],
             ])
             ->assertJsonPath('success', true);

--- a/tests/Feature/Http/Controllers/Api/Auth/RegisterControllerTest.php
+++ b/tests/Feature/Http/Controllers/Api/Auth/RegisterControllerTest.php
@@ -29,8 +29,10 @@ class RegisterControllerTest extends ControllerTestCase
                         'email',
                     ],
                     'access_token',
+                    'refresh_token',
                     'token_type',
                     'expires_in',
+                    'refresh_expires_in',
                 ],
             ])
             ->assertJsonPath('success', true)
@@ -39,6 +41,7 @@ class RegisterControllerTest extends ControllerTestCase
             ->assertJsonPath('data.token_type', 'Bearer');
 
         $this->assertNotEmpty($response->json('data.access_token'));
+        $this->assertNotEmpty($response->json('data.refresh_token'));
 
         // Verify user was created
         $this->assertDatabaseHas('users', [

--- a/tests/Security/Authentication/AuthenticationSecurityTest.php
+++ b/tests/Security/Authentication/AuthenticationSecurityTest.php
@@ -191,11 +191,9 @@ class AuthenticationSecurityTest extends TestCase
         // Check that we have tokens
         $this->assertNotNull($token4);
 
-        // Verify session limit enforcement
-        // The implementation currently allows 4 sessions (to be fixed in future)
-        $activeTokens = $user->tokens()->count();
-        // TODO: Should be 3, but current implementation allows 4
-        $this->assertLessThanOrEqual(4, $activeTokens, 'Session limit check');
+        // Verify session limit enforcement (count access tokens only, not refresh tokens)
+        $activeAccessTokens = $user->tokens()->where('abilities', '!=', '["refresh"]')->count();
+        $this->assertLessThanOrEqual(4, $activeAccessTokens, 'Session limit check');
     }
 
     #[Test]

--- a/tests/Unit/Http/Controllers/Api/Auth/MobileAuthCompatTest.php
+++ b/tests/Unit/Http/Controllers/Api/Auth/MobileAuthCompatTest.php
@@ -42,7 +42,8 @@ describe('LoginController response envelope', function (): void {
 
         expect($source)->toContain("'success' => true")
             ->and($source)->toContain("'data'    => [")
-            ->and($source)->toContain("'access_token' => \$plainToken");
+            ->and($source)->toContain("'access_token'")
+            ->and($source)->toContain("'refresh_token'");
     });
 });
 


### PR DESCRIPTION
## Summary

- **Fixes broken token refresh**: `POST /api/auth/refresh` was behind `auth:sanctum` + `check.token.expiration` middleware, making it impossible to refresh an expired access token
- **Implements proper refresh token flow** using Sanctum's `abilities` column — no DB migration needed. Access tokens get role-based abilities (`['read', 'write']`), refresh tokens get `['refresh']`
- **Token pair on all auth endpoints**: login, register, and passkey auth now return `access_token` + `refresh_token` + `expires_in` + `refresh_expires_in`
- **Refresh endpoint is public**: Moved out of `auth:sanctum` group, validates refresh token manually via `PersonalAccessToken::findToken()`, checks ability + expiry, rotates tokens
- **Session limits exclude refresh tokens**: `enforceSessionLimits()` only counts access tokens

### Files Changed (14)
| Category | Files |
|----------|-------|
| Config | `config/sanctum.php` (refresh_token_expiration: 30 days) |
| Core | `HasApiScopes` (createRefreshToken, createTokenPair), `LoginController` (login, refresh, enforceSessionLimits, revokeTokenPairByName) |
| Auth endpoints | `RegisterController`, `PasskeyController`, `PasskeyAuthenticationService` |
| Routes | `routes/api.php`, `routes/api-v2.php` |
| Tests | 6 test files updated, 5 new test cases added |

## Test plan

- [x] `./vendor/bin/pest tests/Feature/Api/Auth/ tests/Feature/Http/Controllers/Api/Auth/ tests/Unit/Http/Controllers/Api/Auth/ tests/Feature/Security/TokenExpirationTest.php tests/Feature/Security/ConcurrentSessionTest.php` — 55 pass
- [x] `XDEBUG_MODE=off vendor/bin/phpstan analyse --memory-limit=2G` — 0 errors on changed files
- [x] `./vendor/bin/php-cs-fixer fix` — code style clean
- [x] Full suite: `./vendor/bin/pest --parallel` — 4799 pass (1 pre-existing timeout flake in parallel mode)

### New test scenarios
- Refresh works after access token expires (the key scenario)
- Refresh rejects access tokens (wrong ability)
- Refresh rejects expired refresh tokens
- Refresh rotates: old refresh token is revoked
- Refresh without any token returns 401
- Session limit excludes refresh tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)