### PR TITLE
feat(wallet): recovery shard cloud backup CRUD endpoints (#1)

### DIFF
--- a/app/Domain/KeyManagement/Models/RecoveryShardCloudBackup.php
+++ b/app/Domain/KeyManagement/Models/RecoveryShardCloudBackup.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\KeyManagement\Models;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property string $uuid
+ * @property int $user_id
+ * @property string $device_id
+ * @property string $backup_provider
+ * @property string $encrypted_shard_hash
+ * @property string $shard_version
+ * @property array<string, mixed>|null $metadata
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder<RecoveryShardCloudBackup>|static query()
+ * @method static \Illuminate\Database\Eloquent\Builder<RecoveryShardCloudBackup>|static forUser(int $userId)
+ */
+class RecoveryShardCloudBackup extends Model
+{
+    use HasUuids;
+
+    protected $table = 'recovery_shard_cloud_backups';
+
+    protected $primaryKey = 'uuid';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'user_id',
+        'device_id',
+        'backup_provider',
+        'encrypted_shard_hash',
+        'shard_version',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'metadata' => 'array',
+    ];
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder<RecoveryShardCloudBackup> $query
+     * @return \Illuminate\Database\Eloquent\Builder<RecoveryShardCloudBackup>
+     */
+    public function scopeForUser($query, int $userId)
+    {
+        return $query->where('user_id', $userId);
+    }
+}

--- a/app/Domain/Wallet/Routes/api.php
+++ b/app/Domain/Wallet/Routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Api\BlockchainWalletController;
 use App\Http\Controllers\Api\HardwareWalletController;
 use App\Http\Controllers\Api\MultiSigWalletController;
 use App\Http\Controllers\Api\Wallet\MobileWalletController;
+use App\Http\Controllers\Api\Wallet\RecoveryShardController;
 use Illuminate\Support\Facades\Route;
 
 // Blockchain wallet endpoints
@@ -144,4 +145,12 @@ Route::prefix('v1/wallet')->name('mobile.wallet.')
         Route::post('/create-account', [App\Http\Controllers\Api\Relayer\SmartAccountController::class, 'createAccount'])
             ->middleware(['transaction.rate_limit:relayer', 'idempotency'])
             ->name('create-account');
+
+        // Recovery shard cloud backup (v5.8.0)
+        Route::post('/recovery-shard-backup', [RecoveryShardController::class, 'store'])
+            ->name('recovery-shard-backup.store');
+        Route::get('/recovery-shard-backup', [RecoveryShardController::class, 'show'])
+            ->name('recovery-shard-backup.show');
+        Route::delete('/recovery-shard-backup', [RecoveryShardController::class, 'destroy'])
+            ->name('recovery-shard-backup.destroy');
     });

