### PR TITLE
feat(v5.8.0): WebSocket channels, card transactions, privacy calldata stub

### DIFF
--- a/app/Domain/CardIssuance/Contracts/CardIssuerInterface.php
+++ b/app/Domain/CardIssuance/Contracts/CardIssuerInterface.php
@@ -6,6 +6,7 @@ namespace App\Domain\CardIssuance\Contracts;
 
 use App\Domain\CardIssuance\Enums\CardNetwork;
 use App\Domain\CardIssuance\Enums\WalletType;
+use App\Domain\CardIssuance\ValueObjects\CardTransaction;
 use App\Domain\CardIssuance\ValueObjects\ProvisioningData;
 use App\Domain\CardIssuance\ValueObjects\VirtualCard;
 
@@ -66,6 +67,13 @@ interface CardIssuerInterface
      * @return array<VirtualCard>
      */
     public function listUserCards(string $userId): array;
+
+    /**
+     * Get transaction history for a card.
+     *
+     * @return array{transactions: array<CardTransaction>, next_cursor: string|null}
+     */
+    public function getTransactions(string $cardToken, int $limit = 20, ?string $cursor = null): array;
 
     /**
      * Get the issuer name for identification.

--- a/app/Domain/CardIssuance/Services/CardProvisioningService.php
+++ b/app/Domain/CardIssuance/Services/CardProvisioningService.php
@@ -148,4 +148,14 @@ class CardProvisioningService
     {
         return $this->cardIssuer->listUserCards($userId);
     }
+
+    /**
+     * Get transaction history for a card.
+     *
+     * @return array{transactions: array<\App\Domain\CardIssuance\ValueObjects\CardTransaction>, next_cursor: string|null}
+     */
+    public function getTransactions(string $cardToken, int $limit = 20, ?string $cursor = null): array
+    {
+        return $this->cardIssuer->getTransactions($cardToken, $limit, $cursor);
+    }
 }

--- a/app/Domain/CardIssuance/ValueObjects/CardTransaction.php
+++ b/app/Domain/CardIssuance/ValueObjects/CardTransaction.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\CardIssuance\ValueObjects;
+
+use DateTimeImmutable;
+
+/**
+ * Represents a card transaction from the issuer.
+ */
+final readonly class CardTransaction
+{
+    public function __construct(
+        public string $transactionId,
+        public string $cardToken,
+        public string $merchantName,
+        public string $merchantCategory,
+        public int $amountCents,
+        public string $currency,
+        public string $status,
+        public DateTimeImmutable $timestamp,
+    ) {
+    }
+
+    /**
+     * Get the transaction amount as a decimal.
+     */
+    public function getAmountDecimal(): float
+    {
+        return $this->amountCents / 100;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'id'        => $this->transactionId,
+            'amount'    => $this->getAmountDecimal(),
+            'currency'  => $this->currency,
+            'merchant'  => $this->merchantName,
+            'category'  => $this->merchantCategory,
+            'status'    => $this->status,
+            'timestamp' => $this->timestamp->format('c'),
+        ];
+    }
+}

--- a/app/Domain/Commerce/Events/Broadcast/CommercePaymentConfirmed.php
+++ b/app/Domain/Commerce/Events/Broadcast/CommercePaymentConfirmed.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Commerce\Events\Broadcast;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Broadcast event for confirmed commerce payments.
+ *
+ * Merchants subscribe to their commerce channel to receive real-time
+ * payment attestation confirmations.
+ *
+ * Channel: private-commerce.{merchantId}
+ * Event name: commerce.payment.confirmed
+ */
+class CommercePaymentConfirmed implements ShouldBroadcast
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly string $merchantId,
+        public readonly string $attestationId,
+        public readonly string $attestationType,
+        public readonly string $attestationHash,
+        public readonly string $attestedAt,
+    ) {
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, PrivateChannel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel("commerce.{$this->merchantId}"),
+        ];
+    }
+
+    /**
+     * Get the event name for broadcasting.
+     */
+    public function broadcastAs(): string
+    {
+        return 'commerce.payment.confirmed';
+    }
+
+    /**
+     * Get the data to broadcast.
+     *
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        return [
+            'attestation_id'   => $this->attestationId,
+            'attestation_type' => $this->attestationType,
+            'attestation_hash' => $this->attestationHash,
+            'attested_at'      => $this->attestedAt,
+        ];
+    }
+
+    /**
+     * Determine if the event should be broadcast.
+     */
+    public function broadcastWhen(): bool
+    {
+        return config('websocket.enabled', true);
+    }
+
+    /**
+     * Get the broadcast queue connection.
+     */
+    public function broadcastConnection(): string
+    {
+        return config('websocket.queue.connection', 'redis');
+    }
+
+    /**
+     * Get the broadcast queue.
+     */
+    public function broadcastQueue(): string
+    {
+        return config('websocket.queue.name', 'broadcasts');
+    }
+}

