### PR TITLE
test: x402 integration tests + response shape verification (112 tests)

### DIFF
--- a/app/Domain/MobilePayment/Services/ActivityFeedService.php
+++ b/app/Domain/MobilePayment/Services/ActivityFeedService.php
@@ -55,9 +55,9 @@ class ActivityFeedService
         $nextCursor = $hasMore && $lastItem ? $this->encodeCursor($lastItem) : null;
 
         return [
-            'items'      => $items->map(fn (ActivityFeedItem $item) => $item->toApiResponse())->values()->all(),
-            'nextCursor' => $nextCursor,
-            'hasMore'    => $hasMore,
+            'items'       => $items->map(fn (ActivityFeedItem $item) => $item->toApiResponse())->values()->all(),
+            'next_cursor' => $nextCursor,
+            'has_more'    => $hasMore,
         ];
     }
 

--- a/app/Domain/MobilePayment/Services/NetworkAvailabilityService.php
+++ b/app/Domain/MobilePayment/Services/NetworkAvailabilityService.php
@@ -23,7 +23,7 @@ class NetworkAvailabilityService
     /**
      * Get the status of all supported networks.
      *
-     * @return array<int, array{id: string, name: string, nativeAsset: string, status: string, avgFeeUsd: string, avgConfirmationSeconds: int, congestion: string, supportedAssets: array<string>}>
+     * @return array<int, array{id: string, name: string, native_asset: string, status: string, avg_fee_usd: string, avg_confirmation_seconds: int, congestion: string, supported_assets: array<string>}>
      */
     public function getNetworkStatuses(): array
     {
@@ -37,7 +37,7 @@ class NetworkAvailabilityService
     /**
      * Get status for a single network.
      *
-     * @return array{id: string, name: string, nativeAsset: string, status: string, avgFeeUsd: string, avgConfirmationSeconds: int, congestion: string, supportedAssets: array<string>}|null
+     * @return array{id: string, name: string, native_asset: string, status: string, avg_fee_usd: string, avg_confirmation_seconds: int, congestion: string, supported_assets: array<string>}|null
      */
     public function getNetworkStatus(PaymentNetwork $network): ?array
     {
@@ -53,7 +53,7 @@ class NetworkAvailabilityService
     }
 
     /**
-     * @return array<int, array{id: string, name: string, nativeAsset: string, status: string, avgFeeUsd: string, avgConfirmationSeconds: int, congestion: string, supportedAssets: array<string>}>
+     * @return array<int, array{id: string, name: string, native_asset: string, status: string, avg_fee_usd: string, avg_confirmation_seconds: int, congestion: string, supported_assets: array<string>}>
      */
     private function fetchNetworkStatuses(): array
     {
@@ -67,21 +67,21 @@ class NetworkAvailabilityService
     }
 
     /**
-     * @return array{id: string, name: string, nativeAsset: string, status: string, avgFeeUsd: string, avgConfirmationSeconds: int, congestion: string, supportedAssets: array<string>}
+     * @return array{id: string, name: string, native_asset: string, status: string, avg_fee_usd: string, avg_confirmation_seconds: int, congestion: string, supported_assets: array<string>}
      */
     private function checkNetwork(PaymentNetwork $network): array
     {
         $healthy = $this->isNetworkHealthy($network);
 
         return [
-            'id'                     => $network->value,
-            'name'                   => $network->label(),
-            'nativeAsset'            => $network->nativeAsset(),
-            'status'                 => $healthy ? 'active' : 'unavailable',
-            'avgFeeUsd'              => $this->getAverageFeeUsd($network),
-            'avgConfirmationSeconds' => $this->getAvgConfirmationSeconds($network),
-            'congestion'             => $this->getCongestionLevel($network),
-            'supportedAssets'        => ['USDC'],
+            'id'                       => $network->value,
+            'name'                     => $network->label(),
+            'native_asset'             => $network->nativeAsset(),
+            'status'                   => $healthy ? 'active' : 'unavailable',
+            'avg_fee_usd'              => $this->getAverageFeeUsd($network),
+            'avg_confirmation_seconds' => $this->getAvgConfirmationSeconds($network),
+            'congestion'               => $this->getCongestionLevel($network),
+            'supported_assets'         => ['USDC'],
         ];
     }
 

--- a/app/Domain/MobilePayment/Services/ReceiveAddressService.php
+++ b/app/Domain/MobilePayment/Services/ReceiveAddressService.php
@@ -18,7 +18,7 @@ class ReceiveAddressService
     /**
      * Get a receive address for the given user, network, and asset.
      *
-     * @return array{address: string, qrPayload: string, network: string, asset: string, warning: string, minimumAmount: string}
+     * @return array{address: string, qr_payload: string, network: string, asset: string, warning: string, minimum_amount: string}
      */
     public function getReceiveAddress(int $userId, PaymentNetwork $network, PaymentAsset $asset): array
     {
@@ -31,12 +31,12 @@ class ReceiveAddressService
         $address = $addressData->address;
 
         return [
-            'address'       => $address,
-            'qrPayload'     => $this->buildQrValue($address, $network, $asset),
-            'network'       => $network->value,
-            'asset'         => $asset->value,
-            'warning'       => "Only send {$asset->value} on {$network->label()} to this address. Using other tokens or networks may result in loss.",
-            'minimumAmount' => '0.01',
+            'address'        => $address,
+            'qr_payload'     => $this->buildQrValue($address, $network, $asset),
+            'network'        => $network->value,
+            'asset'          => $asset->value,
+            'warning'        => "Only send {$asset->value} on {$network->label()} to this address. Using other tokens or networks may result in loss.",
+            'minimum_amount' => '0.01',
         ];
     }
 

--- a/app/Domain/X402/Models/X402SpendingLimit.php
+++ b/app/Domain/X402/Models/X402SpendingLimit.php
@@ -30,6 +30,16 @@ class X402SpendingLimit extends Model
 
     protected $table = 'x402_spending_limits';
 
+    /**
+     * Default attribute values (mirrors DB column defaults).
+     *
+     * @var array<string, mixed>
+     */
+    protected $attributes = [
+        'spent_today'      => '0',
+        'auto_pay_enabled' => false,
+    ];
+
     protected $fillable = [
         'agent_id',
         'agent_type',

--- a/tests/Feature/Api/ResponseShapeVerificationTest.php
+++ b/tests/Feature/Api/ResponseShapeVerificationTest.php
@@ -1,0 +1,922 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Mobile\Models\MobileDevice;
+use App\Domain\Mobile\Models\MobilePushNotification;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+uses(RefreshDatabase::class);
+
+/*
+|--------------------------------------------------------------------------
+| Response Shape Verification Tests
+|--------------------------------------------------------------------------
+|
+| These tests verify that all mobile-facing API endpoints return
+| correctly-shaped JSON responses. They check:
+|
+| 1. snake_case keys across all response payloads
+| 2. Consistent pagination format (data + meta)
+| 3. Standard error format (error.code + error.message)
+| 4. Auth response shape (token, token_type, etc.)
+|
+*/
+
+// --------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------
+
+/**
+ * Recursively assert that all keys in a JSON structure are snake_case.
+ */
+function assertKeysAreSnakeCase(array $data, string $path = ''): void
+{
+    foreach ($data as $key => $value) {
+        // Skip numeric (array) keys
+        if (is_int($key)) {
+            if (is_array($value)) {
+                assertKeysAreSnakeCase($value, "{$path}[{$key}]");
+            }
+
+            continue;
+        }
+
+        $currentPath = $path ? "{$path}.{$key}" : $key;
+
+        // A snake_case key is lowercase and may contain underscores and digits;
+        // it must NOT contain uppercase letters.
+        expect($key)
+            ->not->toMatch('/[A-Z]/', "Key '{$currentPath}' is not snake_case");
+
+        if (is_array($value)) {
+            assertKeysAreSnakeCase($value, $currentPath);
+        }
+    }
+}
+
+/**
+ * Create an authenticated user and return [user, token].
+ */
+function createShapeTestUser(): array
+{
+    $user = User::factory()->create();
+    $token = $user->createToken('test-token', ['read', 'write'])->plainTextToken;
+
+    return [$user, $token];
+}
+
+// --------------------------------------------------------------------------
+// Setup
+// --------------------------------------------------------------------------
+
+beforeEach(function () {
+    Cache::flush();
+});
+
+// ==========================================================================
+//  1. AUTH ENDPOINTS
+// ==========================================================================
+
+describe('Auth endpoints - POST /api/login', function () {
+    test('login returns correct auth response shape', function () {
+        $user = User::factory()->create([
+            'password' => bcrypt('password123'),
+        ]);
+
+        $response = $this->postJson('/api/login', [
+            'email'    => $user->email,
+            'password' => 'password123',
+        ]);
+
+        $response->assertOk();
+
+        $json = $response->json();
+
+        // Must have success flag
+        expect($json)->toHaveKey('success', true);
+
+        // Must have data envelope
+        expect($json)->toHaveKey('data');
+
+        $data = $json['data'];
+
+        // Auth response must include token fields
+        expect($data)->toHaveKey('access_token');
+        expect($data)->toHaveKey('token_type', 'Bearer');
+        expect($data)->toHaveKey('expires_in');
+        expect($data)->toHaveKey('refresh_token');
+        expect($data)->toHaveKey('refresh_expires_in');
+        expect($data)->toHaveKey('user');
+
+        // All keys should be snake_case
+        assertKeysAreSnakeCase($json);
+    });
+
+    test('login error returns standard validation error shape', function () {
+        $response = $this->postJson('/api/login', [
+            'email'    => 'wrong@example.com',
+            'password' => 'wrongpassword',
+        ]);
+
+        $response->assertUnprocessable();
+
+        $json = $response->json();
+
+        // Laravel validation returns message + errors
+        expect($json)->toHaveKey('message');
+        expect($json)->toHaveKey('errors');
+
+        assertKeysAreSnakeCase($json);
+    });
+
+    test('login with missing fields returns validation error', function () {
+        $response = $this->postJson('/api/login', []);
+
+        $response->assertUnprocessable();
+
+        $json = $response->json();
+        expect($json)->toHaveKey('message');
+        expect($json)->toHaveKey('errors');
+    });
+});
+
+describe('Auth endpoints - POST /api/register', function () {
+    test('register returns correct auth response shape', function () {
+        // Fake HTTP to bypass HaveIBeenPwned API check in password validation
+        Http::fake([
+            'api.pwnedpasswords.com/*' => Http::response('', 200),
+        ]);
+
+        $response = $this->postJson('/api/register', [
+            'name'                  => 'Test User',
+            'email'                 => 'newuser@example.com',
+            'password'              => 'Xk9#mP2$vL7wQ!nR',
+            'password_confirmation' => 'Xk9#mP2$vL7wQ!nR',
+        ]);
+
+        $response->assertCreated();
+
+        $json = $response->json();
+
+        expect($json)->toHaveKey('success', true);
+        expect($json)->toHaveKey('data');
+
+        $data = $json['data'];
+
+        expect($data)->toHaveKey('access_token');
+        expect($data)->toHaveKey('refresh_token');
+        expect($data)->toHaveKey('token_type', 'Bearer');
+        expect($data)->toHaveKey('expires_in');
+        expect($data)->toHaveKey('refresh_expires_in');
+        expect($data)->toHaveKey('user');
+
+        assertKeysAreSnakeCase($json);
+    });
+
+    test('register with duplicate email returns validation error', function () {
+        $existing = User::factory()->create();
+
+        $response = $this->postJson('/api/register', [
+            'name'                  => 'Test User',
+            'email'                 => $existing->email,
+            'password'              => 'password123',
+            'password_confirmation' => 'password123',
+        ]);
+
+        $response->assertUnprocessable();
+
+        $json = $response->json();
+        expect($json)->toHaveKey('message');
+        expect($json)->toHaveKey('errors');
+        expect($json['errors'])->toHaveKey('email');
+    });
+});
+
+// ==========================================================================
+//  2. MOBILE DEVICE MANAGEMENT
+// ==========================================================================
+
+describe('Mobile config - GET /api/mobile/config', function () {
+    test('config response has correct shape with snake_case keys', function () {
+        $response = $this->getJson('/api/mobile/config');
+
+        $response->assertOk();
+
+        $json = $response->json();
+
+        expect($json)->toHaveKey('data');
+
+        $data = $json['data'];
+        expect($data)->toHaveKey('min_app_version');
+        expect($data)->toHaveKey('latest_app_version');
+        expect($data)->toHaveKey('force_update');
+        expect($data)->toHaveKey('maintenance_mode');
+        expect($data)->toHaveKey('features');
+        expect($data)->toHaveKey('websocket');
+
+        // Verify features sub-keys
+        expect($data['features'])->toHaveKey('biometric_auth');
+        expect($data['features'])->toHaveKey('push_notifications');
+
+        assertKeysAreSnakeCase($json);
+    });
+});
+
+describe('Mobile app status - GET /api/v1/app/status', function () {
+    test('app status response has correct shape', function () {
+        $response = $this->getJson('/api/v1/app/status');
+
+        $response->assertOk();
+
+        $json = $response->json();
+
+        expect($json)->toHaveKey('success', true);
+        expect($json)->toHaveKey('data');
+
+        $data = $json['data'];
+        expect($data)->toHaveKey('min_version');
+        expect($data)->toHaveKey('latest_version');
+        expect($data)->toHaveKey('force_update');
+        expect($data)->toHaveKey('maintenance');
+
+        assertKeysAreSnakeCase($json);
+    });
+});
+
+describe('Mobile device endpoints', function () {
+    test('GET /api/mobile/devices returns data array envelope', function () {
+        [$user, $token] = createShapeTestUser();
+
+        MobileDevice::factory()->count(2)->create(['user_id' => $user->id]);
+
+        $response = $this->withToken($token)->getJson('/api/mobile/devices');
+
+        $response->assertOk();
+
+        $json = $response->json();
+
+        // Must have data envelope as array
+        expect($json)->toHaveKey('data');
+        expect($json['data'])->toBeArray();
+        expect($json['data'])->toHaveCount(2);
+
+        // Each device must have snake_case keys
+        $device = $json['data'][0];
+        expect($device)->toHaveKey('device_id');
+        expect($device)->toHaveKey('platform');
+        expect($device)->toHaveKey('device_name');
+        expect($device)->toHaveKey('biometric_enabled');
+        expect($device)->toHaveKey('is_trusted');
+        expect($device)->toHaveKey('is_blocked');
+        expect($device)->toHaveKey('has_push_token');
+        expect($device)->toHaveKey('is_current');
+        expect($device)->toHaveKey('created_at');
+
+        assertKeysAreSnakeCase($json);
+    });
+
+    test('POST /api/mobile/devices returns created device shape', function () {
+        [$user, $token] = createShapeTestUser();
+
+        $response = $this->withToken($token)->postJson('/api/mobile/devices', [
+            'device_id'    => 'test-shape-device-001',
+            'platform'     => 'ios',
+            'app_version'  => '1.0.0',
+            'push_token'   => 'fcm_test_token_shape',
+            'device_name'  => 'iPhone Test',
+            'device_model' => 'iPhone15,3',
+            'os_version'   => '17.0',
+        ]);
+
+        $response->assertCreated();
+
+        $json = $response->json();
+
+        expect($json)->toHaveKey('data');
+        expect($json)->toHaveKey('message');
+
+        $data = $json['data'];
+        expect($data)->toHaveKey('id');
+        expect($data)->toHaveKey('device_id');
+        expect($data)->toHaveKey('platform');
+        expect($data)->toHaveKey('device_name');
+        expect($data)->toHaveKey('biometric_enabled');
+        expect($data)->toHaveKey('is_trusted');
+        expect($data)->toHaveKey('is_blocked');
+        expect($data)->toHaveKey('has_push_token');
+        expect($data)->toHaveKey('created_at');
+
+        assertKeysAreSnakeCase($json);
+    });
+
+    test('POST /api/mobile/devices validation error returns structured error', function () {
+        [$user, $token] = createShapeTestUser();
+
+        $response = $this->withToken($token)->postJson('/api/mobile/devices', []);
+
+        $response->assertUnprocessable();
+
+        $json = $response->json();
+
+        // Mobile endpoints use structured error format
+        expect($json)->toHaveKey('error');
+        expect($json['error'])->toHaveKey('code', 'VALIDATION_ERROR');
+        expect($json['error'])->toHaveKey('message');
+        expect($json['error'])->toHaveKey('details');
+
+        assertKeysAreSnakeCase($json);
+    });
+
+    test('GET /api/mobile/devices requires authentication', function () {
+        $response = $this->getJson('/api/mobile/devices');
+
+        $response->assertUnauthorized();
+    });
+
+    test('POST /api/mobile/devices requires authentication', function () {
+        $response = $this->postJson('/api/mobile/devices', [
+            'device_id'   => 'test',
+            'platform'    => 'ios',
+            'app_version' => '1.0.0',
+        ]);
+
+        $response->assertUnauthorized();
+    });
+});
+
+// ==========================================================================
+//  3. MOBILE AUTH - BIOMETRIC
+// ==========================================================================
+
+describe('Mobile biometric auth endpoints', function () {
+    test('POST /api/mobile/auth/biometric/challenge returns challenge shape', function () {
+        [$user, $token] = createShapeTestUser();
+
+        $device = MobileDevice::factory()->biometricEnabled()->create([
+            'user_id' => $user->id,
+        ]);
+
+        $response = $this->postJson('/api/mobile/auth/biometric/challenge', [
+            'device_id' => $device->device_id,
+        ]);
+
+        $response->assertOk();
+
+        $json = $response->json();
+
+        expect($json)->toHaveKey('data');
+        expect($json['data'])->toHaveKey('challenge');
+        expect($json['data'])->toHaveKey('expires_at');
+
+        assertKeysAreSnakeCase($json);
+    });
+
+    test('POST /api/mobile/auth/biometric/challenge with unknown device returns error shape', function () {
+        $response = $this->postJson('/api/mobile/auth/biometric/challenge', [
+            'device_id' => 'nonexistent-device-xyz',
+        ]);
+
+        $response->assertNotFound();
+
+        $json = $response->json();
+
+        expect($json)->toHaveKey('error');
+        expect($json['error'])->toHaveKey('code', 'NOT_FOUND');
+        expect($json['error'])->toHaveKey('message');
+
+        assertKeysAreSnakeCase($json);
+    });
+
+    test('POST /api/mobile/auth/biometric/challenge with non-biometric device returns error', function () {
+        [$user, $token] = createShapeTestUser();
+
+        $device = MobileDevice::factory()->create([
+            'user_id'           => $user->id,
+            'biometric_enabled' => false,
+        ]);
+
+        $response = $this->postJson('/api/mobile/auth/biometric/challenge', [
+            'device_id' => $device->device_id,
+        ]);
+
+        $response->assertBadRequest();
+
+        $json = $response->json();
+
+        expect($json)->toHaveKey('error');
+        expect($json['error'])->toHaveKey('code', 'BIOMETRIC_NOT_AVAILABLE');
+        expect($json['error'])->toHaveKey('message');
+
+        assertKeysAreSnakeCase($json);
+    });
+
+    test('POST /api/mobile/auth/biometric/verify with unknown device returns error shape', function () {
+        $response = $this->postJson('/api/mobile/auth/biometric/verify', [
+            'device_id' => 'nonexistent-device-xyz',
+            'challenge' => 'fake-challenge',
+            'signature' => 'fake-signature',
+        ]);
+
+        $response->assertNotFound();
+
+        $json = $response->json();
+
+        expect($json)->toHaveKey('error');
+        expect($json['error'])->toHaveKey('code', 'NOT_FOUND');
+        expect($json['error'])->toHaveKey('message');
+
+        assertKeysAreSnakeCase($json);
+    });
+
+    test('POST /api/mobile/auth/biometric/verify with invalid signature returns auth failed error', function () {
+        [$user, $token] = createShapeTestUser();
+
+        $device = MobileDevice::factory()->biometricEnabled()->create([
+            'user_id' => $user->id,
+        ]);
+
+        $response = $this->postJson('/api/mobile/auth/biometric/verify', [
+            'device_id' => $device->device_id,
+            'challenge' => 'fake-challenge',
+            'signature' => base64_encode('fake-signature'),
+        ]);
+
+        $response->assertUnauthorized();
+
+        $json = $response->json();
+
+        expect($json)->toHaveKey('error');
+        expect($json['error'])->toHaveKey('code', 'AUTHENTICATION_FAILED');
+        expect($json['error'])->toHaveKey('message');
+
+        assertKeysAreSnakeCase($json);
+    });
+
+    test('POST /api/mobile/auth/biometric/challenge validation error has correct format', function () {
+        $response = $this->postJson('/api/mobile/auth/biometric/challenge', []);
+
+        $response->assertUnprocessable();
+
+        $json = $response->json();
+
+        // Mobile BaseMobileRequest returns structured error format
+        expect($json)->toHaveKey('error');
+        expect($json['error'])->toHaveKey('code', 'VALIDATION_ERROR');
+        expect($json['error'])->toHaveKey('message');
+    });
+});
+
+// ==========================================================================
+//  4. MOBILE NOTIFICATIONS
+// ==========================================================================
+
+describe('Mobile notifications - GET /api/mobile/notifications', function () {
+    test('notifications response has data array and meta with unread_count', function () {
+        [$user, $token] = createShapeTestUser();
+
+        MobilePushNotification::create([
+            'user_id'           => $user->id,
+            'notification_type' => 'transaction.received',
+            'title'             => 'Payment Received',
+            'body'              => 'You received $50',
+            'status'            => 'delivered',
+        ]);
+
+        MobilePushNotification::create([
+            'user_id'           => $user->id,
+            'notification_type' => 'security.login',
+            'title'             => 'New Login',
+            'body'              => 'Login detected',
+            'status'            => 'sent',
+        ]);
+
+        $response = $this->withToken($token)->getJson('/api/mobile/notifications');
+
+        $response->assertOk();
+
+        $json = $response->json();
+
+        // Must have data array
+        expect($json)->toHaveKey('data');
+        expect($json['data'])->toBeArray();
+        expect($json['data'])->toHaveCount(2);
+
+        // Must have meta with unread_count
+        expect($json)->toHaveKey('meta');
+        expect($json['meta'])->toHaveKey('unread_count');
+
+        // Each notification item shape
+        $notification = $json['data'][0];
+        expect($notification)->toHaveKey('id');
+        expect($notification)->toHaveKey('type');
+        expect($notification)->toHaveKey('title');
+        expect($notification)->toHaveKey('body');
+        expect($notification)->toHaveKey('status');
+        expect($notification)->toHaveKey('created_at');
+
+        assertKeysAreSnakeCase($json);
+    });
+
+    test('notifications response with empty data returns correct shape', function () {
+        [$user, $token] = createShapeTestUser();
+
+        $response = $this->withToken($token)->getJson('/api/mobile/notifications');
+
+        $response->assertOk();
+
+        $json = $response->json();
+
+        expect($json)->toHaveKey('data');
+        expect($json['data'])->toBeArray();
+        expect($json['data'])->toBeEmpty();
+        expect($json)->toHaveKey('meta');
+        expect($json['meta'])->toHaveKey('unread_count');
+    });
+
+    test('notifications endpoint requires authentication', function () {
+        $response = $this->getJson('/api/mobile/notifications');
+
+        $response->assertUnauthorized();
+    });
+});
+
+// ==========================================================================
+//  5. MOBILE PAYMENTS
+// ==========================================================================
+
+describe('Mobile payments - POST /api/v1/payments/intents', function () {
+    test('payment intent validation error returns structured error', function () {
+        [$user, $token] = createShapeTestUser();
+
+        // Missing required fields
+        $response = $this->withToken($token)->postJson('/api/v1/payments/intents', []);
+
+        $response->assertUnprocessable();
+
+        $json = $response->json();
+
+        // Standard Laravel validation error
+        expect($json)->toHaveKey('message');
+        expect($json)->toHaveKey('errors');
+    });
+
+    test('payment intent requires authentication', function () {
+        $response = $this->postJson('/api/v1/payments/intents', [
+            'merchantId'       => 'merchant_test',
+            'amount'           => 25.50,
+            'asset'            => 'USDC',
+            'preferredNetwork' => 'SOLANA',
+        ]);
+
+        $response->assertUnauthorized();
+    });
+});
+
+describe('Mobile payments - GET /api/v1/activity', function () {
+    test('activity feed returns success and data envelope', function () {
+        [$user, $token] = createShapeTestUser();
+
+        $response = $this->withToken($token)->getJson('/api/v1/activity');
+
+        $response->assertOk();
+
+        $json = $response->json();
+
+        expect($json)->toHaveKey('success', true);
+        expect($json)->toHaveKey('data');
+
+        assertKeysAreSnakeCase($json);
+    });
+
+    test('activity feed requires authentication', function () {
+        $response = $this->getJson('/api/v1/activity');
+
+        $response->assertUnauthorized();
+    });
+});
+
+// ==========================================================================
+//  6. WALLET ENDPOINTS
+// ==========================================================================
+
+describe('Wallet receive - GET /api/v1/wallet/receive', function () {
+    test('wallet receive returns success and data envelope', function () {
+        [$user, $token] = createShapeTestUser();
+
+        $response = $this->withToken($token)->getJson('/api/v1/wallet/receive?asset=USDC&network=SOLANA');
+
+        $response->assertOk();
+
+        $json = $response->json();
+
+        expect($json)->toHaveKey('success', true);
+        expect($json)->toHaveKey('data');
+
+        assertKeysAreSnakeCase($json);
+    });
+
+    test('wallet receive with invalid params returns validation error', function () {
+        [$user, $token] = createShapeTestUser();
+
+        $response = $this->withToken($token)->getJson('/api/v1/wallet/receive');
+
+        $response->assertUnprocessable();
+
+        $json = $response->json();
+        expect($json)->toHaveKey('message');
+        expect($json)->toHaveKey('errors');
+    });
+
+    test('wallet receive requires authentication', function () {
+        $response = $this->getJson('/api/v1/wallet/receive?asset=USDC&network=SOLANA');
+
+        $response->assertUnauthorized();
+    });
+});
+
+describe('Network status - GET /api/v1/networks/status', function () {
+    test('network status returns success with networks array', function () {
+        [$user, $token] = createShapeTestUser();
+
+        $response = $this->withToken($token)->getJson('/api/v1/networks/status');
+
+        $response->assertOk();
+
+        $json = $response->json();
+
+        expect($json)->toHaveKey('success', true);
+        expect($json)->toHaveKey('data');
+        expect($json['data'])->toHaveKey('networks');
+        expect($json['data']['networks'])->toBeArray();
+
+        assertKeysAreSnakeCase($json);
+    });
+
+    test('network status requires authentication', function () {
+        $response = $this->getJson('/api/v1/networks/status');
+
+        $response->assertUnauthorized();
+    });
+});
+
+// ==========================================================================
+//  7. CARD ISSUANCE
+// ==========================================================================
+
+describe('Card issuance - GET /api/v1/cards', function () {
+    test('card list returns success with data array', function () {
+        [$user, $token] = createShapeTestUser();
+
+        $response = $this->withToken($token)->getJson('/api/v1/cards');
+
+        $response->assertOk();
+
+        $json = $response->json();
+
+        expect($json)->toHaveKey('success', true);
+        expect($json)->toHaveKey('data');
+        expect($json['data'])->toBeArray();
+
+        assertKeysAreSnakeCase($json);
+    });
+
+    test('card list requires authentication', function () {
+        $response = $this->getJson('/api/v1/cards');
+
+        $response->assertUnauthorized();
+    });
+});
+
+describe('Card issuance - POST /api/v1/cards', function () {
+    test('card creation returns success with data object', function () {
+        [$user, $token] = createShapeTestUser();
+
+        $response = $this->withToken($token)->postJson('/api/v1/cards', [
+            'cardholder_name' => 'Test User',
+            'currency'        => 'USD',
+            'network'         => 'visa',
+        ]);
+
+        // Accept either 201 (created) or 400 (external service unavailable in test)
+        // The shape verification is the important part
+        $status = $response->getStatusCode();
+        expect($status)->toBeIn([201, 400]);
+
+        $json = $response->json();
+
+        // Both success and error responses must have 'success' boolean
+        expect($json)->toHaveKey('success');
+
+        if ($status === 201) {
+            expect($json['success'])->toBeTrue();
+            expect($json)->toHaveKey('data');
+        } else {
+            expect($json['success'])->toBeFalse();
+            expect($json)->toHaveKey('error');
+            expect($json['error'])->toHaveKey('code');
+            expect($json['error'])->toHaveKey('message');
+        }
+
+        assertKeysAreSnakeCase($json);
+    });
+
+    test('card creation requires authentication', function () {
+        $response = $this->postJson('/api/v1/cards', [
+            'cardholder_name' => 'Test User',
+            'currency'        => 'USD',
+        ]);
+
+        $response->assertUnauthorized();
+    });
+});
+
+// ==========================================================================
+//  8. CROSS-CUTTING: snake_case VERIFICATION
+// ==========================================================================
+
+describe('Cross-cutting: all public endpoints use snake_case keys', function () {
+    test('GET /api/mobile/config uses only snake_case keys', function () {
+        $response = $this->getJson('/api/mobile/config');
+        $response->assertOk();
+        assertKeysAreSnakeCase($response->json());
+    });
+
+    test('GET /api/v1/app/status uses only snake_case keys', function () {
+        $response = $this->getJson('/api/v1/app/status');
+        $response->assertOk();
+        assertKeysAreSnakeCase($response->json());
+    });
+});
+
+describe('Cross-cutting: authenticated endpoints use snake_case keys', function () {
+    test('GET /api/mobile/devices uses only snake_case keys', function () {
+        [$user, $token] = createShapeTestUser();
+        MobileDevice::factory()->create(['user_id' => $user->id]);
+
+        $response = $this->withToken($token)->getJson('/api/mobile/devices');
+        $response->assertOk();
+        assertKeysAreSnakeCase($response->json());
+    });
+
+    test('GET /api/mobile/notifications uses only snake_case keys', function () {
+        [$user, $token] = createShapeTestUser();
+
+        MobilePushNotification::create([
+            'user_id'           => $user->id,
+            'notification_type' => 'test.event',
+            'title'             => 'Shape Test',
+            'body'              => 'Checking keys',
+            'status'            => 'delivered',
+        ]);
+
+        $response = $this->withToken($token)->getJson('/api/mobile/notifications');
+        $response->assertOk();
+        assertKeysAreSnakeCase($response->json());
+    });
+
+    test('GET /api/v1/activity uses only snake_case keys', function () {
+        [$user, $token] = createShapeTestUser();
+
+        $response = $this->withToken($token)->getJson('/api/v1/activity');
+        $response->assertOk();
+        assertKeysAreSnakeCase($response->json());
+    });
+
+    test('GET /api/v1/networks/status uses only snake_case keys', function () {
+        [$user, $token] = createShapeTestUser();
+
+        $response = $this->withToken($token)->getJson('/api/v1/networks/status');
+        $response->assertOk();
+        assertKeysAreSnakeCase($response->json());
+    });
+
+    test('GET /api/v1/cards uses only snake_case keys', function () {
+        [$user, $token] = createShapeTestUser();
+
+        $response = $this->withToken($token)->getJson('/api/v1/cards');
+        $response->assertOk();
+        assertKeysAreSnakeCase($response->json());
+    });
+});
+
+// ==========================================================================
+//  9. ERROR RESPONSE CONSISTENCY
+// ==========================================================================
+
+describe('Error response format consistency', function () {
+    test('unauthenticated requests return standard error shape', function () {
+        $endpoints = [
+            ['GET', '/api/mobile/devices'],
+            ['GET', '/api/mobile/notifications'],
+            ['GET', '/api/v1/activity'],
+            ['GET', '/api/v1/networks/status'],
+            ['GET', '/api/v1/cards'],
+        ];
+
+        foreach ($endpoints as [$method, $url]) {
+            $response = $this->json($method, $url);
+
+            $response->assertUnauthorized();
+
+            $json = $response->json();
+
+            // Sanctum returns { "message": "Unauthenticated." }
+            expect($json)->toHaveKey('message');
+        }
+    });
+
+    test('mobile validation errors use structured error envelope', function () {
+        [$user, $token] = createShapeTestUser();
+
+        // RegisterDeviceRequest extends BaseMobileRequest
+        $response = $this->withToken($token)->postJson('/api/mobile/devices', []);
+
+        $response->assertUnprocessable();
+
+        $json = $response->json();
+
+        expect($json)->toHaveKey('error');
+        expect($json['error'])->toHaveKey('code');
+        expect($json['error'])->toHaveKey('message');
+        expect($json['error']['code'])->toBe('VALIDATION_ERROR');
+    });
+
+    test('biometric challenge not found error has error envelope', function () {
+        $response = $this->postJson('/api/mobile/auth/biometric/challenge', [
+            'device_id' => 'nonexistent',
+        ]);
+
+        $response->assertNotFound();
+
+        $json = $response->json();
+
+        expect($json)->toHaveKey('error');
+        expect($json['error'])->toHaveKey('code');
+        expect($json['error'])->toHaveKey('message');
+    });
+
+    test('biometric verify not found error has error envelope', function () {
+        $response = $this->postJson('/api/mobile/auth/biometric/verify', [
+            'device_id' => 'nonexistent',
+            'challenge' => 'fake',
+            'signature' => 'fake',
+        ]);
+
+        $response->assertNotFound();
+
+        $json = $response->json();
+
+        expect($json)->toHaveKey('error');
+        expect($json['error'])->toHaveKey('code', 'NOT_FOUND');
+        expect($json['error'])->toHaveKey('message');
+    });
+});
+
+// ==========================================================================
+// 10. RESPONSE ENVELOPE PATTERNS
+// ==========================================================================
+
+describe('Response envelope patterns', function () {
+    test('successful data responses use data envelope', function () {
+        [$user, $token] = createShapeTestUser();
+
+        // Each of these should have a 'data' key
+        $endpoints = [
+            ['GET', '/api/mobile/config'],
+            ['GET', '/api/v1/app/status'],
+        ];
+
+        foreach ($endpoints as [$method, $url]) {
+            $response = $this->json($method, $url);
+            $response->assertOk();
+            $json = $response->json();
+            expect(array_key_exists('data', $json))->toBeTrue("Missing 'data' key in response for {$method} {$url}");
+        }
+    });
+
+    test('authenticated data responses use data envelope', function () {
+        [$user, $token] = createShapeTestUser();
+
+        $endpoints = [
+            ['GET', '/api/mobile/devices'],
+            ['GET', '/api/mobile/notifications'],
+            ['GET', '/api/v1/activity'],
+            ['GET', '/api/v1/networks/status'],
+            ['GET', '/api/v1/cards'],
+        ];
+
+        foreach ($endpoints as [$method, $url]) {
+            $response = $this->withToken($token)->json($method, $url);
+            $response->assertOk();
+            $json = $response->json();
+            // Check that either 'data' or 'success'+'data' pattern is used
+            $hasData = array_key_exists('data', $json);
+            $hasSuccess = array_key_exists('success', $json);
+            expect($hasData || $hasSuccess)->toBeTrue("Response for {$method} {$url} must have 'data' or 'success' key");
+        }
+    });
+});

--- a/tests/Feature/Api/X402/X402IntegrationTest.php
+++ b/tests/Feature/Api/X402/X402IntegrationTest.php
@@ -1,0 +1,1131 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\X402\Models\X402MonetizedEndpoint;
+use App\Domain\X402\Models\X402Payment;
+use App\Domain\X402\Models\X402SpendingLimit;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+
+uses(RefreshDatabase::class);
+
+// ----------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------
+
+function createAuthenticatedUser(): User
+{
+    $user = User::factory()->withPersonalTeam()->create();
+    Sanctum::actingAs($user);
+
+    return $user;
+}
+
+function teamId(User $user): ?int
+{
+    return (int) $user->currentTeam?->id;
+}
+
+function createEndpoint(User $user, array $overrides = []): X402MonetizedEndpoint
+{
+    return X402MonetizedEndpoint::create(array_merge([
+        'method'      => 'GET',
+        'path'        => 'api/v1/test/resource',
+        'price'       => '0.01',
+        'network'     => 'eip155:8453',
+        'asset'       => 'USDC',
+        'scheme'      => 'exact',
+        'description' => 'Test endpoint',
+        'mime_type'   => 'application/json',
+        'is_active'   => true,
+        'team_id'     => teamId($user),
+    ], $overrides));
+}
+
+function createPayment(User $user, array $overrides = []): X402Payment
+{
+    return X402Payment::create(array_merge([
+        'payer_address'   => '0x1234567890abcdef1234567890abcdef12345678',
+        'pay_to_address'  => '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+        'amount'          => '1000000',
+        'network'         => 'eip155:8453',
+        'asset'           => 'USDC',
+        'scheme'          => 'exact',
+        'status'          => 'pending',
+        'endpoint_method' => 'GET',
+        'endpoint_path'   => 'api/v1/test/resource',
+        'team_id'         => teamId($user),
+    ], $overrides));
+}
+
+function createSpendingLimit(User $user, array $overrides = []): X402SpendingLimit
+{
+    return X402SpendingLimit::create(array_merge([
+        'agent_id'              => 'agent-' . uniqid(),
+        'agent_type'            => 'ai_agent',
+        'daily_limit'           => '10000000',
+        'spent_today'           => '0',
+        'per_transaction_limit' => '1000000',
+        'auto_pay_enabled'      => false,
+        'limit_resets_at'       => now()->addDay(),
+        'team_id'               => teamId($user),
+    ], $overrides));
+}
+
+// ================================================================
+// PUBLIC ENDPOINTS
+// ================================================================
+
+// ----------------------------------------------------------------
+// GET /api/v1/x402/status
+// ----------------------------------------------------------------
+
+test('GET /api/v1/x402/status returns protocol status', function () {
+    config(['x402.enabled' => true]);
+    config(['x402.version' => 2]);
+    config(['x402.server.default_network' => 'eip155:8453']);
+    config(['x402.client.enabled' => false]);
+
+    $response = $this->getJson('/api/v1/x402/status');
+
+    $response->assertOk()
+        ->assertJsonStructure([
+            'data' => [
+                'enabled',
+                'version',
+                'protocol',
+                'default_network',
+                'supported_schemes',
+                'client_enabled',
+            ],
+        ])
+        ->assertJsonPath('data.protocol', 'x402')
+        ->assertJsonPath('data.enabled', true)
+        ->assertJsonPath('data.version', 2)
+        ->assertJsonPath('data.supported_schemes', ['exact']);
+});
+
+test('GET /api/v1/x402/status works without authentication', function () {
+    $response = $this->getJson('/api/v1/x402/status');
+
+    $response->assertOk()
+        ->assertJsonStructure(['data' => ['enabled', 'version', 'protocol']]);
+});
+
+// ----------------------------------------------------------------
+// GET /api/v1/x402/supported
+// ----------------------------------------------------------------
+
+test('GET /api/v1/x402/supported returns supported networks and assets', function () {
+    $response = $this->getJson('/api/v1/x402/supported');
+
+    $response->assertOk()
+        ->assertJsonStructure([
+            'data' => [
+                'networks' => [
+                    '*' => [
+                        'id',
+                        'name',
+                        'testnet',
+                        'chain_id',
+                        'usdc_address',
+                        'usdc_decimals',
+                        'explorer_url',
+                    ],
+                ],
+                'contracts' => [
+                    'permit2',
+                    'exact_permit2_proxy',
+                ],
+                'supported_schemes',
+                'supported_assets',
+            ],
+        ])
+        ->assertJsonPath('data.supported_schemes', ['exact'])
+        ->assertJsonPath('data.supported_assets', ['USDC']);
+});
+
+test('GET /api/v1/x402/supported includes all known networks', function () {
+    $response = $this->getJson('/api/v1/x402/supported');
+
+    $response->assertOk();
+
+    $networks = $response->json('data.networks');
+    $networkIds = collect($networks)->pluck('id')->toArray();
+
+    expect($networkIds)->toContain('eip155:8453')   // Base Mainnet
+        ->toContain('eip155:84532')                   // Base Sepolia
+        ->toContain('eip155:1')                       // Ethereum Mainnet
+        ->toContain('eip155:11155111');                // Sepolia
+});
+
+test('GET /api/v1/x402/supported works without authentication', function () {
+    $response = $this->getJson('/api/v1/x402/supported');
+
+    $response->assertOk();
+});
+
+// ================================================================
+// AUTHENTICATED ENDPOINTS
+// ================================================================
+
+// ----------------------------------------------------------------
+// Authentication Enforcement
+// ----------------------------------------------------------------
+
+test('authenticated endpoints return 401 without auth', function (string $method, string $uri) {
+    $response = $this->json($method, $uri);
+    $response->assertUnauthorized();
+})->with([
+    ['GET', '/api/v1/x402/endpoints'],
+    ['POST', '/api/v1/x402/endpoints'],
+    ['GET', '/api/v1/x402/endpoints/nonexistent-id'],
+    ['PUT', '/api/v1/x402/endpoints/nonexistent-id'],
+    ['DELETE', '/api/v1/x402/endpoints/nonexistent-id'],
+    ['GET', '/api/v1/x402/payments'],
+    ['GET', '/api/v1/x402/payments/stats'],
+    ['GET', '/api/v1/x402/spending-limits'],
+]);
+
+// ================================================================
+// ENDPOINT MANAGEMENT (CRUD)
+// ================================================================
+
+// ----------------------------------------------------------------
+// GET /api/v1/x402/endpoints (index)
+// ----------------------------------------------------------------
+
+test('GET /api/v1/x402/endpoints returns paginated endpoints for current team', function () {
+    $user = createAuthenticatedUser();
+    createEndpoint($user, ['path' => 'api/v1/test/one']);
+    createEndpoint($user, ['method' => 'POST', 'path' => 'api/v1/test/two']);
+
+    $response = $this->getJson('/api/v1/x402/endpoints');
+
+    $response->assertOk()
+        ->assertJsonStructure([
+            'data' => [
+                '*' => [
+                    'id',
+                    'method',
+                    'path',
+                    'price',
+                    'network',
+                    'asset',
+                    'scheme',
+                    'description',
+                    'mimeType',
+                    'isActive',
+                    'createdAt',
+                    'updatedAt',
+                ],
+            ],
+            'meta' => [
+                'current_page',
+                'last_page',
+                'per_page',
+                'total',
+            ],
+        ])
+        ->assertJsonPath('meta.total', 2);
+});
+
+test('GET /api/v1/x402/endpoints does not return endpoints from other teams', function () {
+    $user = createAuthenticatedUser();
+    createEndpoint($user, ['path' => 'api/v1/my/endpoint']);
+
+    // Create an endpoint for a different team
+    $otherUser = User::factory()->withPersonalTeam()->create();
+    createEndpoint($otherUser, ['path' => 'api/v1/other/endpoint']);
+
+    $response = $this->getJson('/api/v1/x402/endpoints');
+
+    $response->assertOk()
+        ->assertJsonPath('meta.total', 1)
+        ->assertJsonPath('data.0.path', 'api/v1/my/endpoint');
+});
+
+test('GET /api/v1/x402/endpoints filters by active status', function () {
+    $user = createAuthenticatedUser();
+    createEndpoint($user, ['path' => 'api/v1/test/active', 'is_active' => true]);
+    createEndpoint($user, ['method' => 'POST', 'path' => 'api/v1/test/inactive', 'is_active' => false]);
+
+    $response = $this->getJson('/api/v1/x402/endpoints?active=true');
+
+    $response->assertOk()
+        ->assertJsonPath('meta.total', 1)
+        ->assertJsonPath('data.0.isActive', true);
+});
+
+test('GET /api/v1/x402/endpoints filters by network', function () {
+    $user = createAuthenticatedUser();
+    createEndpoint($user, ['path' => 'api/v1/test/base', 'network' => 'eip155:8453']);
+    createEndpoint($user, ['method' => 'POST', 'path' => 'api/v1/test/eth', 'network' => 'eip155:1']);
+
+    $response = $this->getJson('/api/v1/x402/endpoints?network=eip155:8453');
+
+    $response->assertOk()
+        ->assertJsonPath('meta.total', 1)
+        ->assertJsonPath('data.0.network', 'eip155:8453');
+});
+
+test('GET /api/v1/x402/endpoints respects per_page parameter', function () {
+    $user = createAuthenticatedUser();
+    for ($i = 1; $i <= 5; $i++) {
+        createEndpoint($user, ['path' => "api/v1/test/ep{$i}", 'method' => $i <= 3 ? 'GET' : 'POST']);
+    }
+
+    $response = $this->getJson('/api/v1/x402/endpoints?per_page=2');
+
+    $response->assertOk()
+        ->assertJsonPath('meta.per_page', 2)
+        ->assertJsonPath('meta.total', 5)
+        ->assertJsonCount(2, 'data');
+});
+
+// ----------------------------------------------------------------
+// POST /api/v1/x402/endpoints (store)
+// ----------------------------------------------------------------
+
+test('POST /api/v1/x402/endpoints creates a monetized endpoint', function () {
+    $user = createAuthenticatedUser();
+
+    $response = $this->postJson('/api/v1/x402/endpoints', [
+        'method'      => 'GET',
+        'path'        => 'api/v1/premium/data',
+        'price'       => '0.005',
+        'network'     => 'eip155:8453',
+        'description' => 'Premium data endpoint',
+        'is_active'   => true,
+    ]);
+
+    $response->assertCreated()
+        ->assertJsonStructure([
+            'data' => [
+                'id',
+                'method',
+                'path',
+                'price',
+                'network',
+                'asset',
+                'scheme',
+                'description',
+                'mimeType',
+                'isActive',
+                'createdAt',
+                'updatedAt',
+            ],
+            'message',
+        ])
+        ->assertJsonPath('data.method', 'GET')
+        ->assertJsonPath('data.path', 'api/v1/premium/data')
+        ->assertJsonPath('data.price', '0.005')
+        ->assertJsonPath('data.network', 'eip155:8453')
+        ->assertJsonPath('data.description', 'Premium data endpoint')
+        ->assertJsonPath('data.isActive', true)
+        ->assertJsonPath('message', 'Endpoint monetized successfully.');
+
+    $this->assertDatabaseHas('x402_monetized_endpoints', [
+        'method'  => 'GET',
+        'path'    => 'api/v1/premium/data',
+        'price'   => '0.005',
+        'team_id' => teamId($user),
+    ]);
+});
+
+test('POST /api/v1/x402/endpoints assigns default network when omitted', function () {
+    createAuthenticatedUser();
+    config(['x402.server.default_network' => 'eip155:84532']);
+
+    $response = $this->postJson('/api/v1/x402/endpoints', [
+        'method' => 'POST',
+        'path'   => 'api/v1/test/default-network',
+        'price'  => '0.01',
+    ]);
+
+    $response->assertCreated()
+        ->assertJsonPath('data.network', 'eip155:84532');
+});
+
+test('POST /api/v1/x402/endpoints returns 422 for missing required fields', function () {
+    createAuthenticatedUser();
+
+    $response = $this->postJson('/api/v1/x402/endpoints', []);
+
+    $response->assertStatus(422)
+        ->assertJsonStructure(['errors'])
+        ->assertJsonValidationErrors(['method', 'path', 'price']);
+});
+
+test('POST /api/v1/x402/endpoints returns 422 for invalid method', function () {
+    createAuthenticatedUser();
+
+    $response = $this->postJson('/api/v1/x402/endpoints', [
+        'method' => 'INVALID',
+        'path'   => 'api/v1/test/invalid',
+        'price'  => '0.01',
+    ]);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['method']);
+});
+
+test('POST /api/v1/x402/endpoints returns 422 for invalid price format', function () {
+    createAuthenticatedUser();
+
+    $response = $this->postJson('/api/v1/x402/endpoints', [
+        'method' => 'GET',
+        'path'   => 'api/v1/test/bad-price',
+        'price'  => 'free',
+    ]);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['price']);
+});
+
+test('POST /api/v1/x402/endpoints returns 422 for invalid network format', function () {
+    createAuthenticatedUser();
+
+    $response = $this->postJson('/api/v1/x402/endpoints', [
+        'method'  => 'GET',
+        'path'    => 'api/v1/test/bad-network',
+        'price'   => '0.01',
+        'network' => 'invalid-network',
+    ]);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['network']);
+});
+
+// ----------------------------------------------------------------
+// GET /api/v1/x402/endpoints/{id} (show)
+// ----------------------------------------------------------------
+
+test('GET /api/v1/x402/endpoints/{id} returns endpoint details', function () {
+    $user = createAuthenticatedUser();
+    $endpoint = createEndpoint($user);
+
+    $response = $this->getJson("/api/v1/x402/endpoints/{$endpoint->id}");
+
+    $response->assertOk()
+        ->assertJsonStructure([
+            'data' => [
+                'id',
+                'method',
+                'path',
+                'price',
+                'network',
+                'asset',
+                'scheme',
+                'description',
+                'mimeType',
+                'isActive',
+                'createdAt',
+                'updatedAt',
+            ],
+        ])
+        ->assertJsonPath('data.id', $endpoint->id)
+        ->assertJsonPath('data.method', 'GET')
+        ->assertJsonPath('data.path', 'api/v1/test/resource');
+});
+
+test('GET /api/v1/x402/endpoints/{id} returns 404 for non-existent endpoint', function () {
+    createAuthenticatedUser();
+
+    $response = $this->getJson('/api/v1/x402/endpoints/00000000-0000-0000-0000-000000000000');
+
+    $response->assertNotFound();
+});
+
+test('GET /api/v1/x402/endpoints/{id} returns 404 for endpoint from different team', function () {
+    createAuthenticatedUser();
+    $otherUser = User::factory()->withPersonalTeam()->create();
+    $otherEndpoint = createEndpoint($otherUser, ['path' => 'api/v1/other/resource']);
+
+    $response = $this->getJson("/api/v1/x402/endpoints/{$otherEndpoint->id}");
+
+    $response->assertNotFound();
+});
+
+// ----------------------------------------------------------------
+// PUT /api/v1/x402/endpoints/{id} (update)
+// ----------------------------------------------------------------
+
+test('PUT /api/v1/x402/endpoints/{id} updates endpoint fields', function () {
+    $user = createAuthenticatedUser();
+    $endpoint = createEndpoint($user);
+
+    $response = $this->putJson("/api/v1/x402/endpoints/{$endpoint->id}", [
+        'price'       => '0.05',
+        'description' => 'Updated description',
+        'is_active'   => false,
+    ]);
+
+    $response->assertOk()
+        ->assertJsonStructure([
+            'data' => ['id', 'method', 'path', 'price', 'isActive'],
+            'message',
+        ])
+        ->assertJsonPath('data.price', '0.05')
+        ->assertJsonPath('data.description', 'Updated description')
+        ->assertJsonPath('data.isActive', false)
+        ->assertJsonPath('message', 'Endpoint updated successfully.');
+});
+
+test('PUT /api/v1/x402/endpoints/{id} returns 404 for non-existent endpoint', function () {
+    createAuthenticatedUser();
+
+    $response = $this->putJson('/api/v1/x402/endpoints/00000000-0000-0000-0000-000000000000', [
+        'price' => '0.05',
+    ]);
+
+    $response->assertNotFound();
+});
+
+test('PUT /api/v1/x402/endpoints/{id} returns 404 for endpoint from different team', function () {
+    createAuthenticatedUser();
+    $otherUser = User::factory()->withPersonalTeam()->create();
+    $otherEndpoint = createEndpoint($otherUser, ['path' => 'api/v1/other/update']);
+
+    $response = $this->putJson("/api/v1/x402/endpoints/{$otherEndpoint->id}", [
+        'price' => '0.05',
+    ]);
+
+    $response->assertNotFound();
+});
+
+test('PUT /api/v1/x402/endpoints/{id} returns 422 for invalid price format', function () {
+    $user = createAuthenticatedUser();
+    $endpoint = createEndpoint($user);
+
+    $response = $this->putJson("/api/v1/x402/endpoints/{$endpoint->id}", [
+        'price' => 'not-a-number',
+    ]);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['price']);
+});
+
+test('PUT /api/v1/x402/endpoints/{id} validates optional fields', function () {
+    $user = createAuthenticatedUser();
+    $endpoint = createEndpoint($user);
+
+    $response = $this->putJson("/api/v1/x402/endpoints/{$endpoint->id}", [
+        'scheme' => 'invalid_scheme',
+    ]);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['scheme']);
+});
+
+// ----------------------------------------------------------------
+// DELETE /api/v1/x402/endpoints/{id} (destroy)
+// ----------------------------------------------------------------
+
+test('DELETE /api/v1/x402/endpoints/{id} removes endpoint', function () {
+    $user = createAuthenticatedUser();
+    $endpoint = createEndpoint($user);
+
+    $response = $this->deleteJson("/api/v1/x402/endpoints/{$endpoint->id}");
+
+    $response->assertNoContent();
+
+    $this->assertDatabaseMissing('x402_monetized_endpoints', [
+        'id' => $endpoint->id,
+    ]);
+});
+
+test('DELETE /api/v1/x402/endpoints/{id} returns 404 for non-existent endpoint', function () {
+    createAuthenticatedUser();
+
+    $response = $this->deleteJson('/api/v1/x402/endpoints/00000000-0000-0000-0000-000000000000');
+
+    $response->assertNotFound();
+});
+
+test('DELETE /api/v1/x402/endpoints/{id} returns 404 for endpoint from different team', function () {
+    createAuthenticatedUser();
+    $otherUser = User::factory()->withPersonalTeam()->create();
+    $otherEndpoint = createEndpoint($otherUser, ['path' => 'api/v1/other/delete']);
+
+    $response = $this->deleteJson("/api/v1/x402/endpoints/{$otherEndpoint->id}");
+
+    $response->assertNotFound();
+});
+
+// ================================================================
+// PAYMENTS
+// ================================================================
+
+// ----------------------------------------------------------------
+// GET /api/v1/x402/payments (index)
+// ----------------------------------------------------------------
+
+test('GET /api/v1/x402/payments returns paginated payments for current team', function () {
+    $user = createAuthenticatedUser();
+    createPayment($user, ['status' => 'settled', 'settled_at' => now()]);
+    createPayment($user, ['status' => 'pending', 'payer_address' => '0xaabbccddaabbccddaabbccddaabbccddaabbccdd']);
+
+    $response = $this->getJson('/api/v1/x402/payments');
+
+    $response->assertOk()
+        ->assertJsonStructure([
+            'data' => [
+                '*' => [
+                    'id',
+                    'payerAddress',
+                    'payToAddress',
+                    'amount',
+                    'amountUsd',
+                    'network',
+                    'asset',
+                    'scheme',
+                    'status',
+                    'transactionHash',
+                    'endpoint',
+                    'error',
+                    'verifiedAt',
+                    'settledAt',
+                    'createdAt',
+                ],
+            ],
+            'meta' => [
+                'current_page',
+                'last_page',
+                'per_page',
+                'total',
+            ],
+        ])
+        ->assertJsonPath('meta.total', 2);
+});
+
+test('GET /api/v1/x402/payments does not return payments from other teams', function () {
+    $user = createAuthenticatedUser();
+    createPayment($user);
+
+    $otherUser = User::factory()->withPersonalTeam()->create();
+    createPayment($otherUser, ['payer_address' => '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef']);
+
+    $response = $this->getJson('/api/v1/x402/payments');
+
+    $response->assertOk()
+        ->assertJsonPath('meta.total', 1);
+});
+
+test('GET /api/v1/x402/payments filters by status', function () {
+    $user = createAuthenticatedUser();
+    createPayment($user, ['status' => 'settled', 'settled_at' => now()]);
+    createPayment($user, ['status' => 'pending', 'payer_address' => '0xaabbccddaabbccddaabbccddaabbccddaabbccdd']);
+
+    $response = $this->getJson('/api/v1/x402/payments?status=settled');
+
+    $response->assertOk()
+        ->assertJsonPath('meta.total', 1)
+        ->assertJsonPath('data.0.status', 'settled');
+});
+
+test('GET /api/v1/x402/payments returns 422 for invalid status', function () {
+    createAuthenticatedUser();
+
+    $response = $this->getJson('/api/v1/x402/payments?status=bogus');
+
+    $response->assertStatus(422)
+        ->assertJsonStructure(['errors' => ['status']]);
+});
+
+test('GET /api/v1/x402/payments filters by network', function () {
+    $user = createAuthenticatedUser();
+    createPayment($user, ['network' => 'eip155:8453']);
+    createPayment($user, ['network' => 'eip155:1', 'payer_address' => '0xaabbccddaabbccddaabbccddaabbccddaabbccdd']);
+
+    $response = $this->getJson('/api/v1/x402/payments?network=eip155:8453');
+
+    $response->assertOk()
+        ->assertJsonPath('meta.total', 1)
+        ->assertJsonPath('data.0.network', 'eip155:8453');
+});
+
+test('GET /api/v1/x402/payments filters by payer_address', function () {
+    $user = createAuthenticatedUser();
+    createPayment($user, ['payer_address' => '0x1111111111111111111111111111111111111111']);
+    createPayment($user, ['payer_address' => '0x2222222222222222222222222222222222222222']);
+
+    $response = $this->getJson('/api/v1/x402/payments?payer_address=0x1111111111111111111111111111111111111111');
+
+    $response->assertOk()
+        ->assertJsonPath('meta.total', 1)
+        ->assertJsonPath('data.0.payerAddress', '0x1111111111111111111111111111111111111111');
+});
+
+test('GET /api/v1/x402/payments respects per_page parameter', function () {
+    $user = createAuthenticatedUser();
+    for ($i = 0; $i < 5; $i++) {
+        createPayment($user, ['payer_address' => '0x' . str_pad((string) ($i + 1), 40, '0', STR_PAD_LEFT)]);
+    }
+
+    $response = $this->getJson('/api/v1/x402/payments?per_page=3');
+
+    $response->assertOk()
+        ->assertJsonPath('meta.per_page', 3)
+        ->assertJsonPath('meta.total', 5)
+        ->assertJsonCount(3, 'data');
+});
+
+// ----------------------------------------------------------------
+// GET /api/v1/x402/payments/stats
+// ----------------------------------------------------------------
+
+test('GET /api/v1/x402/payments/stats returns payment statistics', function () {
+    $user = createAuthenticatedUser();
+
+    // Create some payments within the day
+    createPayment($user, [
+        'status'     => 'settled',
+        'amount'     => '1000000',
+        'settled_at' => now(),
+    ]);
+    createPayment($user, [
+        'status'        => 'settled',
+        'amount'        => '2000000',
+        'payer_address' => '0xaabbccddaabbccddaabbccddaabbccddaabbccdd',
+        'settled_at'    => now(),
+    ]);
+    createPayment($user, [
+        'status'        => 'failed',
+        'amount'        => '500000',
+        'payer_address' => '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        'error_reason'  => 'insufficient_funds',
+        'error_message' => 'Insufficient USDC balance',
+    ]);
+
+    $response = $this->getJson('/api/v1/x402/payments/stats');
+
+    $response->assertOk()
+        ->assertJsonStructure([
+            'data' => [
+                'period',
+                'total_payments',
+                'total_settled',
+                'total_failed',
+                'total_volume_atomic',
+                'total_volume_usd',
+                'unique_payers',
+            ],
+        ])
+        ->assertJsonPath('data.period', 'day')
+        ->assertJsonPath('data.total_payments', 3)
+        ->assertJsonPath('data.total_settled', 2)
+        ->assertJsonPath('data.total_failed', 1);
+});
+
+test('GET /api/v1/x402/payments/stats accepts period parameter', function () {
+    createAuthenticatedUser();
+
+    $response = $this->getJson('/api/v1/x402/payments/stats?period=week');
+
+    $response->assertOk()
+        ->assertJsonPath('data.period', 'week');
+});
+
+test('GET /api/v1/x402/payments/stats accepts period aliases', function () {
+    createAuthenticatedUser();
+
+    $response = $this->getJson('/api/v1/x402/payments/stats?period=7d');
+
+    $response->assertOk()
+        ->assertJsonPath('data.period', 'week');
+});
+
+test('GET /api/v1/x402/payments/stats returns 422 for invalid period', function () {
+    createAuthenticatedUser();
+
+    $response = $this->getJson('/api/v1/x402/payments/stats?period=invalid');
+
+    $response->assertStatus(422)
+        ->assertJsonStructure(['errors' => ['period']]);
+});
+
+test('GET /api/v1/x402/payments/stats returns zeros when no payments exist', function () {
+    createAuthenticatedUser();
+
+    $response = $this->getJson('/api/v1/x402/payments/stats');
+
+    $response->assertOk()
+        ->assertJsonPath('data.total_payments', 0)
+        ->assertJsonPath('data.total_settled', 0)
+        ->assertJsonPath('data.total_failed', 0)
+        ->assertJsonPath('data.unique_payers', 0);
+});
+
+// ================================================================
+// SPENDING LIMITS
+// ================================================================
+
+// ----------------------------------------------------------------
+// GET /api/v1/x402/spending-limits (index)
+// ----------------------------------------------------------------
+
+test('GET /api/v1/x402/spending-limits returns paginated spending limits', function () {
+    $user = createAuthenticatedUser();
+    createSpendingLimit($user, ['agent_id' => 'agent-alpha']);
+    createSpendingLimit($user, ['agent_id' => 'agent-beta']);
+
+    $response = $this->getJson('/api/v1/x402/spending-limits');
+
+    $response->assertOk()
+        ->assertJsonStructure([
+            'data' => [
+                '*' => [
+                    'id',
+                    'agentId',
+                    'agentType',
+                    'dailyLimit',
+                    'spentToday',
+                    'perTransactionLimit',
+                    'autoPayEnabled',
+                    'remainingBudget',
+                    'spentPercentage',
+                    'limitResetsAt',
+                    'createdAt',
+                    'updatedAt',
+                ],
+            ],
+            'meta' => [
+                'current_page',
+                'last_page',
+                'per_page',
+                'total',
+            ],
+        ])
+        ->assertJsonPath('meta.total', 2);
+});
+
+test('GET /api/v1/x402/spending-limits does not return limits from other teams', function () {
+    $user = createAuthenticatedUser();
+    createSpendingLimit($user, ['agent_id' => 'my-agent']);
+
+    $otherUser = User::factory()->withPersonalTeam()->create();
+    createSpendingLimit($otherUser, ['agent_id' => 'other-agent']);
+
+    $response = $this->getJson('/api/v1/x402/spending-limits');
+
+    $response->assertOk()
+        ->assertJsonPath('meta.total', 1);
+});
+
+test('GET /api/v1/x402/spending-limits respects per_page parameter', function () {
+    $user = createAuthenticatedUser();
+    for ($i = 1; $i <= 5; $i++) {
+        createSpendingLimit($user, ['agent_id' => "agent-{$i}"]);
+    }
+
+    $response = $this->getJson('/api/v1/x402/spending-limits?per_page=2');
+
+    $response->assertOk()
+        ->assertJsonPath('meta.per_page', 2)
+        ->assertJsonPath('meta.total', 5)
+        ->assertJsonCount(2, 'data');
+});
+
+// ----------------------------------------------------------------
+// POST /api/v1/x402/spending-limits (store - create)
+// ----------------------------------------------------------------
+
+test('POST /api/v1/x402/spending-limits creates a new spending limit', function () {
+    $user = createAuthenticatedUser();
+
+    $response = $this->postJson('/api/v1/x402/spending-limits', [
+        'agent_id'              => 'new-ai-agent',
+        'agent_type'            => 'ai_agent',
+        'daily_limit'           => '50000000',
+        'per_transaction_limit' => '5000000',
+        'auto_pay_enabled'      => true,
+    ]);
+
+    $response->assertCreated()
+        ->assertJsonStructure([
+            'data' => [
+                'id',
+                'agentId',
+                'agentType',
+                'dailyLimit',
+                'spentToday',
+                'perTransactionLimit',
+                'autoPayEnabled',
+                'remainingBudget',
+                'spentPercentage',
+                'limitResetsAt',
+                'createdAt',
+                'updatedAt',
+            ],
+            'message',
+        ])
+        ->assertJsonPath('data.agentId', 'new-ai-agent')
+        ->assertJsonPath('data.agentType', 'ai_agent')
+        ->assertJsonPath('data.dailyLimit', '50000000')
+        ->assertJsonPath('data.perTransactionLimit', '5000000')
+        ->assertJsonPath('data.autoPayEnabled', true);
+
+    $this->assertDatabaseHas('x402_spending_limits', [
+        'agent_id'    => 'new-ai-agent',
+        'daily_limit' => '50000000',
+        'team_id'     => teamId($user),
+    ]);
+});
+
+test('POST /api/v1/x402/spending-limits updates existing limit for same agent', function () {
+    $user = createAuthenticatedUser();
+    createSpendingLimit($user, [
+        'agent_id'    => 'existing-agent',
+        'daily_limit' => '10000000',
+    ]);
+
+    $response = $this->postJson('/api/v1/x402/spending-limits', [
+        'agent_id'    => 'existing-agent',
+        'daily_limit' => '20000000',
+    ]);
+
+    $response->assertOk()
+        ->assertJsonPath('data.agentId', 'existing-agent')
+        ->assertJsonPath('data.dailyLimit', '20000000');
+
+    // Should still be only one record
+    $this->assertDatabaseCount('x402_spending_limits', 1);
+});
+
+test('POST /api/v1/x402/spending-limits returns 422 for missing required fields', function () {
+    createAuthenticatedUser();
+
+    $response = $this->postJson('/api/v1/x402/spending-limits', []);
+
+    $response->assertStatus(422)
+        ->assertJsonStructure(['errors'])
+        ->assertJsonValidationErrors(['agent_id', 'daily_limit']);
+});
+
+test('POST /api/v1/x402/spending-limits returns 422 for non-integer daily limit', function () {
+    createAuthenticatedUser();
+
+    $response = $this->postJson('/api/v1/x402/spending-limits', [
+        'agent_id'    => 'test-agent',
+        'daily_limit' => 'not-a-number',
+    ]);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['daily_limit']);
+});
+
+// ----------------------------------------------------------------
+// GET /api/v1/x402/spending-limits/{agentId} (show)
+// ----------------------------------------------------------------
+
+test('GET /api/v1/x402/spending-limits/{agentId} returns limit details', function () {
+    $user = createAuthenticatedUser();
+    $limit = createSpendingLimit($user, ['agent_id' => 'my-agent-show']);
+
+    $response = $this->getJson('/api/v1/x402/spending-limits/my-agent-show');
+
+    $response->assertOk()
+        ->assertJsonStructure([
+            'data' => [
+                'id',
+                'agentId',
+                'agentType',
+                'dailyLimit',
+                'spentToday',
+                'perTransactionLimit',
+                'autoPayEnabled',
+                'remainingBudget',
+                'spentPercentage',
+                'limitResetsAt',
+                'createdAt',
+                'updatedAt',
+            ],
+        ])
+        ->assertJsonPath('data.id', $limit->id)
+        ->assertJsonPath('data.agentId', 'my-agent-show');
+});
+
+test('GET /api/v1/x402/spending-limits/{agentId} returns 404 for non-existent agent', function () {
+    createAuthenticatedUser();
+
+    $response = $this->getJson('/api/v1/x402/spending-limits/does-not-exist');
+
+    $response->assertNotFound();
+});
+
+test('GET /api/v1/x402/spending-limits/{agentId} returns 404 for agent from different team', function () {
+    createAuthenticatedUser();
+    $otherUser = User::factory()->withPersonalTeam()->create();
+    createSpendingLimit($otherUser, ['agent_id' => 'other-team-agent']);
+
+    $response = $this->getJson('/api/v1/x402/spending-limits/other-team-agent');
+
+    $response->assertNotFound();
+});
+
+// ----------------------------------------------------------------
+// PUT /api/v1/x402/spending-limits/{agentId} (update)
+// ----------------------------------------------------------------
+
+test('PUT /api/v1/x402/spending-limits/{agentId} updates spending limit', function () {
+    $user = createAuthenticatedUser();
+    createSpendingLimit($user, ['agent_id' => 'agent-update']);
+
+    $response = $this->putJson('/api/v1/x402/spending-limits/agent-update', [
+        'daily_limit'      => '99000000',
+        'auto_pay_enabled' => true,
+    ]);
+
+    $response->assertOk()
+        ->assertJsonStructure([
+            'data' => ['id', 'agentId', 'dailyLimit', 'autoPayEnabled'],
+            'message',
+        ])
+        ->assertJsonPath('data.dailyLimit', '99000000')
+        ->assertJsonPath('data.autoPayEnabled', true)
+        ->assertJsonPath('message', 'Spending limit updated.');
+});
+
+test('PUT /api/v1/x402/spending-limits/{agentId} returns 404 for non-existent agent', function () {
+    createAuthenticatedUser();
+
+    $response = $this->putJson('/api/v1/x402/spending-limits/does-not-exist', [
+        'daily_limit' => '50000000',
+    ]);
+
+    $response->assertNotFound();
+});
+
+test('PUT /api/v1/x402/spending-limits/{agentId} returns 422 for invalid data', function () {
+    $user = createAuthenticatedUser();
+    createSpendingLimit($user, ['agent_id' => 'agent-validate']);
+
+    $response = $this->putJson('/api/v1/x402/spending-limits/agent-validate', [
+        'daily_limit' => 'not-numeric',
+    ]);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['daily_limit']);
+});
+
+// ----------------------------------------------------------------
+// DELETE /api/v1/x402/spending-limits/{agentId} (destroy)
+// ----------------------------------------------------------------
+
+test('DELETE /api/v1/x402/spending-limits/{agentId} removes spending limit', function () {
+    $user = createAuthenticatedUser();
+    $limit = createSpendingLimit($user, ['agent_id' => 'agent-delete']);
+
+    $response = $this->deleteJson('/api/v1/x402/spending-limits/agent-delete');
+
+    $response->assertNoContent();
+
+    $this->assertDatabaseMissing('x402_spending_limits', [
+        'id' => $limit->id,
+    ]);
+});
+
+test('DELETE /api/v1/x402/spending-limits/{agentId} returns 404 for non-existent agent', function () {
+    createAuthenticatedUser();
+
+    $response = $this->deleteJson('/api/v1/x402/spending-limits/nonexistent');
+
+    $response->assertNotFound();
+});
+
+test('DELETE /api/v1/x402/spending-limits/{agentId} returns 404 for agent from different team', function () {
+    createAuthenticatedUser();
+    $otherUser = User::factory()->withPersonalTeam()->create();
+    createSpendingLimit($otherUser, ['agent_id' => 'other-agent-delete']);
+
+    $response = $this->deleteJson('/api/v1/x402/spending-limits/other-agent-delete');
+
+    $response->assertNotFound();
+});
+
+// ================================================================
+// FULL LIFECYCLE TESTS
+// ================================================================
+
+test('full endpoint CRUD lifecycle works end-to-end', function () {
+    createAuthenticatedUser();
+
+    // Create
+    $createResponse = $this->postJson('/api/v1/x402/endpoints', [
+        'method'      => 'POST',
+        'path'        => 'api/v1/lifecycle/test',
+        'price'       => '0.10',
+        'description' => 'Lifecycle test endpoint',
+    ]);
+    $createResponse->assertCreated();
+    $endpointId = $createResponse->json('data.id');
+
+    // Read
+    $showResponse = $this->getJson("/api/v1/x402/endpoints/{$endpointId}");
+    $showResponse->assertOk()
+        ->assertJsonPath('data.price', '0.10');
+
+    // Update
+    $updateResponse = $this->putJson("/api/v1/x402/endpoints/{$endpointId}", [
+        'price'     => '0.25',
+        'is_active' => false,
+    ]);
+    $updateResponse->assertOk()
+        ->assertJsonPath('data.price', '0.25')
+        ->assertJsonPath('data.isActive', false);
+
+    // List
+    $listResponse = $this->getJson('/api/v1/x402/endpoints');
+    $listResponse->assertOk()
+        ->assertJsonPath('meta.total', 1);
+
+    // Delete
+    $deleteResponse = $this->deleteJson("/api/v1/x402/endpoints/{$endpointId}");
+    $deleteResponse->assertNoContent();
+
+    // Verify deleted
+    $this->getJson("/api/v1/x402/endpoints/{$endpointId}")
+        ->assertNotFound();
+});
+
+test('full spending limit lifecycle works end-to-end', function () {
+    createAuthenticatedUser();
+
+    // Create
+    $createResponse = $this->postJson('/api/v1/x402/spending-limits', [
+        'agent_id'    => 'lifecycle-agent',
+        'agent_type'  => 'ai_agent',
+        'daily_limit' => '10000000',
+    ]);
+    $createResponse->assertCreated();
+
+    // Read
+    $showResponse = $this->getJson('/api/v1/x402/spending-limits/lifecycle-agent');
+    $showResponse->assertOk()
+        ->assertJsonPath('data.agentId', 'lifecycle-agent');
+
+    // Update
+    $updateResponse = $this->putJson('/api/v1/x402/spending-limits/lifecycle-agent', [
+        'daily_limit'      => '50000000',
+        'auto_pay_enabled' => true,
+    ]);
+    $updateResponse->assertOk()
+        ->assertJsonPath('data.dailyLimit', '50000000')
+        ->assertJsonPath('data.autoPayEnabled', true);
+
+    // List
+    $listResponse = $this->getJson('/api/v1/x402/spending-limits');
+    $listResponse->assertOk()
+        ->assertJsonPath('meta.total', 1);
+
+    // Delete
+    $deleteResponse = $this->deleteJson('/api/v1/x402/spending-limits/lifecycle-agent');
+    $deleteResponse->assertNoContent();
+
+    // Verify deleted
+    $this->getJson('/api/v1/x402/spending-limits/lifecycle-agent')
+        ->assertNotFound();
+});


