### PR TITLE
feat(cards,commerce,compliance): card listing, DB merchants, sanctions endpoint (#6, #10, #13)

### DIFF
--- a/app/Domain/CardIssuance/Adapters/DemoCardIssuerAdapter.php
+++ b/app/Domain/CardIssuance/Adapters/DemoCardIssuerAdapter.php
@@ -155,4 +155,23 @@ class DemoCardIssuerAdapter implements CardIssuerInterface
     {
         return Cache::get("card:{$cardToken}");
     }
+
+    /**
+     * @return array<VirtualCard>
+     */
+    public function listUserCards(string $userId): array
+    {
+        /** @var array<string> $tokens */
+        $tokens = Cache::get("user_cards:{$userId}", []);
+
+        $cards = [];
+        foreach ($tokens as $token) {
+            $card = $this->getCard($token);
+            if ($card !== null && $card->status !== CardStatus::CANCELLED) {
+                $cards[] = $card;
+            }
+        }
+
+        return $cards;
+    }
 }

--- a/app/Domain/CardIssuance/Contracts/CardIssuerInterface.php
+++ b/app/Domain/CardIssuance/Contracts/CardIssuerInterface.php
@@ -61,6 +61,13 @@ interface CardIssuerInterface
     public function getCard(string $cardToken): ?VirtualCard;
 
     /**
+     * List all cards for a given user.
+     *
+     * @return array<VirtualCard>
+     */
+    public function listUserCards(string $userId): array;
+
+    /**
      * Get the issuer name for identification.
      */
     public function getName(): string;

--- a/app/Domain/CardIssuance/Services/CardProvisioningService.php
+++ b/app/Domain/CardIssuance/Services/CardProvisioningService.php
@@ -138,4 +138,14 @@ class CardProvisioningService
     {
         return $this->cardIssuer->cancelCard($cardToken, $reason);
     }
+
+    /**
+     * List all non-cancelled cards for a user.
+     *
+     * @return array<VirtualCard>
+     */
+    public function listUserCards(string $userId): array
+    {
+        return $this->cardIssuer->listUserCards($userId);
+    }
 }

--- a/app/Domain/Compliance/Routes/api.php
+++ b/app/Domain/Compliance/Routes/api.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Http\Controllers\Api\Compliance\SanctionsCheckController;
 use App\Http\Controllers\Api\ComplianceAlertController;
 use App\Http\Controllers\Api\ComplianceCaseController;
 use App\Http\Controllers\Api\ComplianceCertificationController;
@@ -9,6 +10,15 @@ use App\Http\Controllers\Api\GdprController;
 use App\Http\Controllers\Api\GdprEnhancedController;
 use App\Http\Controllers\Api\KycController;
 use Illuminate\Support\Facades\Route;
+
+// Mobile sanctions check endpoint (v5.8.0)
+Route::prefix('v1/compliance')->name('api.compliance.mobile.')
+    ->middleware(['auth:sanctum', 'check.token.expiration'])
+    ->group(function () {
+        Route::get('/check-address', SanctionsCheckController::class)
+            ->middleware('throttle:30,1')
+            ->name('check-address');
+    });
 
 // Compliance and KYC endpoints
 Route::middleware('auth:sanctum', 'check.token.expiration')->prefix('compliance')->group(function () {

--- a/app/Http/Controllers/Api/CardIssuance/CardController.php
+++ b/app/Http/Controllers/Api/CardIssuance/CardController.php
@@ -146,11 +146,29 @@ class CardController extends Controller
      */
     public function index(Request $request): JsonResponse
     {
-        // Demo implementation - return empty list
-        // In production, query from database
+        $user = $request->user();
+        if ($user === null) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'ERR_AUTH_001',
+                    'message' => 'Authentication required',
+                ],
+            ], 401);
+        }
+
+        $cards = $this->provisioningService->listUserCards((string) $user->id);
+
         return response()->json([
             'success' => true,
-            'data'    => [],
+            'data'    => array_map(fn ($card) => [
+                'card_token' => $card->cardToken,
+                'last4'      => $card->last4,
+                'network'    => $card->network->value,
+                'status'     => $card->status->value,
+                'label'      => $card->label,
+                'expires_at' => $card->expiresAt->format('Y-m-d'),
+            ], $cards),
         ]);
     }
 