--- a/app/Domain/Commerce/Services/PaymentAttestationService.php
+++ b/app/Domain/Commerce/Services/PaymentAttestationService.php
@@ -6,6 +6,7 @@ namespace App\Domain\Commerce\Services;
 
 use App\Domain\Commerce\Contracts\AttestationServiceInterface;
 use App\Domain\Commerce\Enums\AttestationType;
+use App\Domain\Commerce\Events\Broadcast\CommercePaymentConfirmed;
 use App\Domain\Commerce\Events\PaymentAttested;
 use App\Domain\Commerce\ValueObjects\PaymentAttestation;
 use DateTimeImmutable;
@@ -82,6 +83,16 @@ class PaymentAttestationService implements AttestationServiceInterface
             attestationHash: $attestation->getAttestationHash(),
             attestedAt: $issuedAt,
         ));
+
+        // Broadcast to merchant channel for real-time mobile updates
+        $merchantId = $claims['merchant_id'] ?? $subjectId;
+        CommercePaymentConfirmed::dispatch(
+            merchantId: (string) $merchantId,
+            attestationId: $attestationId,
+            attestationType: $type->value,
+            attestationHash: $attestation->getAttestationHash(),
+            attestedAt: $issuedAt->format('c'),
+        );
 
         return $attestation;
     }

--- a/app/Domain/Privacy/Events/Broadcast/PrivacyOperationCompleted.php
+++ b/app/Domain/Privacy/Events/Broadcast/PrivacyOperationCompleted.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Privacy\Events\Broadcast;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Broadcast event for privacy operations (shield/unshield/transfer).
+ *
+ * Mobile clients subscribe to user-specific privacy channels to receive
+ * real-time status updates when privacy pool operations complete.
+ *
+ * Channel: private-privacy.{userId}
+ * Event name: privacy.operation.completed
+ */
+class PrivacyOperationCompleted implements ShouldBroadcast
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly int $userId,
+        public readonly string $operation,
+        public readonly string $token,
+        public readonly string $amount,
+        public readonly string $network,
+        public readonly string $status,
+    ) {
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, PrivateChannel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel("privacy.{$this->userId}"),
+        ];
+    }
+
+    /**
+     * Get the event name for broadcasting.
+     */
+    public function broadcastAs(): string
+    {
+        return 'privacy.operation.completed';
+    }
+
+    /**
+     * Get the data to broadcast.
+     *
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        return [
+            'operation' => $this->operation,
+            'token'     => $this->token,
+            'amount'    => $this->amount,
+            'network'   => $this->network,
+            'status'    => $this->status,
+        ];
+    }
+
+    /**
+     * Determine if the event should be broadcast.
+     */
+    public function broadcastWhen(): bool
+    {
+        return config('websocket.enabled', true);
+    }
+
+    /**
+     * Get the broadcast queue connection.
+     */
+    public function broadcastConnection(): string
+    {
+        return config('websocket.queue.connection', 'redis');
+    }
+
+    /**
+     * Get the broadcast queue.
+     */
+    public function broadcastQueue(): string
+    {
+        return config('websocket.queue.name', 'broadcasts');
+    }
+}

--- a/app/Domain/Privacy/Routes/api.php
+++ b/app/Domain/Privacy/Routes/api.php
@@ -74,5 +74,9 @@ Route::prefix('v1/privacy')->name('api.privacy.')->group(function () {
 
         // SRS status
         Route::get('/srs-status', [PrivacyController::class, 'getSrsStatus'])->name('srs-status');
+
+        // Transaction calldata (stub — deferred to v5.9.0)
+        Route::get('/transaction-calldata/{txHash}', [PrivacyController::class, 'getTransactionCalldata'])
+            ->name('transaction-calldata');
     });
 });