--- a/app/Http/Controllers/Api/Wallet/RecoveryShardController.php
+++ b/app/Http/Controllers/Api/Wallet/RecoveryShardController.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Wallet;
+
+use App\Domain\KeyManagement\Models\RecoveryShardCloudBackup;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * @OA\Tag(name="Recovery Shard Backup", description="Cloud backup metadata for encrypted recovery shards")
+ */
+class RecoveryShardController extends Controller
+{
+    /**
+     * @OA\Post(
+     *     path="/api/v1/wallet/recovery-shard-backup",
+     *     operationId="storeRecoveryShardBackup",
+     *     summary="Register or update a recovery shard cloud backup",
+     *     tags={"Recovery Shard Backup"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"device_id", "backup_provider", "encrypted_shard_hash", "shard_version"},
+     *             @OA\Property(property="device_id", type="string", example="device_abc123"),
+     *             @OA\Property(property="backup_provider", type="string", enum={"icloud", "google_drive", "manual"}, example="icloud"),
+     *             @OA\Property(property="encrypted_shard_hash", type="string", example="sha256hash..."),
+     *             @OA\Property(property="shard_version", type="string", example="v1"),
+     *             @OA\Property(property="metadata", type="object", nullable=true)
+     *         )
+     *     ),
+     *     @OA\Response(response=201, description="Backup registered"),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=422, description="Validation error")
+     * )
+     */
+    public function store(Request $request): JsonResponse
+    {
+        /** @var \App\Models\User $user */
+        $user = $request->user();
+
+        $validated = $request->validate([
+            'device_id'            => ['required', 'string', 'max:255'],
+            'backup_provider'      => ['required', 'string', 'in:icloud,google_drive,manual'],
+            'encrypted_shard_hash' => ['required', 'string', 'max:255'],
+            'shard_version'        => ['required', 'string', 'max:50'],
+            'metadata'             => ['nullable', 'array'],
+        ]);
+
+        $backup = RecoveryShardCloudBackup::updateOrCreate(
+            [
+                'user_id'         => $user->id,
+                'device_id'       => $validated['device_id'],
+                'backup_provider' => $validated['backup_provider'],
+            ],
+            [
+                'encrypted_shard_hash' => $validated['encrypted_shard_hash'],
+                'shard_version'        => $validated['shard_version'],
+                'metadata'             => $validated['metadata'] ?? null,
+            ],
+        );
+
+        return response()->json([
+            'success' => true,
+            'data'    => [
+                'id'                   => $backup->uuid,
+                'device_id'            => $backup->device_id,
+                'backup_provider'      => $backup->backup_provider,
+                'encrypted_shard_hash' => $backup->encrypted_shard_hash,
+                'shard_version'        => $backup->shard_version,
+                'metadata'             => $backup->metadata,
+                'created_at'           => $backup->created_at->toIso8601String(),
+                'updated_at'           => $backup->updated_at->toIso8601String(),
+            ],
+        ], 201);
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/api/v1/wallet/recovery-shard-backup",
+     *     operationId="listRecoveryShardBackups",
+     *     summary="List recovery shard cloud backups for the authenticated user",
+     *     tags={"Recovery Shard Backup"},
+     *     security={{"sanctum": {}}},
+     *     @OA\Parameter(name="device_id", in="query", required=false, @OA\Schema(type="string")),
+     *     @OA\Parameter(name="backup_provider", in="query", required=false, @OA\Schema(type="string", enum={"icloud", "google_drive", "manual"})),
+     *     @OA\Response(response=200, description="List of backups"),
+     *     @OA\Response(response=401, description="Unauthorized")
+     * )
+     */
+    public function show(Request $request): JsonResponse
+    {
+        /** @var \App\Models\User $user */
+        $user = $request->user();
+
+        $query = RecoveryShardCloudBackup::forUser($user->id);
+
+        if ($request->filled('device_id')) {
+            $query->where('device_id', $request->query('device_id'));
+        }
+
+        if ($request->filled('backup_provider')) {
+            $query->where('backup_provider', $request->query('backup_provider'));
+        }
+
+        $backups = $query->orderBy('created_at', 'desc')->get();
+
+        return response()->json([
+            'success' => true,
+            'data'    => $backups->map(fn (RecoveryShardCloudBackup $b) => [
+                'id'                   => $b->uuid,
+                'device_id'            => $b->device_id,
+                'backup_provider'      => $b->backup_provider,
+                'encrypted_shard_hash' => $b->encrypted_shard_hash,
+                'shard_version'        => $b->shard_version,
+                'metadata'             => $b->metadata,
+                'created_at'           => $b->created_at->toIso8601String(),
+                'updated_at'           => $b->updated_at->toIso8601String(),
+            ])->all(),
+        ]);
+    }
+
+    /**
+     * @OA\Delete(
+     *     path="/api/v1/wallet/recovery-shard-backup",
+     *     operationId="deleteRecoveryShardBackup",
+     *     summary="Delete a recovery shard cloud backup",
+     *     tags={"Recovery Shard Backup"},
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"device_id", "backup_provider"},
+     *             @OA\Property(property="device_id", type="string", example="device_abc123"),
+     *             @OA\Property(property="backup_provider", type="string", enum={"icloud", "google_drive", "manual"}, example="icloud")
+     *         )
+     *     ),
+     *     @OA\Response(response=200, description="Backup deleted"),
+     *     @OA\Response(response=401, description="Unauthorized"),
+     *     @OA\Response(response=404, description="Backup not found")
+     * )
+     */
+    public function destroy(Request $request): JsonResponse
+    {
+        /** @var \App\Models\User $user */
+        $user = $request->user();
+
+        $validated = $request->validate([
+            'device_id'       => ['required', 'string'],
+            'backup_provider' => ['required', 'string', 'in:icloud,google_drive,manual'],
+        ]);
+
+        $deleted = RecoveryShardCloudBackup::where('user_id', $user->id)
+            ->where('device_id', $validated['device_id'])
+            ->where('backup_provider', $validated['backup_provider'])
+            ->delete();
+
+        if ($deleted === 0) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'BACKUP_NOT_FOUND',
+                    'message' => 'No matching recovery shard backup found.',
+                ],
+            ], 404);
+        }
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Recovery shard backup deleted.',
+        ]);
+    }
+}

