### PR TITLE
docs: sync roadmap to v5.4.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ git status && git branch --show-current
 ### Version Status
 | Version | Status | Key Changes |
 |---------|--------|-------------|
+| v5.4.1 | ✅ Released | Platform Hardening: Dependabot triage (PRs #642-#659), IdempotencyMiddleware, E2E tests, multi-tenancy isolation tests, CI reliability, docs refresh |
 | v5.4.0 | ✅ Released | Ondato KYC, Sanctions Screening & Card Issuing: Ondato identity verification with TrustCert linkage, Chainalysis sanctions adapter, Marqeta card issuing adapter, Firebase FCM v1 migration, X402/mobile test hardening, CVE patches |
 | v5.2.0 | ✅ Released | X402 Protocol: HTTP-native micropayments (USDC on Base), payment gate middleware, facilitator integration, AI agent payments, spending limits, GraphQL/REST APIs, MCP tool |
 | v5.1.6 | ✅ Released | Security Hardening: copyright year, accessibility improvements, CSP headers, email config defaults |

--- a/docs/01-VISION/ROADMAP.md
+++ b/docs/01-VISION/ROADMAP.md
@@ -1,8 +1,8 @@
 # FinAegis Platform Roadmap
 
-**Last Updated:** 2026-02-21
-**Current Version:** v5.1.5
-**Domains:** 41 bounded contexts
+**Last Updated:** 2026-02-27
+**Current Version:** v5.4.1
+**Domains:** 42 bounded contexts
 
 ---
 
@@ -24,9 +24,9 @@
 | **CQRS** | Command/Query Bus with read/write separation across all domains |
 | **Multi-Tenancy** | Team-based isolation (stancl/tenancy v3.9) |
 | **Event Streaming** | Redis Streams-based real-time event distribution with live dashboard |
-| **41 DDD Domains** | Comprehensive bounded contexts covering banking, trading, compliance, DeFi, and more |
+| **42 DDD Domains** | Comprehensive bounded contexts covering banking, trading, compliance, DeFi, and more |
 
-### Domain Architecture (41 Domains)
+### Domain Architecture (42 Domains)
 
 | Category | Domains |
 |----------|---------|
@@ -37,6 +37,7 @@
 | **AI & Agents** | AI, AgentProtocol |
 | **Compliance & Regulation** | RegTech, Regulatory, Fraud, Security |
 | **Infrastructure** | Monitoring, Batch, Webhook, Performance |
+| **Protocols** | X402 |
 | **Business** | Governance, Cgo, Basket, Asset, Custodian, FinancialInstitution, CardIssuance |
 | **Engagement** | Activity, Contact, Newsletter, Product |
 
@@ -158,17 +159,38 @@
 - Access/refresh token pairs with rotation via Sanctum abilities
 - `POST /api/auth/refresh` on public route, PHPStan fix, OpenAPI update
 
-### v5.1.5 -- Dependency Cleanup & Production Readiness (Current)
+### v5.1.5 -- Dependency Cleanup & Production Readiness
 - Upgrade l5-swagger 9 to 10 (swagger-php 5 to 6, modern architecture)
 - Fix PSR-4 autoloading for plugin directories
 - Production environment template (`.env.production.example`)
 - Card API enhancements: network selection, labels, transactions, biometric cancel
 
+### v5.1.6 -- Security Hardening
+- Copyright year updates, accessibility improvements
+- CSP headers, email config defaults
+
+### v5.2.0 -- X402 Protocol
+- HTTP-native micropayments (USDC on Base)
+- Payment gate middleware, facilitator integration
+- AI agent payments, spending limits
+- GraphQL/REST APIs, MCP tool
+
+### v5.4.0 -- Ondato KYC, Sanctions Screening & Card Issuing
+- Ondato identity verification with TrustCert linkage
+- Chainalysis sanctions adapter, Marqeta card issuing adapter
+- Firebase FCM v1 migration, X402/mobile test hardening, CVE patches
+
+### v5.4.1 -- Platform Hardening (Current)
+- Dependabot triage (PRs #642-#659)
+- IdempotencyMiddleware, E2E tests
+- Multi-tenancy isolation tests, docs refresh
+- CI reliability improvements
+
 ---
 
 ## Future Roadmap
 
-### v5.2.0 -- OpenAPI Attribute Migration (Planned)
+### v5.5.0 -- OpenAPI Attribute Migration (Planned)
 - Migrate 10,000+ `@OA\` docblock annotations to PHP 8 `#[OA\]` attributes
 - Drop `doctrine/annotations` dependency entirely
 - Laravel 13 upgrade when available, PHP 8.5 features
@@ -190,7 +212,7 @@
 ### Architecture Patterns Demonstrated
 - **Event Sourcing**: Complete audit trail architecture with domain-specific stores
 - **CQRS**: Full command/query separation with read models
-- **DDD**: 41 bounded contexts with proper domain isolation
+- **DDD**: 42 bounded contexts with proper domain isolation
 - **Saga Pattern**: Compensatable workflows for distributed transactions
 - **Plugin Architecture**: Sandboxed plugin execution with security scanning
 - **GraphQL**: Type-safe API with subscriptions and DataLoaders

--- a/docs/ARCHITECTURAL_ROADMAP.md
+++ b/docs/ARCHITECTURAL_ROADMAP.md
@@ -17,7 +17,7 @@ Transform FinAegis into the **premier open source core banking platform** that:
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
-│                     FINAEGIS CORE BANKING PLATFORM (v5.1.5)              │
+│                     FINAEGIS CORE BANKING PLATFORM (v5.4.1)              │
 ├─────────────────────────────────────────────────────────────────────────┤
 │  CORE BANKING                                                            │
 │  ┌────────────┐  ┌────────────┐  ┌────────────┐  ┌────────────┐        │
@@ -58,7 +58,7 @@ Transform FinAegis into the **premier open source core banking platform** that:
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-### Domain Inventory (41 Bounded Contexts)
+### Domain Inventory (42 Bounded Contexts)
 
 | Category | Domains | Status |
 |----------|---------|--------|
@@ -68,17 +68,17 @@ Transform FinAegis into the **premier open source core banking platform** that:
 | **Digital Assets** | Stablecoin, Wallet (HW+Multi-Sig), Governance | Production Ready |
 | **Cross-Chain & DeFi** | CrossChain (Wormhole/LayerZero/Axelar), DeFi (Uniswap/Aave/Curve/Lido) | Production Ready |
 | **Privacy & Identity** | Privacy (ZK-KYC/Merkle), KeyManagement (Shamir/HSM), Commerce (SBT), TrustCert (W3C VC) | Production Ready |
-| **Mobile & Payments** | Mobile, MobilePayment, Relayer (ERC-4337), Payment | Production Ready |
+| **Mobile & Payments** | Mobile, MobilePayment, Relayer (ERC-4337), Payment, X402 (HTTP 402) | Production Ready |
 | **Financial Services** | Treasury, Lending, Custodian, CardIssuance | Mature |
 | **Platform & AI** | AI (MCP/NLP/ML), AgentProtocol, Monitoring, Performance, Security | Mature |
 | **BaaS** | FinancialInstitution (Partner APIs, SDKs, Widgets, Billing, Marketplace) | Mature |
 | **Supporting** | User, Contact, Newsletter, Webhook, Activity, Batch, Cgo, Shared | Complete |
 
-### Key Metrics (as of v5.1.5)
+### Key Metrics (as of v5.4.1)
 
 | Metric | Value |
 |--------|-------|
-| Bounded Contexts | 41 |
+| Bounded Contexts | 42 |
 | Services | 330+ |
 | Controllers | 174 |
 | API Routes | 1,150+ |
@@ -224,7 +224,7 @@ interface CachingQueryBus extends QueryBus
 |--------|---------|--------|
 | Test Coverage | 50%+ | 80% |
 | PHPStan Level | **8** | 8 ✅ |
-| Bounded Contexts | 41 | — |
+| Bounded Contexts | 42 | — |
 | CI Pipeline Pass Rate | 99% | 99% ✅ |
 
 ### Community Engagement
@@ -247,7 +247,7 @@ interface CachingQueryBus extends QueryBus
    - Mitigation: Automated security audit, HSM integration, ZK-KYC, OWASP checks
 
 ### Medium Risk
-3. **Complexity Barrier** - DDD + Event Sourcing + 41 domains is sophisticated
+3. **Complexity Barrier** - DDD + Event Sourcing + 42 domains is sophisticated
    - Mitigation: Excellent documentation, tutorials, developer portal
 
 4. **Maintenance Burden** - Open source requires ongoing support
@@ -261,7 +261,7 @@ interface CachingQueryBus extends QueryBus
 
 ## Conclusion
 
-The FinAegis platform has evolved from a core banking prototype to a comprehensive financial infrastructure platform spanning 41 domains. Key capabilities now include:
+The FinAegis platform has evolved from a core banking prototype to a comprehensive financial infrastructure platform spanning 42 domains. Key capabilities now include:
 
 1. **GraphQL API** - Schema-first Lighthouse PHP across 33 domains with subscriptions and DataLoaders
 2. **Event Streaming** - Redis Streams publisher/consumer, live dashboard, multi-channel notifications
@@ -273,10 +273,10 @@ The FinAegis platform has evolved from a core banking prototype to a comprehensi
 8. **Banking-as-a-Service** - Partner APIs, SDK generation, embeddable widgets
 9. **AI Framework** - MCP tools, NLP queries, ML anomaly detection
 
-**v5.1.5 Focus**: Dependency cleanup — l5-swagger 9→10 (swagger-php 6), PSR-4 plugin fix, `.env.production.example` for mobile backend deployment, passkey test fix.
+**v5.4.1 Focus**: Platform hardening — Dependabot triage, CI reliability, IdempotencyMiddleware, E2E tests, multi-tenancy isolation tests.
 
 ---
 
-*Document Version: 5.1.5*
-*Last Updated: February 21, 2026*
+*Document Version: 5.4.1*
+*Last Updated: February 27, 2026*
 *Author: Architecture Review*


### PR DESCRIPTION
## Summary
- Update `docs/01-VISION/ROADMAP.md` header to v5.4.1 (2026-02-27), domains 41→42
- Add release history entries for v5.1.6, v5.2.0, v5.4.0, v5.4.1
- Renumber future OpenAPI migration from v5.2.0 to v5.5.0
- Update `docs/ARCHITECTURAL_ROADMAP.md` ASCII header, domain count, metrics, footer
- Add v5.4.1 to `CLAUDE.md` version status table

## Test plan
- [ ] Verify all three files render correctly in GitHub markdown preview
- [ ] Confirm version numbers are consistent across docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)