### PR TITLE
feat(v5.8.0): real bundler submission, status query & config-driven tokens

### DIFF
--- a/config/supported_tokens.php
+++ b/config/supported_tokens.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'USDC' => [
+        'name'     => 'USD Coin',
+        'decimals' => 6,
+        'icon'     => 'usdc',
+        'networks' => [
+            'polygon'  => env('USDC_POLYGON', '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359'),
+            'base'     => env('USDC_BASE', '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'),
+            'arbitrum' => env('USDC_ARBITRUM', '0xaf88d065e77c8cC2239327C5EDb3A432268e5831'),
+            'optimism' => env('USDC_OPTIMISM', '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85'),
+            'ethereum' => env('USDC_ETHEREUM', '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'),
+        ],
+    ],
+    'USDT' => [
+        'name'     => 'Tether USD',
+        'decimals' => 6,
+        'icon'     => 'usdt',
+        'networks' => [
+            'polygon'  => env('USDT_POLYGON', '0xc2132D05D31c914a87C6611C10748AEb04B58e8F'),
+            'arbitrum' => env('USDT_ARBITRUM', '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9'),
+            'optimism' => env('USDT_OPTIMISM', '0x94b008aA00579c1307B0EF2c499aD98a8ce58e58'),
+            'ethereum' => env('USDT_ETHEREUM', '0xdAC17F958D2ee523a2206206994597C13D831ec7'),
+        ],
+    ],
+    'WETH' => [
+        'name'     => 'Wrapped Ether',
+        'decimals' => 18,
+        'icon'     => 'weth',
+        'networks' => [
+            'polygon'  => env('WETH_POLYGON', '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619'),
+            'base'     => env('WETH_BASE', '0x4200000000000000000000000000000000000006'),
+            'arbitrum' => env('WETH_ARBITRUM', '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1'),
+            'optimism' => env('WETH_OPTIMISM', '0x4200000000000000000000000000000000000006'),
+        ],
+    ],
+    'WBTC' => [
+        'name'     => 'Wrapped Bitcoin',
+        'decimals' => 8,
+        'icon'     => 'wbtc',
+        'networks' => [
+            'polygon'  => env('WBTC_POLYGON', '0x1BFD67037B42Cf73acF2047067bd4F2C47D9BfD6'),
+            'arbitrum' => env('WBTC_ARBITRUM', '0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f'),
+            'ethereum' => env('WBTC_ETHEREUM', '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599'),
+        ],
+    ],
+];

--- a/tests/Unit/Http/Controllers/Api/Relayer/MobileRelayerControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/Relayer/MobileRelayerControllerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Domain\Relayer\Contracts\BundlerInterface;
 use App\Domain\Relayer\Enums\SupportedNetwork;
 use App\Domain\Relayer\Services\GasStationService;
 use App\Domain\Relayer\Services\SmartAccountService;
@@ -15,6 +16,7 @@ uses(UnitTestCase::class);
 beforeEach(function (): void {
     $this->gasStation = Mockery::mock(GasStationService::class);
     $this->smartAccountService = Mockery::mock(SmartAccountService::class);
+    $this->bundler = Mockery::mock(BundlerInterface::class);
 });
 
 function makeRelayerController($test): MobileRelayerController
@@ -22,6 +24,7 @@ function makeRelayerController($test): MobileRelayerController
     return new MobileRelayerController(
         $test->gasStation,
         $test->smartAccountService,
+        $test->bundler,
     );
 }
 
