### PR TITLE
refactor: Mobile backend code quality improvements

### DIFF
--- a/app/Domain/Mobile/Services/MobileDeviceService.php
+++ b/app/Domain/Mobile/Services/MobileDeviceService.php
@@ -204,6 +204,25 @@ class MobileDeviceService
     }
 
     /**
+     * Find all passkey-enabled devices for a user identified by email.
+     *
+     * @return \Illuminate\Support\Collection<int, MobileDevice>
+     */
+    public function findPasskeyDevicesByEmail(string $email): \Illuminate\Support\Collection
+    {
+        $user = User::where('email', $email)->first();
+
+        if (! $user) {
+            return collect();
+        }
+
+        return MobileDevice::where('user_id', $user->id)
+            ->where('passkey_enabled', true)
+            ->whereNotNull('passkey_credential_id')
+            ->get();
+    }
+
+    /**
      * Block a device.
      */
     public function blockDevice(MobileDevice $device, string $reason): void

--- a/app/Domain/MobilePayment/Enums/PaymentNetwork.php
+++ b/app/Domain/MobilePayment/Enums/PaymentNetwork.php
@@ -97,6 +97,21 @@ enum PaymentNetwork: string
     }
 
     /**
+     * Average time in seconds for a transfer to reach required confirmations.
+     */
+    public function avgConfirmationSeconds(): int
+    {
+        return match ($this) {
+            self::SOLANA   => 5,
+            self::TRON     => 30,
+            self::POLYGON  => 6,
+            self::BASE     => 2,
+            self::ARBITRUM => 3,
+            self::ETHEREUM => 15,
+        };
+    }
+
+    /**
      * @return array<string>
      */
     public static function values(): array

--- a/app/Domain/MobilePayment/Services/NetworkAvailabilityService.php
+++ b/app/Domain/MobilePayment/Services/NetworkAvailabilityService.php
@@ -108,14 +108,7 @@ class NetworkAvailabilityService
 
     private function getAvgConfirmationSeconds(PaymentNetwork $network): int
     {
-        return match ($network) {
-            PaymentNetwork::SOLANA   => 5,
-            PaymentNetwork::TRON     => 3,
-            PaymentNetwork::POLYGON  => 6,
-            PaymentNetwork::BASE     => 2,
-            PaymentNetwork::ARBITRUM => 3,
-            PaymentNetwork::ETHEREUM => 15,
-        };
+        return $network->avgConfirmationSeconds();
     }
 
     private function getCongestionLevel(PaymentNetwork $network): string

--- a/app/Domain/MobilePayment/Services/PaymentIntentService.php
+++ b/app/Domain/MobilePayment/Services/PaymentIntentService.php
@@ -190,14 +190,10 @@ class PaymentIntentService implements PaymentIntentServiceInterface
 
     private function generateDemoTxHash(PaymentNetwork $network): string
     {
-        if ($network->isEvm()) {
-            return '0x' . bin2hex(random_bytes(32));
-        }
-
         return match ($network) {
             PaymentNetwork::SOLANA => Str::random(88),
             PaymentNetwork::TRON   => Str::random(64),
-            default                => '0x' . bin2hex(random_bytes(32)),
+            PaymentNetwork::POLYGON, PaymentNetwork::BASE, PaymentNetwork::ARBITRUM, PaymentNetwork::ETHEREUM => '0x' . bin2hex(random_bytes(32)),
         };
     }
 }

--- a/app/Domain/MobilePayment/Services/ReceiveAddressService.php
+++ b/app/Domain/MobilePayment/Services/ReceiveAddressService.php
@@ -60,14 +60,10 @@ class ReceiveAddressService
     {
         $hash = hash('sha256', "demo:{$userId}:{$network->value}");
 
-        if ($network->isEvm()) {
-            return '0x' . substr($hash, 0, 40);
-        }
-
         return match ($network) {
             PaymentNetwork::SOLANA => $this->toBase58Like($hash),
             PaymentNetwork::TRON   => 'T' . substr(strtoupper($hash), 0, 33),
-            default                => '0x' . substr($hash, 0, 40),
+            PaymentNetwork::POLYGON, PaymentNetwork::BASE, PaymentNetwork::ARBITRUM, PaymentNetwork::ETHEREUM => '0x' . substr($hash, 0, 40),
         };
     }
 
@@ -76,14 +72,10 @@ class ReceiveAddressService
      */
     private function buildQrValue(string $address, PaymentNetwork $network, PaymentAsset $asset): string
     {
-        if ($network->isEvm()) {
-            return "ethereum:{$address}";
-        }
-
         return match ($network) {
             PaymentNetwork::SOLANA => "solana:{$address}?spl-token=USDC",
             PaymentNetwork::TRON   => $address,
-            default                => $address,
+            PaymentNetwork::POLYGON, PaymentNetwork::BASE, PaymentNetwork::ARBITRUM, PaymentNetwork::ETHEREUM => "ethereum:{$address}",
         };
     }
 

