### PR TITLE
fix: Platform polish v5.2.2 — banner cleanup, Swagger CSP, x402 docs, status redesign

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -252,3 +252,9 @@ EVENT_STORE_COMPACTION_ENABLED=false
 EVENT_STORE_KEEP_LATEST=100
 EVENT_STORE_PARTITION_STRATEGY=none
 EVENT_STORE_GROWTH_RATE_THRESHOLD=10000
+
+# =============================================================================
+# POST-DEPLOYMENT
+# =============================================================================
+# After deployment, run: php artisan l5-swagger:generate
+# This generates the OpenAPI spec for /api/documentation

--- a/app/Http/Controllers/StatusController.php
+++ b/app/Http/Controllers/StatusController.php
@@ -230,26 +230,57 @@ class StatusController extends Controller
             'web' => [
                 'name'        => 'Web Application',
                 'description' => 'Main platform interface',
+                'category'    => 'Core Platform',
+            ],
+            'auth' => [
+                'name'        => 'Authentication',
+                'description' => 'Login, registration, and session management',
+                'category'    => 'Core Platform',
             ],
             'api' => [
-                'name'        => 'API Services',
+                'name'        => 'REST API',
                 'description' => 'REST API endpoints and webhooks',
+                'category'    => 'API Services',
+            ],
+            'graphql' => [
+                'name'        => 'GraphQL API',
+                'description' => 'Schema-first API with 34 domain schemas',
+                'category'    => 'API Services',
+            ],
+            'x402' => [
+                'name'        => 'x402 Payment Gate',
+                'description' => 'HTTP-native micropayment protocol',
+                'category'    => 'API Services',
             ],
             'database' => [
-                'name'        => 'Database Cluster',
+                'name'        => 'Database',
                 'description' => 'Primary and replica databases',
-            ],
-            'queue' => [
-                'name'        => 'Queue Workers',
-                'description' => 'Background job processing',
+                'category'    => 'Infrastructure',
             ],
             'cache' => [
-                'name'        => 'CDN & Cache',
-                'description' => 'Content delivery and caching',
+                'name'        => 'Cache',
+                'description' => 'Redis cache layer',
+                'category'    => 'Infrastructure',
+            ],
+            'queue' => [
+                'name'        => 'Queue',
+                'description' => 'Background job processing',
+                'category'    => 'Infrastructure',
+            ],
+            'storage' => [
+                'name'        => 'Storage',
+                'description' => 'File and object storage',
+                'category'    => 'Infrastructure',
             ],
             'email' => [
-                'name'        => 'Email Service',
+                'name'        => 'Email',
                 'description' => 'Transactional email delivery',
+                'category'    => 'Integrations',
+            ],
+            'blockchain' => [
+                'name'        => 'Blockchain (Demo)',
+                'description' => 'On-chain settlement and smart accounts',
+                'category'    => 'Integrations',
             ],
         ];
 
@@ -266,6 +297,7 @@ class StatusController extends Controller
             $result[] = [
                 'name'        => $serviceInfo['name'],
                 'description' => $serviceInfo['description'],
+                'category'    => $serviceInfo['category'],
                 'status'      => $status,
                 'uptime'      => $uptime . '%',
             ];
