### PR TITLE
chore: v5.1.4 release — Refresh Token Mechanism

### DIFF
--- a/.serena/memories/version_roadmap_decisions.md
+++ b/.serena/memories/version_roadmap_decisions.md
@@ -173,8 +173,39 @@ Key deliverables:
 - API Gateway Middleware: Centralized request routing, rate limiting, authentication
 - 41 domains total, 775+ test files, 6300+ tests, PHPStan Level 8
 
+v5.1.0 — Mobile API Completeness & GraphQL Full Coverage (COMPLETED)
+Status: Released (2026-02-16)
+Key deliverables:
+- 21 missing mobile API endpoints (Privacy 11, Commerce 4, Card Issuance 3, Mobile 2, Wallet 1)
+- GraphQL schemas for 9 remaining domains (completing 33-domain coverage)
+- GraphQL integration tests for 14 domains
+- BlockchainAddress/BlockchainTransaction Eloquent models with UUID support
+- 42 new feature tests, 9 pre-existing test failures fixed
+- CI hardening: k6 non-blocking, PHPStan bootstrap, PHPCS fixes
+- Security: axios CVE-2025-27152 fix, PHPStan generic types, MariaDB timestamp fixes
+
+v5.1.3 — Mobile API Compatibility (COMPLETED)
+Status: Released (2026-02-17)
+Key deliverables:
+- Optional `owner_address` for `POST /api/v1/relayer/account` — mobile onboarding fix
+- Auth response standardization (register, passkey) — `{ success, data }` envelope with full User model
+- Token refresh endpoint (`POST /api/auth/refresh`) and logout-all (`POST /api/auth/logout-all`)
+- Rate limiter crash fix for unknown transaction types
+
+v5.1.4 — Refresh Token Mechanism (COMPLETED)
+Status: Released (2026-02-18)
+Key deliverables:
+- Proper access/refresh token pairs using Sanctum `abilities` column — no DB migration
+- Token rotation on refresh (old pair revoked, new pair issued)
+- `POST /api/auth/refresh` moved to public route group (works after access tokens expire)
+- `refresh_token` and `refresh_expires_in` in all auth responses
+- `sanctum.refresh_token_expiration` config (default: 30 days)
+- PHPStan `config/sanctum.php` type error fixed
+- OpenAPI/Swagger annotations updated for login/register endpoints
+- 5 new security tests for refresh token flows
+
 Future roadmap:
-- v5.1.0 — TBD (Laravel 13 upgrade when available, PHP 8.5 features)
+- v5.2.0 — TBD (Laravel 13 upgrade when available, PHP 8.5 features)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to the FinAegis Core Banking Platform will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.4] - 2026-02-18
+
+### Added
+- Proper refresh token mechanism with token rotation — access tokens (short-lived, role-based abilities) paired with refresh tokens (`['refresh']` ability, 30-day lifetime) using Sanctum's `abilities` column; no DB migration needed
+- `POST /api/auth/refresh` now accepts refresh token via request body (`refresh_token`) or `Authorization: Bearer` header — endpoint moved out of `auth:sanctum` middleware so it works after access tokens expire
+- Token pair rotation on refresh — old access + refresh tokens are revoked before issuing new pair, preventing replay attacks
+- `refresh_token`, `refresh_expires_in` fields in login, register, passkey auth, and refresh responses
+- `sanctum.refresh_token_expiration` config (default: 30 days / 43200 minutes)
+- `createTokenPair()` and `createRefreshToken()` methods in `HasApiScopes` trait
+- 5 new security tests: refresh after access token expiry, reject access tokens for refresh, reject expired refresh tokens, token rotation revocation, missing token handling
+- Session limit enforcement now excludes refresh tokens from count
+
+### Fixed
+- PHPStan type error in `config/sanctum.php` — `explode()` received `bool|string` from `env()`, now cast to `(string)`
+- OpenAPI/Swagger annotations for login and register endpoints missing `refresh_token` and `refresh_expires_in` fields
+
+---
+
 ## [5.1.3] - 2026-02-17
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ git status && git branch --show-current
 ### Version Status
 | Version | Status | Key Changes |
 |---------|--------|-------------|
+| v5.1.4 | ✅ Released | Refresh Token Mechanism: proper access/refresh token pairs with rotation, PHPStan fix, OpenAPI docs update |
 | v5.1.3 | ✅ Released | Mobile API Compat: optional `owner_address` for smart account onboarding, auth response standardization, token refresh/logout-all endpoints, rate limiter 500 fix |
 | v5.1.2 | ✅ Released | Production Landing Page Fix: standalone pre-compiled CSS for `/app` (CSP-compliant, Vite-independent) |
 | v5.1.1 | ✅ Released | Mobile App Landing Page: `/app` teaser with email signup, feature showcase, flaky Azure HSM test fix |