--- a/database/migrations/2026_02_28_200000_create_recovery_shard_cloud_backups_table.php
+++ b/database/migrations/2026_02_28_200000_create_recovery_shard_cloud_backups_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('recovery_shard_cloud_backups', function (Blueprint $table) {
+            $table->uuid('uuid')->primary();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('device_id');
+            $table->string('backup_provider'); // icloud, google_drive, manual
+            $table->string('encrypted_shard_hash');
+            $table->string('shard_version');
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+
+            $table->unique(['user_id', 'device_id', 'backup_provider'], 'shard_cloud_user_device_provider_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('recovery_shard_cloud_backups');
+    }
+};

--- a/tests/Feature/Api/Wallet/RecoveryShardBackupTest.php
+++ b/tests/Feature/Api/Wallet/RecoveryShardBackupTest.php
@@ -1,0 +1,291 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\Wallet;
+
+use App\Domain\KeyManagement\Models\RecoveryShardCloudBackup;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class RecoveryShardBackupTest extends TestCase
+{
+    protected User $user;
+
+    protected string $token;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+
+        $this->user = User::factory()->create();
+        $this->token = $this->user->createToken('test-token', ['read', 'write'])->plainTextToken;
+    }
+
+    // --- Store ---
+
+    public function test_store_requires_authentication(): void
+    {
+        $response = $this->postJson('/api/v1/wallet/recovery-shard-backup', [
+            'device_id'            => 'device_001',
+            'backup_provider'      => 'icloud',
+            'encrypted_shard_hash' => 'abc123hash',
+            'shard_version'        => 'v1',
+        ]);
+
+        $response->assertUnauthorized();
+    }
+
+    public function test_store_validates_required_fields(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/wallet/recovery-shard-backup', []);
+
+        $response->assertUnprocessable();
+    }
+
+    public function test_store_validates_backup_provider(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/wallet/recovery-shard-backup', [
+                'device_id'            => 'device_001',
+                'backup_provider'      => 'dropbox',
+                'encrypted_shard_hash' => 'abc123hash',
+                'shard_version'        => 'v1',
+            ]);
+
+        $response->assertUnprocessable();
+    }
+
+    public function test_store_creates_backup(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/wallet/recovery-shard-backup', [
+                'device_id'            => 'device_001',
+                'backup_provider'      => 'icloud',
+                'encrypted_shard_hash' => 'sha256_abc123',
+                'shard_version'        => 'v1',
+                'metadata'             => ['cloud_path' => '/backups/shard_001'],
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.device_id', 'device_001')
+            ->assertJsonPath('data.backup_provider', 'icloud')
+            ->assertJsonPath('data.encrypted_shard_hash', 'sha256_abc123')
+            ->assertJsonPath('data.shard_version', 'v1')
+            ->assertJsonPath('data.metadata.cloud_path', '/backups/shard_001');
+
+        $this->assertDatabaseHas('recovery_shard_cloud_backups', [
+            'user_id'         => $this->user->id,
+            'device_id'       => 'device_001',
+            'backup_provider' => 'icloud',
+        ]);
+    }
+
+    public function test_store_upserts_on_duplicate(): void
+    {
+        // Create initial backup
+        $this->withToken($this->token)
+            ->postJson('/api/v1/wallet/recovery-shard-backup', [
+                'device_id'            => 'device_001',
+                'backup_provider'      => 'icloud',
+                'encrypted_shard_hash' => 'hash_v1',
+                'shard_version'        => 'v1',
+            ]);
+
+        // Upsert with new hash
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/wallet/recovery-shard-backup', [
+                'device_id'            => 'device_001',
+                'backup_provider'      => 'icloud',
+                'encrypted_shard_hash' => 'hash_v2',
+                'shard_version'        => 'v2',
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.encrypted_shard_hash', 'hash_v2')
+            ->assertJsonPath('data.shard_version', 'v2');
+
+        // Only one record exists
+        $this->assertDatabaseCount('recovery_shard_cloud_backups', 1);
+    }
+
+    // --- Show ---
+
+    public function test_show_requires_authentication(): void
+    {
+        $response = $this->getJson('/api/v1/wallet/recovery-shard-backup');
+
+        $response->assertUnauthorized();
+    }
+
+    public function test_show_returns_user_backups(): void
+    {
+        RecoveryShardCloudBackup::create([
+            'user_id'              => $this->user->id,
+            'device_id'            => 'device_001',
+            'backup_provider'      => 'icloud',
+            'encrypted_shard_hash' => 'hash_1',
+            'shard_version'        => 'v1',
+        ]);
+        RecoveryShardCloudBackup::create([
+            'user_id'              => $this->user->id,
+            'device_id'            => 'device_002',
+            'backup_provider'      => 'google_drive',
+            'encrypted_shard_hash' => 'hash_2',
+            'shard_version'        => 'v1',
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/wallet/recovery-shard-backup');
+
+        $response->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonCount(2, 'data');
+    }
+
+    public function test_show_filters_by_device_id(): void
+    {
+        RecoveryShardCloudBackup::create([
+            'user_id'              => $this->user->id,
+            'device_id'            => 'device_001',
+            'backup_provider'      => 'icloud',
+            'encrypted_shard_hash' => 'hash_1',
+            'shard_version'        => 'v1',
+        ]);
+        RecoveryShardCloudBackup::create([
+            'user_id'              => $this->user->id,
+            'device_id'            => 'device_002',
+            'backup_provider'      => 'google_drive',
+            'encrypted_shard_hash' => 'hash_2',
+            'shard_version'        => 'v1',
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/wallet/recovery-shard-backup?device_id=device_001');
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.device_id', 'device_001');
+    }
+
+    public function test_show_does_not_return_other_users_backups(): void
+    {
+        $otherUser = User::factory()->create();
+
+        RecoveryShardCloudBackup::create([
+            'user_id'              => $otherUser->id,
+            'device_id'            => 'device_other',
+            'backup_provider'      => 'icloud',
+            'encrypted_shard_hash' => 'other_hash',
+            'shard_version'        => 'v1',
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/wallet/recovery-shard-backup');
+
+        $response->assertOk()
+            ->assertJsonPath('data', []);
+    }
+
+    public function test_show_returns_empty_for_new_user(): void
+    {
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/wallet/recovery-shard-backup');
+
+        $response->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data', []);
+    }
+
+    // --- Destroy ---
+
+    public function test_destroy_requires_authentication(): void
+    {
+        $response = $this->deleteJson('/api/v1/wallet/recovery-shard-backup', [
+            'device_id'       => 'device_001',
+            'backup_provider' => 'icloud',
+        ]);
+
+        $response->assertUnauthorized();
+    }
+
+    public function test_destroy_deletes_matching_backup(): void
+    {
+        RecoveryShardCloudBackup::create([
+            'user_id'              => $this->user->id,
+            'device_id'            => 'device_001',
+            'backup_provider'      => 'icloud',
+            'encrypted_shard_hash' => 'hash_1',
+            'shard_version'        => 'v1',
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->deleteJson('/api/v1/wallet/recovery-shard-backup', [
+                'device_id'       => 'device_001',
+                'backup_provider' => 'icloud',
+            ]);
+
+        $response->assertOk()
+            ->assertJsonPath('success', true);
+
+        $this->assertDatabaseMissing('recovery_shard_cloud_backups', [
+            'user_id'         => $this->user->id,
+            'device_id'       => 'device_001',
+            'backup_provider' => 'icloud',
+        ]);
+    }
+
+    public function test_destroy_returns_404_for_nonexistent(): void
+    {
+        $response = $this->withToken($this->token)
+            ->deleteJson('/api/v1/wallet/recovery-shard-backup', [
+                'device_id'       => 'nonexistent',
+                'backup_provider' => 'icloud',
+            ]);
+
+        $response->assertNotFound()
+            ->assertJsonPath('success', false)
+            ->assertJsonPath('error.code', 'BACKUP_NOT_FOUND');
+    }
+
+    public function test_destroy_does_not_delete_other_users_backups(): void
+    {
+        $otherUser = User::factory()->create();
+
+        RecoveryShardCloudBackup::create([
+            'user_id'              => $otherUser->id,
+            'device_id'            => 'device_001',
+            'backup_provider'      => 'icloud',
+            'encrypted_shard_hash' => 'hash_1',
+            'shard_version'        => 'v1',
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->deleteJson('/api/v1/wallet/recovery-shard-backup', [
+                'device_id'       => 'device_001',
+                'backup_provider' => 'icloud',
+            ]);
+
+        $response->assertNotFound();
+
+        // Other user's backup still exists
+        $this->assertDatabaseHas('recovery_shard_cloud_backups', [
+            'user_id'   => $otherUser->id,
+            'device_id' => 'device_001',
+        ]);
+    }
+
+    // --- Routes ---
+
+    public function test_routes_exist(): void
+    {
+        $routes = app('router')->getRoutes();
+        $this->assertNotNull($routes->getByName('mobile.wallet.recovery-shard-backup.store'));
+        $this->assertNotNull($routes->getByName('mobile.wallet.recovery-shard-backup.show'));
+        $this->assertNotNull($routes->getByName('mobile.wallet.recovery-shard-backup.destroy'));
+    }
+}


### PR DESCRIPTION
## Summary
- **Item #1 — Recovery Shard Backup CRUD**: New endpoints for mobile clients to register, query, and revoke encrypted recovery shard cloud backup metadata.
  - `POST /api/v1/wallet/recovery-shard-backup` — Register/update a backup (upserts on `user_id + device_id + backup_provider`)
  - `GET /api/v1/wallet/recovery-shard-backup` — List backups with optional `?device_id=` and `?backup_provider=` filters
  - `DELETE /api/v1/wallet/recovery-shard-backup` — Remove a specific backup by device/provider
- New migration: `recovery_shard_cloud_backups` table with UUID primary key and unique composite constraint
- New model: `RecoveryShardCloudBackup` in KeyManagement domain with `forUser` scope
- New controller: `RecoveryShardController` with OpenAPI annotations

## Test plan
- [x] 15 feature tests pass (auth, validation, CRUD, upsert, user isolation, routes)
- [x] PHPStan clean on all new files
- [x] php-cs-fixer applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)