@@ -312,7 +344,7 @@ class StatusController extends Controller
     private function calculateUptime()
     {
         // Calculate overall platform uptime based on all services
-        $services = ['web', 'api', 'database', 'queue', 'cache', 'email'];
+        $services = ['web', 'auth', 'api', 'graphql', 'x402', 'database', 'cache', 'queue', 'storage', 'email', 'blockchain'];
         $totalUptime = 0;
         $serviceCount = 0;
 

--- a/resources/views/components/platform-banners.blade.php
+++ b/resources/views/components/platform-banners.blade.php
@@ -1,37 +1,35 @@
-<!-- Platform Banners (Alpha + CGO) -->
-<div class="relative z-50">
-    <!-- Alpha Testing Banner (From main branch) - Only show on non-CGO pages -->
-    @unless(request()->routeIs('cgo') || request()->routeIs('cgo.*'))
-    <div class="bg-gradient-to-r from-red-600 to-orange-600 text-white shadow-lg">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="py-2">
-                <div class="flex items-center justify-center space-x-3">
-                    <div class="flex items-center space-x-2">
-                        <svg class="w-5 h-5 animate-pulse" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
-                        </svg>
-                        <span class="font-bold text-sm">ALPHA TESTING</span>
-                    </div>
-                    <div class="hidden sm:flex items-center space-x-2 text-xs">
-                        <span class="px-2 py-0.5 bg-white/20 backdrop-blur-sm rounded-full">No Real Transactions</span>
-                        <span class="px-2 py-0.5 bg-white/20 backdrop-blur-sm rounded-full">Demo Only</span>
-                        <span class="px-2 py-0.5 bg-white/20 backdrop-blur-sm rounded-full">Prototype Mode</span>
-                    </div>
-                </div>
-            </div>
-        </div>
+{{-- Demo Mode Indicator — only visible when APP_ENV=demo --}}
+@if(app()->environment('demo'))
+<div id="demo-pill" class="fixed bottom-6 left-6 z-50" onclick="this.classList.toggle('expanded')">
+    {{-- Collapsed pill --}}
+    <div class="demo-pill-collapsed cursor-pointer flex items-center gap-2 px-4 py-2 bg-amber-100 border border-amber-300 rounded-full shadow-lg hover:shadow-xl transition-all">
+        <span class="relative flex h-2.5 w-2.5">
+            <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-amber-500 opacity-75"></span>
+            <span class="relative inline-flex rounded-full h-2.5 w-2.5 bg-amber-500"></span>
+        </span>
+        <span class="text-sm font-semibold text-amber-800">Demo Mode</span>
     </div>
-    @endunless
-    
-    <!-- CGO (Continuous Growth Offering) Banner -->
-    <div class="bg-gradient-to-r from-indigo-600 to-purple-600 text-white py-2 px-4 text-center">
-        <div class="max-w-7xl mx-auto flex items-center justify-center space-x-4">
-            <p class="font-semibold text-sm sm:text-base">
-                🚀 Invest in FinAegis CGO - Continuous Growth Offering
-            </p>
-            <a href="{{ route('cgo') }}" class="bg-white text-indigo-600 px-4 py-1 rounded-full text-sm font-bold hover:bg-gray-100 transition">
-                Learn More
-            </a>
+
+    {{-- Expanded card --}}
+    <div class="demo-pill-expanded hidden mt-2 w-80 bg-white border border-amber-200 rounded-xl shadow-2xl p-5">
+        <div class="flex items-center gap-2 mb-3">
+            <span class="relative flex h-2.5 w-2.5">
+                <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-amber-500 opacity-75"></span>
+                <span class="relative inline-flex rounded-full h-2.5 w-2.5 bg-amber-500"></span>
+            </span>
+            <h3 class="text-base font-bold text-amber-900">Demo Environment</h3>
+        </div>
+        <p class="text-sm text-gray-600 mb-3">This is a demonstration instance. No real transactions are processed.</p>
+        <div class="flex flex-wrap gap-2">
+            <span class="inline-flex items-center px-2.5 py-1 bg-amber-50 text-amber-700 text-xs font-medium rounded-full border border-amber-200">No Real Funds</span>
+            <span class="inline-flex items-center px-2.5 py-1 bg-amber-50 text-amber-700 text-xs font-medium rounded-full border border-amber-200">Test Data</span>
         </div>
     </div>
 </div>
+
+<style>
+    #demo-pill.expanded .demo-pill-collapsed { display: none; }
+    #demo-pill.expanded .demo-pill-expanded { display: block; }
+    #demo-pill:not(.expanded) .demo-pill-expanded { display: none; }
+</style>
+@endif

--- a/resources/views/developers/api-docs.blade.php
+++ b/resources/views/developers/api-docs.blade.php
@@ -45,6 +45,7 @@
                     <a href="#ai" class="text-gray-600 hover:text-gray-900">AI</a>
                     <a href="#graphql" class="text-sky-600 hover:text-sky-800">GraphQL</a>
                     <a href="#event-streaming" class="text-lime-600 hover:text-lime-800">Event Streaming</a>
+                    <a href="#x402" class="text-emerald-600 hover:text-emerald-800">x402 Protocol</a>
                     <a href="#webhooks" class="text-gray-600 hover:text-gray-900">Webhooks</a>
                     <a href="#errors" class="text-gray-600 hover:text-gray-900">Errors</a>
                 </nav>
@@ -60,7 +61,7 @@
                         <h2 class="text-3xl font-bold text-gray-900 mb-8">Getting Started</h2>
                         
                         <div class="prose prose-lg max-w-none">
-                            <p>The FinAegis API provides programmatic access to our multi-asset banking platform spanning 41 DDD domains with over 1,150 routes. Our API is organized around REST principles with predictable, resource-oriented URLs. Domains include core banking, CrossChain bridging, DeFi protocols, RegTech compliance, Mobile Payment, Partner BaaS, and AI-powered queries.</p>
+                            <p>The FinAegis API provides programmatic access to our multi-asset banking platform spanning 42 DDD domains with over 1,200 routes. Our API is organized around REST principles with predictable, resource-oriented URLs. Domains include core banking, CrossChain bridging, DeFi protocols, RegTech compliance, Mobile Payment, Partner BaaS, and AI-powered queries.</p>
                             
                             <h3>Base URL</h3>
                             <x-code-block language="plaintext">
@@ -1249,8 +1250,8 @@ curl -H "Authorization: Bearer your_api_key" \
                         <h2 class="text-3xl font-bold text-gray-900 mb-8">GraphQL API</h2>
 
                         <div class="prose prose-lg max-w-none mb-8">
-                            <p>Schema-first GraphQL API powered by Lighthouse PHP. Provides queries, mutations, and subscriptions across 33 domain schemas with DataLoader-optimized resolvers and WebSocket-based real-time subscriptions.</p>
-                            <p class="text-sm text-gray-500">33 domain schemas &middot; Queries, Mutations, Subscriptions</p>
+                            <p>Schema-first GraphQL API powered by Lighthouse PHP. Provides queries, mutations, and subscriptions across 34 domain schemas with DataLoader-optimized resolvers and WebSocket-based real-time subscriptions.</p>
+                            <p class="text-sm text-gray-500">34 domain schemas &middot; Queries, Mutations, Subscriptions</p>
                         </div>
 
                         <div class="space-y-8">
@@ -1262,7 +1263,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                         <span class="ml-2 font-mono text-sm">/graphql</span>
                                     </div>
                                 </div>
-                                <p class="text-gray-600 mb-4">Execute a GraphQL query or mutation against the unified schema. Supports all 33 domain schemas including Account, AgentProtocol, Basket, Batch, CardIssuance, Cgo, Compliance, CrossChain, DeFi, Exchange, FinancialInstitution, Product, Regulatory, User, Wallet, and more.</p>
+                                <p class="text-gray-600 mb-4">Execute a GraphQL query or mutation against the unified schema. Supports all 34 domain schemas including Account, AgentProtocol, Basket, Batch, CardIssuance, Cgo, Compliance, CrossChain, DeFi, Exchange, FinancialInstitution, Product, Regulatory, User, Wallet, and more.</p>
                                 <x-code-block language="bash">
 curl -X POST \
   -H "Authorization: Bearer your_api_key" \
@@ -1410,6 +1411,143 @@ curl -H "Authorization: Bearer your_api_key" \
                             </div>
                         </div>
                     </section>
+
+                    <!-- x402 Protocol API -->
+                    <section id="x402" class="mb-16">
+                        <h2 class="text-3xl font-bold text-gray-900 mb-8">x402 Protocol API</h2>
+
+                        <div class="prose prose-lg max-w-none mb-8">
+                            <p>The x402 Protocol enables HTTP-native micropayments using USDC on Base. Monetize any API endpoint by returning HTTP 402 responses with payment requirements. Supports AI agent autonomous payments, spending limits, and multi-network settlement.</p>
+                            <p class="text-sm text-gray-500">15+ endpoints &middot; <a href="/api/documentation#/X402" target="_blank" class="text-emerald-600 hover:text-emerald-800">View in Swagger UI</a></p>
+                        </div>
+
+                        <div class="space-y-8">
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">Protocol Status</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/x402/status</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Get the current x402 protocol status including supported networks, assets, and facilitator connectivity.</p>
+                                <x-code-block language="bash">
+curl -H "Authorization: Bearer your_api_key" \
+     https://api.finaegis.org/v2/x402/status
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">Supported Networks</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/x402/supported</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">List all supported blockchain networks and payment assets for x402 settlement.</p>
+                                <x-code-block language="bash">
+curl -H "Authorization: Bearer your_api_key" \
+     https://api.finaegis.org/v2/x402/supported
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">Monetized Endpoints</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/x402/endpoints</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Register an API endpoint for x402 monetization with pricing configuration.</p>
+                                <x-code-block language="bash">
+curl -X POST \
+  -H "Authorization: Bearer your_api_key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "path": "/v2/premium/data",
+    "price_usd_cents": 100,
+    "network": "eip155:8453",
+    "asset": "USDC",
+    "description": "Premium market data"
+  }' \
+  https://api.finaegis.org/v2/x402/endpoints
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">Payment History</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/x402/payments</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">Retrieve payment history and settlement status for x402 transactions.</p>
+                                <x-code-block language="bash">
+curl -H "Authorization: Bearer your_api_key" \
+     "https://api.finaegis.org/v2/x402/payments?page=1&per_page=20"
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6">
+                                <h3 class="text-xl font-semibold mb-4">Spending Limits</h3>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                                    <div>
+                                        <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
+                                        <span class="ml-2 font-mono text-sm">/v2/x402/spending-limits</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 mb-4">View and manage spending limits for automated x402 payments including AI agent budgets.</p>
+                                <x-code-block language="bash">
+curl -H "Authorization: Bearer your_api_key" \
+     https://api.finaegis.org/v2/x402/spending-limits
+                                </x-code-block>
+                            </div>
+
+                            <div class="border rounded-lg p-6 bg-emerald-50 border-emerald-200">
+                                <h3 class="text-xl font-semibold mb-4">Handling 402 Responses</h3>
+                                <p class="text-gray-600 mb-4">When a client hits a monetized endpoint without payment, it receives an HTTP 402 with payment requirements in headers:</p>
+                                <x-code-block language="plaintext">
+HTTP/1.1 402 Payment Required
+X-Payment-Required: true
+X-Payment-Network: eip155:8453
+X-Payment-Asset: USDC
+X-Payment-Amount: 0.01
+X-Payment-Receiver: 0x...
+X-Payment-Facilitator: https://x402.org/facilitator
+                                </x-code-block>
+
+                                <h4 class="font-semibold mb-2 mt-6">JavaScript Client Example:</h4>
+                                <x-code-block language="javascript">
+const response = await fetch('https://api.finaegis.org/v2/premium/data', {
+  headers: { 'Authorization': 'Bearer YOUR_API_KEY' }
+});
+
+if (response.status === 402) {
+  const paymentInfo = {
+    network: response.headers.get('X-Payment-Network'),
+    asset: response.headers.get('X-Payment-Asset'),
+    amount: response.headers.get('X-Payment-Amount'),
+    receiver: response.headers.get('X-Payment-Receiver'),
+  };
+
+  // Sign and submit payment, then retry with proof
+  const proof = await signPayment(paymentInfo);
+  const paid = await fetch('https://api.finaegis.org/v2/premium/data', {
+    headers: {
+      'Authorization': 'Bearer YOUR_API_KEY',
+      'X-Payment-Signature': proof.signature,
+      'X-Payment-Payload': proof.payload,
+    }
+  });
+  const data = await paid.json(); // 200 + data
+}
+                                </x-code-block>
+                            </div>
+                        </div>
+                    </section>
                 </div>
 
                 <!-- Sidebar -->
