### PR TITLE
feat: Card API enhancements for mobile readiness

### DIFF
--- a/app/Domain/CardIssuance/Adapters/DemoCardIssuerAdapter.php
+++ b/app/Domain/CardIssuance/Adapters/DemoCardIssuerAdapter.php
@@ -29,7 +29,9 @@ class DemoCardIssuerAdapter implements CardIssuerInterface
     public function createCard(
         string $userId,
         string $cardholderName,
-        array $metadata = []
+        array $metadata = [],
+        ?CardNetwork $network = null,
+        ?string $label = null,
     ): VirtualCard {
         $cardToken = 'card_demo_' . bin2hex(random_bytes(16));
         $last4 = (string) random_int(1000, 9999);
@@ -38,11 +40,12 @@ class DemoCardIssuerAdapter implements CardIssuerInterface
         $card = new VirtualCard(
             cardToken: $cardToken,
             last4: $last4,
-            network: CardNetwork::VISA,
+            network: $network ?? CardNetwork::VISA,
             status: CardStatus::ACTIVE,
             cardholderName: $cardholderName,
             expiresAt: $expiresAt,
-            metadata: array_merge($metadata, ['user_id' => $userId]),
+            metadata: array_merge($metadata, ['user_id' => $userId, 'label' => $label]),
+            label: $label,
         );
 
         // Store in cache for demo purposes
@@ -94,6 +97,7 @@ class DemoCardIssuerAdapter implements CardIssuerInterface
             cardholderName: $card->cardholderName,
             expiresAt: $card->expiresAt,
             metadata: $card->metadata,
+            label: $card->label,
         );
 
         Cache::put("card:{$cardToken}", $frozenCard, now()->addDays(30));
@@ -116,6 +120,7 @@ class DemoCardIssuerAdapter implements CardIssuerInterface
             cardholderName: $card->cardholderName,
             expiresAt: $card->expiresAt,
             metadata: $card->metadata,
+            label: $card->label,
         );
 
         Cache::put("card:{$cardToken}", $activeCard, now()->addDays(30));
@@ -138,6 +143,7 @@ class DemoCardIssuerAdapter implements CardIssuerInterface
             cardholderName: $card->cardholderName,
             expiresAt: $card->expiresAt,
             metadata: array_merge($card->metadata, ['cancellation_reason' => $reason]),
+            label: $card->label,
         );
 
         Cache::put("card:{$cardToken}", $cancelledCard, now()->addDays(30));

--- a/app/Domain/CardIssuance/Contracts/CardIssuerInterface.php
+++ b/app/Domain/CardIssuance/Contracts/CardIssuerInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Domain\CardIssuance\Contracts;
 
+use App\Domain\CardIssuance\Enums\CardNetwork;
 use App\Domain\CardIssuance\Enums\WalletType;
 use App\Domain\CardIssuance\ValueObjects\ProvisioningData;
 use App\Domain\CardIssuance\ValueObjects\VirtualCard;
