### PR TITLE
chore(env): sync .env.zelta.example with production vars

### DIFF
--- a/.env.zelta.example
+++ b/.env.zelta.example
@@ -238,6 +238,23 @@ BALANCE_CACHE_TTL=30
 # Pimlico (ERC-4337 bundler) — domain-agnostic, can share keys
 PIMLICO_API_KEY=
 PIMLICO_CHAIN_ID=137
+PIMLICO_TIMEOUT=15
+PIMLICO_RETRY_COUNT=3
+
+# Network RPC URLs (Alchemy or public endpoints)
+POLYGON_RPC_URL=
+BASE_RPC_URL=
+ARBITRUM_RPC_URL=
+
+# Smart Account Factory addresses (deploy or use existing SimpleAccountFactory)
+POLYGON_FACTORY_ADDRESS=
+BASE_FACTORY_ADDRESS=
+ARBITRUM_FACTORY_ADDRESS=
+
+# Paymaster contract addresses
+POLYGON_PAYMASTER_ADDRESS=
+BASE_PAYMASTER_ADDRESS=
+ARBITRUM_PAYMASTER_ADDRESS=
 
 # Alchemy (balance provider) — domain-agnostic, can share keys
 ALCHEMY_API_KEY=
@@ -264,6 +281,15 @@ X402_REQUIRE_APPROVAL_ABOVE=1000000
 X402_PER_TRANSACTION_LIMIT=100000
 
 # =============================================================================
+# CARD ISSUANCE (Marqeta)
+# =============================================================================
+CARD_ISSUER=marqeta
+MARQETA_BASE_URL=https://sandbox-api.marqeta.com/v3
+MARQETA_APPLICATION_TOKEN=
+MARQETA_ADMIN_ACCESS_TOKEN=
+MARQETA_WEBHOOK_SECRET=
+
+# =============================================================================
 # MOBILE PAYMENT
 # =============================================================================
 MOBILE_PAYMENT_NETWORKS=SOLANA,TRON
@@ -280,6 +306,10 @@ REGTECH_ENABLED=true
 REGTECH_DEMO_MODE=false
 REGTECH_ML_ENABLED=true
 REGTECH_ML_MODEL_VERSION=1.0.0
+
+# Chainalysis Sanctions Screening
+CHAINALYSIS_API_KEY=
+CHAINALYSIS_ENABLED=false
 
 # =============================================================================
 # AI FRAMEWORK


### PR DESCRIPTION
## Summary
- Add Marqeta card issuance env vars (`CARD_ISSUER`, `MARQETA_BASE_URL`, `MARQETA_APPLICATION_TOKEN`, `MARQETA_ADMIN_ACCESS_TOKEN`, `MARQETA_WEBHOOK_SECRET`)
- Add Pimlico timeout/retry config (`PIMLICO_TIMEOUT`, `PIMLICO_RETRY_COUNT`)
- Add network RPC URLs (`POLYGON_RPC_URL`, `BASE_RPC_URL`, `ARBITRUM_RPC_URL`)
- Add Smart Account Factory addresses (`POLYGON_FACTORY_ADDRESS`, `BASE_FACTORY_ADDRESS`, `ARBITRUM_FACTORY_ADDRESS`)
- Add Paymaster contract addresses (`POLYGON_PAYMASTER_ADDRESS`, `BASE_PAYMASTER_ADDRESS`, `ARBITRUM_PAYMASTER_ADDRESS`)
- Add Chainalysis sanctions screening config (`CHAINALYSIS_API_KEY`, `CHAINALYSIS_ENABLED`)

Syncs `.env.zelta.example` with vars already present in `.env.production.example` (from PRs #662 and #663).

## Test plan
- [ ] Verify `.env.zelta.example` has all sections from `.env.production.example`
- [ ] Confirm no duplicate keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)