@@ -1436,6 +1574,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <li><a href="#ai" class="text-gray-600 hover:text-gray-800 flex justify-between"><span>AI Query</span><span class="text-gray-400">2 routes</span></a></li>
                                 <li><a href="#graphql" class="text-sky-600 hover:text-sky-800 flex justify-between"><span>GraphQL</span><span class="text-gray-400">33 domains</span></a></li>
                                 <li><a href="#event-streaming" class="text-lime-600 hover:text-lime-800 flex justify-between"><span>Event Streaming</span><span class="text-gray-400">5 endpoints</span></a></li>
+                                <li><a href="#x402" class="text-emerald-600 hover:text-emerald-800 flex justify-between"><span>x402 Protocol</span><span class="text-gray-400">15+ endpoints</span></a></li>
                             </ul>
                         </div>
 

--- a/resources/views/developers/index.blade.php
+++ b/resources/views/developers/index.blade.php
@@ -140,7 +140,7 @@
                 <div class="text-center">
                     <div class="inline-flex items-center px-4 py-2 bg-white/10 backdrop-blur-sm rounded-full text-sm mb-6">
                         <span class="w-2 h-2 bg-green-400 rounded-full mr-2 animate-pulse"></span>
-                        <span>v5.0 Documentation -- 41 Domains, 1,189+ Routes, GraphQL + REST</span>
+                        <span>v5.2 Documentation -- 42 Domains, 1,200+ Routes, GraphQL + REST + x402</span>
                     </div>
                     <h1 class="text-5xl md:text-7xl font-bold mb-6 bg-clip-text text-transparent bg-gradient-to-r from-white to-blue-200">
                         Built for Developers
@@ -180,8 +180,8 @@
                     <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                     </svg>
-                    <span class="font-medium">v5.0 Released:</span>
-                    <span class="ml-2">41 DDD domains, 1,189+ API routes with GraphQL API (33 domains), Event Streaming, Plugin Marketplace, CrossChain, DeFi, RegTech, and Partner BaaS.</span>
+                    <span class="font-medium">v5.2 Released:</span>
+                    <span class="ml-2">42 DDD domains, 1,200+ API routes with GraphQL API (34 domains), x402 Protocol, Event Streaming, Plugin Marketplace, CrossChain, DeFi, RegTech, and Partner BaaS.</span>
                 </div>
             </div>
         </section>
@@ -437,7 +437,7 @@
                 <!-- Platform API Area Cards -->
                 <div class="mt-16">
                     <h3 class="text-2xl font-bold text-gray-900 mb-2 text-center">Platform API Areas</h3>
-                    <p class="text-gray-600 text-center mb-8">Explore the full breadth of the FinAegis platform across 41 DDD domains</p>
+                    <p class="text-gray-600 text-center mb-8">Explore the full breadth of the FinAegis platform across 42 DDD domains</p>
                     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
 
                         <!-- CrossChain -->
@@ -566,10 +566,10 @@
                                     </div>
                                     <div>
                                         <h4 class="text-lg font-semibold text-gray-900">GraphQL API</h4>
-                                        <span class="text-xs text-gray-500">33 domains</span>
+                                        <span class="text-xs text-gray-500">34 domains</span>
                                     </div>
                                 </div>
-                                <p class="text-gray-600 text-sm mb-3">Schema-first GraphQL via Lighthouse PHP with queries, mutations, subscriptions, and DataLoaders across 33 domain schemas.</p>
+                                <p class="text-gray-600 text-sm mb-3">Schema-first GraphQL via Lighthouse PHP with queries, mutations, subscriptions, and DataLoaders across 34 domain schemas.</p>
                                 <span class="text-sky-600 text-sm font-medium group-hover:text-sky-700">View endpoints &rarr;</span>
                             </div>
                         </a>
@@ -590,6 +590,25 @@
                                 </div>
                                 <p class="text-gray-600 text-sm mb-3">Redis Streams-based event publishing, consumer groups, live metrics dashboard with projector lag and throughput monitoring.</p>
                                 <span class="text-lime-600 text-sm font-medium group-hover:text-lime-700">View endpoints &rarr;</span>
+                            </div>
+                        </a>
+
+                        <!-- x402 Protocol -->
+                        <a href="{{ route('developers.show', 'api-docs') }}#x402" class="group block">
+                            <div class="bg-white rounded-xl border border-gray-200 p-6 hover:shadow-lg transition-all hover:-translate-y-1 h-full">
+                                <div class="flex items-center mb-3">
+                                    <div class="w-10 h-10 bg-gradient-to-br from-emerald-500 to-green-600 rounded-lg flex items-center justify-center text-white mr-3">
+                                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z"></path>
+                                        </svg>
+                                    </div>
+                                    <div>
+                                        <h4 class="text-lg font-semibold text-gray-900">x402 Protocol</h4>
+                                        <span class="text-xs text-gray-500">15+ endpoints</span>
+                                    </div>
+                                </div>
+                                <p class="text-gray-600 text-sm mb-3">HTTP-native micropayments. Monetize APIs with USDC on Base. GraphQL + REST with AI agent payment support.</p>
+                                <span class="text-emerald-600 text-sm font-medium group-hover:text-emerald-700">View endpoints &rarr;</span>
                             </div>
                         </a>
 
@@ -671,7 +690,7 @@
             <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                 <div class="grid grid-cols-2 md:grid-cols-5 gap-8 text-center">
                     <div>
-                        <div class="text-4xl md:text-5xl font-bold mb-2">1,150+</div>
+                        <div class="text-4xl md:text-5xl font-bold mb-2">1,200+</div>
                         <p class="text-indigo-200 flex items-center justify-center">
                             <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
@@ -680,7 +699,7 @@
                         </p>
                     </div>
                     <div>
-                        <div class="text-4xl md:text-5xl font-bold mb-2">41</div>
+                        <div class="text-4xl md:text-5xl font-bold mb-2">42</div>
                         <p class="text-indigo-200 flex items-center justify-center">
                             <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"></path>

--- a/resources/views/developers/sdks.blade.php
+++ b/resources/views/developers/sdks.blade.php
@@ -186,7 +186,7 @@
                     <div class="flex flex-wrap items-center justify-center gap-3 mb-6">
                         <span class="inline-flex items-center px-4 py-2 bg-green-500/20 backdrop-blur-sm rounded-full text-sm">
                             <span class="w-2 h-2 bg-green-400 rounded-full mr-2"></span>
