### PR TITLE
fix: Resolve intermittent CI timeout from process-level max_execution_time

### DIFF
--- a/bin/pest-batch
+++ b/bin/pest-batch
@@ -82,7 +82,7 @@ fi
 
 # Run tests with error handling
 set +e
-php -d memory_limit=$MEMORY_LIMIT ./vendor/bin/pest "${VALID_PATHS[@]}" \
+php -d memory_limit=$MEMORY_LIMIT -d max_execution_time=0 ./vendor/bin/pest "${VALID_PATHS[@]}" \
     --configuration=$CONFIG_FILE \
     --no-coverage \
     --stop-on-failure \

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -62,8 +62,7 @@
         <env name="LIGHTHOUSE_SCHEMA_CACHE_ENABLE" value="false"/>
         <!-- Parallel testing configuration -->
         <env name="PEST_PARALLEL" value="false"/>
-        <!-- Test timeout configuration -->
-        <ini name="max_execution_time" value="300"/>
+        <!-- Memory limit for test process -->
         <ini name="memory_limit" value="1G"/>
     </php>
 </phpunit>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -24,6 +24,8 @@ abstract class TestCase extends BaseTestCase
     use CreatesApplication;
     use LazilyRefreshDatabase;
 
+    private static int $testCounter = 0;
+
     protected User $user;
 
     protected User $business_user;
@@ -34,10 +36,13 @@ abstract class TestCase extends BaseTestCase
     {
         parent::tearDown();
 
-        // Close any Mockery mocks
-        // Force garbage collection to free memory
-        gc_collect_cycles();
         Mockery::close();
+
+        // Run GC every 50 tests instead of every test to avoid
+        // accumulating into process-level max_execution_time
+        if (++self::$testCounter % 50 === 0) {
+            gc_collect_cycles();
+        }
     }
 
     protected function setUp(): void


### PR DESCRIPTION
## Summary
- Removed `max_execution_time=300` INI setting from `phpunit.xml` — it accumulates across all 849 tests in a single Pest process, causing intermittent CI timeouts (run 22458725582)
- Optimized GC in `TestCase::tearDown()` to run every 50 tests instead of every test
- Added `-d max_execution_time=0` to `bin/pest-batch` PHP invocation

CI job `timeout-minutes` and per-test `defaultTimeLimit=10` remain as sufficient guards.

## Test plan
- [x] Local test suite completes without timeout (865s, 3099 passed)
- [ ] CI pipeline passes without intermittent timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)