--- a/app/Http/Controllers/Api/Auth/LoginController.php
+++ b/app/Http/Controllers/Api/Auth/LoginController.php
@@ -28,7 +28,7 @@ class LoginController extends Controller
      * @OA\Post(
      *     path="/api/auth/login",
      *     summary="Login user",
-     *     description="Authenticate user with email and password to receive an access token",
+     *     description="Authenticate user with email and password to receive an access/refresh token pair",
      *     operationId="login",
      *     tags={"Authentication"},
      *
@@ -63,8 +63,10 @@ class LoginController extends Controller
      * @OA\Property(property="email_verified_at", type="string", nullable=true)
      *                 ),
      * @OA\Property(property="access_token",      type="string", example="2|VVGVrIVokPBXkWLOi2yK13eHlQwQtQQONX5GCngZ..."),
+     * @OA\Property(property="refresh_token",     type="string", example="3|rEfReShToKeNhErE..."),
      * @OA\Property(property="token_type",        type="string", example="Bearer"),
-     * @OA\Property(property="expires_in",        type="integer", nullable=true, example=null, description="Token expiration time in seconds")
+     * @OA\Property(property="expires_in",        type="integer", nullable=true, example=86400, description="Access token expiration time in seconds"),
+     * @OA\Property(property="refresh_expires_in", type="integer", nullable=true, example=2592000, description="Refresh token expiration time in seconds")
      *             )
      *         )
      *     ),

--- a/app/Http/Controllers/Api/Auth/RegisterController.php
+++ b/app/Http/Controllers/Api/Auth/RegisterController.php
@@ -63,8 +63,10 @@ class RegisterController extends Controller
      * @OA\Property(property="email_verified_at",     type="string", nullable=true, example=null)
      *                 ),
      * @OA\Property(property="access_token",          type="string", example="1|aBcDeFgHiJkLmNoPqRsTuVwXyZ..."),
+     * @OA\Property(property="refresh_token",         type="string", example="2|rEfReShToKeNhErE..."),
      * @OA\Property(property="token_type",            type="string", example="Bearer"),