-                            <span>REST API v5.0</span>
+                            <span>REST API v5.2</span>
                         </span>
                         <span class="inline-flex items-center px-4 py-2 bg-green-500/20 backdrop-blur-sm rounded-full text-sm">
                             <span class="w-2 h-2 bg-green-400 rounded-full mr-2"></span>
@@ -639,8 +639,8 @@ curl -X POST https://api.finaegis.org/api/v1/partner/sdk/generate \
         "language": "go",
         "version": "5.0.0",
         "package_name": "github.com/finaegis/sdk-go",
-        "download_url": "https://sdk.finaegis.org/packages/go/finaegis-sdk-go-5.0.0.tar.gz",
-        "install_command": "go get github.com/finaegis/sdk-go@v5.0.0"
+        "download_url": "https://sdk.finaegis.org/packages/go/finaegis-sdk-go-5.2.0.tar.gz",
+        "install_command": "go get github.com/finaegis/sdk-go@v5.2.0"
       },
       {
         "language": "php",
@@ -678,7 +678,7 @@ curl -X POST https://api.finaegis.org/api/v1/partner/sdk/generate \
                         <div>
                             <p class="text-sm font-medium text-gray-700 mb-2">Go</p>
                             <div class="bg-gray-900 rounded-lg p-4 font-mono text-green-400 text-sm">
-                                <code>go get github.com/finaegis/sdk-go@v5.0.0</code>
+                                <code>go get github.com/finaegis/sdk-go@v5.2.0</code>
                             </div>
                         </div>
                         <div>
@@ -754,7 +754,7 @@ client = FinAegis(
                         <div class="bg-gradient-to-r from-cyan-600 to-teal-600 px-6 py-4">
                             <div class="flex items-center">
                                 <span class="w-8 h-8 bg-white text-cyan-600 rounded-full flex items-center justify-center font-bold text-sm mr-3">2</span>
-                                <h3 class="text-lg font-semibold text-white">Access Cross-Chain and DeFi Modules (v5.0)</h3>
+                                <h3 class="text-lg font-semibold text-white">Access Cross-Chain and DeFi Modules (v5.2)</h3>
                             </div>
                         </div>
                         <div class="p-6">
@@ -919,12 +919,12 @@ console.log('Total volume:', insights.data.analytics.total_volume);</pre>
                             <div class="border border-gray-200 rounded-lg p-4">
                                 <h4 class="font-semibold text-gray-900 mb-1">client.crosschain</h4>
                                 <p class="text-sm text-gray-600">Bridge protocols, multi-chain portfolio</p>
-                                <span class="text-xs text-gray-400">v5.0+</span>
+                                <span class="text-xs text-gray-400">v5.2+</span>
                             </div>
                             <div class="border border-gray-200 rounded-lg p-4">
                                 <h4 class="font-semibold text-gray-900 mb-1">client.defi</h4>
                                 <p class="text-sm text-gray-600">DEX aggregation, lending, staking, yield</p>
-                                <span class="text-xs text-gray-400">v5.0+</span>
+                                <span class="text-xs text-gray-400">v5.2+</span>
                             </div>
                             <div class="border border-gray-200 rounded-lg p-4">
                                 <h4 class="font-semibold text-gray-900 mb-1">client.ai</h4>

--- a/resources/views/features/index.blade.php
+++ b/resources/views/features/index.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'Features - Modern Banking Platform',
-        'description' => 'FinAegis features - Global Currency Unit (GCU), cross-chain bridges, DeFi protocols, privacy-preserving identity, mobile payments, RegTech compliance, BaaS, and AI analytics.',
+        'description' => 'FinAegis features - Global Currency Unit (GCU), x402 protocol, cross-chain bridges, DeFi protocols, privacy-preserving identity, mobile payments, RegTech compliance, BaaS, and AI analytics.',
         'keywords' => 'FinAegis features, GCU, global currency unit, cross-chain, DeFi, privacy, mobile payments, RegTech, BaaS, AI, multi-tenancy',
     ])
 
@@ -441,6 +441,25 @@
                         Redis Streams-powered event streaming with a live dashboard, consumer groups, backpressure handling, and dead-letter queues.
                     </p>
                     <a href="{{ route('features') }}" class="text-teal-600 font-medium hover:text-teal-700">
+                        Learn more &rarr;
+                    </a>
+                </div>
+
+                <!-- x402 Protocol -->
+                <div class="feature-card bg-white border border-gray-200 rounded-xl p-8">
+                    <div class="w-14 h-14 bg-emerald-100 rounded-lg flex items-center justify-center mb-6">
+                        <svg class="w-8 h-8 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z"></path>
+                        </svg>
+                    </div>
+                    <div class="flex items-center gap-2 mb-3">
+                        <h3 class="text-xl font-semibold">x402 Protocol</h3>
+                        <span class="inline-flex items-center px-2 py-0.5 bg-green-100 text-green-700 text-xs rounded-full font-medium">Available</span>
+                    </div>
+                    <p class="text-gray-600 mb-4">
+                        HTTP-native micropayments with USDC on Base. Instant settlement, AI agent autonomous payments, spending limits, and multi-network support.
+                    </p>
+                    <a href="{{ route('features.show', 'x402-protocol') }}" class="text-emerald-600 font-medium hover:text-emerald-700">
                         Learn more &rarr;
                     </a>
                 </div>