--- a/app/Domain/TrustCert/Events/Broadcast/TrustCertStatusChanged.php
+++ b/app/Domain/TrustCert/Events/Broadcast/TrustCertStatusChanged.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\TrustCert\Events\Broadcast;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Broadcast event for TrustCert certificate status changes.
+ *
+ * Users subscribe to their trustcert channel to receive real-time
+ * certificate issuance and revocation notifications.
+ *
+ * Channel: private-trustcert.{userId}
+ * Event name: trustcert.status.changed
+ */
+class TrustCertStatusChanged implements ShouldBroadcast
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly string $userId,
+        public readonly string $certificateId,
+        public readonly string $status,
+        public readonly string $subjectId,
+        public readonly string $changedAt,
+    ) {
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return array<int, PrivateChannel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel("trustcert.{$this->userId}"),
+        ];
+    }
+
+    /**
+     * Get the event name for broadcasting.
+     */
+    public function broadcastAs(): string
+    {
+        return 'trustcert.status.changed';
+    }
+
+    /**
+     * Get the data to broadcast.
+     *
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        return [
+            'certificate_id' => $this->certificateId,
+            'status'         => $this->status,
+            'subject_id'     => $this->subjectId,
+            'changed_at'     => $this->changedAt,
+        ];
+    }
+
+    /**
+     * Determine if the event should be broadcast.
+     */
+    public function broadcastWhen(): bool
+    {
+        return config('websocket.enabled', true);
+    }
+
+    /**
+     * Get the broadcast queue connection.
+     */
+    public function broadcastConnection(): string
+    {
+        return config('websocket.queue.connection', 'redis');
+    }
+
+    /**
+     * Get the broadcast queue.
+     */
+    public function broadcastQueue(): string
+    {
+        return config('websocket.queue.name', 'broadcasts');
+    }
+}

--- a/app/Domain/TrustCert/Services/CertificateAuthorityService.php
+++ b/app/Domain/TrustCert/Services/CertificateAuthorityService.php
@@ -6,6 +6,7 @@ namespace App\Domain\TrustCert\Services;
 
 use App\Domain\TrustCert\Contracts\CertificateAuthorityInterface;
 use App\Domain\TrustCert\Enums\CertificateStatus;
+use App\Domain\TrustCert\Events\Broadcast\TrustCertStatusChanged;
 use App\Domain\TrustCert\Events\CertificateIssued;
 use App\Domain\TrustCert\Events\CertificateRevoked;
 use App\Domain\TrustCert\ValueObjects\Certificate;
@@ -98,6 +99,15 @@ class CertificateAuthorityService implements CertificateAuthorityInterface
             issuedAt: new DateTimeImmutable(),
         ));
 
+        // Broadcast certificate status change for mobile
+        TrustCertStatusChanged::dispatch(
+            userId: $subjectId,
+            certificateId: $certificateId,
+            status: CertificateStatus::ACTIVE->value,
+            subjectId: $subjectId,
+            changedAt: (new DateTimeImmutable())->format('c'),
+        );
+
         return $certificate;
     }
 
@@ -144,6 +154,15 @@ class CertificateAuthorityService implements CertificateAuthorityInterface
             reason: $reason,
             revokedAt: $revokedAt,
         ));
+
+        // Broadcast certificate status change for mobile
+        TrustCertStatusChanged::dispatch(
+            userId: $certificate->subjectId,
+            certificateId: $certificateId,
+            status: CertificateStatus::REVOKED->value,
+            subjectId: $certificate->subjectId,
+            changedAt: $revokedAt->format('c'),
+        );
 
         return true;
     }

--- a/app/Http/Controllers/Api/CardIssuance/CardController.php
+++ b/app/Http/Controllers/Api/CardIssuance/CardController.php
@@ -347,14 +347,27 @@ class CardController extends Controller
      */
     public function transactions(Request $request, string $cardId): JsonResponse
     {
-        // TODO: Replace with real Marqeta transaction history when integration matures
+        $limit = min((int) $request->query('limit', '20'), 100);
+        $cursor = $request->query('cursor');
+
+        $result = $this->provisioningService->getTransactions(
+            $cardId,
+            $limit,
+            is_string($cursor) ? $cursor : null,
+        );
+
+        $transactions = array_map(
+            fn ($tx) => $tx->toArray(),
+            $result['transactions'],
+        );
+
         return response()->json([
             'success'    => true,
-            'data'       => [],
+            'data'       => $transactions,
             'pagination' => [
-                'next_cursor' => null,
-                'has_more'    => false,
-                'total'       => 0,
+                'next_cursor' => $result['next_cursor'],
+                'has_more'    => $result['next_cursor'] !== null,
+                'total'       => count($transactions),
             ],
         ]);
     }

--- a/app/Http/Controllers/Api/Privacy/PrivacyController.php
+++ b/app/Http/Controllers/Api/Privacy/PrivacyController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api\Privacy;
 
 use App\Domain\Privacy\Contracts\MerkleTreeServiceInterface;
