### PR TITLE
feat: Wire IdempotencyMiddleware to 24 financial mutation routes

### DIFF
--- a/app/Domain/Account/Routes/api.php
+++ b/app/Domain/Account/Routes/api.php
@@ -41,9 +41,9 @@ Route::middleware('auth:sanctum', 'check.token.expiration')->group(function () {
 
     // Transaction endpoints
     Route::post('/accounts/{uuid}/deposit', [TransactionController::class, 'deposit'])
-        ->middleware(['transaction.rate_limit:deposit', 'scope:write']);
+        ->middleware(['transaction.rate_limit:deposit', 'idempotency', 'scope:write']);
     Route::post('/accounts/{uuid}/withdraw', [TransactionController::class, 'withdraw'])
-        ->middleware(['transaction.rate_limit:withdraw', 'scope:write']);
+        ->middleware(['transaction.rate_limit:withdraw', 'idempotency', 'scope:write']);
 
     // Transfer endpoints
     Route::post('/transfers', [TransferController::class, 'store'])

--- a/app/Domain/Commerce/Routes/api.php
+++ b/app/Domain/Commerce/Routes/api.php
@@ -15,10 +15,10 @@ Route::prefix('v1/commerce')->name('mobile.commerce.')
             ->middleware('api.rate_limit:query')
             ->name('parse-qr');
         Route::post('/payment-requests', [MobileCommerceController::class, 'createPaymentRequest'])
-            ->middleware('transaction.rate_limit:payment_intent')
+            ->middleware(['transaction.rate_limit:payment_intent', 'idempotency'])
             ->name('payment-requests');
         Route::post('/payments', [MobileCommerceController::class, 'processPayment'])
-            ->middleware('transaction.rate_limit:payment_intent')
+            ->middleware(['transaction.rate_limit:payment_intent', 'idempotency'])
             ->name('payments');
         Route::post('/generate-qr', [MobileCommerceController::class, 'generateQr'])
             ->middleware('api.rate_limit:query')

--- a/app/Domain/CrossChain/Routes/api.php
+++ b/app/Domain/CrossChain/Routes/api.php
@@ -11,12 +11,12 @@ Route::prefix('v1/crosschain')->name('api.crosschain.')->group(function () {
     Route::middleware(['auth:sanctum', 'check.token.expiration'])->group(function () {
         Route::post('/bridge/quote', [CrossChainController::class, 'bridgeQuote'])->name('bridge.quote');
         Route::post('/bridge/initiate', [CrossChainController::class, 'bridgeInitiate'])
-            ->middleware('transaction.rate_limit:crosschain')
+            ->middleware(['transaction.rate_limit:crosschain', 'idempotency'])
             ->name('bridge.initiate');
         Route::get('/bridge/{id}/status', [CrossChainController::class, 'bridgeStatus'])->name('bridge.status');
         Route::post('/swap/quote', [CrossChainController::class, 'swapQuote'])->name('swap.quote');
         Route::post('/swap/execute', [CrossChainController::class, 'swapExecute'])
-            ->middleware('transaction.rate_limit:crosschain')
+            ->middleware(['transaction.rate_limit:crosschain', 'idempotency'])
             ->name('swap.execute');
     });
 });

--- a/app/Domain/DeFi/Routes/api.php
+++ b/app/Domain/DeFi/Routes/api.php
@@ -11,7 +11,7 @@ Route::prefix('v1/defi')->name('api.defi.')->group(function () {
     Route::middleware(['auth:sanctum', 'check.token.expiration'])->group(function () {
         Route::post('/swap/quote', [DeFiController::class, 'swapQuote'])->name('swap.quote');
         Route::post('/swap/execute', [DeFiController::class, 'swapExecute'])
-            ->middleware('transaction.rate_limit:defi')
+            ->middleware(['transaction.rate_limit:defi', 'idempotency'])
             ->name('swap.execute');
         Route::get('/lending/markets', [DeFiController::class, 'lendingMarkets'])->name('lending.markets');
         Route::get('/portfolio', [DeFiController::class, 'portfolio'])->name('portfolio');

--- a/app/Domain/Exchange/Routes/api.php
+++ b/app/Domain/Exchange/Routes/api.php
@@ -34,7 +34,7 @@ Route::middleware('api.rate_limit:public')->group(function () {
 
         Route::middleware('auth:sanctum', 'check.token.expiration')->group(function () {
             Route::post('/orders', [App\Http\Controllers\Api\ExchangeController::class, 'placeOrder'])
-                ->middleware('transaction.rate_limit:exchange_order')
+                ->middleware(['transaction.rate_limit:exchange_order', 'idempotency'])
                 ->name('orders.place');
             Route::delete('/orders/{orderId}', [App\Http\Controllers\Api\ExchangeController::class, 'cancelOrder'])->name('orders.cancel');
             Route::get('/orders', [App\Http\Controllers\Api\ExchangeController::class, 'getOrders'])->name('orders.index');
@@ -59,12 +59,12 @@ Route::middleware('api.rate_limit:public')->group(function () {
         Route::get('/pools/{poolId}', [App\Http\Controllers\Api\LiquidityPoolController::class, 'show'])->name('pools.show');
 
         Route::middleware('auth:sanctum', 'check.token.expiration')->group(function () {
-            Route::post('/pools', [App\Http\Controllers\Api\LiquidityPoolController::class, 'create'])->name('pools.create');
-            Route::post('/add', [App\Http\Controllers\Api\LiquidityPoolController::class, 'addLiquidity'])->name('add');
-            Route::post('/remove', [App\Http\Controllers\Api\LiquidityPoolController::class, 'removeLiquidity'])->name('remove');
-            Route::post('/swap', [App\Http\Controllers\Api\LiquidityPoolController::class, 'swap'])->name('swap');
+            Route::post('/pools', [App\Http\Controllers\Api\LiquidityPoolController::class, 'create'])->middleware('idempotency')->name('pools.create');
+            Route::post('/add', [App\Http\Controllers\Api\LiquidityPoolController::class, 'addLiquidity'])->middleware('idempotency')->name('add');
+            Route::post('/remove', [App\Http\Controllers\Api\LiquidityPoolController::class, 'removeLiquidity'])->middleware('idempotency')->name('remove');
+            Route::post('/swap', [App\Http\Controllers\Api\LiquidityPoolController::class, 'swap'])->middleware('idempotency')->name('swap');
             Route::get('/positions', [App\Http\Controllers\Api\LiquidityPoolController::class, 'positions'])->name('positions');
-            Route::post('/claim-rewards', [App\Http\Controllers\Api\LiquidityPoolController::class, 'claimRewards'])->name('claim-rewards');
+            Route::post('/claim-rewards', [App\Http\Controllers\Api\LiquidityPoolController::class, 'claimRewards'])->middleware('idempotency')->name('claim-rewards');
 
             // IL Protection endpoints
             Route::get('/il-protection/{positionId}', [App\Http\Controllers\Api\LiquidityPoolController::class, 'calculateImpermanentLoss'])->name('il-protection.calculate');

--- a/app/Domain/Lending/Routes/api.php
+++ b/app/Domain/Lending/Routes/api.php
@@ -14,7 +14,7 @@ Route::prefix('lending')->middleware(['auth:sanctum', 'check.token.expiration', 
         Route::get('/applications/{id}', [LoanApplicationController::class, 'show']);
     });
 
-    Route::middleware('transaction.rate_limit:lending')->group(function () {
+    Route::middleware(['transaction.rate_limit:lending', 'idempotency'])->group(function () {
         Route::post('/applications', [LoanApplicationController::class, 'store']);
         Route::post('/applications/{id}/cancel', [LoanApplicationController::class, 'cancel']);
     });
@@ -26,7 +26,7 @@ Route::prefix('lending')->middleware(['auth:sanctum', 'check.token.expiration', 
         Route::get('/loans/{id}/settlement-quote', [LoanController::class, 'settleEarly']);
     });
 
-    Route::middleware('transaction.rate_limit:lending')->group(function () {
+    Route::middleware(['transaction.rate_limit:lending', 'idempotency'])->group(function () {
         Route::post('/loans/{id}/payments', [LoanController::class, 'makePayment']);
         Route::post('/loans/{id}/settle', [LoanController::class, 'confirmSettlement'])->name('api.loans.confirm-settlement');
     });

--- a/app/Domain/MobilePayment/Routes/api.php
+++ b/app/Domain/MobilePayment/Routes/api.php
@@ -14,16 +14,16 @@ use Illuminate\Support\Facades\Route;
 Route::prefix('v1')->middleware(['auth:sanctum', 'check.token.expiration'])->group(function () {
     // Payment Intents
     Route::post('/payments/intents', [PaymentIntentController::class, 'create'])
-        ->middleware('transaction.rate_limit:payment_intent')
+        ->middleware(['transaction.rate_limit:payment_intent', 'idempotency'])
         ->name('mobile.payments.intents.create');
     Route::get('/payments/intents/{intentId}', [PaymentIntentController::class, 'show'])
         ->middleware('api.rate_limit:query')
         ->name('mobile.payments.intents.show');
     Route::post('/payments/intents/{intentId}/submit', [PaymentIntentController::class, 'submit'])
-        ->middleware('transaction.rate_limit:payment_submit')
+        ->middleware(['transaction.rate_limit:payment_submit', 'idempotency'])
         ->name('mobile.payments.intents.submit');
     Route::post('/payments/intents/{intentId}/cancel', [PaymentIntentController::class, 'cancel'])
-        ->middleware('transaction.rate_limit:payment_submit')
+        ->middleware(['transaction.rate_limit:payment_submit', 'idempotency'])
         ->name('mobile.payments.intents.cancel');
 
     // Activity Feed

--- a/app/Domain/Stablecoin/Routes/api.php
+++ b/app/Domain/Stablecoin/Routes/api.php
@@ -27,9 +27,9 @@ Route::prefix('v2')->group(function () {
 
     // Stablecoin operations endpoints
     Route::middleware(['auth:sanctum', 'check.token.expiration', 'sub_product:stablecoins'])->prefix('stablecoin-operations')->group(function () {
-        Route::post('/mint', [StablecoinOperationsController::class, 'mint']);
-        Route::post('/burn', [StablecoinOperationsController::class, 'burn']);
-        Route::post('/add-collateral', [StablecoinOperationsController::class, 'addCollateral']);
+        Route::post('/mint', [StablecoinOperationsController::class, 'mint'])->middleware('idempotency');
+        Route::post('/burn', [StablecoinOperationsController::class, 'burn'])->middleware('idempotency');
+        Route::post('/add-collateral', [StablecoinOperationsController::class, 'addCollateral'])->middleware('idempotency');
 
         // Position management
         Route::get('/accounts/{accountUuid}/positions', [StablecoinOperationsController::class, 'getAccountPositions']);

--- a/app/Domain/Treasury/Routes/api.php
+++ b/app/Domain/Treasury/Routes/api.php
@@ -15,11 +15,11 @@ Route::prefix('treasury')->name('api.treasury.')->group(function () {
         Route::prefix('portfolios')->name('portfolios.')->group(function () {
             Route::get('/', [PortfolioController::class, 'index'])->name('index');
             Route::post('/', [PortfolioController::class, 'store'])
-                ->middleware('transaction.rate_limit:treasury')
+                ->middleware(['transaction.rate_limit:treasury', 'idempotency'])
                 ->name('store');
             Route::get('/{id}', [PortfolioController::class, 'show'])->name('show');
             Route::put('/{id}', [PortfolioController::class, 'update'])
-                ->middleware('transaction.rate_limit:treasury')
+                ->middleware(['transaction.rate_limit:treasury', 'idempotency'])
                 ->name('update');
             Route::delete('/{id}', [PortfolioController::class, 'destroy'])
                 ->middleware('transaction.rate_limit:treasury')
@@ -27,17 +27,17 @@ Route::prefix('treasury')->name('api.treasury.')->group(function () {
 
             // Asset allocation endpoints
             Route::post('/{id}/allocate', [PortfolioController::class, 'allocate'])
-                ->middleware('transaction.rate_limit:treasury')
+                ->middleware(['transaction.rate_limit:treasury', 'idempotency'])
                 ->name('allocate');
             Route::get('/{id}/allocations', [PortfolioController::class, 'getAllocations'])->name('allocations');
 
             // Rebalancing endpoints
             Route::post('/{id}/rebalance', [PortfolioController::class, 'triggerRebalancing'])
-                ->middleware('transaction.rate_limit:treasury')
+                ->middleware(['transaction.rate_limit:treasury', 'idempotency'])
                 ->name('rebalance');
             Route::get('/{id}/rebalancing-plan', [PortfolioController::class, 'getRebalancingPlan'])->name('rebalancing-plan');
             Route::post('/{id}/approve-rebalancing', [PortfolioController::class, 'approveRebalancing'])
-                ->middleware('transaction.rate_limit:treasury')
+                ->middleware(['transaction.rate_limit:treasury', 'idempotency'])
                 ->name('approve-rebalancing');
 
             // Performance and analytics endpoints

--- a/app/Domain/Wallet/Routes/api.php
+++ b/app/Domain/Wallet/Routes/api.php
@@ -17,7 +17,7 @@ Route::prefix('blockchain-wallets')->middleware(['auth:sanctum', 'check.token.ex
         Route::get('/{walletId}/transactions', [BlockchainWalletController::class, 'transactions']);
     });
 
-    Route::middleware('transaction.rate_limit:blockchain')->group(function () {
+    Route::middleware(['transaction.rate_limit:blockchain', 'idempotency'])->group(function () {
         Route::post('/', [BlockchainWalletController::class, 'store']);
         Route::put('/{walletId}', [BlockchainWalletController::class, 'update']);
         Route::post('/{walletId}/addresses', [BlockchainWalletController::class, 'generateAddress']);
@@ -132,6 +132,6 @@ Route::prefix('v1/wallet')->name('mobile.wallet.')
             ->middleware('api.rate_limit:query')
             ->name('transactions.detail');
         Route::post('/transactions/send', [MobileWalletController::class, 'send'])
-            ->middleware('transaction.rate_limit:payment_intent')
+            ->middleware(['transaction.rate_limit:payment_intent', 'idempotency'])
             ->name('transactions.send');
     });

--- a/app/Domain/X402/Routes/api.php
+++ b/app/Domain/X402/Routes/api.php
@@ -18,11 +18,11 @@ Route::prefix('v1/x402')->name('api.x402.')->group(function () {
         // Monetized endpoint management
         Route::get('/endpoints', [X402EndpointController::class, 'index'])->name('endpoints.index');
         Route::post('/endpoints', [X402EndpointController::class, 'store'])
-            ->middleware('transaction.rate_limit:x402')
+            ->middleware(['transaction.rate_limit:x402', 'idempotency'])
             ->name('endpoints.store');
         Route::get('/endpoints/{id}', [X402EndpointController::class, 'show'])->name('endpoints.show');
         Route::put('/endpoints/{id}', [X402EndpointController::class, 'update'])
-            ->middleware('transaction.rate_limit:x402')
+            ->middleware(['transaction.rate_limit:x402', 'idempotency'])
             ->name('endpoints.update');
         Route::delete('/endpoints/{id}', [X402EndpointController::class, 'destroy'])
             ->middleware('transaction.rate_limit:x402')
@@ -36,11 +36,11 @@ Route::prefix('v1/x402')->name('api.x402.')->group(function () {
         // Agent spending limits
         Route::get('/spending-limits', [X402SpendingLimitController::class, 'index'])->name('spending-limits.index');
         Route::post('/spending-limits', [X402SpendingLimitController::class, 'store'])
-            ->middleware('transaction.rate_limit:x402')
+            ->middleware(['transaction.rate_limit:x402', 'idempotency'])
             ->name('spending-limits.store');
         Route::get('/spending-limits/{agentId}', [X402SpendingLimitController::class, 'show'])->name('spending-limits.show');
         Route::put('/spending-limits/{agentId}', [X402SpendingLimitController::class, 'update'])
-            ->middleware('transaction.rate_limit:x402')
+            ->middleware(['transaction.rate_limit:x402', 'idempotency'])
             ->name('spending-limits.update');
         Route::delete('/spending-limits/{agentId}', [X402SpendingLimitController::class, 'destroy'])
             ->middleware('transaction.rate_limit:x402')

--- a/tests/Feature/Middleware/IdempotencyMiddlewareTest.php
+++ b/tests/Feature/Middleware/IdempotencyMiddlewareTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\Sanctum;
+
+beforeEach(function () {
+    // Register a test route with the idempotency middleware
+    Route::middleware(['api', 'idempotency'])->post('/test/idempotency', function () {
+        return response()->json([
+            'id'        => Str::uuid()->toString(),
+            'message'   => 'created',
+            'timestamp' => now()->toIso8601String(),
+        ], 201);
+    });
+
+    Route::middleware(['api', 'idempotency'])->get('/test/idempotency-get', function () {
+        return response()->json(['message' => 'ok']);
+    });
+
+    $this->user = User::factory()->create();
+    Sanctum::actingAs($this->user, ['read', 'write']);
+});
+
+it('returns cached response with X-Idempotency-Replayed header on duplicate POST', function () {
+    $idempotencyKey = Str::uuid()->toString();
+
+    // First request
+    $firstResponse = $this->postJson('/test/idempotency', ['amount' => 100], [
+        'Idempotency-Key' => $idempotencyKey,
+    ]);
+
+    $firstResponse->assertStatus(201);
+    $firstResponse->assertHeader('X-Idempotency-Key', $idempotencyKey);
+    $firstResponse->assertHeader('X-Idempotency-Replayed', 'false');
+    $firstId = $firstResponse->json('id');
+
+    // Duplicate request with same key and body
+    $secondResponse = $this->postJson('/test/idempotency', ['amount' => 100], [
+        'Idempotency-Key' => $idempotencyKey,
+    ]);
+
+    $secondResponse->assertStatus(201);
+    $secondResponse->assertHeader('X-Idempotency-Key', $idempotencyKey);
+    $secondResponse->assertHeader('X-Idempotency-Replayed', 'true');
+    $secondResponse->assertJsonPath('id', $firstId);
+});
+
+it('rejects different request body with same idempotency key', function () {
+    $idempotencyKey = Str::uuid()->toString();
+
+    // First request
+    $this->postJson('/test/idempotency', ['amount' => 100], [
+        'Idempotency-Key' => $idempotencyKey,
+    ])->assertStatus(201);
+
+    // Different body, same key
+    $response = $this->postJson('/test/idempotency', ['amount' => 200], [
+        'Idempotency-Key' => $idempotencyKey,
+    ]);
+
+    $response->assertStatus(409);
+    $response->assertJsonPath('error', 'Idempotency key already used');
+});
+
+it('bypasses idempotency for GET requests', function () {
+    $idempotencyKey = Str::uuid()->toString();
+
+    $response = $this->getJson('/test/idempotency-get', [
+        'Idempotency-Key' => $idempotencyKey,
+    ]);
+
+    $response->assertStatus(200);
+    $response->assertHeaderMissing('X-Idempotency-Key');
+});
+
+it('processes request normally without Idempotency-Key header', function () {
+    $first = $this->postJson('/test/idempotency', ['amount' => 100]);
+    $first->assertStatus(201);
+    $first->assertHeaderMissing('X-Idempotency-Key');
+
+    // Second request without key creates a new resource
+    $second = $this->postJson('/test/idempotency', ['amount' => 100]);
+    $second->assertStatus(201);
+
+    // IDs should be different since no idempotency key was used
+    expect($second->json('id'))->not->toBe($first->json('id'));
+});
+
+it('allows re-submission after idempotency key expires', function () {
+    $idempotencyKey = Str::uuid()->toString();
+
+    // First request
+    $firstResponse = $this->postJson('/test/idempotency', ['amount' => 100], [
+        'Idempotency-Key' => $idempotencyKey,
+    ]);
+    $firstResponse->assertStatus(201);
+    $firstId = $firstResponse->json('id');
+
+    // Manually flush the cache to simulate expiration
+    Cache::flush();
+
+    // Same key should now create a new resource
+    $secondResponse = $this->postJson('/test/idempotency', ['amount' => 100], [
+        'Idempotency-Key' => $idempotencyKey,
+    ]);
+    $secondResponse->assertStatus(201);
+    $secondResponse->assertHeader('X-Idempotency-Replayed', 'false');
+
+    expect($secondResponse->json('id'))->not->toBe($firstId);
+});
+
+it('rejects invalid idempotency key format', function () {
+    $response = $this->postJson('/test/idempotency', ['amount' => 100], [
+        'Idempotency-Key' => 'short',
+    ]);
+
+    $response->assertStatus(400);
+    $response->assertJsonPath('error', 'Invalid idempotency key format');
+});


### PR DESCRIPTION
## Summary
- Applied existing `IdempotencyMiddleware` to 24 financial POST/PUT endpoints across 11 domain route files
- Routes covered: Exchange orders/swaps, Lending applications/payments, Treasury allocations/rebalancing, MobilePayment intents, DeFi swaps, CrossChain bridges, Commerce payments, Wallet sends, Stablecoin mint/burn, X402 endpoints, Account deposits/withdrawals
- Added 6 feature tests for the middleware behavior

## Routes wired (by domain)
| Domain | Endpoints |
|--------|-----------|
| Account | deposit, withdraw |
| Exchange | place order, pool create/add/remove/swap/claim-rewards |
| Lending | applications, payments, settlements |
| Treasury | store/update portfolio, allocate, rebalance, approve-rebalancing |
| MobilePayment | create/submit/cancel payment intents |
| DeFi | swap execute |
| CrossChain | bridge initiate, swap execute |
| Commerce | payment-requests, process payment |
| Wallet | store/update, generate address, backup, send |
| Stablecoin | mint, burn, add-collateral |
| X402 | endpoints store/update, spending-limits store/update |

## Test plan
- [x] 6 new tests pass: `tests/Feature/Middleware/IdempotencyMiddlewareTest.php`
- [ ] Existing tests still pass (idempotency is opt-in via `Idempotency-Key` header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)