--- a/resources/views/features/x402-protocol.blade.php
+++ b/resources/views/features/x402-protocol.blade.php
@@ -1,0 +1,225 @@
+@extends('layouts.public')
+
+@section('title', 'x402 Protocol - HTTP-Native Micropayments | FinAegis')
+
+@section('seo')
+    @include('partials.seo', [
+        'title' => 'x402 Protocol - HTTP-Native Micropayments',
+        'description' => 'Monetize APIs with HTTP 402 responses. USDC payments on Base with instant settlement, AI agent support, and spending limits.',
+        'keywords' => 'x402, HTTP 402, micropayments, USDC, Base, API monetization, AI agent payments, spending limits',
+    ])
+@endsection
+
+@push('styles')
+<style>
+    .x402-gradient { background: linear-gradient(135deg, #059669 0%, #10b981 50%, #34d399 100%); }
+</style>
+@endpush
+
+@section('content')
+
+    <!-- Hero -->
+    <section class="x402-gradient text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
+            <div class="max-w-3xl">
+                <div class="inline-flex items-center px-3 py-1 bg-white/20 backdrop-blur-sm rounded-full text-sm mb-6">
+                    <span class="w-2 h-2 bg-white rounded-full mr-2"></span>
+                    v5.2.0 &middot; Production Ready
+                </div>
+                <h1 class="text-5xl font-bold mb-6">x402 Protocol</h1>
+                <p class="text-xl text-emerald-100 mb-8">
+                    HTTP-native micropayments for APIs. Return a 402, get paid in USDC, deliver data. No subscriptions, no API keys to manage &mdash; just pay-per-request built into HTTP.
+                </p>
+                <div class="flex flex-wrap gap-4">
+                    <a href="{{ route('developers.show', 'api-docs') }}#x402" class="bg-white text-emerald-700 px-6 py-3 rounded-lg font-semibold hover:bg-emerald-50 transition">
+                        API Reference
+                    </a>
+                    <a href="/api/documentation#/X402" target="_blank" class="border-2 border-white text-white px-6 py-3 rounded-lg font-semibold hover:bg-white hover:text-emerald-700 transition">
+                        Swagger UI
+                    </a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- How It Works -->
+    <section class="py-20 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <h2 class="text-3xl font-bold text-gray-900 text-center mb-4">How It Works</h2>
+            <p class="text-gray-600 text-center mb-12 max-w-2xl mx-auto">Three HTTP round-trips. No out-of-band negotiation.</p>
+
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+                <!-- Step 1 -->
+                <div class="text-center">
+                    <div class="w-16 h-16 bg-emerald-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                        <span class="text-2xl font-bold text-emerald-600">1</span>
+                    </div>
+                    <h3 class="text-lg font-semibold mb-2">Request Resource</h3>
+                    <p class="text-gray-600 text-sm mb-4">Client sends a standard HTTP request to a monetized endpoint.</p>
+                    <div class="bg-gray-50 rounded-lg p-3 text-left font-mono text-xs text-gray-700">
+                        <div>GET /v2/premium/data HTTP/1.1</div>
+                        <div>Authorization: Bearer ...</div>
+                    </div>
+                </div>
+
+                <!-- Step 2 -->
+                <div class="text-center">
+                    <div class="w-16 h-16 bg-amber-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                        <span class="text-2xl font-bold text-amber-600">2</span>
+                    </div>
+                    <h3 class="text-lg font-semibold mb-2">402 + Payment Info</h3>
+                    <p class="text-gray-600 text-sm mb-4">Server responds with 402 and payment requirements in headers.</p>
+                    <div class="bg-gray-50 rounded-lg p-3 text-left font-mono text-xs text-gray-700">
+                        <div class="text-amber-600 font-semibold">HTTP/1.1 402 Payment Required</div>
+                        <div>X-Payment-Amount: 0.01</div>
+                        <div>X-Payment-Asset: USDC</div>
+                        <div>X-Payment-Network: eip155:8453</div>
+                    </div>
+                </div>
+
+                <!-- Step 3 -->
+                <div class="text-center">
+                    <div class="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                        <span class="text-2xl font-bold text-green-600">3</span>
+                    </div>
+                    <h3 class="text-lg font-semibold mb-2">Pay & Receive Data</h3>
+                    <p class="text-gray-600 text-sm mb-4">Client signs payment, retries with proof. Server settles and delivers.</p>
+                    <div class="bg-gray-50 rounded-lg p-3 text-left font-mono text-xs text-gray-700">
+                        <div class="text-green-600 font-semibold">HTTP/1.1 200 OK</div>
+                        <div>X-Payment-Settled: true</div>
+                        <div>Content-Type: application/json</div>
+                        <div class="text-gray-400 mt-1">{"data": { ... }}</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Key Features -->
+    <section class="py-20 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <h2 class="text-3xl font-bold text-gray-900 text-center mb-12">Key Features</h2>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+                <div class="bg-white rounded-xl border border-gray-200 p-6">
+                    <div class="w-10 h-10 bg-emerald-100 rounded-lg flex items-center justify-center mb-4">
+                        <svg class="w-5 h-5 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
+                        </svg>
+                    </div>
+                    <h3 class="font-semibold mb-2">Payment Gate Middleware</h3>
+                    <p class="text-gray-600 text-sm">Protect any route with x402. Configurable pricing, automatic 402 responses, and settlement verification.</p>
+                </div>
+
+                <div class="bg-white rounded-xl border border-gray-200 p-6">
+                    <div class="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center mb-4">
+                        <svg class="w-5 h-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
+                        </svg>
+                    </div>
+                    <h3 class="font-semibold mb-2">AI Agent Payments</h3>
+                    <p class="text-gray-600 text-sm">Autonomous agents can pay for API access with budget limits, approval thresholds, and MCP tool integration.</p>
+                </div>
+
+                <div class="bg-white rounded-xl border border-gray-200 p-6">
+                    <div class="w-10 h-10 bg-amber-100 rounded-lg flex items-center justify-center mb-4">
+                        <svg class="w-5 h-5 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                        </svg>
+                    </div>
+                    <h3 class="font-semibold mb-2">Spending Limits</h3>
+                    <p class="text-gray-600 text-sm">Daily, per-transaction, and per-agent spending caps with approval-required thresholds above configurable amounts.</p>
+                </div>
+
+                <div class="bg-white rounded-xl border border-gray-200 p-6">
+                    <div class="w-10 h-10 bg-purple-100 rounded-lg flex items-center justify-center mb-4">
+                        <svg class="w-5 h-5 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                        </svg>
+                    </div>
+                    <h3 class="font-semibold mb-2">Multi-Network</h3>
+                    <p class="text-gray-600 text-sm">Settle on Base (primary), Ethereum, or Avalanche. Configurable per-endpoint with automatic network detection.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Supported Networks -->
+    <section class="py-20 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <h2 class="text-3xl font-bold text-gray-900 text-center mb-12">Supported Networks</h2>
+
+            <div class="max-w-3xl mx-auto">
+                <div class="bg-white rounded-xl border border-gray-200 overflow-hidden">
+                    <table class="w-full">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th class="px-6 py-3 text-left text-sm font-semibold text-gray-900">Network</th>
+                                <th class="px-6 py-3 text-left text-sm font-semibold text-gray-900">Chain ID</th>
+                                <th class="px-6 py-3 text-left text-sm font-semibold text-gray-900">Asset</th>
+                                <th class="px-6 py-3 text-left text-sm font-semibold text-gray-900">Status</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-gray-200">
+                            <tr>
+                                <td class="px-6 py-4 text-sm font-medium text-gray-900">Base</td>
+                                <td class="px-6 py-4 text-sm text-gray-600 font-mono">eip155:8453</td>
+                                <td class="px-6 py-4 text-sm text-gray-600">USDC</td>
+                                <td class="px-6 py-4"><span class="inline-flex items-center px-2 py-0.5 bg-green-100 text-green-700 text-xs rounded-full font-medium">Primary</span></td>
+                            </tr>
+                            <tr class="bg-gray-50">
+                                <td class="px-6 py-4 text-sm font-medium text-gray-900">Ethereum</td>
+                                <td class="px-6 py-4 text-sm text-gray-600 font-mono">eip155:1</td>
+                                <td class="px-6 py-4 text-sm text-gray-600">USDC</td>
+                                <td class="px-6 py-4"><span class="inline-flex items-center px-2 py-0.5 bg-blue-100 text-blue-700 text-xs rounded-full font-medium">Supported</span></td>
+                            </tr>
+                            <tr>
+                                <td class="px-6 py-4 text-sm font-medium text-gray-900">Avalanche</td>
+                                <td class="px-6 py-4 text-sm text-gray-600 font-mono">eip155:43114</td>
+                                <td class="px-6 py-4 text-sm text-gray-600">USDC</td>
+                                <td class="px-6 py-4"><span class="inline-flex items-center px-2 py-0.5 bg-blue-100 text-blue-700 text-xs rounded-full font-medium">Supported</span></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Developer Integration -->
+    <section class="py-20 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <h2 class="text-3xl font-bold text-gray-900 text-center mb-4">Developer Integration</h2>
+            <p class="text-gray-600 text-center mb-12 max-w-2xl mx-auto">Protect any Laravel route with x402 middleware in one line.</p>
+
+            <div class="max-w-3xl mx-auto">
+                <x-code-block language="php">
+// routes/api.php
+Route::get('/premium/market-data', [MarketDataController::class, 'index'])
+    ->middleware('x402:100000'); // Price in micro-USDC (= $0.10)
+
+// Or with full configuration
+Route::get('/premium/analytics', [AnalyticsController::class, 'show'])
+    ->middleware('x402:500000,eip155:8453,USDC');
+                </x-code-block>
+            </div>
+        </div>
+    </section>
+
+    <!-- CTA -->
+    <section class="py-20 x402-gradient text-white">
+        <div class="max-w-4xl mx-auto text-center px-4 sm:px-6 lg:px-8">
+            <h2 class="text-3xl font-bold mb-4">Start Monetizing Your APIs</h2>
+            <p class="text-lg text-emerald-100 mb-8">Add x402 payment gates to your endpoints and get paid per request.</p>
+            <div class="flex flex-wrap gap-4 justify-center">
+                <a href="{{ route('developers.show', 'api-docs') }}#x402" class="bg-white text-emerald-700 px-6 py-3 rounded-lg font-semibold hover:bg-emerald-50 transition">
+                    Read the Docs
+                </a>
+                <a href="{{ route('developers') }}" class="border-2 border-white text-white px-6 py-3 rounded-lg font-semibold hover:bg-white hover:text-emerald-700 transition">
+                    Developer Portal
+                </a>
+            </div>
+        </div>
+    </section>
+
+@endsection

--- a/resources/views/status.blade.php
+++ b/resources/views/status.blade.php
@@ -5,225 +5,120 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'System Status - FinAegis',
-        'description' => 'Real-time status of FinAegis prototype platform services and functionality.',
+        'description' => 'Real-time status of FinAegis platform services and infrastructure.',
         'keywords' => 'FinAegis status, system status, platform uptime, service availability',
     ])
 @endsection
 
 @section('content')