+use App\Domain\Privacy\Events\Broadcast\PrivacyOperationCompleted;
 use App\Domain\Privacy\Exceptions\CommitmentNotFoundException;
 use App\Domain\Privacy\Models\DelegatedProofJob;
 use App\Domain\Privacy\Services\DelegatedProofService;
@@ -732,6 +733,15 @@ class PrivacyController extends Controller
                 $validated['network'],
             );
 
+            PrivacyOperationCompleted::dispatch(
+                userId: $user->id,
+                operation: 'shield',
+                token: $validated['token'],
+                amount: $validated['amount'],
+                network: $validated['network'],
+                status: 'completed',
+            );
+
             return response()->json([
                 'success' => true,
                 'data'    => $result,
@@ -745,6 +755,15 @@ class PrivacyController extends Controller
             $validated['network'],
             ['amount' => $validated['amount'], 'token' => $validated['token']],
             $validated['encrypted_inputs'] ?? '',
+        );
+
+        PrivacyOperationCompleted::dispatch(
+            userId: $user->id,
+            operation: 'shield',
+            token: $validated['token'],
+            amount: $validated['amount'],
+            network: $validated['network'],
+            status: 'pending',
         );
 
         return response()->json([
@@ -800,6 +819,15 @@ class PrivacyController extends Controller
                 $validated['network'],
             );
 
+            PrivacyOperationCompleted::dispatch(
+                userId: $user->id,
+                operation: 'unshield',
+                token: $validated['token'],
+                amount: $validated['amount'],
+                network: $validated['network'],
+                status: 'completed',
+            );
+
             return response()->json([
                 'success' => true,
                 'data'    => $result,
@@ -817,6 +845,15 @@ class PrivacyController extends Controller
                 'recipient' => $validated['recipient'],
             ],
             $validated['encrypted_inputs'] ?? '',
+        );
+
+        PrivacyOperationCompleted::dispatch(
+            userId: $user->id,
+            operation: 'unshield',
+            token: $validated['token'],
+            amount: $validated['amount'],
+            network: $validated['network'],
+            status: 'pending',
         );
 
         return response()->json([
@@ -872,6 +909,15 @@ class PrivacyController extends Controller
                 $validated['network'],
             );
 
+            PrivacyOperationCompleted::dispatch(
+                userId: $user->id,
+                operation: 'transfer',
+                token: $validated['token'],
+                amount: $validated['amount'],
+                network: $validated['network'],
+                status: 'completed',
+            );
+
             return response()->json([
                 'success' => true,
                 'data'    => $result,
@@ -889,6 +935,15 @@ class PrivacyController extends Controller
                 'recipient_commitment' => $validated['recipient_commitment'] ?? '',
             ],
             $validated['encrypted_inputs'] ?? '',
+        );
+
+        PrivacyOperationCompleted::dispatch(
+            userId: $user->id,
+            operation: 'transfer',
+            token: $validated['token'],
+            amount: $validated['amount'],
+            network: $validated['network'],
+            status: 'pending',
         );
 
         return response()->json([
@@ -1116,5 +1171,28 @@ class PrivacyController extends Controller
                 'required_circuits' => $requiredCircuits,
             ],
         ]);
+    }
+
+    /**
+     * Get transaction calldata (stub — deferred to v5.9.0).
+     *
+     * @OA\Get(
+     *     path="/api/v1/privacy/transaction-calldata/{txHash}",
+     *     operationId="getTransactionCalldata",
+     *     tags={"Privacy"},
+     *     summary="Get transaction calldata for a privacy transaction (not yet implemented)",
+     *     security={{"sanctum":{}}},
+     *     @OA\Parameter(name="txHash", in="path", required=true, @OA\Schema(type="string")),
+     *     @OA\Response(response=501, description="Not implemented"),
+     *     @OA\Response(response=401, description="Unauthenticated")
+     * )
+     */
+    public function getTransactionCalldata(string $txHash): JsonResponse
+    {
+        return response()->json([
+            'success'         => false,
+            'error'           => 'Transaction calldata retrieval is not yet implemented.',
+            'planned_version' => 'v5.9.0',
+        ], 501);
     }
 }

--- a/tests/Feature/Api/MobileHandoverV571Test.php
+++ b/tests/Feature/Api/MobileHandoverV571Test.php
@@ -134,9 +134,9 @@ class MobileHandoverV571Test extends TestCase
         $this->assertNull($data[0]['name']);
     }
 
-    // --- #7: Card Transactions Returns Empty (not fake data) ---
+    // --- #7: Card Transactions Returns Demo Data (v5.8.0) ---
 