--- a/app/Http/Controllers/Api/Compliance/SanctionsCheckController.php
+++ b/app/Http/Controllers/Api/Compliance/SanctionsCheckController.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Compliance;
+
+use App\Domain\Compliance\Contracts\SanctionsScreeningInterface;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * @OA\Get(
+ *     path="/api/v1/compliance/check-address",
+ *     operationId="complianceCheckAddress",
+ *     summary="Screen a blockchain address against sanctions lists",
+ *     description="Checks whether a blockchain address appears on any sanctions lists using the configured screening provider.",
+ *     tags={"Compliance"},
+ *     security={{"sanctum": {}}},
+ *     @OA\Parameter(
+ *         name="address",
+ *         in="query",
+ *         required=true,
+ *         description="The blockchain address to screen",
+ *         @OA\Schema(type="string", example="0x1234567890abcdef1234567890abcdef12345678")
+ *     ),
+ *     @OA\Parameter(
+ *         name="network",
+ *         in="query",
+ *         required=false,
+ *         description="Blockchain network (default: ethereum)",
+ *         @OA\Schema(type="string", example="ethereum")
+ *     ),
+ *     @OA\Response(
+ *         response=200,
+ *         description="Sanctions check result",
+ *         @OA\JsonContent(
+ *             @OA\Property(property="success", type="boolean", example=true),
+ *             @OA\Property(property="data", type="object",
+ *                 @OA\Property(property="sanctioned", type="boolean", example=false),
+ *                 @OA\Property(property="risk_score", type="string", example="low"),
+ *                 @OA\Property(property="provider", type="string", example="chainalysis"),
+ *                 @OA\Property(property="details", type="object")
+ *             )
+ *         )
+ *     ),
+ *     @OA\Response(response=401, description="Unauthorized"),
+ *     @OA\Response(response=422, description="Validation error"),
+ *     @OA\Response(response=429, description="Rate limit exceeded"),
+ *     @OA\Response(response=503, description="Screening service unavailable")
+ * )
+ */
+class SanctionsCheckController extends Controller
+{
+    public function __construct(
+        private readonly SanctionsScreeningInterface $screening,
+    ) {
+    }
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        $request->validate([
+            'address' => ['required', 'string', 'min:10'],
+            'network' => ['nullable', 'string'],
+        ]);
+
+        $address = $request->input('address');
+        $network = $request->input('network', 'ethereum');
+
+        try {
+            $result = $this->screening->screenAddress($address, $network);
+
+            $sanctioned = ($result['total_matches'] ?? 0) > 0;
+            $riskScore = $sanctioned ? 'high' : 'low';
+
+            return response()->json([
+                'success' => true,
+                'data'    => [
+                    'sanctioned'    => $sanctioned,
+                    'risk_score'    => $riskScore,
+                    'provider'      => $this->screening->getName(),
+                    'lists_checked' => $result['lists_checked'] ?? [],
+                    'total_matches' => $result['total_matches'] ?? 0,
+                    'details'       => $result['matches'] ?? [],
+                ],
+            ]);
+        } catch (Throwable $e) {
+            Log::error('Sanctions screening failed', [
+                'address' => $address,
+                'network' => $network,
+                'error'   => $e->getMessage(),
+            ]);
+
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'SCREENING_UNAVAILABLE',
+                    'message' => 'Sanctions screening service is temporarily unavailable.',
+                ],
+            ], 503);
+        }
+    }
+}