-    <div class="bg-white">
-        <!-- Header -->
-        <div class="bg-gradient-to-r from-{{ $status['overall'] === 'operational' ? 'green' : ($status['overall'] === 'degraded' ? 'yellow' : 'red') }}-600 to-{{ $status['overall'] === 'operational' ? 'green' : ($status['overall'] === 'degraded' ? 'yellow' : 'red') }}-700">
-            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-                <div class="text-center">
-                    <div class="flex justify-center items-center mb-4">
-                        <div class="w-4 h-4 bg-{{ $status['overall'] === 'operational' ? 'green' : ($status['overall'] === 'degraded' ? 'yellow' : 'red') }}-400 rounded-full animate-pulse mr-3"></div>
-                        <span class="text-{{ $status['overall'] === 'operational' ? 'green' : ($status['overall'] === 'degraded' ? 'yellow' : 'red') }}-100 text-lg font-medium">
-                            @if($status['overall'] === 'operational')
-                                All Systems Operational
-                            @elseif($status['overall'] === 'degraded')
-                                Some Systems Degraded
-                            @else
-                                Major Outage
-                            @endif
-                        </span>
+    <div class="bg-gray-50 min-h-screen">
+        <!-- Status Header -->
+        <div class="bg-white border-b border-gray-200">
+            <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+                <div class="flex items-center justify-between">
+                    <div class="flex items-center gap-4">
+                        @if($status['overall'] === 'operational')
+                            <div class="w-10 h-10 bg-green-500 rounded-full flex items-center justify-center">
+                                <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+                                </svg>
+                            </div>
+                        @elseif($status['overall'] === 'degraded')
+                            <div class="w-10 h-10 bg-yellow-500 rounded-full flex items-center justify-center">
+                                <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01"></path>
+                                </svg>
+                            </div>
+                        @else
+                            <div class="w-10 h-10 bg-red-500 rounded-full flex items-center justify-center">
+                                <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                                </svg>
+                            </div>
+                        @endif
+                        <div>
+                            <h1 class="text-2xl font-bold text-gray-900">
+                                @if($status['overall'] === 'operational')
+                                    All Systems Operational
+                                @elseif($status['overall'] === 'degraded')
+                                    Some Systems Degraded
+                                @else
+                                    Major Outage
+                                @endif
+                            </h1>
+                            <p class="text-sm text-gray-500">Updated {{ $status['last_checked']->diffForHumans() }}</p>
+                        </div>
                     </div>
-                    <h1 class="text-4xl font-bold text-white sm:text-5xl">
-                        System Status
-                    </h1>
-                    <p class="mt-4 text-xl text-{{ $status['overall'] === 'operational' ? 'green' : ($status['overall'] === 'degraded' ? 'yellow' : 'red') }}-100">
-                        Real-time status of FinAegis prototype platform
-                    </p>
-                    <p class="mt-2 text-sm text-{{ $status['overall'] === 'operational' ? 'green' : ($status['overall'] === 'degraded' ? 'yellow' : 'red') }}-200">
-                        Last updated: {{ $status['last_checked']->diffForHumans() }}
-                    </p>
+                    <div class="hidden sm:flex items-center gap-6 text-sm text-gray-500">
+                        <div class="text-center">
+                            <div class="text-lg font-bold text-gray-900">{{ $uptime['percentage'] }}%</div>
+                            <div>Uptime</div>
+                        </div>
+                        <div class="text-center">
+                            <div class="text-lg font-bold text-gray-900">{{ $status['response_time'] }}ms</div>
+                            <div>Avg Response</div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
 
-        <!-- Current Status Overview -->
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-            <div class="grid grid-cols-1 md:grid-cols-4 gap-6 mb-12">
-                <div class="bg-white rounded-lg border border-gray-200 p-6 text-center">
-                    <div class="w-12 h-12 bg-{{ $status['overall'] === 'operational' ? 'green' : ($status['overall'] === 'degraded' ? 'yellow' : 'red') }}-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                        <svg class="w-6 h-6 text-{{ $status['overall'] === 'operational' ? 'green' : ($status['overall'] === 'degraded' ? 'yellow' : 'red') }}-600" fill="currentColor" viewBox="0 0 24 24">
-                            <path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
-                        </svg>
-                    </div>
-                    <h3 class="text-lg font-semibold text-gray-900">Platform Status</h3>
-                    <p class="text-2xl font-bold text-{{ $status['overall'] === 'operational' ? 'green' : ($status['overall'] === 'degraded' ? 'yellow' : 'red') }}-600 mt-2 capitalize">{{ $status['overall'] }}</p>
-                </div>
+        <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+            <!-- Services grouped by category -->
+            @php
+                $grouped = collect($services)->groupBy('category');
+            @endphp
 