@@ -111,7 +114,44 @@ describe('MobileRelayerController buildUserOp', function (): void {
 });
 
 describe('MobileRelayerController submitUserOp', function (): void {
-    it('submits a signed UserOperation', function (): void {
+    it('submits a signed UserOperation via bundler', function (): void {
+        $this->bundler->shouldReceive('submitUserOperation')
+            ->once()
+            ->andReturn('0xreal_bundler_hash_abc123');
+
+        $controller = makeRelayerController($this);
+
+        $request = relayerUserRequest('/api/v1/relayer/submit', 'POST', [
+            'network' => 'polygon',
+            'user_op' => [
+                'sender'               => '0x123',
+                'nonce'                => '0x0',
+                'initCode'             => '0x',
+                'callData'             => '0x',
+                'callGasLimit'         => '0x30D40',
+                'verificationGasLimit' => '0x186A0',
+                'preVerificationGas'   => '0xC350',
+                'maxFeePerGas'         => '0x6FC23AC00',
+                'maxPriorityFeePerGas' => '0x59682F00',
+                'paymasterAndData'     => '0x',
+            ],
+            'signature' => '0xsig',
+        ]);
+
+        $response = $controller->submitUserOp($request);
+        $data = $response->getData(true);
+
+        expect($response->getStatusCode())->toBe(201)
+            ->and($data['success'])->toBeTrue()
+            ->and($data['data']['user_op_hash'])->toBe('0xreal_bundler_hash_abc123')
+            ->and($data['data']['status'])->toBe('pending');
+    });
+
+    it('returns 502 when bundler fails', function (): void {
+        $this->bundler->shouldReceive('submitUserOperation')
+            ->once()
+            ->andThrow(new RuntimeException('Bundler unavailable'));
+
         $controller = makeRelayerController($this);
 
         $request = relayerUserRequest('/api/v1/relayer/submit', 'POST', [
@@ -123,15 +163,37 @@ describe('MobileRelayerController submitUserOp', function (): void {
         $response = $controller->submitUserOp($request);
         $data = $response->getData(true);
 
-        expect($response->getStatusCode())->toBe(201)
-            ->and($data['success'])->toBeTrue()
-            ->and($data['data']['user_op_hash'])->toStartWith('0x')
-            ->and($data['data']['status'])->toBe('pending');
+        expect($response->getStatusCode())->toBe(502)
+            ->and($data['success'])->toBeFalse()
+            ->and($data['error']['code'])->toBe('BUNDLER_ERROR');
+    });
+
+    it('returns 422 for unsupported network', function (): void {
+        $controller = makeRelayerController($this);
+
+        $request = relayerUserRequest('/api/v1/relayer/submit', 'POST', [
+            'network'   => 'invalid_network',
+            'user_op'   => ['sender' => '0x123'],
+            'signature' => '0xsig',
+        ]);
+
+        $response = $controller->submitUserOp($request);
+
+        expect($response->getStatusCode())->toBe(422);
     });
 });
 
 describe('MobileRelayerController getUserOp', function (): void {
-    it('returns UserOp status', function (): void {
+    it('returns confirmed status from bundler', function (): void {
+        $this->bundler->shouldReceive('getUserOperationStatus')
+            ->with('0xhash123')
+            ->once()
+            ->andReturn([
+                'status'  => 'success',
+                'tx_hash' => '0xtx_hash_abc',
+                'receipt' => ['blockNumber' => 12345678],
+            ]);
+
         $controller = makeRelayerController($this);
 
         $response = $controller->getUserOp('0xhash123');
@@ -139,7 +201,65 @@ describe('MobileRelayerController getUserOp', function (): void {
 
         expect($data['success'])->toBeTrue()
             ->and($data['data']['user_op_hash'])->toBe('0xhash123')
-            ->and($data['data'])->toHaveKeys(['status', 'tx_hash', 'block_number']);
+            ->and($data['data']['status'])->toBe('confirmed')
+            ->and($data['data']['tx_hash'])->toBe('0xtx_hash_abc')
+            ->and($data['data']['block_number'])->toBe(12345678);
+    });
+
+    it('returns pending status when bundler status unknown', function (): void {
+        $this->bundler->shouldReceive('getUserOperationStatus')
+            ->with('0xhash_pending')
+            ->once()
+            ->andReturn([
+                'status'  => 'not_found',
+                'tx_hash' => null,
+                'receipt' => null,
+            ]);
+
+        $controller = makeRelayerController($this);
+
+        $response = $controller->getUserOp('0xhash_pending');
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue()
+            ->and($data['data']['status'])->toBe('pending')
+            ->and($data['data']['tx_hash'])->toBeNull();
+    });
+
+    it('returns failed status when UserOp reverted', function (): void {
+        $this->bundler->shouldReceive('getUserOperationStatus')
+            ->with('0xhash_failed')
+            ->once()
+            ->andReturn([
+                'status'  => 'reverted',
+                'tx_hash' => '0xtx_reverted',
+                'receipt' => ['blockNumber' => 99999999],
+            ]);
+
+        $controller = makeRelayerController($this);
+
+        $response = $controller->getUserOp('0xhash_failed');
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue()
+            ->and($data['data']['status'])->toBe('failed')
+            ->and($data['data']['tx_hash'])->toBe('0xtx_reverted');
+    });
+
+    it('gracefully falls back to pending on bundler error', function (): void {
+        $this->bundler->shouldReceive('getUserOperationStatus')
+            ->with('0xhash_error')
+            ->once()
+            ->andThrow(new RuntimeException('RPC timeout'));
+
+        $controller = makeRelayerController($this);
+
+        $response = $controller->getUserOp('0xhash_error');
+        $data = $response->getData(true);
+
+        expect($data['success'])->toBeTrue()
+            ->and($data['data']['status'])->toBe('pending')
+            ->and($data['data']['tx_hash'])->toBeNull();
     });
 });
 


### PR DESCRIPTION
## Summary
- **#8** `POST /api/v1/relayer/submit` — now calls `BundlerInterface::submitUserOperation()` (Pimlico/Demo) instead of generating random hash; returns 502 on bundler failure
- **#9** `GET /api/v1/relayer/userop/{hash}` — queries real bundler status via `getUserOperationStatus()`, maps to `confirmed`/`pending`/`failed`; graceful fallback on errors
- **#5** `GET /api/v1/wallet/tokens` — reads from `config/supported_tokens.php` with per-chain contract addresses; supports `?chain_id=` filtering

## Test plan
- [x] 32 unit tests pass (16 relayer + 16 wallet)
- [x] `submitUserOp` returns real bundler hash, handles bundler errors (502)
- [x] `getUserOp` returns confirmed/pending/failed states from bundler
- [x] Token list reads from config, includes contract addresses
- [x] Chain filtering excludes tokens not on requested chain
- [x] Code style checks pass (php-cs-fixer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)