### PR TITLE
fix: Harden security headers and config defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,7 +60,7 @@ DB_PASSWORD=
 # =============================================================================
 SESSION_DRIVER=database
 SESSION_LIFETIME=120
-SESSION_ENCRYPT=false
+SESSION_ENCRYPT=true
 SESSION_PATH=/
 SESSION_DOMAIN=null
 
@@ -89,7 +89,7 @@ MAIL_PORT=2525
 MAIL_USERNAME=null
 MAIL_PASSWORD=null
 MAIL_ENCRYPTION=null
-MAIL_FROM_ADDRESS="hello@example.com"
+MAIL_FROM_ADDRESS="noreply@finaegis.org"
 MAIL_FROM_NAME="${APP_NAME}"
 
 # Resend Email Service (https://resend.com)
@@ -254,6 +254,7 @@ MAILCHIMP_LIST_ID=
 # SECURITY
 # =============================================================================
 APP_LOCAL_HOSTNAMES=localhost,127.0.0.1,finaegis.local,finaegis.test
+CORS_LOCAL_ORIGINS=http://localhost:3000,http://localhost:8080,http://localhost:5173,http://localhost:8081
 FORCE_HTTPS=false
 CSP_FONT_SOURCES=https://fonts.gstatic.com,https://fonts.bunny.net
 CSP_STYLE_SOURCES=https://fonts.googleapis.com,https://fonts.bunny.net

--- a/.env.production.example
+++ b/.env.production.example
@@ -100,6 +100,7 @@ RESEND_KEY=
 # SECURITY
 # =============================================================================
 FORCE_HTTPS=true
+CORS_LOCAL_ORIGINS=
 CSP_API_ENDPOINT=https://api.your-domain.com
 CSP_WS_ENDPOINT=wss://ws.your-domain.com
 

--- a/config/cors.php
+++ b/config/cors.php
@@ -19,19 +19,20 @@ return [
 
     'allowed_methods' => ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
 
-    'allowed_origins' => [
-        env('FRONTEND_URL', 'http://localhost:3000'),
-        'http://localhost:3000',
-        'http://localhost:8080',
-        'http://localhost:5173',
-        'http://localhost:8081',
+    'allowed_origins' => array_filter(array_merge(
         // Production origins
-        'https://finaegis.org',
-        'https://www.finaegis.org',
-        'https://api.finaegis.org',
-        'https://app.finaegis.org',
-        'https://dashboard.finaegis.org',
-    ],
+        [
+            'https://finaegis.org',
+            'https://www.finaegis.org',
+            'https://api.finaegis.org',
+            'https://app.finaegis.org',
+            'https://dashboard.finaegis.org',
+        ],
+        // Frontend URL (configurable per environment)
+        array_filter([env('FRONTEND_URL')]),
+        // Local development origins (set to empty string in production to disable)
+        explode(',', env('CORS_LOCAL_ORIGINS', 'http://localhost:3000,http://localhost:8080,http://localhost:5173,http://localhost:8081'))
+    )),
 
     'allowed_origins_patterns' => [],
 

--- a/config/mail.php
+++ b/config/mail.php
@@ -109,8 +109,8 @@ return [
     */
 
     'from' => [
-        'address' => env('MAIL_FROM_ADDRESS', 'hello@example.com'),
-        'name'    => env('MAIL_FROM_NAME', 'Example'),
+        'address' => env('MAIL_FROM_ADDRESS', 'noreply@finaegis.org'),
+        'name'    => env('MAIL_FROM_NAME', env('APP_NAME', 'FinAegis')),
     ],
 
 ];


### PR DESCRIPTION
## Summary
- Remove `unsafe-eval` from production CSP `script-src` (kept in local/dev for Vite HMR)
- Remove HSTS from testing/local/development environments (only production)
- Fix email defaults: `hello@example.com` -> `noreply@finaegis.org`
- Make CORS localhost origins env-driven via `CORS_LOCAL_ORIGINS` (empty in production)
- Default `SESSION_ENCRYPT=true` in `.env.example`

## Test plan
- [x] `./vendor/bin/pest tests/Security/ComprehensiveSecurityTest.php` — all 12 tests pass
- [x] `./vendor/bin/php-cs-fixer fix` — no violations
- [ ] `curl -I localhost:8000` — verify CSP headers lack `unsafe-eval` in production mode
- [ ] Verify CORS works correctly with new env-driven origins

🤖 Generated with [Claude Code](https://claude.com/claude-code)