### PR TITLE
chore: add Marqeta card issuing env vars to production example

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -248,6 +248,15 @@ X402_REQUIRE_APPROVAL_ABOVE=1000000
 X402_PER_TRANSACTION_LIMIT=100000
 
 # =============================================================================
+# CARD ISSUANCE (Marqeta)
+# =============================================================================
+CARD_ISSUER=marqeta
+MARQETA_BASE_URL=https://sandbox-api.marqeta.com/v3
+MARQETA_APPLICATION_TOKEN=
+MARQETA_ADMIN_ACCESS_TOKEN=
+MARQETA_WEBHOOK_SECRET=
+
+# =============================================================================
 # MOBILE PAYMENT
 # =============================================================================
 MOBILE_PAYMENT_NETWORKS=SOLANA,TRON


### PR DESCRIPTION
## Summary

- Add `CARD_ISSUER`, `MARQETA_BASE_URL`, `MARQETA_APPLICATION_TOKEN`, `MARQETA_ADMIN_ACCESS_TOKEN`, and `MARQETA_WEBHOOK_SECRET` to `.env.production.example`
- These vars are already read by `config/cardissuance.php` and used by `MarqetaCardIssuerAdapter`, but were missing from the production env template

## Test plan

- [x] No code changes, only env example file
- [ ] Verify Marqeta sandbox credentials work after setting values

🤖 Generated with [Claude Code](https://claude.com/claude-code)