@@ -21,7 +22,9 @@ interface CardIssuerInterface
     public function createCard(
         string $userId,
         string $cardholderName,
-        array $metadata = []
+        array $metadata = [],
+        ?CardNetwork $network = null,
+        ?string $label = null,
     ): VirtualCard;
 
     /**

--- a/app/Domain/CardIssuance/Services/CardProvisioningService.php
+++ b/app/Domain/CardIssuance/Services/CardProvisioningService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Domain\CardIssuance\Services;
 
 use App\Domain\CardIssuance\Contracts\CardIssuerInterface;
+use App\Domain\CardIssuance\Enums\CardNetwork;
 use App\Domain\CardIssuance\Enums\WalletType;
 use App\Domain\CardIssuance\Events\CardProvisioned;
 use App\Domain\CardIssuance\ValueObjects\ProvisioningData;
@@ -31,14 +32,16 @@ class CardProvisioningService
     public function createCard(
         string $userId,
         string $cardholderName,
-        array $metadata = []
+        array $metadata = [],
+        ?CardNetwork $network = null,
+        ?string $label = null,
     ): VirtualCard {
         Log::info('Creating virtual card', [
             'user_id' => $userId,
             'issuer'  => $this->cardIssuer->getName(),
         ]);
 
-        $card = $this->cardIssuer->createCard($userId, $cardholderName, $metadata);
+        $card = $this->cardIssuer->createCard($userId, $cardholderName, $metadata, $network, $label);
 
         Log::info('Virtual card created', [
             'user_id'    => $userId,

--- a/app/Domain/CardIssuance/ValueObjects/VirtualCard.php
+++ b/app/Domain/CardIssuance/ValueObjects/VirtualCard.php
@@ -26,6 +26,7 @@ final readonly class VirtualCard
         public ?string $pan = null,          // Only available in secure contexts
         public ?string $cvv = null,          // Only available in secure contexts
         public array $metadata = [],
+        public ?string $label = null,
     ) {
     }
 
@@ -46,6 +47,7 @@ final readonly class VirtualCard
             'status'          => $this->status->value,
             'cardholder_name' => $this->cardholderName,
             'expires_at'      => $this->expiresAt->format('Y-m-d'),
+            'label'           => $this->label,
             'metadata'        => $this->metadata,
         ];
     }

--- a/app/Http/Controllers/Api/CardIssuance/CardController.php
+++ b/app/Http/Controllers/Api/CardIssuance/CardController.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Api\CardIssuance;
 
+use App\Domain\CardIssuance\Enums\CardNetwork;
 use App\Domain\CardIssuance\Enums\WalletType;
 use App\Domain\CardIssuance\Services\CardProvisioningService;
+use App\Domain\Mobile\Services\BiometricJWTService;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
+use RuntimeException;
 use Throwable;
 
 /**
@@ -22,6 +25,7 @@ class CardController extends Controller
 {
     public function __construct(
         private readonly CardProvisioningService $provisioningService,
+        private readonly ?BiometricJWTService $biometricJWTService = null,
     ) {
     }
 
@@ -161,7 +165,9 @@ class CardController extends Controller
      *     @OA\RequestBody(
      *         @OA\JsonContent(
      *             @OA\Property(property="cardholder_name", type="string", example="John Doe"),
-     *             @OA\Property(property="currency", type="string", example="USD")
+     *             @OA\Property(property="currency", type="string", example="USD"),
+     *             @OA\Property(property="network", type="string", enum={"visa", "mastercard"}, example="visa"),
+     *             @OA\Property(property="label", type="string", example="My Travel Card", maxLength=50)
      *         )
      *     ),
      *     @OA\Response(
@@ -170,15 +176,17 @@ class CardController extends Controller
      *         @OA\JsonContent(
      *             @OA\Property(property="success", type="boolean", example=true),
      *             @OA\Property(property="data", type="object",
-     *                 @OA\Property(property="card_id", type="string"),
+     *                 @OA\Property(property="card_token", type="string"),
      *                 @OA\Property(property="last4", type="string"),
      *                 @OA\Property(property="network", type="string"),
-     *                 @OA\Property(property="status", type="string")
+     *                 @OA\Property(property="status", type="string"),
+     *                 @OA\Property(property="label", type="string", nullable=true)
      *             )
      *         )
      *     ),
      *     @OA\Response(response=400, description="Card creation failed"),
-     *     @OA\Response(response=401, description="Unauthorized")
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=422, description="Validation error")
      * )
      */
     public function store(Request $request): JsonResponse
@@ -186,6 +194,8 @@ class CardController extends Controller
         $validated = $request->validate([
             'cardholder_name' => 'nullable|string|max:255',
             'currency'        => 'nullable|string|max:10',
+            'network'         => 'nullable|string|in:visa,mastercard',
+            'label'           => 'nullable|string|max:50',
         ]);
 
         try {
@@ -201,10 +211,13 @@ class CardController extends Controller
             }
 
             $cardholderName = $validated['cardholder_name'] ?? $user->name ?? 'FinAegis User';
+            $network = isset($validated['network']) ? CardNetwork::from($validated['network']) : null;
 
             $card = $this->provisioningService->createCard(
                 userId: (string) $user->id,
                 cardholderName: $cardholderName,
+                network: $network,
+                label: $validated['label'] ?? null,
             );
 
             $data = $card->toArray();
