### PR TITLE
fix: Update x402 status tests for data envelope wrapper

### DIFF
--- a/tests/Feature/Api/X402/X402StatusEndpointTest.php
+++ b/tests/Feature/Api/X402/X402StatusEndpointTest.php
@@ -10,11 +10,13 @@ test('x402 status endpoint returns protocol info', function () {
 
     $response->assertOk();
     $response->assertJsonStructure([
-        'enabled',
-        'version',
-        'protocol',
-        'default_network',
-        'supported_schemes',
+        'data' => [
+            'enabled',
+            'version',
+            'protocol',
+            'default_network',
+            'supported_schemes',
+        ],
     ]);
     $response->assertJsonFragment(['protocol' => 'x402']);
 });
@@ -24,12 +26,14 @@ test('x402 supported endpoint returns networks', function () {
 
     $response->assertOk();
     $response->assertJsonStructure([
-        'networks' => [
-            '*' => ['id', 'name', 'testnet', 'chain_id', 'usdc_address', 'usdc_decimals'],
+        'data' => [
+            'networks' => [
+                '*' => ['id', 'name', 'testnet', 'chain_id', 'usdc_address', 'usdc_decimals'],
+            ],
+            'contracts',
+            'supported_schemes',
+            'supported_assets',
         ],
-        'contracts',
-        'supported_schemes',
-        'supported_assets',
     ]);
 });
 


### PR DESCRIPTION
## Summary
- Aligns x402 feature tests with the `data` envelope wrapping applied in PR #600
- `status` and `supported` endpoints now wrap responses in `{ "data": { ... } }` for API consistency
- Tests updated to assert against `data.enabled`, `data.networks`, etc.

## Test plan
- [x] All 30 x402 tests pass locally (domain + feature)
- [x] No other tests affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)