-                <div class="bg-white rounded-lg border border-gray-200 p-6 text-center">
-                    <div class="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                        <svg class="w-6 h-6 text-green-600" fill="currentColor" viewBox="0 0 24 24">
-                            <path d="M13 10V3L4 14h7v7l9-11h-7z"/>
-                        </svg>
-                    </div>
-                    <h3 class="text-lg font-semibold text-gray-900">Uptime</h3>
-                    <p class="text-2xl font-bold text-green-600 mt-2">{{ $uptime['percentage'] }}%</p>
-                    <p class="text-xs text-gray-500 mt-1">Last {{ $uptime['period'] }}</p>
-                </div>
-
-                <div class="bg-white rounded-lg border border-gray-200 p-6 text-center">
-                    <div class="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                        <svg class="w-6 h-6 text-blue-600" fill="currentColor" viewBox="0 0 24 24">
-                            <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
-                        </svg>
-                    </div>
-                    <h3 class="text-lg font-semibold text-gray-900">Response Time</h3>
-                    <p class="text-2xl font-bold text-blue-600 mt-2">{{ $status['response_time'] }}ms</p>
-                </div>
-
-                <div class="bg-white rounded-lg border border-gray-200 p-6 text-center">
-                    <div class="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                        <svg class="w-6 h-6 text-purple-600" fill="currentColor" viewBox="0 0 24 24">
-                            <path d="M12 2L2 7v10c0 5.55 3.84 9.74 9 11 5.16-1.26 9-5.45 9-11V7l-10-5z"/>
-                        </svg>
-                    </div>
-                    <h3 class="text-lg font-semibold text-gray-900">Security Status</h3>
-                    <p class="text-2xl font-bold text-purple-600 mt-2">Secure</p>
-                </div>
-            </div>
-
-            <!-- Prototype Notice -->
-            <div class="bg-amber-50 border border-amber-200 rounded-lg p-6 mb-12">
-                <div class="flex items-start">
-                    <svg class="w-6 h-6 text-amber-600 mr-3 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                    </svg>
-                    <div>
-                        <h3 class="text-lg font-semibold text-amber-900 mb-2">Prototype Platform</h3>
-                        <p class="text-amber-800">
-                            This is a demonstration of FinAegis core banking functionality. The status page shows actual prototype system health and available features.
-                        </p>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Service Status -->
-            <div class="bg-white rounded-lg shadow-sm border border-gray-200 mb-12">
-                <div class="px-6 py-4 border-b border-gray-200">
-                    <h2 class="text-xl font-semibold text-gray-900">Prototype Services</h2>
-                </div>
-                <div class="divide-y divide-gray-200">
-                    @foreach($services as $service)
-                    <div class="px-6 py-4 flex items-center justify-between">
-                        <div class="flex items-center">
-                            <div class="w-3 h-3 bg-{{ $service['status'] === 'operational' ? 'green' : ($service['status'] === 'degraded' ? 'yellow' : 'red') }}-400 rounded-full mr-4"></div>
+            @foreach($grouped as $category => $categoryServices)
+            <div class="mb-6">
+                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3 px-1">{{ $category }}</h2>
+                <div class="bg-white rounded-lg border border-gray-200 divide-y divide-gray-100">
+                    @foreach($categoryServices as $service)
+                    <div class="px-5 py-4 flex items-center justify-between">
+                        <div class="flex items-center gap-3">
+                            <div class="w-2.5 h-2.5 rounded-full {{ $service['status'] === 'operational' ? 'bg-green-500' : ($service['status'] === 'degraded' ? 'bg-yellow-500' : 'bg-red-500') }}"></div>
                             <div>
-                                <h3 class="text-lg font-medium text-gray-900">{{ $service['name'] }}</h3>
-                                <p class="text-gray-600">{{ $service['description'] }}</p>
+                                <span class="text-sm font-medium text-gray-900">{{ $service['name'] }}</span>
+                                <span class="text-sm text-gray-400 ml-2 hidden sm:inline">{{ $service['description'] }}</span>
                             </div>
                         </div>
-                        <div class="text-right">
-                            <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-{{ $service['status'] === 'operational' ? 'green' : ($service['status'] === 'degraded' ? 'yellow' : 'red') }}-100 text-{{ $service['status'] === 'operational' ? 'green' : ($service['status'] === 'degraded' ? 'yellow' : 'red') }}-800">
+                        <div class="flex items-center gap-4">
+                            <span class="text-xs text-gray-400 hidden sm:inline">{{ $service['uptime'] }} uptime</span>
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{ $service['status'] === 'operational' ? 'bg-green-50 text-green-700' : ($service['status'] === 'degraded' ? 'bg-yellow-50 text-yellow-700' : 'bg-red-50 text-red-700') }}">
                                 {{ ucfirst($service['status']) }}
                             </span>
-                            <p class="text-xs text-gray-500 mt-1">{{ $service['uptime'] }} uptime</p>
                         </div>
                     </div>
                     @endforeach
                 </div>
             </div>
+            @endforeach
 
-            <!-- Available Features -->
-            <div class="bg-white rounded-lg shadow-sm border border-gray-200 mb-12">
-                <div class="px-6 py-4 border-b border-gray-200">
-                    <h2 class="text-xl font-semibold text-gray-900">Available Features</h2>
-                </div>
-                <div class="p-6">
-                    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                        <div class="flex items-start">
-                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-                                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
-                            </svg>
-                            <div>
-                                <h4 class="text-lg font-medium text-gray-900">User Authentication</h4>
-                                <p class="text-gray-600">Registration, login, and session management</p>
-                            </div>
-                        </div>
-                        <div class="flex items-start">
-                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-                                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
-                            </svg>
-                            <div>
-                                <h4 class="text-lg font-medium text-gray-900">Account Management</h4>
-                                <p class="text-gray-600">Create and manage banking accounts</p>
-                            </div>
-                        </div>
-                        <div class="flex items-start">
-                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-                                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
-                            </svg>
-                            <div>
-                                <h4 class="text-lg font-medium text-gray-900">Transaction Processing</h4>
-                                <p class="text-gray-600">Deposits, withdrawals, and transfers</p>
-                            </div>
-                        </div>
-                        <div class="flex items-start">
-                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-                                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
-                            </svg>
-                            <div>
-                                <h4 class="text-lg font-medium text-gray-900">API Access</h4>
-                                <p class="text-gray-600">RESTful API with authentication</p>
-                            </div>
-                        </div>
-                        <div class="flex items-start">
-                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-                                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
-                            </svg>
-                            <div>
-                                <h4 class="text-lg font-medium text-gray-900">Multi-Currency Support</h4>
-                                <p class="text-gray-600">GCU and traditional currencies</p>
-                            </div>
-                        </div>
-                        <div class="flex items-start">
-                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-                                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
-                            </svg>
-                            <div>
-                                <h4 class="text-lg font-medium text-gray-900">Ledger System</h4>
-                                <p class="text-gray-600">Double-entry bookkeeping</p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- System Checks -->
-            <div class="bg-white rounded-lg shadow-sm border border-gray-200 mb-12">
-                <div class="px-6 py-4 border-b border-gray-200">
-                    <h2 class="text-xl font-semibold text-gray-900">System Health Checks</h2>
-                </div>
-                <div class="p-6">
-                    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <!-- System Health Checks -->
+            <div class="mb-6">
+                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3 px-1">System Health</h2>
+                <div class="bg-white rounded-lg border border-gray-200">
+                    <div class="grid grid-cols-1 sm:grid-cols-2 divide-y sm:divide-y-0 sm:divide-x divide-gray-100">
                         @foreach($status['checks'] as $check => $result)
-                        <div class="flex items-start">
-                            <div class="flex-shrink-0">
-                                @if($result['status'] === 'operational')
-                                    <svg class="w-6 h-6 text-green-500" fill="currentColor" viewBox="0 0 20 20">
-                                        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
-                                    </svg>
-                                @elseif($result['status'] === 'degraded')
-                                    <svg class="w-6 h-6 text-yellow-500" fill="currentColor" viewBox="0 0 20 20">
-                                        <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
-                                    </svg>
-                                @else
-                                    <svg class="w-6 h-6 text-red-500" fill="currentColor" viewBox="0 0 20 20">
-                                        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
-                                    </svg>
-                                @endif
-                            </div>
-                            <div class="ml-3">
-                                <h4 class="text-lg font-medium text-gray-900 capitalize">{{ str_replace('_', ' ', $check) }}</h4>
-                                <p class="text-gray-600">{{ $result['message'] }}</p>
+                        <div class="px-5 py-4 flex items-start gap-3">
+                            @if($result['status'] === 'operational')
+                                <svg class="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+                                </svg>
+                            @elseif($result['status'] === 'degraded')
+                                <svg class="w-5 h-5 text-yellow-500 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
+                                </svg>
+                            @else
+                                <svg class="w-5 h-5 text-red-500 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
+                                </svg>
+                            @endif
+                            <div>
+                                <div class="text-sm font-medium text-gray-900 capitalize">{{ str_replace('_', ' ', $check) }}</div>
+                                <div class="text-xs text-gray-500">{{ $result['message'] }}</div>
                                 @if(isset($result['response_time']))