--- a/app/Domain/Wallet/Services/WalletTransferService.php
+++ b/app/Domain/Wallet/Services/WalletTransferService.php
@@ -190,13 +190,6 @@ class WalletTransferService
      */
     private function estimateTransferTime(PaymentNetwork $network): int
     {
-        return match ($network) {
-            PaymentNetwork::SOLANA   => 5,
-            PaymentNetwork::TRON     => 30,
-            PaymentNetwork::POLYGON  => 6,
-            PaymentNetwork::BASE     => 2,
-            PaymentNetwork::ARBITRUM => 3,
-            PaymentNetwork::ETHEREUM => 15,
-        };
+        return $network->avgConfirmationSeconds();
     }
 }

--- a/app/Http/Controllers/Api/Auth/PasskeyController.php
+++ b/app/Http/Controllers/Api/Auth/PasskeyController.php
@@ -10,7 +10,6 @@ use App\Domain\Mobile\Services\MobileDeviceService;
 use App\Domain\Mobile\Services\PasskeyAuthenticationService;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Mobile\PasskeyAuthenticateRequest;
-use App\Models\User;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -139,25 +138,10 @@ class PasskeyController extends Controller
      */
     private function challengeByEmail(Request $request, string $email): JsonResponse
     {
-        $user = User::where('email', $email)->first();
-
-        if (! $user) {
-            // Return generic error to avoid user enumeration
-            return response()->json([
-                'success' => false,
-                'error'   => [
-                    'code'    => 'PASSKEY_NOT_AVAILABLE',
-                    'message' => 'No passkeys available for this account.',
-                ],
-            ], 400);
-        }
-
-        $devices = MobileDevice::where('user_id', $user->id)
-            ->where('passkey_enabled', true)
-            ->whereNotNull('passkey_credential_id')
-            ->get();
+        $devices = $this->deviceService->findPasskeyDevicesByEmail($email);
 
         if ($devices->isEmpty()) {
+            // Generic error to avoid user enumeration
             return response()->json([
                 'success' => false,
                 'error'   => [

--- a/tests/Unit/Domain/MobilePayment/Enums/PaymentNetworkTest.php
+++ b/tests/Unit/Domain/MobilePayment/Enums/PaymentNetworkTest.php
@@ -88,4 +88,13 @@ describe('PaymentNetwork Enum', function (): void {
         expect((bool) preg_match($pattern, 'invalid'))->toBeFalse();
         expect((bool) preg_match($pattern, '0xshort'))->toBeFalse();
     });
+
+    it('returns avg confirmation seconds for all networks', function (): void {
+        expect(PaymentNetwork::SOLANA->avgConfirmationSeconds())->toBe(5);
+        expect(PaymentNetwork::TRON->avgConfirmationSeconds())->toBe(30);
+        expect(PaymentNetwork::POLYGON->avgConfirmationSeconds())->toBe(6);
+        expect(PaymentNetwork::BASE->avgConfirmationSeconds())->toBe(2);
+        expect(PaymentNetwork::ARBITRUM->avgConfirmationSeconds())->toBe(3);
+        expect(PaymentNetwork::ETHEREUM->avgConfirmationSeconds())->toBe(15);
+    });
 });


### PR DESCRIPTION
## Summary
- **Service-layer architecture**: Moved direct Eloquent queries (`User::where`, `MobileDevice::where`) from `PasskeyController::challengeByEmail()` into `MobileDeviceService::findPasskeyDevicesByEmail()` — controller no longer bypasses the service layer
- **DRY confirmation times**: Added `PaymentNetwork::avgConfirmationSeconds()` as single source of truth; `NetworkAvailabilityService` and `WalletTransferService` now delegate to it instead of maintaining separate match statements
- **Bug fix**: TRON confirmation time was inconsistent — 3s in `NetworkAvailabilityService` vs 30s in `WalletTransferService`. Correct value is 30s (20 confirmations × ~1.5s/block). Now consistent everywhere.
- **Exhaustive match expressions**: Replaced `isEvm()` early-return + unreachable `default` branches with explicit case-listing for PHPStan Level 8 compliance
- **Test quality**: Rewrote `NetworkAvailabilityServiceTest` to test public interface (`getNetworkStatuses()`, `getNetworkStatus()`) instead of private methods via Reflection; added EVM chain coverage

## Files Changed (9)
| File | Change |
|------|--------|
| `PaymentNetwork.php` | Added `avgConfirmationSeconds()` method |
| `MobileDeviceService.php` | Added `findPasskeyDevicesByEmail()` method |
| `PasskeyController.php` | Use service method, remove `User` import |
| `NetworkAvailabilityService.php` | Delegate to enum |
| `WalletTransferService.php` | Delegate to enum |
| `PaymentIntentService.php` | Exhaustive match |
| `ReceiveAddressService.php` | Exhaustive match (2 methods) |
| `PaymentNetworkTest.php` | Add `avgConfirmationSeconds` test |
| `NetworkAvailabilityServiceTest.php` | Full rewrite using public API |

## Test plan
- [x] PHPStan Level 8: 0 errors on all 7 modified files
- [x] php-cs-fixer: 0 fixable files
- [x] 34 targeted tests pass (204 assertions)
- [x] Full suite: 4053 passed (15733 assertions), 0 new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)