-    public function test_card_transactions_returns_empty_array(): void
+    public function test_card_transactions_returns_demo_data(): void
     {
         $response = $this->withToken($this->token)
             ->getJson('/api/v1/cards/test-card-123/transactions');
@@ -145,8 +145,9 @@ class MobileHandoverV571Test extends TestCase
         $data = $response->json();
 
         $this->assertTrue($data['success']);
-        $this->assertEmpty($data['data']);
-        $this->assertEquals(0, $data['pagination']['total']);
-        $this->assertFalse($data['pagination']['has_more']);
+        $this->assertNotEmpty($data['data']);
+        $this->assertArrayHasKey('id', $data['data'][0]);
+        $this->assertArrayHasKey('amount', $data['data'][0]);
+        $this->assertArrayHasKey('merchant', $data['data'][0]);
     }
 }

--- a/tests/Feature/Api/Privacy/TransactionCalldataTest.php
+++ b/tests/Feature/Api/Privacy/TransactionCalldataTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\Privacy;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class TransactionCalldataTest extends TestCase
+{
+    protected User $user;
+
+    protected string $token;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+
+        $this->user = User::factory()->create();
+        $this->token = $this->user->createToken('test-token', ['read', 'write'])->plainTextToken;
+    }
+
+    public function test_transaction_calldata_requires_auth(): void
+    {
+        $response = $this->getJson('/api/v1/privacy/transaction-calldata/0xabc123');
+
+        $response->assertUnauthorized();
+    }
+
+    public function test_transaction_calldata_returns_501(): void
+    {
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/privacy/transaction-calldata/0xabc123');
+
+        $response->assertStatus(501)
+            ->assertJsonPath('success', false)
+            ->assertJsonPath('planned_version', 'v5.9.0')
+            ->assertJsonStructure([
+                'success',
+                'error',
+                'planned_version',
+            ]);
+    }
+
+    public function test_transaction_calldata_route_exists(): void
+    {
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/privacy/transaction-calldata/0x1234567890abcdef');
+
+        // Should get 501, not 404
+        $this->assertNotEquals(404, $response->status());
+        $response->assertStatus(501);
+    }
+}

