### PR TITLE
fix: API error fixes — TrustCert numeric IDs + X402 limit alias

### DIFF
--- a/app/Http/Controllers/Api/X402/X402PaymentController.php
+++ b/app/Http/Controllers/Api/X402/X402PaymentController.php
@@ -34,7 +34,7 @@ class X402PaymentController extends Controller
      *     @OA\Parameter(name="status", in="query", required=false, @OA\Schema(type="string", enum={"pending", "verified", "settled", "failed", "expired"})),
      *     @OA\Parameter(name="network", in="query", required=false, @OA\Schema(type="string")),
      *     @OA\Parameter(name="payer_address", in="query", required=false, @OA\Schema(type="string")),
-     *     @OA\Parameter(name="per_page", in="query", required=false, @OA\Schema(type="integer", default=20, maximum=100)),
+     *     @OA\Parameter(name="per_page", in="query", required=false, description="Items per page (alias: limit)", @OA\Schema(type="integer", default=20, maximum=100)),
      *     @OA\Response(
      *         response=200,
      *         description="Paginated payment records"
@@ -65,7 +65,7 @@ class X402PaymentController extends Controller
             $query->where('payer_address', $request->input('payer_address'));
         }
 
-        $perPage = min(max((int) $request->input('per_page', 20), 1), 100);
+        $perPage = min(max((int) $request->input('per_page', $request->input('limit', 20)), 1), 100);
 
         $payments = $query->orderByDesc('created_at')
             ->paginate($perPage);

--- a/tests/Unit/Http/Controllers/Api/TrustCert/MobileTrustCertControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/TrustCert/MobileTrustCertControllerTest.php
@@ -133,6 +133,39 @@ describe('MobileTrustCertController requirementsByLevel', function (): void {
 
         expect($response->getStatusCode())->toBe(404);
     });
+
+    it('accepts numeric level values', function (): void {
+        $controller = makeTrustCertController($this);
+
+        $response = $controller->requirementsByLevel('1');
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue()
+            ->and($data['data']['level'])->toBe('basic')
+            ->and($data['data']['numeric_value'])->toBe(1);
+    });
+
+    it('maps all numeric levels correctly', function (): void {
+        $controller = makeTrustCertController($this);
+
+        $expected = [['0', 'unknown'], ['1', 'basic'], ['2', 'verified'], ['3', 'high'], ['4', 'ultimate']];
+
+        foreach ($expected as [$numeric, $name]) {
+            $response = $controller->requirementsByLevel($numeric);
+            $data = $response->getData(true);
+
+            expect($data['success'])->toBeTrue()
+                ->and($data['data']['level'])->toBe($name);
+        }
+    });
+
+    it('returns 404 for out-of-range numeric level', function (): void {
+        $controller = makeTrustCertController($this);
+
+        $response = $controller->requirementsByLevel('99');
+
+        expect($response->getStatusCode())->toBe(404);
+    });
 });
 
 describe('MobileTrustCertController limits', function (): void {


### PR DESCRIPTION
## Summary
- **TrustCert 404 fix**: `requirementsByLevel` endpoint now accepts numeric level values (0-4) in addition to string names (`basic`, `verified`, etc.). Mobile app was calling `/requirements/1` which returned 404 because `TrustLevel::tryFrom('1')` failed.
- **X402 limit alias**: Payments index endpoint now accepts `limit` as an alias for `per_page` query parameter, matching mobile app conventions.
- **X402 500 errors**: These are caused by unmigrated `x402_payments` table — migration already exists (`2026_02_22_000001`), just needs `php artisan migrate` on the server.

## Changes
| File | Change |
|------|--------|
| `MobileTrustCertController.php` | Added numeric-to-enum mapping for trust levels |
| `X402PaymentController.php` | `limit` query param alias for `per_page` |
| `MobileTrustCertControllerTest.php` | 3 new tests for numeric level support |

## Test plan
- [x] All 15 TrustCert controller tests pass (54 assertions)
- [x] PHPStan clean
- [x] PHP CS Fixer clean
- [ ] Run `php artisan migrate` on server to create x402_payments table

🤖 Generated with [Claude Code](https://claude.com/claude-code)