-     * @OA\Property(property="expires_in",            type="integer", nullable=true, example=86400, description="Token expiration time in seconds")
+     * @OA\Property(property="expires_in",            type="integer", nullable=true, example=86400, description="Access token expiration time in seconds"),
+     * @OA\Property(property="refresh_expires_in",    type="integer", nullable=true, example=2592000, description="Refresh token expiration time in seconds")
      *             )
      *         )
      *     ),

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
+    'stateful' => explode(',', (string) env('SANCTUM_STATEFUL_DOMAINS', sprintf(
         '%s%s',
         'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
         Sanctum::currentApplicationUrlWithPort()

--- a/docs/06-DEVELOPMENT/CLAUDE.md
+++ b/docs/06-DEVELOPMENT/CLAUDE.md
@@ -2145,6 +2145,6 @@ $user->assignRole('customer_business');
 
 ---
 
-**Last Updated**: 2026-02-17
-**Version**: 5.1.3
-**Status**: Production Ready - v5.1.3 with Mobile API Compatibility, Token Refresh, Smart Account Onboarding, Auth Standardization
+**Last Updated**: 2026-02-18
+**Version**: 5.1.4
+**Status**: Production Ready - v5.1.4 with Refresh Token Mechanism, Token Rotation, PHPStan Fix, OpenAPI Update

--- a/docs/ARCHITECTURAL_ROADMAP.md
+++ b/docs/ARCHITECTURAL_ROADMAP.md
@@ -17,7 +17,7 @@ Transform FinAegis into the **premier open source core banking platform** that:
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
-│                     FINAEGIS CORE BANKING PLATFORM (v5.1.3)              │
+│                     FINAEGIS CORE BANKING PLATFORM (v5.1.4)              │
 ├─────────────────────────────────────────────────────────────────────────┤
 │  CORE BANKING                                                            │
 │  ┌────────────┐  ┌────────────┐  ┌────────────┐  ┌────────────┐        │
@@ -74,7 +74,7 @@ Transform FinAegis into the **premier open source core banking platform** that:
 | **BaaS** | FinancialInstitution (Partner APIs, SDKs, Widgets, Billing, Marketplace) | Mature |
 | **Supporting** | User, Contact, Newsletter, Webhook, Activity, Batch, Cgo, Shared | Complete |
 
-### Key Metrics (as of v5.1.3)
+### Key Metrics (as of v5.1.4)
 
 | Metric | Value |
 |--------|-------|
@@ -273,10 +273,10 @@ The FinAegis platform has evolved from a core banking prototype to a comprehensi
 8. **Banking-as-a-Service** - Partner APIs, SDK generation, embeddable widgets
 9. **AI Framework** - MCP tools, NLP queries, ML anomaly detection
 
-**v5.1.3 Focus**: Mobile API compatibility — optional smart account onboarding, auth response standardization, token refresh & logout-all endpoints.
+**v5.1.4 Focus**: Refresh token mechanism — proper access/refresh token pairs with rotation, tech debt cleanup, OpenAPI documentation update.
 
 ---
 
-*Document Version: 5.1.3*
-*Last Updated: February 17, 2026*
+*Document Version: 5.1.4*
+*Last Updated: February 18, 2026*
 *Author: Architecture Review*

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,11 +96,12 @@ Welcome to the FinAegis documentation. This guide will help you understand, use,
 
 ## Platform Status
 
-- **Version**: 5.1.3 (Mobile API Compatibility)
+- **Version**: 5.1.4 (Refresh Token Mechanism)
 - **Status**: Demonstration Prototype
-- **Last Updated**: February 17, 2026
+- **Last Updated**: February 18, 2026
 
-### Current Release Features (v5.1.3)
+### Current Release Features (v5.1.4)
+- **v5.1.4**: Refresh token mechanism — proper access/refresh token pairs with rotation, PHPStan fix, OpenAPI docs update
 - **v5.1.3**: Mobile API compat — optional `owner_address` for smart account onboarding, auth response standardization, token refresh & logout-all endpoints, rate limiter fix
 - **v5.1.2**: Production CSS fix for `/app` landing page — standalone pre-compiled Tailwind CSS (CSP-compliant, Vite-independent)
 - **v5.1.1**: Mobile app landing page (`/app`) with email signup, flaky Azure HSM test fix

--- a/docs/VERSION_ROADMAP.md
+++ b/docs/VERSION_ROADMAP.md
@@ -1121,6 +1121,8 @@ main ─────────●─────────●─────
 | **v5.1.0** | Mobile API Completeness | 21 mobile endpoints, GraphQL 33-domain full coverage, blockchain models, CI hardening, axios CVE fix | ✅ Released 2026-02-16 |
 | **v5.1.1** | Mobile App Landing Page | Landing page at `/app` with email signup, flaky Azure HSM test fix | ✅ Released 2026-02-16 |
 | **v5.1.2** | Production Landing Page Fix | Standalone pre-compiled CSS for `/app` (CSP-compliant, Vite-independent) | ✅ Released 2026-02-16 |
+| **v5.1.3** | Mobile API Compatibility | Auth response standardization, token refresh/logout-all endpoints, rate limiter fix | ✅ Released 2026-02-17 |
+| **v5.1.4** | Refresh Token Mechanism | Proper access/refresh token pairs, token rotation, PHPStan fix, OpenAPI docs update | ✅ Released 2026-02-18 |
 
 ---
 
@@ -1832,6 +1834,26 @@ After 18 releases (v1.1.0 → v3.0.0), the platform has grown to 41 domains, 266
 
 ---
 
+## v5.1.4 — Refresh Token Mechanism ✅ COMPLETED
+
+**Released**: February 18, 2026
+**Theme**: Proper Access/Refresh Token Pairs, Tech Debt, Documentation
+
+### Delivered
+
+| Feature | Status | Description |
+|---------|--------|-------------|
+| Refresh token mechanism | ✅ | Access tokens (short-lived, role-based) paired with refresh tokens (`['refresh']` ability, 30-day default) via Sanctum `abilities` column — no DB migration |
+| Token rotation | ✅ | `POST /api/auth/refresh` revokes old access+refresh pair, issues new pair; prevents replay attacks |
+| Public refresh endpoint | ✅ | `/refresh` route moved out of `auth:sanctum` middleware — works after access tokens expire; accepts token via body or `Authorization: Bearer` |
+| Auth response enrichment | ✅ | `refresh_token` and `refresh_expires_in` in login, register, passkey auth, and refresh responses |
+| Session limit fix | ✅ | `enforceSessionLimits()` now excludes refresh tokens from concurrent session count |
+| PHPStan config fix | ✅ | `config/sanctum.php` `explode()` type error resolved with `(string)` cast |
+| OpenAPI docs update | ✅ | Swagger annotations for login and register endpoints now include `refresh_token` and `refresh_expires_in` |
+| Security tests | ✅ | 5 new tests: refresh after expiry, reject access tokens for refresh, reject expired refresh tokens, token rotation, missing token |
+
+---
+
 ## v5.1.3 — Mobile API Compatibility ✅ COMPLETED
 
 **Released**: February 17, 2026
@@ -1867,6 +1889,6 @@ The `/app` landing page rendered correctly locally but broke in production becau
 
 ---
 
-*Document Version: 5.1.3*
+*Document Version: 5.1.4*
 *Created: January 11, 2026*
-*Updated: February 17, 2026 (v5.1.3 Mobile API Compatibility released)*
+*Updated: February 18, 2026 (v5.1.4 Refresh Token Mechanism released)*

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -5449,7 +5449,7 @@
                     "Authentication"
                 ],
                 "summary": "Login user",
-                "description": "Authenticate user with email and password to receive an access token",
+                "description": "Authenticate user with email and password to receive an access/refresh token pair",
                 "operationId": "login",
                 "requestBody": {
                     "required": true,
@@ -5520,14 +5520,24 @@
                                                     "type": "string",
                                                     "example": "2|VVGVrIVokPBXkWLOi2yK13eHlQwQtQQONX5GCngZ..."
                                                 },
+                                                "refresh_token": {
+                                                    "type": "string",
+                                                    "example": "3|rEfReShToKeNhErE..."
+                                                },
                                                 "token_type": {
                                                     "type": "string",
                                                     "example": "Bearer"
                                                 },
                                                 "expires_in": {
-                                                    "description": "Token expiration time in seconds",
+                                                    "description": "Access token expiration time in seconds",
                                                     "type": "integer",
-                                                    "example": null,
+                                                    "example": 86400,
+                                                    "nullable": true
+                                                },
+                                                "refresh_expires_in": {
+                                                    "description": "Refresh token expiration time in seconds",
+                                                    "type": "integer",
+                                                    "example": 2592000,
                                                     "nullable": true
                                                 }
                                             },
@@ -5588,6 +5598,162 @@
                                         "message": {
                                             "type": "string",
                                             "example": "Logged out successfully"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthenticated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Unauthenticated"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/auth/refresh": {
+            "post": {
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Refresh access token",
+                "description": "Uses a refresh token to obtain a new access/refresh token pair. Does not require auth:sanctum middleware.",
+                "operationId": "refreshToken",
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "refresh_token": {
+                                        "description": "Refresh token (alternatively send via Authorization: Bearer header)",
+                                        "type": "string",
+                                        "example": "2|xyz..."
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Token refreshed successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "access_token": {
+                                                    "type": "string",
+                                                    "example": "3|newTokenHere..."
+                                                },
+                                                "refresh_token": {
+                                                    "type": "string",
+                                                    "example": "4|newRefreshHere..."
+                                                },
+                                                "token_type": {
+                                                    "type": "string",
+                                                    "example": "Bearer"
+                                                },
+                                                "expires_in": {
+                                                    "description": "Access token expiration time in seconds",
+                                                    "type": "integer",
+                                                    "example": 86400,
+                                                    "nullable": true
+                                                },
+                                                "refresh_expires_in": {
+                                                    "description": "Refresh token expiration time in seconds",
+                                                    "type": "integer",
+                                                    "example": 2592000,
+                                                    "nullable": true
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid or expired refresh token",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": false
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Invalid or expired refresh token."
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/auth/logout-all": {
+            "post": {
+                "tags": [
+                    "Authentication"
+                ],
+                "summary": "Logout from all devices",
+                "description": "Revokes all tokens for the authenticated user across all devices",
+                "operationId": "logoutAll",
+                "responses": {
+                    "200": {
+                        "description": "All sessions terminated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "message": {
+                                                    "type": "string",
+                                                    "example": "All sessions terminated successfully"
+                                                },
+                                                "revoked_count": {
+                                                    "type": "integer",
+                                                    "example": 3
+                                                }
+                                            },
+                                            "type": "object"
                                         }
                                     },
                                     "type": "object"
@@ -5839,12 +6005,20 @@
                                         },
                                         "data": {
                                             "properties": {
+                                                "user": {
+                                                    "type": "object"
+                                                },
                                                 "access_token": {
                                                     "type": "string"
                                                 },
                                                 "token_type": {
                                                     "type": "string",
                                                     "example": "Bearer"
+                                                },
+                                                "expires_in": {
+                                                    "type": "integer",
+                                                    "example": 86400,
+                                                    "nullable": true
                                                 },
                                                 "expires_at": {
                                                     "type": "string",
@@ -6237,39 +6411,60 @@
                             "application/json": {
                                 "schema": {
                                     "properties": {
-                                        "message": {
-                                            "type": "string",
-                                            "example": "User registered successfully"
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
                                         },
-                                        "user": {
+                                        "data": {
                                             "properties": {
-                                                "id": {
+                                                "user": {
+                                                    "properties": {
+                                                        "id": {
+                                                            "type": "integer",
+                                                            "example": 1
+                                                        },
+                                                        "name": {
+                                                            "type": "string",
+                                                            "example": "John Doe"
+                                                        },
+                                                        "email": {
+                                                            "type": "string",
+                                                            "example": "john@example.com"
+                                                        },
+                                                        "email_verified_at": {
+                                                            "type": "string",
+                                                            "example": null,
+                                                            "nullable": true
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "access_token": {
+                                                    "type": "string",
+                                                    "example": "1|aBcDeFgHiJkLmNoPqRsTuVwXyZ..."
+                                                },
+                                                "refresh_token": {
+                                                    "type": "string",
+                                                    "example": "2|rEfReShToKeNhErE..."
+                                                },
+                                                "token_type": {
+                                                    "type": "string",
+                                                    "example": "Bearer"
+                                                },
+                                                "expires_in": {
+                                                    "description": "Access token expiration time in seconds",
                                                     "type": "integer",
-                                                    "example": 1
+                                                    "example": 86400,
+                                                    "nullable": true
                                                 },
-                                                "name": {
-                                                    "type": "string",
-                                                    "example": "John Doe"
-                                                },
-                                                "email": {
-                                                    "type": "string",
-                                                    "example": "john@example.com"
-                                                },
-                                                "email_verified_at": {
-                                                    "type": "string",
-                                                    "example": null,
+                                                "refresh_expires_in": {
+                                                    "description": "Refresh token expiration time in seconds",
+                                                    "type": "integer",
+                                                    "example": 2592000,
                                                     "nullable": true
                                                 }
                                             },
                                             "type": "object"
-                                        },
-                                        "access_token": {
-                                            "type": "string",
-                                            "example": "1|aBcDeFgHiJkLmNoPqRsTuVwXyZ..."
-                                        },
-                                        "token_type": {
-                                            "type": "string",
-                                            "example": "Bearer"
                                         }
                                     },
                                     "type": "object"
@@ -37185,7 +37380,7 @@
                     "Smart Accounts"
                 ],
                 "summary": "Create or retrieve a smart account",
-                "description": "Create or retrieve a smart account.\n\nReturns the counterfactual smart account address for the given owner.\nThe account is computed deterministically but not deployed on-chain\nuntil the first transaction.",
+                "description": "Create or retrieve a smart account.\n\nReturns the counterfactual smart account address for the given owner.\nThe account is computed deterministically but not deployed on-chain\nuntil the first transaction.\n\nIf owner_address is omitted, the server derives a deterministic address\nfrom the authenticated user, enabling initial account creation during\nonboarding when the user has no wallet yet.",
                 "operationId": "db3d0966b9d62887c4b1a9f102719b22",
                 "requestBody": {
                     "required": true,
@@ -37193,13 +37388,14 @@
                         "application/json": {
                             "schema": {
                                 "required": [
-                                    "owner_address",
                                     "network"
                                 ],
                                 "properties": {
                                     "owner_address": {
+                                        "description": "EOA owner address. If omitted, derived from authenticated user.",
                                         "type": "string",
-                                        "example": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e"
+                                        "example": "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
+                                        "nullable": true
                                     },
                                     "network": {
                                         "type": "string",
@@ -37265,6 +37461,9 @@
                     },
                     "401": {
                         "description": "Unauthorized"
+                    },
+                    "422": {
+                        "description": "Validation error"
                     }
                 },
                 "security": [


### PR DESCRIPTION
## Summary
- Fix pre-existing PHPStan type error in `config/sanctum.php` (`explode()` received `bool|string`)
- Update OpenAPI/Swagger annotations for login and register endpoints to include `refresh_token` and `refresh_expires_in` fields
- Regenerate `storage/api-docs/api-docs.json` with complete refresh token documentation
- Version bumps and changelog entries for v5.1.4 across all documentation files

## Test plan
- [x] PHPStan passes on `config/sanctum.php` (was failing before)
- [x] All 102 auth/security tests pass
- [x] Full suite: 3305 pass, 0 failures in our changes (1 pre-existing flaky ExchangeRateController test in parallel mode only)
- [x] OpenAPI docs regenerated with `refresh_token` and `refresh_expires_in` across all 3 auth endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)