--- a/tests/Feature/Broadcasting/MobileChannelRegistrationTest.php
+++ b/tests/Feature/Broadcasting/MobileChannelRegistrationTest.php
@@ -1,0 +1,295 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Broadcasting;
+
+use App\Domain\Commerce\Events\Broadcast\CommercePaymentConfirmed;
+use App\Domain\Privacy\Events\Broadcast\PrivacyOperationCompleted;
+use App\Domain\Privacy\Models\DelegatedProofJob;
+use App\Domain\Privacy\Services\DelegatedProofService;
+use App\Domain\TrustCert\Events\Broadcast\TrustCertStatusChanged;
+use App\Models\User;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Event;
+use Mockery\MockInterface;
+use Tests\TestCase;
+
+class MobileChannelRegistrationTest extends TestCase
+{
+    protected User $user;
+
+    protected string $token;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+
+        $this->user = User::factory()->create();
+        $this->token = $this->user->createToken('test-token', ['read', 'write'])->plainTextToken;
+    }
+
+    // ---- Channel callback tests ----
+
+    public function test_user_channel_is_registered(): void
+    {
+        // Verify that the user channel is registered in routes/channels.php
+        // by checking that broadcasting auth returns 200 for own user with log driver
+        $response = $this->withToken($this->token)
+            ->postJson('/broadcasting/auth', [
+                'channel_name' => "private-user.{$this->user->id}",
+            ]);
+
+        $response->assertOk();
+    }
+
+    public function test_privacy_channel_auth_returns_200(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/broadcasting/auth', [
+                'channel_name' => "private-privacy.{$this->user->id}",
+            ]);
+
+        $response->assertOk();
+    }
+
+    public function test_privacy_proof_channel_auth_returns_200(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/broadcasting/auth', [
+                'channel_name' => "private-privacy.proof.{$this->user->id}",
+            ]);
+
+        $response->assertOk();
+    }
+
+    public function test_commerce_channel_auth_returns_200_in_testing(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/broadcasting/auth', [
+                'channel_name' => 'private-commerce.merchant_123',
+            ]);
+
+        $response->assertOk();
+    }
+
+    public function test_trustcert_channel_auth_returns_200(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/broadcasting/auth', [
+                'channel_name' => "private-trustcert.{$this->user->id}",
+            ]);
+
+        $response->assertOk();
+    }
+
+    // ---- Broadcast event class tests ----
+
+    public function test_privacy_operation_completed_broadcasts_on_correct_channel(): void
+    {
+        $event = new PrivacyOperationCompleted(
+            userId: $this->user->id,
+            operation: 'shield',
+            token: 'USDC',
+            amount: '100.00',
+            network: 'polygon',
+            status: 'completed',
+        );
+
+        $channels = $event->broadcastOn();
+        $this->assertCount(1, $channels);
+        $this->assertInstanceOf(PrivateChannel::class, $channels[0]);
+        $this->assertEquals('privacy.operation.completed', $event->broadcastAs());
+    }
+
+    public function test_commerce_payment_confirmed_broadcasts_on_correct_channel(): void
+    {
+        $event = new CommercePaymentConfirmed(
+            merchantId: 'merchant_123',
+            attestationId: 'att_123',
+            attestationType: 'payment',
+            attestationHash: 'hash_abc',
+            attestedAt: '2026-03-01T12:00:00+00:00',
+        );
+
+        $channels = $event->broadcastOn();
+        $this->assertCount(1, $channels);
+        $this->assertInstanceOf(PrivateChannel::class, $channels[0]);
+        $this->assertEquals('commerce.payment.confirmed', $event->broadcastAs());
+    }
+
+    public function test_trust_cert_status_changed_broadcasts_on_correct_channel(): void
+    {
+        $event = new TrustCertStatusChanged(
+            userId: (string) $this->user->id,
+            certificateId: 'cert_123',
+            status: 'active',
+            subjectId: 'subject_123',
+            changedAt: '2026-03-01T12:00:00+00:00',
+        );
+
+        $channels = $event->broadcastOn();
+        $this->assertCount(1, $channels);
+        $this->assertInstanceOf(PrivateChannel::class, $channels[0]);
+        $this->assertEquals('trustcert.status.changed', $event->broadcastAs());
+    }
+
+    public function test_privacy_event_broadcast_data(): void
+    {
+        $event = new PrivacyOperationCompleted(
+            userId: $this->user->id,
+            operation: 'unshield',
+            token: 'DAI',
+            amount: '50.00',
+            network: 'base',
+            status: 'pending',
+        );
+
+        $data = $event->broadcastWith();
+        $this->assertEquals('unshield', $data['operation']);
+        $this->assertEquals('DAI', $data['token']);
+        $this->assertEquals('50.00', $data['amount']);
+        $this->assertEquals('base', $data['network']);
+        $this->assertEquals('pending', $data['status']);
+    }
+
+    public function test_commerce_event_broadcast_data(): void
+    {
+        $event = new CommercePaymentConfirmed(
+            merchantId: 'merchant_abc',
+            attestationId: 'att_xyz',
+            attestationType: 'payment',
+            attestationHash: 'hash_123',
+            attestedAt: '2026-03-01T10:00:00+00:00',
+        );
+
+        $data = $event->broadcastWith();
+        $this->assertEquals('att_xyz', $data['attestation_id']);
+        $this->assertEquals('payment', $data['attestation_type']);
+        $this->assertEquals('hash_123', $data['attestation_hash']);
+        $this->assertEquals('2026-03-01T10:00:00+00:00', $data['attested_at']);
+    }
+
+    public function test_trustcert_event_broadcast_data(): void
+    {
+        $event = new TrustCertStatusChanged(
+            userId: '42',
+            certificateId: 'cert_abc',
+            status: 'revoked',
+            subjectId: 'subject_42',
+            changedAt: '2026-03-01T14:00:00+00:00',
+        );
+
+        $data = $event->broadcastWith();
+        $this->assertEquals('cert_abc', $data['certificate_id']);
+        $this->assertEquals('revoked', $data['status']);
+        $this->assertEquals('subject_42', $data['subject_id']);
+        $this->assertEquals('2026-03-01T14:00:00+00:00', $data['changed_at']);
+    }
+
+    public function test_broadcast_events_respect_websocket_enabled_config(): void
+    {
+        config(['websocket.enabled' => false]);
+
+        $event = new PrivacyOperationCompleted(
+            userId: $this->user->id,
+            operation: 'shield',
+            token: 'USDC',
+            amount: '100.00',
+            network: 'polygon',
+            status: 'completed',
+        );
+
+        $this->assertFalse($event->broadcastWhen());
+    }
+
+    public function test_broadcast_events_use_broadcasts_queue(): void
+    {
+        $event = new PrivacyOperationCompleted(
+            userId: 1,
+            operation: 'shield',
+            token: 'USDC',
+            amount: '100.00',
+            network: 'polygon',
+            status: 'completed',
+        );
+
+        $this->assertEquals('broadcasts', $event->broadcastQueue());
+    }
+
+    private function mockDelegatedProofService(): void
+    {
+        /** @var DelegatedProofJob&MockInterface $mockJob */
+        $mockJob = $this->mock(DelegatedProofJob::class, function (MockInterface $mock) {
+            $mock->shouldReceive('toApiResponse')
+                ->andReturn(['job_id' => 'job_123', 'status' => 'pending']);
+        });
+
+        $this->mock(DelegatedProofService::class, function (MockInterface $mock) use ($mockJob) {
+            $mock->shouldReceive('requestProof')
+                ->andReturn($mockJob);
+        });
+    }
+
+    public function test_privacy_shield_dispatches_broadcast_event(): void
+    {
+        Event::fake([PrivacyOperationCompleted::class]);
+        $this->mockDelegatedProofService();
+
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/privacy/shield', [
+                'amount'  => '100.00',
+                'token'   => 'USDC',
+                'network' => 'polygon',
+            ]);
+
+        $response->assertCreated();
+
+        Event::assertDispatched(PrivacyOperationCompleted::class, function ($event) {
+            return $event->userId === $this->user->id
+                && $event->operation === 'shield'
+                && $event->token === 'USDC';
+        });
+    }
+
+    public function test_privacy_unshield_dispatches_broadcast_event(): void
+    {
+        Event::fake([PrivacyOperationCompleted::class]);
+        $this->mockDelegatedProofService();
+
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/privacy/unshield', [
+                'amount'    => '50.00',
+                'token'     => 'USDC',
+                'network'   => 'polygon',
+                'recipient' => '0x1234567890abcdef',
+            ]);
+
+        $response->assertCreated();
+
+        Event::assertDispatched(PrivacyOperationCompleted::class, function ($event) {
+            return $event->operation === 'unshield';
+        });
+    }
+
+    public function test_privacy_transfer_dispatches_broadcast_event(): void
+    {
+        Event::fake([PrivacyOperationCompleted::class]);
+        $this->mockDelegatedProofService();
+
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/privacy/transfer', [
+                'amount'  => '25.00',
+                'token'   => 'USDC',
+                'network' => 'polygon',
+            ]);
+
+        $response->assertCreated();
+
+        Event::assertDispatched(PrivacyOperationCompleted::class, function ($event) {
+            return $event->operation === 'transfer';
+        });
+    }
+}

