### PR TITLE
chore: Dependabot triage — ignore rules for 5 breaking major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,13 @@ updates:
       - "composer"
     reviewers:
       - "FinAegis/maintainers"
+    ignore:
+      - dependency-name: "resend/resend-php"
+        versions: [">=1.0.0"]
+      - dependency-name: "symfony/http-client"
+        versions: [">=8.0.0"]
+      - dependency-name: "squizlabs/php_codesniffer"
+        versions: [">=4.0.0"]
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -21,6 +28,11 @@ updates:
     labels:
       - "dependencies"
       - "npm"
+    ignore:
+      - dependency-name: "tailwindcss"
+        versions: [">=4.0.0"]
+      - dependency-name: "@ledgerhq/hw-app-eth"
+        versions: [">=7.0.0"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary
- Merged 4 safe Dependabot PRs: #612 (docker/build-push-action 5→6), #613 (laravel/sail), #621 (spatie/laravel-permission 7.2.3), #624 (endroid/qr-code 6.1.3)
- Closed 5 breaking major bump PRs with explanatory comments: #614, #616, #617, #618, #619
- Added ignore rules to `.github/dependabot.yml` to prevent re-opening

## Ignore Rules Added
| Package | Ignored Versions | Reason |
|---------|-----------------|--------|
| `tailwindcss` | >=4.0.0 | Complete config format rewrite |
| `resend/resend-php` | >=1.0.0 | Breaking API changes |
| `symfony/http-client` | >=8.0.0 | Conflicts with Laravel's Symfony 7.x |
| `@ledgerhq/hw-app-eth` | >=7.0.0 | Breaking hardware wallet API |
| `squizlabs/php_codesniffer` | >=4.0.0 | Major rewrite |

## Test plan
- [ ] Verify dependabot does not re-open closed PRs
- [ ] Confirm CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)