### PR TITLE
chore: Update documentation for v5.1.5 release

### DIFF
--- a/.serena/memories/version_roadmap_decisions.md
+++ b/.serena/memories/version_roadmap_decisions.md
@@ -204,8 +204,18 @@ Key deliverables:
 - OpenAPI/Swagger annotations updated for login/register endpoints
 - 5 new security tests for refresh token flows
 
+v5.1.5 — Dependency Cleanup & Production Readiness (COMPLETED)
+Status: Released (2026-02-21)
+Key deliverables:
+- l5-swagger upgrade 9.0.1 → 10.1.0 (swagger-php 5 → 6)
+- doctrine/annotations as direct dependency (docblock OA support)
+- PSR-4 fix: plugin directories renamed to PascalCase
+- .env.production.example for mobile backend deployment
+- PasskeyAuthenticationServiceTest fix (v5.1.4 token pair alignment)
+- Roadmap updated with v5.1.0–v5.1.4 entries
+
 Future roadmap:
-- v5.2.0 — TBD (Laravel 13 upgrade when available, PHP 8.5 features)
+- v5.2.0 — OpenAPI Attribute Migration (10,385 @OA\ docblocks → PHP 8 #[OA\] attributes, drop doctrine/annotations), Laravel 13 upgrade when available, PHP 8.5 features
 
 ---
 

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,4 +1,3 @@
-
 # whether to use the project's gitignore file to ignore files
 # Added on 2025-04-07
 ignore_all_files_in_gitignore: true
@@ -113,3 +112,7 @@ encoding: utf-8
 # Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
 languages:
 - php
+
+# override of the corresponding setting in serena_config.yml, see the documentation there.
+# If null or missing, the value from the global config is used.
+symbol_info_budget:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to the FinAegis Core Banking Platform will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.5] - 2026-02-21
+
+### Changed
+- Upgraded `darkaonline/l5-swagger` from v9 to v10 — pulls in `zircote/swagger-php` v6, drops transitive `doctrine/annotations` dependency
+- Added `doctrine/annotations ^2.0` as direct dependency — required for existing 10,385 `@OA\` docblock annotations until attribute migration (planned v5.2.0)
+- Renamed plugin directories from kebab-case to PascalCase (`audit-exporter` → `AuditExporter`, `dashboard-widget` → `DashboardWidget`, `webhook-notifier` → `WebhookNotifier`) — fixes PSR-4 autoloading violations
+
+### Added
+- `.env.production.example` — production environment template with demo mode disabled, real service drivers (Pimlico bundler, Alchemy balance provider), Redis sessions/queues, HTTPS enforcement, HSM enabled
+
+### Fixed
+- PasskeyAuthenticationServiceTest expected `$result['token']` but service returns `access_token`/`refresh_token` after v5.1.4 token format change
+- OpenAPI `@OA\Info` version updated from 5.0.0 to 5.1.5
+
+---
+
 ## [5.1.4] - 2026-02-18
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ git status && git branch --show-current
 ### Version Status
 | Version | Status | Key Changes |
 |---------|--------|-------------|
+| v5.1.5 | ✅ Released | Dependency Cleanup: l5-swagger 9→10 (swagger-php 6), PSR-4 plugin fix, `.env.production.example`, passkey test fix |
 | v5.1.4 | ✅ Released | Refresh Token Mechanism: proper access/refresh token pairs with rotation, PHPStan fix, OpenAPI docs update |
 | v5.1.3 | ✅ Released | Mobile API Compat: optional `owner_address` for smart account onboarding, auth response standardization, token refresh/logout-all endpoints, rate limiter 500 fix |
 | v5.1.2 | ✅ Released | Production Landing Page Fix: standalone pre-compiled CSS for `/app` (CSP-compliant, Vite-independent) |
@@ -260,7 +261,7 @@ Before marking any task complete:
 
 | Category | Files |
 |----------|-------|
-| Config | `.env.example`, `phpunit.xml`, `phpstan.neon`, `.php-cs-fixer.php` |
+| Config | `.env.example`, `.env.production.example`, `phpunit.xml`, `phpstan.neon`, `.php-cs-fixer.php` |
 | CI/CD | `.github/workflows/ci-pipeline.yml`, `.github/workflows/security.yml` |
 | Docs | `docs/`, `README.md` |
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FinAegis Core Banking Platform
 
 [![CI Pipeline](https://github.com/finaegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml/badge.svg)](https://github.com/finaegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml)
-[![Version](https://img.shields.io/badge/version-5.0.1-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-5.1.5-blue.svg)](CHANGELOG.md)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![PHP Version](https://img.shields.io/badge/php-%3E%3D8.4-8892BF.svg)](https://php.net/)
 [![Laravel Version](https://img.shields.io/badge/Laravel-12.x-FF2D20.svg)](https://laravel.com/)

--- a/app/Http/Controllers/Api/Documentation/OpenApiDoc.php
+++ b/app/Http/Controllers/Api/Documentation/OpenApiDoc.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers\Api\Documentation;
 /**
  * @OA\Info(
  *     title="FinAegis Core Banking API",
- *     version="5.0.0",
+ *     version="5.1.5",
  *     description="Open Source Core Banking as a Service - A modern, scalable, and secure core banking platform built with Laravel 12, featuring 41 DDD domains, event sourcing, CQRS, cross-chain bridges, DeFi protocol integration, privacy-preserving identity, RegTech compliance, Banking-as-a-Service, and AI-powered analytics.",
  *
  * @OA\Contact(

--- a/docs/06-DEVELOPMENT/CLAUDE.md
+++ b/docs/06-DEVELOPMENT/CLAUDE.md
@@ -2145,6 +2145,6 @@ $user->assignRole('customer_business');
 
 ---
 
-**Last Updated**: 2026-02-18
-**Version**: 5.1.4
-**Status**: Production Ready - v5.1.4 with Refresh Token Mechanism, Token Rotation, PHPStan Fix, OpenAPI Update
+**Last Updated**: 2026-02-21
+**Version**: 5.1.5
+**Status**: Production Ready - v5.1.5 with Dependency Cleanup (l5-swagger 10, swagger-php 6), PSR-4 Plugin Fix, Production Env Template

--- a/docs/ARCHITECTURAL_ROADMAP.md
+++ b/docs/ARCHITECTURAL_ROADMAP.md
@@ -17,7 +17,7 @@ Transform FinAegis into the **premier open source core banking platform** that:
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
-│                     FINAEGIS CORE BANKING PLATFORM (v5.1.4)              │
+│                     FINAEGIS CORE BANKING PLATFORM (v5.1.5)              │
 ├─────────────────────────────────────────────────────────────────────────┤
 │  CORE BANKING                                                            │
 │  ┌────────────┐  ┌────────────┐  ┌────────────┐  ┌────────────┐        │
@@ -74,7 +74,7 @@ Transform FinAegis into the **premier open source core banking platform** that:
 | **BaaS** | FinancialInstitution (Partner APIs, SDKs, Widgets, Billing, Marketplace) | Mature |
 | **Supporting** | User, Contact, Newsletter, Webhook, Activity, Batch, Cgo, Shared | Complete |
 
-### Key Metrics (as of v5.1.4)
+### Key Metrics (as of v5.1.5)
 
 | Metric | Value |
 |--------|-------|
@@ -273,10 +273,10 @@ The FinAegis platform has evolved from a core banking prototype to a comprehensi
 8. **Banking-as-a-Service** - Partner APIs, SDK generation, embeddable widgets
 9. **AI Framework** - MCP tools, NLP queries, ML anomaly detection
 
-**v5.1.4 Focus**: Refresh token mechanism — proper access/refresh token pairs with rotation, tech debt cleanup, OpenAPI documentation update.
+**v5.1.5 Focus**: Dependency cleanup — l5-swagger 9→10 (swagger-php 6), PSR-4 plugin fix, `.env.production.example` for mobile backend deployment, passkey test fix.
 
 ---
 
-*Document Version: 5.1.4*
-*Last Updated: February 18, 2026*
+*Document Version: 5.1.5*
+*Last Updated: February 21, 2026*
 *Author: Architecture Review*

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,11 +96,12 @@ Welcome to the FinAegis documentation. This guide will help you understand, use,
 
 ## Platform Status
 
-- **Version**: 5.1.4 (Refresh Token Mechanism)
-- **Status**: Demonstration Prototype
-- **Last Updated**: February 18, 2026
+- **Version**: 5.1.5 (Dependency Cleanup & Production Readiness)
+- **Status**: Demonstration Prototype / Production Mobile Backend
+- **Last Updated**: February 21, 2026
 
-### Current Release Features (v5.1.4)
+### Current Release Features (v5.1.5)
+- **v5.1.5**: Dependency cleanup — l5-swagger 9→10 (swagger-php 6), PSR-4 plugin fix, `.env.production.example` for mobile backend deployment, passkey test fix
 - **v5.1.4**: Refresh token mechanism — proper access/refresh token pairs with rotation, PHPStan fix, OpenAPI docs update
 - **v5.1.3**: Mobile API compat — optional `owner_address` for smart account onboarding, auth response standardization, token refresh & logout-all endpoints, rate limiter fix
 - **v5.1.2**: Production CSS fix for `/app` landing page — standalone pre-compiled Tailwind CSS (CSP-compliant, Vite-independent)

--- a/docs/VERSION_ROADMAP.md
+++ b/docs/VERSION_ROADMAP.md
@@ -1123,6 +1123,7 @@ main ─────────●─────────●─────
 | **v5.1.2** | Production Landing Page Fix | Standalone pre-compiled CSS for `/app` (CSP-compliant, Vite-independent) | ✅ Released 2026-02-16 |
 | **v5.1.3** | Mobile API Compatibility | Auth response standardization, token refresh/logout-all endpoints, rate limiter fix | ✅ Released 2026-02-17 |
 | **v5.1.4** | Refresh Token Mechanism | Proper access/refresh token pairs, token rotation, PHPStan fix, OpenAPI docs update | ✅ Released 2026-02-18 |
+| **v5.1.5** | Dependency Cleanup & Production Readiness | l5-swagger 9→10 (swagger-php 6), PSR-4 plugin fix, `.env.production.example` for mobile backend, passkey test fix | ✅ Released 2026-02-21 |
 
 ---
 
@@ -1889,6 +1890,6 @@ The `/app` landing page rendered correctly locally but broke in production becau
 
 ---
 
-*Document Version: 5.1.4*
+*Document Version: 5.1.5*
 *Created: January 11, 2026*
-*Updated: February 18, 2026 (v5.1.4 Refresh Token Mechanism released)*
+*Updated: February 21, 2026 (v5.1.5 Dependency Cleanup & Production Readiness released)*


### PR DESCRIPTION
## Summary
- Update version references from 5.1.4/5.0.0 to 5.1.5 across all documentation files
- Add v5.1.5 CHANGELOG entry (l5-swagger upgrade, PSR-4 plugin fix, production env template, passkey test fix)
- Add v5.1.5 row to VERSION_ROADMAP.md release table
- Update OpenAPI `@OA\Info` version from 5.0.0 to 5.1.5
- Update CLAUDE.md version table, README badge, architectural roadmap focus text

## Files Changed
| File | Change |
|------|--------|
| `CHANGELOG.md` | Added v5.1.5 entry |
| `CLAUDE.md` | v5.1.5 in version table, `.env.production.example` in Important Files |
| `README.md` | Version badge 5.0.1 → 5.1.5 |
| `docs/README.md` | Version, date, status, current features |
| `docs/ARCHITECTURAL_ROADMAP.md` | Header, metrics, focus text, footer |
| `docs/VERSION_ROADMAP.md` | v5.1.5 table row, footer |
| `docs/06-DEVELOPMENT/CLAUDE.md` | Footer version and date |
| `app/Http/.../OpenApiDoc.php` | `@OA\Info` version 5.0.0 → 5.1.5 |

## Test plan
- [ ] Verify `php artisan l5-swagger:generate` still works with updated `@OA\Info` version
- [ ] Verify CI passes (no code changes, documentation only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)