### PR TITLE
fix: Make l5-swagger config serializable for config:cache/optimize

### DIFF
--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -131,15 +131,13 @@ return [
             ],
 
             /**
-             * analyser: ReflectionAnalyser with both DocBlock and Attribute support.
-             * l5-swagger v10 defaults to attributes-only; we need docblock support too.
+             * analyser: Set to null here so the config is serializable for caching.
+             * The actual ReflectionAnalyser with DocBlock + Attribute support is
+             * registered in AppServiceProvider (or the l5-swagger service provider).
              *
              * @see OpenApi\scan
              */
-            'analyser' => new OpenApi\Analysers\ReflectionAnalyser([
-                new OpenApi\Analysers\DocBlockAnnotationFactory(),
-                new OpenApi\Analysers\AttributeAnnotationFactory(),
-            ]),
+            'analyser' => null,
 
             /**
              * analysis: defaults to a new \OpenApi\Analysis .


### PR DESCRIPTION
## Summary

- Fix `php artisan optimize` / `php artisan config:cache` failing with `ReflectionAnalyser::__set_state()` error
- Move `ReflectionAnalyser` instantiation from `config/l5-swagger.php` to `AppServiceProvider::boot()`
- Config value set to `null` (serializable), analyser injected at generation time via `app()->resolving(GeneratorFactory::class)`

## Test plan

- [ ] `php artisan optimize` completes without error
- [ ] `php artisan config:cache` completes without error
- [ ] `php artisan l5-swagger:generate` still generates API docs correctly
- [ ] `/api/documentation` loads Swagger UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)