@@ -289,22 +302,63 @@ class CardController extends Controller
      *     tags={"Card Issuance"},
      *     security={{"sanctum": {}}},
      *     @OA\Parameter(name="cardId", in="path", required=true, @OA\Schema(type="string")),
+     *     @OA\Parameter(name="limit", in="query", required=false, @OA\Schema(type="integer", default=20, maximum=100)),
+     *     @OA\Parameter(name="cursor", in="query", required=false, @OA\Schema(type="string")),
      *     @OA\Response(
      *         response=200,
      *         description="Card transactions",
      *         @OA\JsonContent(
      *             @OA\Property(property="success", type="boolean", example=true),
-     *             @OA\Property(property="data", type="array", @OA\Items(type="object"))
+     *             @OA\Property(property="data", type="array", @OA\Items(
+     *                 @OA\Property(property="id", type="string"),
+     *                 @OA\Property(property="amount", type="number"),
+     *                 @OA\Property(property="currency", type="string"),
+     *                 @OA\Property(property="merchant", type="string"),
+     *                 @OA\Property(property="category", type="string"),
+     *                 @OA\Property(property="status", type="string"),
+     *                 @OA\Property(property="timestamp", type="string", format="date-time")
+     *             )),
+     *             @OA\Property(property="pagination", type="object",
+     *                 @OA\Property(property="next_cursor", type="string", nullable=true),
+     *                 @OA\Property(property="has_more", type="boolean"),
+     *                 @OA\Property(property="total", type="integer")
+     *             )
      *         )
      *     )
      * )
      */
     public function transactions(Request $request, string $cardId): JsonResponse
     {
-        // Demo implementation — return empty list
+        $limit = min((int) $request->query('limit', '20'), 100);
+        $cursor = $request->query('cursor');
+
+        // Generate deterministic demo transactions seeded by cardId
+        $allTransactions = $this->generateDemoTransactions($cardId);
+
+        // Apply cursor-based pagination
+        $offset = 0;
+        if ($cursor !== null) {
+            foreach ($allTransactions as $index => $tx) {
+                if ($tx['id'] === $cursor) {
+                    $offset = $index + 1;
+
+                    break;
+                }
+            }
+        }
+
+        $page = array_slice($allTransactions, $offset, $limit);
+        $hasMore = ($offset + $limit) < count($allTransactions);
+        $nextCursor = $hasMore && count($page) > 0 ? $page[count($page) - 1]['id'] : null;
+
         return response()->json([
-            'success' => true,
-            'data'    => [],
+            'success'    => true,
+            'data'       => $page,
+            'pagination' => [
+                'next_cursor' => $nextCursor,
+                'has_more'    => $hasMore,
+                'total'       => count($allTransactions),
+            ],
         ]);
     }
 
@@ -375,28 +429,57 @@ class CardController extends Controller
     }
 
     /**
-     * Cancel a virtual card.
+     * Cancel a virtual card (requires biometric authentication).
      *
      * @OA\Delete(
      *     path="/api/v1/cards/{cardId}",
-     *     summary="Cancel a virtual card permanently",
+     *     summary="Cancel a virtual card permanently (requires biometric auth)",
      *     tags={"Card Issuance"},
      *     security={{"sanctum": {}}},
      *     @OA\Parameter(name="cardId", in="path", required=true, @OA\Schema(type="string")),
      *     @OA\RequestBody(
+     *         required=true,
      *         @OA\JsonContent(
+     *             required={"biometric_token"},
+     *             @OA\Property(property="biometric_token", type="string", minLength=32, maxLength=2048, description="Biometric JWT or demo HMAC token"),
      *             @OA\Property(property="reason", type="string", example="User requested cancellation")
      *         )
      *     ),
      *     @OA\Response(response=200, description="Card cancelled"),
-     *     @OA\Response(response=404, description="Card not found")
+     *     @OA\Response(response=403, description="Biometric verification failed"),
+     *     @OA\Response(response=404, description="Card not found"),
+     *     @OA\Response(response=422, description="Validation error"),
+     *     @OA\Response(response=503, description="Biometric service unavailable")
      * )
      */
     public function cancel(Request $request, string $cardId): JsonResponse
     {
         $validated = $request->validate([
-            'reason' => 'nullable|string|max:500',
+            'biometric_token' => 'required|string|min:32|max:2048',
+            'reason'          => 'nullable|string|max:500',
         ]);
+
+        $user = $request->user();
+        if ($user === null) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'ERR_AUTH_001',
+                    'message' => 'Authentication required',
+                ],
+            ], 401);
+        }
+
+        // Verify biometric token
+        if (! $this->verifyBiometricToken($user, $validated['biometric_token'])) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'ERR_BIOMETRIC_001',
+                    'message' => 'Biometric verification failed',
+                ],
+            ], 403);
+        }
 
         try {
             $result = $this->provisioningService->cancelCard(
@@ -417,5 +500,93 @@ class CardController extends Controller
                 ],
             ], 400);
         }
