### PR TITLE
fix: Remove dangerous hardcoded placeholders (CRITICAL)

### DIFF
--- a/config/cgo.php
+++ b/config/cgo.php
@@ -39,6 +39,24 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Deposit Crypto Addresses
+    |--------------------------------------------------------------------------
+    |
+    | Configure cryptocurrency deposit addresses for the wallet deposit page.
+    | These are the addresses shown to users for direct crypto deposits.
+    |
+    | WARNING: Never hardcode third-party addresses. Always configure via env.
+    |
+    */
+
+    'deposit_addresses' => [
+        'btc'  => env('DEPOSIT_BTC_ADDRESS', ''),
+        'eth'  => env('DEPOSIT_ETH_ADDRESS', ''),
+        'usdt' => env('DEPOSIT_USDT_ADDRESS', ''),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Production Crypto Enable Flag
     |--------------------------------------------------------------------------
     |
@@ -60,7 +78,7 @@ return [
     */
 
     'bank_details' => [
-        'bank_name'      => env('CGO_BANK_NAME', 'Example Bank Ltd.'),
+        'bank_name'      => env('CGO_BANK_NAME', 'FinAegis Banking'),
         'account_name'   => env('CGO_BANK_ACCOUNT_NAME', 'FinAegis CGO Holdings'),
         'account_number' => env('CGO_BANK_ACCOUNT_NUMBER', ''),
         'routing_number' => env('CGO_BANK_ROUTING_NUMBER', ''),

--- a/resources/views/components/demo-banner.blade.php
+++ b/resources/views/components/demo-banner.blade.php
@@ -1,0 +1,21 @@
+@props(['title' => 'Demo Mode Active'])
+
+@if(app()->environment('demo'))
+    <div class="mb-6 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4">
+        <div class="flex">
+            <div class="flex-shrink-0">
+                <svg class="h-5 w-5 text-yellow-400" aria-hidden="true" fill="currentColor" viewBox="0 0 20 20">
+                    <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
+                </svg>
+            </div>
+            <div class="ml-3">
+                <h3 class="text-sm font-medium text-yellow-800 dark:text-yellow-200">
+                    {{ $title }}
+                </h3>
+                <div class="mt-2 text-sm text-yellow-700 dark:text-yellow-300">
+                    {{ $slot }}
+                </div>
+            </div>
+        </div>
+    </div>
+@endif

--- a/resources/views/crosschain/index.blade.php
+++ b/resources/views/crosschain/index.blade.php
@@ -184,169 +184,20 @@
                                 </div>
                             </div>
 
-                            <!-- Placeholder Transactions -->
-                            <div class="divide-y divide-gray-200 dark:divide-gray-700">
-                                <!-- Transaction 1 -->
-                                <div class="grid grid-cols-1 md:grid-cols-6 gap-2 md:gap-4 py-4 items-center">
-                                    <div class="text-sm text-gray-600 dark:text-gray-400">
-                                        <span class="md:hidden text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mr-2">Date:</span>
-                                        Feb 10, 2026
-                                    </div>
-                                    <div class="text-sm text-gray-900 dark:text-white">
-                                        <span class="md:hidden text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mr-2">Route:</span>
-                                        <span class="inline-flex items-center">
-                                            Ethereum
-                                            <svg class="w-4 h-4 mx-1 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"></path>
-                                            </svg>
-                                            Polygon
-                                        </span>
-                                    </div>
-                                    <div class="text-sm text-gray-900 dark:text-white">
-                                        <span class="md:hidden text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mr-2">Token:</span>
-                                        USDC
-                                    </div>
-                                    <div class="text-sm text-gray-900 dark:text-white md:text-right">
-                                        <span class="md:hidden text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mr-2">Amount:</span>
-                                        1,500.00
-                                    </div>
-                                    <div class="md:text-center">
-                                        <span class="md:hidden text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mr-2">Status:</span>
-                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
-                                            Completed
-                                        </span>
-                                    </div>
-                                    <div class="text-sm text-gray-600 dark:text-gray-400">
-                                        <span class="md:hidden text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mr-2">Provider:</span>
-                                        Wormhole
-                                    </div>
-                                </div>
-
-                                <!-- Transaction 2 -->
-                                <div class="grid grid-cols-1 md:grid-cols-6 gap-2 md:gap-4 py-4 items-center">
-                                    <div class="text-sm text-gray-600 dark:text-gray-400">
-                                        <span class="md:hidden text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mr-2">Date:</span>
-                                        Feb 9, 2026
-                                    </div>
-                                    <div class="text-sm text-gray-900 dark:text-white">
-                                        <span class="md:hidden text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mr-2">Route:</span>
-                                        <span class="inline-flex items-center">
-                                            Arbitrum
-                                            <svg class="w-4 h-4 mx-1 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"></path>
-                                            </svg>
-                                            Optimism
-                                        </span>
-                                    </div>
-                                    <div class="text-sm text-gray-900 dark:text-white">
-                                        <span class="md:hidden text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mr-2">Token:</span>
-                                        ETH
-                                    </div>
-                                    <div class="text-sm text-gray-900 dark:text-white md:text-right">
-                                        <span class="md:hidden text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mr-2">Amount:</span>
-                                        0.5000
-                                    </div>
-                                    <div class="md:text-center">
-                                        <span class="md:hidden text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mr-2">Status:</span>
-                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200">
-                                            Pending
-                                        </span>
-                                    </div>
-                                    <div class="text-sm text-gray-600 dark:text-gray-400">
-                                        <span class="md:hidden text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mr-2">Provider:</span>
-                                        LayerZero
-                                    </div>
-                                </div>
-
-                                <!-- Transaction 3 -->
-                                <div class="grid grid-cols-1 md:grid-cols-6 gap-2 md:gap-4 py-4 items-center">
-                                    <div class="text-sm text-gray-600 dark:text-gray-400">
-                                        <span class="md:hidden text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mr-2">Date:</span>
-                                        Feb 8, 2026
-                                    </div>
-                                    <div class="text-sm text-gray-900 dark:text-white">
-                                        <span class="md:hidden text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mr-2">Route:</span>
-                                        <span class="inline-flex items-center">
-                                            BSC
-                                            <svg class="w-4 h-4 mx-1 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"></path>
-                                            </svg>
-                                            Ethereum
-                                        </span>
-                                    </div>
-                                    <div class="text-sm text-gray-900 dark:text-white">
-                                        <span class="md:hidden text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mr-2">Token:</span>
-                                        WBTC
-                                    </div>
-                                    <div class="text-sm text-gray-900 dark:text-white md:text-right">
-                                        <span class="md:hidden text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mr-2">Amount:</span>
-                                        0.0250
-                                    </div>
-                                    <div class="md:text-center">
-                                        <span class="md:hidden text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mr-2">Status:</span>
-                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
-                                            Completed
-                                        </span>
-                                    </div>
-                                    <div class="text-sm text-gray-600 dark:text-gray-400">
-                                        <span class="md:hidden text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mr-2">Provider:</span>
-                                        Axelar
-                                    </div>
-                                </div>
-
-                                <!-- Transaction 4 -->
-                                <div class="grid grid-cols-1 md:grid-cols-6 gap-2 md:gap-4 py-4 items-center">
-                                    <div class="text-sm text-gray-600 dark:text-gray-400">
-                                        <span class="md:hidden text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mr-2">Date:</span>
-                                        Feb 7, 2026
-                                    </div>
-                                    <div class="text-sm text-gray-900 dark:text-white">
-                                        <span class="md:hidden text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mr-2">Route:</span>
-                                        <span class="inline-flex items-center">
-                                            Polygon
-                                            <svg class="w-4 h-4 mx-1 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"></path>
-                                            </svg>
-                                            Arbitrum
-                                        </span>
-                                    </div>
-                                    <div class="text-sm text-gray-900 dark:text-white">
-                                        <span class="md:hidden text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mr-2">Token:</span>
-                                        USDT
-                                    </div>
-                                    <div class="text-sm text-gray-900 dark:text-white md:text-right">
-                                        <span class="md:hidden text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mr-2">Amount:</span>
-                                        3,200.00
-                                    </div>
-                                    <div class="md:text-center">
-                                        <span class="md:hidden text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mr-2">Status:</span>
-                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200">
-                                            Failed
-                                        </span>
-                                    </div>
-                                    <div class="text-sm text-gray-600 dark:text-gray-400">
-                                        <span class="md:hidden text-xs font-medium text-gray-500 dark:text-gray-400 uppercase mr-2">Provider:</span>
-                                        Wormhole
-                                    </div>
-                                </div>
-                            </div>
-
-                            <!-- Empty State (hidden when transactions exist, shown as reference) -->
-                            {{--
+                            <!-- Empty State -->
                             <div class="bg-gray-50 dark:bg-gray-700 rounded-lg p-8 text-center">
-                                <svg class="w-12 h-12 text-gray-400 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <svg class="w-12 h-12 text-gray-400 mx-auto mb-4" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"></path>
                                 </svg>
                                 <p class="text-gray-600 dark:text-gray-400">No bridge transactions yet</p>
                                 <p class="text-sm text-gray-500 dark:text-gray-500 mt-1">Your cross-chain transfer history will appear here</p>
                                 <a href="#" class="inline-flex items-center mt-4 px-4 py-2 bg-teal-600 text-white text-sm font-medium rounded-lg hover:bg-teal-700 transition">
-                                    <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <svg class="w-4 h-4 mr-2" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
                                     </svg>
                                     Start Your First Bridge
                                 </a>
                             </div>
-                            --}}
                         </div>
                     </div>
                 </div>

--- a/resources/views/defi/index.blade.php
+++ b/resources/views/defi/index.blade.php
@@ -161,43 +161,6 @@
                                 </a>
                             </div>
 
-                            <!-- Positions Table -->
-                            <div class="overflow-x-auto">
-                                <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 hidden" id="positions-table">
-                                    <thead>
-                                        <tr>
-                                            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Protocol</th>
-                                            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Type</th>
-                                            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Chain</th>
-                                            <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Asset</th>
-                                            <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Amount</th>
-                                            <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Value (USD)</th>
-                                            <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">APY</th>
-                                            <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Health</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
-                                        {{-- Placeholder row for future data --}}
-                                        <tr>
-                                            <td class="px-4 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">Aave</td>
-                                            <td class="px-4 py-4 whitespace-nowrap">
-                                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400">
-                                                    Lending
-                                                </span>
-                                            </td>
-                                            <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400">Ethereum</td>
-                                            <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-600 dark:text-gray-400">USDC</td>
-                                            <td class="px-4 py-4 whitespace-nowrap text-sm text-right text-gray-900 dark:text-white">0.00</td>
-                                            <td class="px-4 py-4 whitespace-nowrap text-sm text-right text-gray-900 dark:text-white">$0.00</td>
-                                            <td class="px-4 py-4 whitespace-nowrap text-sm text-right text-green-600 dark:text-green-400">3.45%</td>
-                                            <td class="px-4 py-4 whitespace-nowrap text-sm text-right">
-                                                <span class="text-green-600 dark:text-green-400">1.85</span>
-                                            </td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            </div>
-
                             <!-- Empty State -->
                             <div class="text-center py-12" id="positions-empty">
                                 <svg class="w-16 h-16 text-gray-300 dark:text-gray-600 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/resources/views/wallet/blockchain/index.blade.php
+++ b/resources/views/wallet/blockchain/index.blade.php
@@ -29,9 +29,10 @@
                             if (!isset($balance['error'])) {
                                 $address = $addresses->firstWhere('uuid', $addressId);
                                 $chain = $supportedChains[$address->chain];
-                                // Mock USD conversion - in production, use real exchange rates
-                                $usdValue = $balance['balance'] * ($chain['symbol'] === 'BTC' ? 30000 : ($chain['symbol'] === 'ETH' ? 2000 : 1));
-                                $totalUSD += $usdValue;
+                                $rate = $usdRates[$chain['symbol']] ?? null;
+                                if ($rate !== null) {
+                                    $totalUSD += $balance['balance'] * $rate;
+                                }
                             }
                         }
                     @endphp

--- a/resources/views/wallet/deposit-card.blade.php
+++ b/resources/views/wallet/deposit-card.blade.php
@@ -22,25 +22,9 @@
                         </p>
                     </div>
 
-                    @if(app()->environment('demo'))
-                        <div class="mb-6 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4">
-                            <div class="flex">
-                                <div class="flex-shrink-0">
-                                    <svg class="h-5 w-5 text-yellow-400" fill="currentColor" viewBox="0 0 20 20">
-                                        <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
-                                    </svg>
-                                </div>
-                                <div class="ml-3">
-                                    <h3 class="text-sm font-medium text-yellow-800 dark:text-yellow-200">
-                                        Demo Mode Active
-                                    </h3>
-                                    <div class="mt-2 text-sm text-yellow-700 dark:text-yellow-300">
-                                        <p>You're in demo mode. No real money will be transferred. Use the quick deposit button below to instantly add funds to your account.</p>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    @endif
+                    <x-demo-banner>
+                        <p>You're in demo mode. No real money will be transferred. Use the quick deposit button below to instantly add funds to your account.</p>
+                    </x-demo-banner>
 
                     <form id="deposit-form" class="space-y-6">
                         @csrf

--- a/resources/views/wallet/deposit-crypto.blade.php
+++ b/resources/views/wallet/deposit-crypto.blade.php
@@ -16,19 +16,23 @@
                         </p>
                     </div>
 
+                    <x-demo-banner>
+                        <p>You're in demo mode. Do not send real cryptocurrency to the addresses shown below.</p>
+                    </x-demo-banner>
+
                     <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
                         <button onclick="selectCrypto('BTC')" class="crypto-option p-4 border-2 border-gray-200 dark:border-gray-600 rounded-lg hover:border-blue-500 transition-colors cursor-pointer text-center">
                             <div class="text-3xl mb-2">₿</div>
                             <h4 class="font-semibold">Bitcoin (BTC)</h4>
                             <p class="text-sm text-gray-500 dark:text-gray-400">Network: Bitcoin</p>
                         </button>
-                        
+
                         <button onclick="selectCrypto('ETH')" class="crypto-option p-4 border-2 border-gray-200 dark:border-gray-600 rounded-lg hover:border-blue-500 transition-colors cursor-pointer text-center">
                             <div class="text-3xl mb-2">Ξ</div>
                             <h4 class="font-semibold">Ethereum (ETH)</h4>
                             <p class="text-sm text-gray-500 dark:text-gray-400">Network: ERC-20</p>
                         </button>
-                        
+
                         <button onclick="selectCrypto('USDT')" class="crypto-option p-4 border-2 border-gray-200 dark:border-gray-600 rounded-lg hover:border-blue-500 transition-colors cursor-pointer text-center">
                             <div class="text-3xl mb-2">₮</div>
                             <h4 class="font-semibold">Tether (USDT)</h4>
@@ -88,23 +92,25 @@
     <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script>
     
     <script>
+        const configuredAddresses = @json($cryptoAddresses ?? []);
+
         function selectCrypto(crypto) {
             // Remove active state from all options
             document.querySelectorAll('.crypto-option').forEach(el => {
                 el.classList.remove('border-blue-500');
             });
-            
+
             // Add active state to selected option
             event.target.closest('.crypto-option').classList.add('border-blue-500');
-            
+
             // Show deposit details
             document.getElementById('depositDetails').classList.remove('hidden');
-            
-            // Update crypto-specific details
+
+            // Update crypto-specific details — addresses from server config
             const addresses = {
-                'BTC': '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
-                'ETH': '0x742d35Cc6634C0532925a3b844Bc9e7595f06789',
-                'USDT': 'TN3W4H6rK2UM6GnKms9iFGQfVY73Gmwm7T'
+                'BTC': configuredAddresses.btc || '',
+                'ETH': configuredAddresses.eth || '',
+                'USDT': configuredAddresses.usdt || ''
             };
             
             const minDeposits = {
@@ -120,13 +126,17 @@
             };
             
             const address = addresses[crypto];
-            document.getElementById('cryptoAddress').value = address;
+            document.getElementById('cryptoAddress').value = address || 'Not configured';
             document.getElementById('selectedCrypto').textContent = crypto;
             document.getElementById('minDeposit').textContent = minDeposits[crypto];
             document.getElementById('confirmations').textContent = confirmations[crypto];
-            
-            // Generate QR code
-            generateQRCode(address, crypto);
+
+            // Generate QR code only if address is configured
+            if (address) {
+                generateQRCode(address, crypto);
+            } else {
+                document.getElementById('qrcode').innerHTML = '<div class="text-gray-400 text-sm p-4">Address not configured</div>';
+            }
         }
         
         function generateQRCode(address, crypto) {

--- a/resources/views/wallet/deposit-manual.blade.php
+++ b/resources/views/wallet/deposit-manual.blade.php
@@ -16,27 +16,31 @@
                         </p>
                     </div>
 
+                    <x-demo-banner>
+                        <p>You're in demo mode. The bank details below are simulated. Do not send real funds.</p>
+                    </x-demo-banner>
+
                     <div class="bg-gray-50 dark:bg-gray-700 rounded-lg p-6 mb-6">
                         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                             <div>
                                 <p class="text-sm font-medium text-gray-500 dark:text-gray-400">Bank Name</p>
-                                <p class="text-lg font-semibold">FinAegis Banking Ltd.</p>
+                                <p class="text-lg font-semibold">{{ $bankDetails['bank_name'] ?? 'Not configured' }}</p>
                             </div>
                             <div>
                                 <p class="text-sm font-medium text-gray-500 dark:text-gray-400">Account Name</p>
-                                <p class="text-lg font-semibold">FinAegis Core Banking</p>
+                                <p class="text-lg font-semibold">{{ $bankDetails['account_name'] ?? 'Not configured' }}</p>
                             </div>
                             <div>
                                 <p class="text-sm font-medium text-gray-500 dark:text-gray-400">Account Number</p>
-                                <p class="text-lg font-semibold">1234567890</p>
+                                <p class="text-lg font-semibold">{{ $bankDetails['account_number'] ?: 'Not configured' }}</p>
                             </div>
                             <div>
                                 <p class="text-sm font-medium text-gray-500 dark:text-gray-400">Routing Number</p>
-                                <p class="text-lg font-semibold">021000021</p>
+                                <p class="text-lg font-semibold">{{ $bankDetails['routing_number'] ?: 'Not configured' }}</p>
                             </div>
                             <div>
                                 <p class="text-sm font-medium text-gray-500 dark:text-gray-400">SWIFT/BIC</p>
-                                <p class="text-lg font-semibold">FINAEGISXXX</p>
+                                <p class="text-lg font-semibold">{{ $bankDetails['swift_code'] ?: 'Not configured' }}</p>
                             </div>
                             <div>
                                 <p class="text-sm font-medium text-gray-500 dark:text-gray-400">Reference Code</p>

--- a/resources/views/wallet/deposit-openbanking.blade.php
+++ b/resources/views/wallet/deposit-openbanking.blade.php
@@ -36,25 +36,9 @@
                         </div>
                     </div>
 
-                    @if(app()->environment('demo'))
-                        <div class="mb-6 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4">
-                            <div class="flex">
-                                <div class="flex-shrink-0">
-                                    <svg class="h-5 w-5 text-yellow-400" fill="currentColor" viewBox="0 0 20 20">
-                                        <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
-                                    </svg>
-                                </div>
-                                <div class="ml-3">
-                                    <h3 class="text-sm font-medium text-yellow-800 dark:text-yellow-200">
-                                        Demo Mode Active
-                                    </h3>
-                                    <div class="mt-2 text-sm text-yellow-700 dark:text-yellow-300">
-                                        <p>In demo mode, Open Banking connections are simulated. You won't be redirected to a real bank.</p>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    @endif
+                    <x-demo-banner>
+                        <p>In demo mode, Open Banking connections are simulated. You won't be redirected to a real bank.</p>
+                    </x-demo-banner>
 
                     <!-- Bank Selection -->
                     <div class="mb-8">

--- a/routes/web.php
+++ b/routes/web.php
@@ -675,13 +675,18 @@ Route::middleware([
             // Manual bank transfer
             Route::get('/manual', function () {
                 $account = Auth::user()->accounts()->first();
+                $bankDetails = config('cgo.bank_details');
+                $isDemo = app()->environment('demo');
 
-                return view('wallet.deposit-manual', compact('account'));
+                return view('wallet.deposit-manual', compact('account', 'bankDetails', 'isDemo'));
             })->name('manual');
 
-            // Crypto deposits (placeholder)
+            // Crypto deposits
             Route::get('/crypto', function () {
-                return view('wallet.deposit-crypto');
+                $cryptoAddresses = config('cgo.deposit_addresses');
+                $isDemo = app()->environment('demo');
+
+                return view('wallet.deposit-crypto', compact('cryptoAddresses', 'isDemo'));
             })->name('crypto');
         });
 


### PR DESCRIPTION
## Summary
- **SECURITY**: Remove hardcoded third-party crypto addresses (Satoshi genesis address, hacked Bitfinex address) that could cause users to send real funds to wrong parties
- Create reusable `<x-demo-banner>` Blade component and refactor all demo banners
- Config-drive bank details, crypto deposit addresses, and exchange rates via ExchangeRateService
- Replace QR code placeholder with actual qrcode.js generation
- Replace fake crosschain transactions with empty state; remove hidden defi placeholder row

## Changed Files
| File | Change |
|------|--------|
| `resources/views/components/demo-banner.blade.php` | New reusable demo banner component |
| `resources/views/wallet/deposit-crypto.blade.php` | Config-driven addresses via `@json($cryptoAddresses)` |
| `resources/views/wallet/deposit-manual.blade.php` | Config-driven bank details from `config('cgo.bank_details')` |
| `resources/views/wallet/blockchain/address.blade.php` | Real exchange rates + QR code generation |
| `resources/views/wallet/blockchain/index.blade.php` | Real exchange rates from ExchangeRateService |
| `app/Http/Controllers/BlockchainWalletController.php` | Inject ExchangeRateService, compute USD rates |
| `config/cgo.php` | Add `deposit_addresses` config, fix `bank_name` default |
| `routes/web.php` | Pass config data to route closures |
| `resources/views/crosschain/index.blade.php` | Replace 4 fake transactions with empty state CTA |
| `resources/views/defi/index.blade.php` | Remove hidden placeholder Aave row |
| `tests/Feature/CryptoDepositTest.php` | Update to verify config-driven addresses |

## Test plan
- [x] `./vendor/bin/pest tests/Feature/CryptoDepositTest.php` — all 7 tests pass
- [x] `./vendor/bin/pest --parallel` — full suite passes
- [x] `grep -r "1A1zP1" resources/` — returns nothing (no hardcoded crypto addresses)
- [ ] Verify views render in both demo and local environments
- [ ] Verify QR code generates on blockchain/address page

🤖 Generated with [Claude Code](https://claude.com/claude-code)