-                                    <p class="text-sm text-gray-500 mt-1">Response time: {{ $result['response_time'] }}ms</p>
-                                @endif
-                                @if(isset($result['usage']))
-                                    <p class="text-sm text-gray-500 mt-1">Usage: {{ $result['usage'] }}</p>
+                                    <div class="text-xs text-gray-400 mt-0.5">{{ $result['response_time'] }}ms</div>
                                 @endif
                             </div>
                         </div>
@@ -234,41 +129,35 @@
 
             <!-- Recent Incidents -->
             @if(count($incidents) > 0)
-            <div class="bg-white rounded-lg shadow-sm border border-gray-200">
-                <div class="px-6 py-4 border-b border-gray-200">
-                    <h2 class="text-xl font-semibold text-gray-900">Recent Incidents</h2>
-                </div>
-                <div class="divide-y divide-gray-200">
+            <div class="mb-6">
+                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3 px-1">Recent Incidents</h2>
+                <div class="bg-white rounded-lg border border-gray-200 divide-y divide-gray-100">
                     @foreach($incidents as $incident)
-                    <div class="p-6">
-                        <div class="flex items-start justify-between">
+                    <div class="px-5 py-4">
+                        <div class="flex items-start justify-between mb-2">
                             <div>
-                                <h3 class="text-lg font-medium text-gray-900">{{ $incident['title'] }}</h3>
-                                <p class="text-sm text-gray-500 mt-1">
-                                    {{ $incident['started_at']->format('M d, Y H:i') }} - 
+                                <h3 class="text-sm font-medium text-gray-900">{{ $incident['title'] }}</h3>
+                                <p class="text-xs text-gray-500 mt-0.5">
+                                    {{ $incident['started_at']->format('M d, Y H:i') }}
                                     @if($incident['resolved_at'])
-                                        {{ $incident['resolved_at']->format('M d, Y H:i') }}
+                                        &mdash; {{ $incident['resolved_at']->format('M d, Y H:i') }}
                                     @else
-                                        Ongoing
+                                        &mdash; Ongoing
                                     @endif
                                 </p>
                             </div>
-                            <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-{{ $incident['status'] === 'resolved' ? 'green' : ($incident['status'] === 'in_progress' ? 'yellow' : 'red') }}-100 text-{{ $incident['status'] === 'resolved' ? 'green' : ($incident['status'] === 'in_progress' ? 'yellow' : 'red') }}-800">
+                            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium
+                                {{ $incident['status'] === 'resolved' ? 'bg-green-50 text-green-700' : ($incident['status'] === 'in_progress' ? 'bg-yellow-50 text-yellow-700' : 'bg-red-50 text-red-700') }}">
                                 {{ ucfirst(str_replace('_', ' ', $incident['status'])) }}
                             </span>
                         </div>
-                        
+
                         @if(count($incident['updates']) > 0)
-                        <div class="mt-4 space-y-3">
+                        <div class="ml-4 border-l-2 border-gray-200 pl-4 mt-3 space-y-2">
                             @foreach($incident['updates'] as $update)
-                            <div class="flex items-start">
-                                <div class="flex-shrink-0">
-                                    <div class="w-2 h-2 bg-gray-400 rounded-full mt-2"></div>
-                                </div>
-                                <div class="ml-3">
-                                    <p class="text-sm text-gray-600">{{ $update['message'] }}</p>
-                                    <p class="text-xs text-gray-500 mt-1">{{ $update['created_at']->format('M d, Y H:i') }}</p>
-                                </div>
+                            <div>
+                                <p class="text-xs text-gray-600">{{ $update['message'] }}</p>
+                                <p class="text-xs text-gray-400">{{ $update['created_at']->format('M d, H:i') }}</p>
                             </div>
                             @endforeach
                         </div>
@@ -279,10 +168,10 @@
             </div>
             @endif
 
-            <!-- API Status Link -->
-            <div class="mt-12 text-center">
-                <p class="text-gray-600">
-                    Need programmatic access? Check our 
+            <!-- Footer -->
+            <div class="text-center py-8">
+                <p class="text-sm text-gray-500">
+                    Programmatic access:
                     <a href="{{ route('status.api') }}" class="text-indigo-600 hover:text-indigo-700 font-medium">Status API</a>
                 </p>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -75,7 +75,7 @@ Route::get('/features', function () {
 
 Route::get('/features/{feature}', function ($feature) {
     // List of valid feature pages
-    $validFeatures = ['gcu', 'multi-asset', 'settlements', 'governance', 'bank-integration', 'api', 'crosschain-defi', 'privacy-identity', 'mobile-payments', 'regtech-compliance', 'baas-platform', 'ai-framework', 'multi-tenancy'];
+    $validFeatures = ['gcu', 'multi-asset', 'settlements', 'governance', 'bank-integration', 'api', 'crosschain-defi', 'privacy-identity', 'mobile-payments', 'regtech-compliance', 'baas-platform', 'ai-framework', 'multi-tenancy', 'x402-protocol'];
 
     if (! in_array($feature, $validFeatures)) {
         abort(404);


### PR DESCRIPTION
## Summary

- **Banner cleanup**: Replace ALPHA TESTING and CGO global banners with a floating demo mode indicator (only visible when `APP_ENV=demo`)
- **Swagger CSP fix**: Relax Content-Security-Policy for `/api/documentation` routes to allow CDN assets and `unsafe-eval`
- **x402 documentation**: Add x402 Protocol to developer portal, API docs, features page, and create `/features/x402-protocol` detail page
- **Status page redesign**: Professional redesign with services grouped by category (Core Platform, API Services, Infrastructure, Integrations)
- **Version sync**: Update version labels from v5.0 to v5.2 across developer pages and SDK references
- **Deployment note**: Add `l5-swagger:generate` reminder to `.env.production.example`

## Files Changed (11 modified + 1 new)

| File | Change |
|------|--------|
| `resources/views/components/platform-banners.blade.php` | Replace banners with floating demo pill |
| `app/Http/Middleware/SecurityHeaders.php` | Relax CSP for swagger routes |
| `.env.production.example` | Add swagger generate deployment note |
| `resources/views/developers/index.blade.php` | Add x402 card, update version/stats |
| `resources/views/developers/api-docs.blade.php` | Add x402 API documentation section |
| `resources/views/developers/sdks.blade.php` | Update version labels v5.0 → v5.2 |
| `resources/views/features/index.blade.php` | Add x402 feature card |
| `resources/views/features/x402-protocol.blade.php` | **New** — x402 feature detail page |
| `resources/views/status.blade.php` | Professional redesign with grouped services |
| `app/Http/Controllers/StatusController.php` | Add services, group by category |
| `routes/web.php` | Add `x402-protocol` to valid features |

## Test plan

- [ ] Visit `/` — no banners visible (unless `APP_ENV=demo`, then small floating pill)
- [ ] Visit `/api/documentation` — Swagger UI loads without 403 or CSP errors
- [ ] Visit `/developers` — x402 card visible, version says "v5.2"
- [ ] Visit `/features` — x402 card visible with link to detail page
- [ ] Visit `/features/x402-protocol` — full feature page renders
- [ ] Visit `/status` — professional redesigned page with grouped services
- [ ] All tests pass: `./vendor/bin/pest --parallel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)