+    }
+
+    /**
+     * Verify biometric token using BiometricJWTService or demo fallback.
+     *
+     * @param \App\Models\User $user
+     */
+    private function verifyBiometricToken($user, string $biometricToken): bool
+    {
+        if (empty($biometricToken)) {
+            return false;
+        }
+
+        // Production mode: Use JWT verification
+        if ($this->biometricJWTService !== null) {
+            return $this->biometricJWTService->verifyToken($user, $biometricToken);
+        }
+
+        // Reject in production environment without JWT service
+        if (app()->environment('production')) {
+            Log::critical('BiometricJWTService not configured in production for card cancellation', [
+                'user_id' => $user->id,
+            ]);
+
+            throw new RuntimeException('Biometric verification unavailable.');
+        }
+
+        // Demo mode: Verify using HMAC signature with app key
+        Log::warning('Using demo biometric verification for card cancellation', [
+            'user_id'     => $user->id,
+            'environment' => app()->environment(),
+        ]);
+
+        $expectedToken = hash_hmac('sha256', 'demo_biometric:' . $user->id, (string) config('app.key'));
+
+        return hash_equals($expectedToken, $biometricToken);
+    }
+
+    /**
+     * Generate deterministic demo transactions for a card.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function generateDemoTransactions(string $cardId): array
+    {
+        $seed = crc32($cardId);
+        mt_srand($seed);
+
+        $merchants = [
+            ['name' => 'Amazon', 'category' => 'shopping'],
+            ['name' => 'Uber', 'category' => 'transport'],
+            ['name' => 'Starbucks', 'category' => 'food_and_drink'],
+            ['name' => 'Netflix', 'category' => 'entertainment'],
+            ['name' => 'Shell Gas Station', 'category' => 'fuel'],
+            ['name' => 'Whole Foods', 'category' => 'groceries'],
+            ['name' => 'Apple Store', 'category' => 'electronics'],
+            ['name' => 'Hilton Hotels', 'category' => 'travel'],
+        ];
+
+        $statuses = ['completed', 'completed', 'completed', 'pending', 'completed'];
+
+        $transactions = [];
+        $count = mt_rand(7, 10);
+        $baseTime = time();
+
+        for ($i = 0; $i < $count; $i++) {
+            $merchant = $merchants[mt_rand(0, count($merchants) - 1)];
+            $amount = mt_rand(199, 25000) / 100;
+            $hoursAgo = mt_rand(1, 720); // up to 30 days
+
+            $transactions[] = [
+                'id'        => sprintf('txn_%s_%d', substr(md5($cardId . $i), 0, 12), $i),
+                'amount'    => round($amount, 2),
+                'currency'  => 'USD',
+                'merchant'  => $merchant['name'],
+                'category'  => $merchant['category'],
+                'status'    => $statuses[mt_rand(0, count($statuses) - 1)],
+                'timestamp' => date('c', $baseTime - ($hoursAgo * 3600)),
+            ];
+        }
+
+        // Sort by timestamp DESC
+        usort($transactions, fn (array $a, array $b): int => strcmp($b['timestamp'], $a['timestamp']));
+
+        // Reset random seed
+        mt_srand();
+
+        return $transactions;
     }
 }

--- a/tests/Feature/Api/CardIssuance/CardDetailTest.php
+++ b/tests/Feature/Api/CardIssuance/CardDetailTest.php
@@ -41,8 +41,56 @@ class CardDetailTest extends TestCase
             ->assertJsonPath('success', true)
             ->assertJsonStructure([
                 'success',
-                'data' => ['card_token', 'last4', 'network', 'status'],
+                'data' => ['card_token', 'last4', 'network', 'status', 'label'],
             ]);
+    }
+
+    public function test_store_card_with_network_mastercard(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/cards', [
+                'cardholder_name' => 'Test User',
+                'network'         => 'mastercard',
+            ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.network', 'mastercard');
+    }
+
+    public function test_store_card_with_label(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/cards', [
+                'cardholder_name' => 'Test User',
+                'label'           => 'My Travel Card',
+            ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.label', 'My Travel Card');
+    }
+
+    public function test_store_card_defaults_to_visa_without_network(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/cards', [
+                'cardholder_name' => 'Test User',
+            ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.network', 'visa');
+    }
+
+    public function test_store_card_rejects_invalid_network(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/cards', [
+                'cardholder_name' => 'Test User',
+                'network'         => 'amex',
+            ]);
+
+        $response->assertUnprocessable();
     }
 
     public function test_show_card_requires_authentication(): void
@@ -59,13 +107,128 @@ class CardDetailTest extends TestCase
         $response->assertUnauthorized();
     }
 
-    public function test_card_transactions_returns_empty_list(): void
+    public function test_card_transactions_returns_sorted_data(): void
     {
+        // Create a card first so we have a valid card ID
+        $createResponse = $this->withToken($this->token)
+            ->postJson('/api/v1/cards', [
+                'cardholder_name' => 'Test User',
+            ]);
+
+        $cardToken = $createResponse->json('data.card_token');
+
         $response = $this->withToken($this->token)
-            ->getJson('/api/v1/cards/test-card-id/transactions');
+            ->getJson("/api/v1/cards/{$cardToken}/transactions");
 
         $response->assertOk()
             ->assertJsonPath('success', true)
-            ->assertJsonPath('data', []);
+            ->assertJsonStructure([
+                'success',
+                'data' => [
+                    '*' => ['id', 'amount', 'currency', 'merchant', 'category', 'status', 'timestamp'],
+                ],
+                'pagination' => ['next_cursor', 'has_more', 'total'],
+            ]);
+
+        $data = $response->json('data');
+        $this->assertNotEmpty($data);
+
+        // Verify sorted by timestamp DESC
+        for ($i = 1; $i < count($data); $i++) {
+            $this->assertGreaterThanOrEqual(
+                $data[$i]['timestamp'],
+                $data[$i - 1]['timestamp'],
+                'Transactions should be sorted by timestamp DESC'
+            );
+        }
+    }
+
+    public function test_card_transactions_supports_pagination(): void
+    {
+        $createResponse = $this->withToken($this->token)
+            ->postJson('/api/v1/cards', [
+                'cardholder_name' => 'Test User',
+            ]);
+
+        $cardToken = $createResponse->json('data.card_token');
+
+        // Fetch first page with limit=3
+        $response = $this->withToken($this->token)
+            ->getJson("/api/v1/cards/{$cardToken}/transactions?limit=3");
+
+        $response->assertOk();
+        $firstPage = $response->json('data');
+        $this->assertCount(3, $firstPage);
+        $this->assertTrue($response->json('pagination.has_more'));
+
+        $nextCursor = $response->json('pagination.next_cursor');
+        $this->assertNotNull($nextCursor);
+
+        // Fetch second page
+        $response2 = $this->withToken($this->token)
+            ->getJson("/api/v1/cards/{$cardToken}/transactions?limit=3&cursor={$nextCursor}");
+
+        $response2->assertOk();
+        $secondPage = $response2->json('data');
+        $this->assertNotEmpty($secondPage);
+
+        // Verify no overlap between pages
+        $firstIds = array_column($firstPage, 'id');
+        $secondIds = array_column($secondPage, 'id');
+        $this->assertEmpty(array_intersect($firstIds, $secondIds));
+    }
+
+    public function test_cancel_card_requires_biometric_token(): void
+    {
+        $response = $this->withToken($this->token)
+            ->deleteJson('/api/v1/cards/some-card-id', [
+                'reason' => 'No longer needed',
+            ]);
+
+        $response->assertUnprocessable();
+    }
+
+    public function test_cancel_card_rejects_invalid_biometric_token(): void
+    {
+        // Create a card first
+        $createResponse = $this->withToken($this->token)
+            ->postJson('/api/v1/cards', [
+                'cardholder_name' => 'Test User',
+            ]);
+
+        $cardToken = $createResponse->json('data.card_token');
+
+        $response = $this->withToken($this->token)
+            ->deleteJson("/api/v1/cards/{$cardToken}", [
+                'biometric_token' => str_repeat('a', 64),
+                'reason'          => 'No longer needed',
+            ]);
+
+        $response->assertForbidden()
+            ->assertJsonPath('error.code', 'ERR_BIOMETRIC_001');
+    }
+
+    public function test_cancel_card_with_valid_biometric_token(): void
+    {
+        // Create a card first
+        $createResponse = $this->withToken($this->token)
+            ->postJson('/api/v1/cards', [
+                'cardholder_name' => 'Test User',
+            ]);
+
+        $cardToken = $createResponse->json('data.card_token');
+
+        // Generate valid demo HMAC token
+        $biometricToken = hash_hmac('sha256', 'demo_biometric:' . $this->user->id, (string) config('app.key'));
+
+        $response = $this->withToken($this->token)
+            ->deleteJson("/api/v1/cards/{$cardToken}", [
+                'biometric_token' => $biometricToken,
+                'reason'          => 'No longer needed',
+            ]);
+
+        $response->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('message', 'Card cancelled successfully');
     }
 }


### PR DESCRIPTION
## Summary

- **Network selection**: `store()` now accepts `network` (visa/mastercard) instead of hardcoding VISA. Defaults to VISA when omitted.
- **Card labels**: `label` field added to VirtualCard value object, passed through the full creation flow (interface → adapter → service → controller), and returned in all card responses.
- **Transactions endpoint**: Replaced empty-array stub with deterministic demo data (7-10 transactions per card), sorted by timestamp DESC, with cursor-based pagination (`limit`, `cursor`, `has_more`, `next_cursor`, `total`).
- **Biometric cancel**: Card cancellation now requires `biometric_token` (min 32 chars). Verifies via `BiometricJWTService` in production or demo HMAC fallback (matching the Relayer `UserOperationSigningService` pattern).
- **OpenAPI annotations**: Updated on `store()`, `transactions()`, and `cancel()` endpoints.

### Files changed (6)
| File | Change |
|------|--------|
| `VirtualCard.php` | Added `label` constructor param + `toArray()` |
| `CardIssuerInterface.php` | Added `?CardNetwork $network`, `?string $label` to `createCard()` |
| `DemoCardIssuerAdapter.php` | Accepts network/label, preserves label on freeze/unfreeze/cancel |
| `CardProvisioningService.php` | Pass-through for network/label |
| `CardController.php` | Network+label validation, demo transactions w/ pagination, biometric cancel |
| `CardDetailTest.php` | 13 tests (was 5) covering all new functionality |

## Test plan

- [x] `test_store_card_with_network_mastercard` — POST with `network: 'mastercard'` returns mastercard
- [x] `test_store_card_with_label` — POST with `label` returns it in response
- [x] `test_store_card_defaults_to_visa_without_network` — Omitting network defaults to visa
- [x] `test_store_card_rejects_invalid_network` — `network: 'amex'` → 422
- [x] `test_card_transactions_returns_sorted_data` — Transactions sorted by timestamp DESC
- [x] `test_card_transactions_supports_pagination` — limit/cursor pagination, no overlap
- [x] `test_cancel_card_requires_biometric_token` — Missing token → 422
- [x] `test_cancel_card_rejects_invalid_biometric_token` — Bad token → 403
- [x] `test_cancel_card_with_valid_biometric_token` — Happy path with demo HMAC

🤖 Generated with [Claude Code](https://claude.com/claude-code)