### PR TITLE
fix: Remaining audit items (blog SEO, sandbox branding, sitemap, docs)

### DIFF
--- a/public/docs/postman/FinAegis-Environment.postman_environment.json
+++ b/public/docs/postman/FinAegis-Environment.postman_environment.json
@@ -4,13 +4,13 @@
     "values": [
         {
             "key": "base_url",
-            "value": "http://finaegis.local/api/v2",
+            "value": "https://finaegis.org/api/v2",
             "type": "text",
             "enabled": true
         },
         {
             "key": "sandbox_url",
-            "value": "http://finaegis.local/api/v2",
+            "value": "https://finaegis.org/api/v2",
             "type": "text",
             "enabled": true
         },

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -29,6 +29,13 @@
     <url><loc>https://finaegis.org/support/contact</loc><lastmod>2026-02-26</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
     <url><loc>https://finaegis.org/support/faq</loc><lastmod>2026-02-26</lastmod><changefreq>weekly</changefreq><priority>0.6</priority></url>
     <url><loc>https://finaegis.org/support/guides</loc><lastmod>2026-02-26</lastmod><changefreq>weekly</changefreq><priority>0.6</priority></url>
+    <url><loc>https://finaegis.org/ai-framework/demo</loc><lastmod>2026-02-26</lastmod><changefreq>weekly</changefreq><priority>0.6</priority></url>
+    <url><loc>https://finaegis.org/ai-framework/docs</loc><lastmod>2026-02-26</lastmod><changefreq>weekly</changefreq><priority>0.6</priority></url>
+    <url><loc>https://finaegis.org/demo/ai-agent</loc><lastmod>2026-02-26</lastmod><changefreq>weekly</changefreq><priority>0.6</priority></url>
+    <url><loc>https://finaegis.org/developers/examples</loc><lastmod>2026-02-26</lastmod><changefreq>weekly</changefreq><priority>0.6</priority></url>
+    <url><loc>https://finaegis.org/developers/webhooks</loc><lastmod>2026-02-26</lastmod><changefreq>weekly</changefreq><priority>0.6</priority></url>
+    <url><loc>https://finaegis.org/developers/postman</loc><lastmod>2026-02-26</lastmod><changefreq>weekly</changefreq><priority>0.6</priority></url>
+    <url><loc>https://finaegis.org/financial-institutions/apply</loc><lastmod>2026-02-26</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
     <url><loc>https://finaegis.org/cgo</loc><lastmod>2026-02-26</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
     <url><loc>https://finaegis.org/partners</loc><lastmod>2026-02-26</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>
     <url><loc>https://finaegis.org/blog</loc><lastmod>2026-02-26</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>

--- a/resources/views/blog/index.blade.php
+++ b/resources/views/blog/index.blade.php
@@ -1,4 +1,16 @@
-<x-guest-layout>
+<x-guest-layout :title="'Blog — ' . config('app.name', 'FinAegis')">
+    @push('meta')
+        <meta name="description" content="Insights, updates, and thought leadership on multi-asset banking, financial technology, and the future of open-source core banking from the FinAegis team.">
+        <meta property="og:title" content="Blog — {{ config('app.name', 'FinAegis') }}">
+        <meta property="og:description" content="Insights, updates, and thought leadership on multi-asset banking, financial technology, and the future of open-source core banking.">
+        <meta property="og:type" content="website">
+        <meta property="og:url" content="{{ url('/blog') }}">
+        <meta name="twitter:card" content="summary">
+        <meta name="twitter:title" content="Blog — {{ config('app.name', 'FinAegis') }}">
+        <meta name="twitter:description" content="Insights, updates, and thought leadership on multi-asset banking, financial technology, and open-source core banking.">
+        <link rel="canonical" href="{{ url('/blog') }}">
+    @endpush
+
     <div class="bg-white">
         <!-- Header -->
         <div class="bg-gradient-to-r from-gray-900 to-gray-800">

--- a/resources/views/components/platform-banners.blade.php
+++ b/resources/views/components/platform-banners.blade.php
@@ -1,25 +1,25 @@
-{{-- Demo Mode Indicator — only visible when APP_ENV=demo --}}
+{{-- Sandbox Indicator — only visible when APP_ENV=demo --}}
 @if(app()->environment('demo'))
-<div id="demo-pill" class="fixed bottom-6 left-6 z-50" onclick="this.classList.toggle('expanded')">
+<div id="sandbox-pill" class="fixed bottom-6 left-6 z-50" onclick="this.classList.toggle('expanded')">
     {{-- Collapsed pill --}}
-    <div class="demo-pill-collapsed cursor-pointer flex items-center gap-2 px-4 py-2 bg-amber-100 border border-amber-300 rounded-full shadow-lg hover:shadow-xl transition-all">
+    <div class="sandbox-pill-collapsed cursor-pointer flex items-center gap-2 px-4 py-2 bg-amber-100 border border-amber-300 rounded-full shadow-lg hover:shadow-xl transition-all">
         <span class="relative flex h-2.5 w-2.5">
             <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-amber-500 opacity-75"></span>
             <span class="relative inline-flex rounded-full h-2.5 w-2.5 bg-amber-500"></span>
         </span>
-        <span class="text-sm font-semibold text-amber-800">Demo Mode</span>
+        <span class="text-sm font-semibold text-amber-800">Sandbox</span>
     </div>
 
     {{-- Expanded card --}}
-    <div class="demo-pill-expanded hidden mt-2 w-80 bg-white border border-amber-200 rounded-xl shadow-2xl p-5">
+    <div class="sandbox-pill-expanded hidden mt-2 w-80 bg-white border border-amber-200 rounded-xl shadow-2xl p-5">
         <div class="flex items-center gap-2 mb-3">
             <span class="relative flex h-2.5 w-2.5">
                 <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-amber-500 opacity-75"></span>
                 <span class="relative inline-flex rounded-full h-2.5 w-2.5 bg-amber-500"></span>
             </span>
-            <h3 class="text-base font-bold text-amber-900">Demo Environment</h3>
+            <h3 class="text-base font-bold text-amber-900">Sandbox Environment</h3>
         </div>
-        <p class="text-sm text-gray-600 mb-3">This is a demonstration instance. No real transactions are processed.</p>
+        <p class="text-sm text-gray-600 mb-3">All transactions use test data. No real funds are processed.</p>
         <div class="flex flex-wrap gap-2">
             <span class="inline-flex items-center px-2.5 py-1 bg-amber-50 text-amber-700 text-xs font-medium rounded-full border border-amber-200">No Real Funds</span>
             <span class="inline-flex items-center px-2.5 py-1 bg-amber-50 text-amber-700 text-xs font-medium rounded-full border border-amber-200">Test Data</span>
@@ -28,8 +28,8 @@
 </div>
 
 <style>
-    #demo-pill.expanded .demo-pill-collapsed { display: none; }
-    #demo-pill.expanded .demo-pill-expanded { display: block; }
-    #demo-pill:not(.expanded) .demo-pill-expanded { display: none; }
+    #sandbox-pill.expanded .sandbox-pill-collapsed { display: none; }
+    #sandbox-pill.expanded .sandbox-pill-expanded { display: block; }
+    #sandbox-pill:not(.expanded) .sandbox-pill-expanded { display: none; }
 </style>
 @endif

--- a/resources/views/developers/postman.blade.php
+++ b/resources/views/developers/postman.blade.php
@@ -144,7 +144,7 @@
                                         </svg>
                                         <code class="text-sm font-medium text-blue-600">base_url</code>
                                     </div>
-                                    <span class="text-sm text-gray-600">http://finaegis.local/api/v2</span>
+                                    <span class="text-sm text-gray-600">https://finaegis.org/api/v2</span>
                                 </div>
                             </div>
                             <div class="bg-white rounded-lg p-3 border border-gray-200">
@@ -155,7 +155,7 @@
                                         </svg>
                                         <code class="text-sm font-medium text-blue-600">sandbox_url</code>
                                     </div>
-                                    <span class="text-sm text-gray-600">http://finaegis.local/api/v2</span>
+                                    <span class="text-sm text-gray-600">https://finaegis.org/api/v2</span>
                                 </div>
                             </div>
                             <div class="bg-white rounded-lg p-3 border border-gray-200">

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -5,8 +5,9 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="csrf-token" content="{{ csrf_token() }}">
 
-        <title>{{ config('app.name', 'Laravel') }}</title>
+        <title>{{ $title ?? config('app.name', 'Laravel') }}</title>
 
+        @stack('meta')
         @include('partials.favicon')
 
         <!-- Fonts -->

--- a/resources/views/support/index.blade.php
+++ b/resources/views/support/index.blade.php
@@ -186,7 +186,7 @@
             </div>
         </section>
 
-        <!-- Alpha Notice -->
+        <!-- Development Notice -->
         <section class="py-16 bg-amber-50 border-y border-amber-200">
             <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
                 <div class="flex items-center justify-center mb-4">


### PR DESCRIPTION
## Summary

Follow-up to PR #637 — addresses remaining findings from the comprehensive audit.

### SEO (2 fixes)
- **`guest.blade.php`**: Added `@stack('meta')` and dynamic `$title` prop to support SEO meta tags in component-based layouts
- **`blog/index.blade.php`**: Added meta description, OpenGraph tags, Twitter card, and canonical URL — previously had zero SEO meta tags

### Sitemap (7 new pages)
Added missing routes to `sitemap.xml` (now 49 URLs total):
- `/ai-framework/demo`, `/ai-framework/docs`
- `/demo/ai-agent`
- `/developers/examples`, `/developers/webhooks`, `/developers/postman`
- `/financial-institutions/apply`

### Branding Consistency (2 fixes)
- **`platform-banners.blade.php`**: "Demo Mode" → "Sandbox" / "Sandbox Environment" (consistent with alpha-banner changes in #637)
- **`support/index.blade.php`**: Updated HTML comment from "Alpha Notice" to "Development Notice"

### Public-Facing Docs (2 fixes)
- **`developers/postman.blade.php`**: Fixed displayed API URLs from `finaegis.local` → `finaegis.org`
- **`FinAegis-Environment.postman_environment.json`**: Fixed Postman env variables from `finaegis.local` → `finaegis.org`

## Test plan
- [x] `php-cs-fixer` — 0 fixes needed
- [x] `phpstan analyse` — No errors
- [ ] Verify blog page renders with correct meta tags in page source
- [ ] Verify sitemap.xml is valid XML
- [ ] Verify Postman environment import works with updated URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)