--- a/tests/Feature/Api/Compliance/SanctionsCheckTest.php
+++ b/tests/Feature/Api/Compliance/SanctionsCheckTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\Compliance;
+
+use App\Domain\Compliance\Contracts\SanctionsScreeningInterface;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use RuntimeException;
+use Tests\TestCase;
+
+class SanctionsCheckTest extends TestCase
+{
+    protected User $user;
+
+    protected string $token;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+
+        $this->user = User::factory()->create();
+        $this->token = $this->user->createToken('test-token', ['read', 'write'])->plainTextToken;
+    }
+
+    public function test_requires_authentication(): void
+    {
+        $response = $this->getJson('/api/v1/compliance/check-address?address=0x1234567890abcdef1234567890abcdef12345678');
+
+        $response->assertUnauthorized();
+    }
+
+    public function test_validates_address_required(): void
+    {
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/compliance/check-address');
+
+        $response->assertUnprocessable();
+    }
+
+    public function test_returns_screening_result(): void
+    {
+        $mock = $this->mock(SanctionsScreeningInterface::class);
+        $mock->shouldReceive('screenAddress')
+            ->with('0x1234567890abcdef1234567890abcdef12345678', 'ethereum')
+            ->once()
+            ->andReturn([
+                'matches'       => [],
+                'lists_checked' => ['OFAC SDN', 'EU Sanctions'],
+                'total_matches' => 0,
+            ]);
+        $mock->shouldReceive('getName')->andReturn('test_provider');
+
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/compliance/check-address?address=0x1234567890abcdef1234567890abcdef12345678');
+
+        $response->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.sanctioned', false)
+            ->assertJsonPath('data.risk_score', 'low')
+            ->assertJsonPath('data.provider', 'test_provider');
+    }
+
+    public function test_returns_sanctioned_when_matches_found(): void
+    {
+        $mock = $this->mock(SanctionsScreeningInterface::class);
+        $mock->shouldReceive('screenAddress')
+            ->once()
+            ->andReturn([
+                'matches'       => ['OFAC SDN' => [['name' => 'Test Entity']]],
+                'lists_checked' => ['OFAC SDN'],
+                'total_matches' => 1,
+            ]);
+        $mock->shouldReceive('getName')->andReturn('test_provider');
+
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/compliance/check-address?address=0xSanctionedAddress1234567890abcdef12345678');
+
+        $response->assertOk()
+            ->assertJsonPath('data.sanctioned', true)
+            ->assertJsonPath('data.risk_score', 'high')
+            ->assertJsonPath('data.total_matches', 1);
+    }
+
+    public function test_uses_ethereum_as_default_network(): void
+    {
+        $mock = $this->mock(SanctionsScreeningInterface::class);
+        $mock->shouldReceive('screenAddress')
+            ->with('0x1234567890abcdef1234567890abcdef12345678', 'ethereum')
+            ->once()
+            ->andReturn([
+                'matches'       => [],
+                'lists_checked' => [],
+                'total_matches' => 0,
+            ]);
+        $mock->shouldReceive('getName')->andReturn('test_provider');
+
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/compliance/check-address?address=0x1234567890abcdef1234567890abcdef12345678');
+
+        $response->assertOk();
+    }
+
+    public function test_accepts_custom_network(): void
+    {
+        $mock = $this->mock(SanctionsScreeningInterface::class);
+        $mock->shouldReceive('screenAddress')
+            ->with('0x1234567890abcdef1234567890abcdef12345678', 'polygon')
+            ->once()
+            ->andReturn([
+                'matches'       => [],
+                'lists_checked' => [],
+                'total_matches' => 0,
+            ]);
+        $mock->shouldReceive('getName')->andReturn('test_provider');
+
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/compliance/check-address?address=0x1234567890abcdef1234567890abcdef12345678&network=polygon');
+
+        $response->assertOk();
+    }
+
+    public function test_returns_503_on_screening_failure(): void
+    {
+        $mock = $this->mock(SanctionsScreeningInterface::class);
+        $mock->shouldReceive('screenAddress')
+            ->once()
+            ->andThrow(new RuntimeException('Service unavailable'));
+
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/compliance/check-address?address=0x1234567890abcdef1234567890abcdef12345678');
+
+        $response->assertStatus(503)
+            ->assertJsonPath('success', false)
+            ->assertJsonPath('error.code', 'SCREENING_UNAVAILABLE');
+    }
+
+    public function test_route_exists(): void
+    {
+        $route = app('router')->getRoutes()->getByName('api.compliance.mobile.check-address');
+        $this->assertNotNull($route);
+    }
+}

--- a/tests/Unit/Http/Controllers/Api/Commerce/MobileCommerceControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/Commerce/MobileCommerceControllerTest.php
@@ -35,19 +35,8 @@ function commerceUserRequest(string $uri, string $method = 'GET', array $data = 
     return $request;
 }
 
-describe('MobileCommerceController merchants', function (): void {
-    it('returns list of demo merchants', function (): void {
-        $controller = makeCommerceController($this);
-
-        $response = $controller->merchants(commerceUserRequest('/api/v1/commerce/merchants'));
-        $data = $response->getData(true);
-
-        expect($data['success'])->toBeTrue()
-            ->and($data['data'])->toBeArray()
-            ->and(count($data['data']))->toBeGreaterThan(0)
-            ->and($data['data'][0])->toHaveKeys(['id', 'display_name', 'category', 'accepted_tokens']);
-    });
-});
+// MobileCommerceController merchants() and merchantDetail() now query the database;
+// see Feature/Api/Commerce/MobileCommerceDetailTest for DB-backed merchant tests.
 
 describe('MobileCommerceController parseQr', function (): void {
     it('parses valid QR code data', function (): void {


### PR DESCRIPTION
## Summary
- **Item #6 — Card listing**: Added `listUserCards()` to `CardIssuerInterface`, implemented in `DemoCardIssuerAdapter` (Cache-based) and `MarqetaCardIssuerAdapter` (HTTP API). Updated `CardController::index()` to return real card data instead of empty array.
- **Item #10 — DB merchants**: Rewrote `MobileCommerceController::merchants()` and `merchantDetail()` to query `Merchant` model from DB with pagination and `?search=` filter. Removed hardcoded `getDemoMerchants()`.
- **Item #13 — Sanctions endpoint**: Created `SanctionsCheckController` exposing `GET /api/v1/compliance/check-address` via `SanctionsScreeningInterface`, rate limited at 30 req/min. Returns `sanctioned`, `risk_score`, `provider`, and match details.

## Test plan
- [x] 28 new/updated tests pass (commerce unit, commerce feature, compliance feature)
- [x] 40 card issuance tests pass (domain + feature)
- [x] PHPStan clean on all modified files
- [x] php-cs-fixer applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)