--- a/tests/Unit/Domain/CardIssuance/ValueObjects/CardTransactionTest.php
+++ b/tests/Unit/Domain/CardIssuance/ValueObjects/CardTransactionTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\CardIssuance\ValueObjects;
+
+use App\Domain\CardIssuance\ValueObjects\CardTransaction;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+
+class CardTransactionTest extends TestCase
+{
+    private CardTransaction $transaction;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->transaction = new CardTransaction(
+            transactionId: 'txn_abc123',
+            cardToken: 'card_demo_xyz',
+            merchantName: 'Starbucks',
+            merchantCategory: '5814',
+            amountCents: 475,
+            currency: 'USD',
+            status: 'settled',
+            timestamp: new DateTimeImmutable('2026-03-01T12:00:00Z'),
+        );
+    }
+
+    public function test_to_array_returns_correct_structure(): void
+    {
+        $array = $this->transaction->toArray();
+
+        $this->assertEquals('txn_abc123', $array['id']);
+        $this->assertEquals(4.75, $array['amount']);
+        $this->assertEquals('USD', $array['currency']);
+        $this->assertEquals('Starbucks', $array['merchant']);
+        $this->assertEquals('5814', $array['category']);
+        $this->assertEquals('settled', $array['status']);
+        $this->assertEquals('2026-03-01T12:00:00+00:00', $array['timestamp']);
+    }
+
+    public function test_get_amount_decimal_converts_cents_to_dollars(): void
+    {
+        $this->assertEquals(4.75, $this->transaction->getAmountDecimal());
+    }
+
+    public function test_get_amount_decimal_with_zero(): void
+    {
+        $transaction = new CardTransaction(
+            transactionId: 'txn_zero',
+            cardToken: 'card_demo_xyz',
+            merchantName: 'Test',
+            merchantCategory: '0000',
+            amountCents: 0,
+            currency: 'USD',
+            status: 'pending',
+            timestamp: new DateTimeImmutable(),
+        );
+
+        $this->assertEquals(0.0, $transaction->getAmountDecimal());
+    }
+
+    public function test_get_amount_decimal_with_large_amount(): void
+    {
+        $transaction = new CardTransaction(
+            transactionId: 'txn_large',
+            cardToken: 'card_demo_xyz',
+            merchantName: 'Amazon',
+            merchantCategory: '5942',
+            amountCents: 999999,
+            currency: 'USD',
+            status: 'settled',
+            timestamp: new DateTimeImmutable(),
+        );
+
+        $this->assertEquals(9999.99, $transaction->getAmountDecimal());
+    }
+
+    public function test_to_array_does_not_include_card_token(): void
+    {
+        $array = $this->transaction->toArray();
+
+        $this->assertArrayNotHasKey('card_token', $array);
+        $this->assertArrayNotHasKey('cardToken', $array);
+    }
+}


