### PR TITLE
fix: PHPStan null guards in NetworkAvailabilityServiceTest

### DIFF
--- a/tests/Unit/Domain/MobilePayment/Services/NetworkAvailabilityServiceTest.php
+++ b/tests/Unit/Domain/MobilePayment/Services/NetworkAvailabilityServiceTest.php
@@ -48,41 +48,41 @@ describe('NetworkAvailabilityService', function (): void {
     it('returns correct status for a single network', function (): void {
         $service = new NetworkAvailabilityService();
         $status = $service->getNetworkStatus(PaymentNetwork::SOLANA);
+        assert($status !== null);
 
-        expect($status)->not->toBeNull()
-            ->and($status['id'])->toBe('SOLANA')
-            ->and($status['name'])->toBe('Solana')
-            ->and($status['native_asset'])->toBe('SOL')
-            ->and($status['avg_fee_usd'])->toBe('0.001')
-            ->and($status['avg_confirmation_seconds'])->toBe(5);
+        expect($status['id'])->toBe('SOLANA');
+        expect($status['name'])->toBe('Solana');
+        expect($status['native_asset'])->toBe('SOL');
+        expect($status['avg_fee_usd'])->toBe('0.001');
+        expect($status['avg_confirmation_seconds'])->toBe(5);
     });
 
     it('returns correct fee and confirmation time for Tron', function (): void {
         $service = new NetworkAvailabilityService();
         $status = $service->getNetworkStatus(PaymentNetwork::TRON);
+        assert($status !== null);
 
-        expect($status)->not->toBeNull()
-            ->and($status['avg_fee_usd'])->toBe('0.500')
-            ->and($status['avg_confirmation_seconds'])->toBe(30);
+        expect($status['avg_fee_usd'])->toBe('0.500');
+        expect($status['avg_confirmation_seconds'])->toBe(30);
     });
 
     it('returns correct data for EVM chains', function (): void {
         $service = new NetworkAvailabilityService();
 
         $polygon = $service->getNetworkStatus(PaymentNetwork::POLYGON);
-        expect($polygon)->not->toBeNull()
-            ->and($polygon['native_asset'])->toBe('MATIC')
-            ->and($polygon['avg_fee_usd'])->toBe('0.010');
+        assert($polygon !== null);
+        expect($polygon['native_asset'])->toBe('MATIC');
+        expect($polygon['avg_fee_usd'])->toBe('0.010');
 
         $base = $service->getNetworkStatus(PaymentNetwork::BASE);
-        expect($base)->not->toBeNull()
-            ->and($base['native_asset'])->toBe('ETH')
-            ->and($base['avg_fee_usd'])->toBe('0.005');
+        assert($base !== null);
+        expect($base['native_asset'])->toBe('ETH');
+        expect($base['avg_fee_usd'])->toBe('0.005');
 
         $ethereum = $service->getNetworkStatus(PaymentNetwork::ETHEREUM);
-        expect($ethereum)->not->toBeNull()
-            ->and($ethereum['native_asset'])->toBe('ETH')
-            ->and($ethereum['avg_fee_usd'])->toBe('2.000');
+        assert($ethereum !== null);
+        expect($ethereum['native_asset'])->toBe('ETH');
+        expect($ethereum['avg_fee_usd'])->toBe('2.000');
     });
 
     it('returns low congestion level by default', function (): void {
@@ -90,6 +90,7 @@ describe('NetworkAvailabilityService', function (): void {
 
         foreach (PaymentNetwork::cases() as $network) {
             $status = $service->getNetworkStatus($network);
+            assert($status !== null);
             expect($status['congestion'])->toBe('low');
         }
     });


### PR DESCRIPTION
## Summary
- Add `assert($status !== null)` before array offset access on nullable `getNetworkStatus()` return
- Fixes PHPStan Level 8 `offsetAccess.notFound` errors (22 errors) introduced in PR #632

## Test plan
- [x] PHPStan: 0 errors
- [x] Tests pass locally (6 passed, 110 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)