### PR DESCRIPTION
## Summary
- **65 x402 integration tests**: Full CRUD for monetized endpoints, payments, spending limits; auth enforcement; lifecycle tests
- **47 response shape verification tests**: snake_case key enforcement, pagination format, error envelopes, auth response structure
- **Bug fixes**: camelCase→snake_case in ActivityFeedService, NetworkAvailabilityService, ReceiveAddressService; X402SpendingLimit model defaults

## Test Coverage

### X402 Integration (65 tests, 427 assertions)
- Public endpoints (status, supported networks)
- Auth enforcement (401 for all authenticated endpoints)
- Endpoint CRUD (create, read, update, delete, filtering)
- Payment listing (pagination, filters, stats)
- Spending limits CRUD
- Full lifecycle tests

### Response Shape Verification (47 tests, 512 assertions)
- Auth login/register response shapes
- Mobile config, app status, devices, biometric auth
- Notifications, payments, wallet/network endpoints
- Card issuance endpoints
- Cross-cutting snake_case verification
- Error format consistency

## Bug Fixes
| Service | Issue |
|---------|-------|
| `ActivityFeedService` | `nextCursor`→`next_cursor`, `hasMore`→`has_more` |
| `NetworkAvailabilityService` | `nativeAsset`→`native_asset`, `avgFeeUsd`→`avg_fee_usd`, etc. |
| `ReceiveAddressService` | `qrPayload`→`qr_payload`, `minimumAmount`→`minimum_amount` |
| `X402SpendingLimit` | Added model `$attributes` defaults for `spent_today`/`auto_pay_enabled` |

## Test plan
- [x] All 112 new tests pass (939 assertions)
- [x] PHPStan clean
- [x] php-cs-fixer clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)