### PR DESCRIPTION
## Summary
- **Blocker #1 (HIGH)**: Register 5 mobile WebSocket channels (`user`, `privacy`, `privacy.proof`, `commerce`, `trustcert`) and create 3 broadcast event classes (`PrivacyOperationCompleted`, `CommercePaymentConfirmed`, `TrustCertStatusChanged`) with event dispatching wired into PrivacyController, PaymentAttestationService, and CertificateAuthorityService
- **Blocker #2 (MEDIUM)**: Implement card transaction history via `CardTransaction` VO, `getTransactions()` on `CardIssuerInterface` with Marqeta API adapter and demo adapter (5 deterministic transactions with cursor pagination), replacing the empty stub in `CardController::transactions()`
- **Blocker #3 (LOW)**: Add `GET /api/v1/privacy/transaction-calldata/{txHash}` returning 501 with `planned_version: v5.9.0` so mobile gets a clear "not implemented" response instead of 404

## Files Changed (19 files, +1151/-16)

### New Files (4 created)
| File | Purpose |
|------|---------|
| `app/Domain/CardIssuance/ValueObjects/CardTransaction.php` | Readonly VO: transactionId, merchantName, amountCents, status, `toArray()`, `getAmountDecimal()` |
| `app/Domain/Privacy/Events/Broadcast/PrivacyOperationCompleted.php` | ShouldBroadcast on `privacy.{userId}` channel |
| `app/Domain/Commerce/Events/Broadcast/CommercePaymentConfirmed.php` | ShouldBroadcast on `commerce.{merchantId}` channel |
| `app/Domain/TrustCert/Events/Broadcast/TrustCertStatusChanged.php` | ShouldBroadcast on `trustcert.{userId}` channel |

### Modified Files (12 modified)
| File | Change |
|------|--------|
| `routes/channels.php` | +5 channel registrations (user, privacy, privacy.proof, commerce, trustcert) |
| `CardIssuerInterface.php` | +`getTransactions()` method |
| `MarqetaCardIssuerAdapter.php` | +`getTransactions()` + `mapTransactionResponse()` (Marqeta API) |
| `DemoCardIssuerAdapter.php` | +`getTransactions()` (5 demo merchants) |
| `CardProvisioningService.php` | +pass-through `getTransactions()` |
| `CardController.php` | Rewrite `transactions()` from stub to real service call |
| `PrivacyController.php` | +dispatch `PrivacyOperationCompleted` in shield/unshield/transfer, +`getTransactionCalldata()` 501 stub |
| `Privacy/Routes/api.php` | +`transaction-calldata/{txHash}` route |
| `PaymentAttestationService.php` | +dispatch `CommercePaymentConfirmed` after `PaymentAttested` |
| `CertificateAuthorityService.php` | +dispatch `TrustCertStatusChanged` in issue/revoke |

### Tests (3 new, 2 updated = 38 new test cases)
| File | Tests |
|------|-------|
| `tests/Feature/Broadcasting/MobileChannelRegistrationTest.php` | 16 tests: channel auth, event classes, broadcastAs/With/When/Queue, dispatch verification |
| `tests/Unit/Domain/CardIssuance/ValueObjects/CardTransactionTest.php` | 5 tests: toArray, getAmountDecimal, edge cases |
| `tests/Feature/Api/Privacy/TransactionCalldataTest.php` | 3 tests: auth required, 501 response, route exists |
| `tests/Feature/Api/CardIssuance/CardDetailTest.php` | Updated: demo data, limit, cursor pagination |
| `tests/Feature/Api/MobileHandoverV571Test.php` | Updated: reflects new demo data behavior |

## Test plan
- [x] PHPStan level 8 passes (0 errors)
- [x] php-cs-fixer passes (0 fixable)
- [x] All 38 new tests pass
- [x] Full test suite: 3306 passed (2 pre-existing flaky failures in FundFlowControllerTest unrelated to changes)
- [ ] Verify WebSocket channels work with Pusher/Soketi in staging
- [ ] Verify card transactions render correctly in mobile app

🤖 Generated with [Claude Code](https://claude.com/claude-code)