### PR TITLE
feat(privacy): persist transaction calldata and replace 501 stub

### DIFF
--- a/app/Domain/Privacy/Models/PrivacyTransaction.php
+++ b/app/Domain/Privacy/Models/PrivacyTransaction.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Privacy\Models;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Persisted privacy transaction calldata.
+ *
+ * Stores the EVM calldata returned by RAILGUN bridge operations so mobile
+ * clients can retrieve it later if the initial HTTP response is lost.
+ *
+ * @property string $id
+ * @property int $user_id
+ * @property string|null $tx_hash
+ * @property string $operation
+ * @property string $token
+ * @property string $amount
+ * @property string $network
+ * @property string $to_address
+ * @property string $calldata
+ * @property string|null $value
+ * @property string|null $gas_estimate
+ * @property string $status
+ * @property string|null $recipient
+ * @property array<string, mixed>|null $metadata
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ */
+class PrivacyTransaction extends Model
+{
+    use HasUuids;
+
+    protected $table = 'privacy_transactions';
+
+    public const STATUS_PENDING = 'pending';
+
+    public const STATUS_SUBMITTED = 'submitted';
+
+    public const STATUS_CONFIRMED = 'confirmed';
+
+    public const STATUS_FAILED = 'failed';
+
+    protected $fillable = [
+        'user_id',
+        'tx_hash',
+        'operation',
+        'token',
+        'amount',
+        'network',
+        'to_address',
+        'calldata',
+        'value',
+        'gas_estimate',
+        'status',
+        'recipient',
+        'metadata',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'calldata' => 'encrypted',
+            'metadata' => 'json',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Scope for transactions owned by a user.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder<PrivacyTransaction> $query
+     * @return \Illuminate\Database\Eloquent\Builder<PrivacyTransaction>
+     */
+    public function scopeForUser($query, int $userId)
+    {
+        return $query->where('user_id', $userId);
+    }
+
+    /**
+     * Scope for transactions on a specific network.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder<PrivacyTransaction> $query
+     * @return \Illuminate\Database\Eloquent\Builder<PrivacyTransaction>
+     */
+    public function scopeForNetwork($query, string $network)
+    {
+        return $query->where('network', $network);
+    }
+
+    /**
+     * Scope for transactions with a specific tx hash.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder<PrivacyTransaction> $query
+     * @return \Illuminate\Database\Eloquent\Builder<PrivacyTransaction>
+     */
+    public function scopeForTxHash($query, string $txHash)
+    {
+        return $query->where('tx_hash', $txHash);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toApiResponse(): array
+    {
+        return [
+            'id'           => $this->id,
+            'tx_hash'      => $this->tx_hash,
+            'operation'    => $this->operation,
+            'token'        => $this->token,
+            'amount'       => $this->amount,
+            'network'      => $this->network,
+            'to_address'   => $this->to_address,
+            'calldata'     => $this->calldata,
+            'value'        => $this->value,
+            'gas_estimate' => $this->gas_estimate,
+            'status'       => $this->status,
+            'recipient'    => $this->recipient,
+            'created_at'   => $this->created_at->toIso8601String(),
+        ];
+    }
+}

--- a/app/Domain/Privacy/Routes/api.php
+++ b/app/Domain/Privacy/Routes/api.php
@@ -75,8 +75,10 @@ Route::prefix('v1/privacy')->name('api.privacy.')->group(function () {
         // SRS status
         Route::get('/srs-status', [PrivacyController::class, 'getSrsStatus'])->name('srs-status');
 
-        // Transaction calldata (stub — deferred to v5.9.0)
+        // Transaction calldata
         Route::get('/transaction-calldata/{txHash}', [PrivacyController::class, 'getTransactionCalldata'])
             ->name('transaction-calldata');
+        Route::put('/transactions/{transactionId}/tx-hash', [PrivacyController::class, 'updateTransactionHash'])
+            ->name('transaction.update-hash');
     });
 });

--- a/database/migrations/2026_03_01_100000_create_privacy_transactions_table.php
+++ b/database/migrations/2026_03_01_100000_create_privacy_transactions_table.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('privacy_transactions', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('tx_hash', 66)->nullable()->index();
+            $table->string('operation', 20); // shield|unshield|transfer
+            $table->string('token', 20);
+            $table->string('amount');
+            $table->string('network', 20)->index();
+            $table->string('to_address');
+            $table->text('calldata'); // encrypted via model cast
+            $table->string('value')->nullable();
+            $table->string('gas_estimate')->nullable();
+            $table->string('status', 20)->default('pending')->index();
+            $table->string('recipient')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+
+            $table->index('user_id');
+            $table->index(['user_id', 'network']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('privacy_transactions');
+    }
+};

--- a/tests/Feature/Api/Privacy/TransactionCalldataTest.php
+++ b/tests/Feature/Api/Privacy/TransactionCalldataTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Api\Privacy;
 
+use App\Domain\Privacy\Models\PrivacyTransaction;
 use App\Models\User;
 use Illuminate\Support\Facades\Cache;
 use Tests\TestCase;
@@ -30,18 +31,30 @@ class TransactionCalldataTest extends TestCase
         $response->assertUnauthorized();
     }
 
-    public function test_transaction_calldata_returns_501(): void
+    public function test_transaction_calldata_returns_data_in_demo_mode(): void
     {
         $response = $this->withToken($this->token)
             ->getJson('/api/v1/privacy/transaction-calldata/0xabc123');
 
-        $response->assertStatus(501)
-            ->assertJsonPath('success', false)
-            ->assertJsonPath('planned_version', 'v5.9.0')
+        $response->assertOk()
+            ->assertJsonPath('success', true)
             ->assertJsonStructure([
                 'success',
-                'error',
-                'planned_version',
+                'data' => [
+                    'id',
+                    'tx_hash',
+                    'operation',
+                    'token',
+                    'amount',
+                    'network',
+                    'to_address',
+                    'calldata',
+                    'value',
+                    'gas_estimate',
+                    'status',
+                    'recipient',
+                    'created_at',
+                ],
             ]);
     }
 
@@ -50,8 +63,171 @@ class TransactionCalldataTest extends TestCase
         $response = $this->withToken($this->token)
             ->getJson('/api/v1/privacy/transaction-calldata/0x1234567890abcdef');
 
-        // Should get 501, not 404
         $this->assertNotEquals(404, $response->status());
-        $response->assertStatus(501);
+        $response->assertOk();
+    }
+
+    public function test_calldata_retrieved_by_tx_hash(): void
+    {
+        $txHash = '0x' . str_repeat('aa', 32);
+
+        PrivacyTransaction::create([
+            'user_id'    => $this->user->id,
+            'tx_hash'    => $txHash,
+            'operation'  => 'shield',
+            'token'      => 'USDC',
+            'amount'     => '100.00',
+            'network'    => 'polygon',
+            'to_address' => '0x' . str_repeat('ab', 20),
+            'calldata'   => '0xdeadbeef',
+            'value'      => '0',
+            'status'     => PrivacyTransaction::STATUS_SUBMITTED,
+        ]);
+
+        // Force RAILGUN mode
+        config(['privacy.zk.provider' => 'railgun']);
+
+        $response = $this->withToken($this->token)
+            ->getJson("/api/v1/privacy/transaction-calldata/{$txHash}");
+
+        $response->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.tx_hash', $txHash)
+            ->assertJsonPath('data.operation', 'shield')
+            ->assertJsonPath('data.token', 'USDC')
+            ->assertJsonPath('data.amount', '100.00');
+    }
+
+    public function test_calldata_retrieved_by_uuid(): void
+    {
+        $tx = PrivacyTransaction::create([
+            'user_id'    => $this->user->id,
+            'operation'  => 'unshield',
+            'token'      => 'USDT',
+            'amount'     => '50.00',
+            'network'    => 'ethereum',
+            'to_address' => '0x' . str_repeat('cd', 20),
+            'calldata'   => '0xcafebabe',
+            'status'     => PrivacyTransaction::STATUS_PENDING,
+            'recipient'  => '0x' . str_repeat('ef', 20),
+        ]);
+
+        config(['privacy.zk.provider' => 'railgun']);
+
+        $response = $this->withToken($this->token)
+            ->getJson("/api/v1/privacy/transaction-calldata/{$tx->id}");
+
+        $response->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.id', $tx->id)
+            ->assertJsonPath('data.operation', 'unshield');
+    }
+
+    public function test_calldata_404_for_unknown_transaction(): void
+    {
+        config(['privacy.zk.provider' => 'railgun']);
+
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/privacy/transaction-calldata/0x' . str_repeat('ff', 32));
+
+        $response->assertNotFound()
+            ->assertJsonPath('success', false)
+            ->assertJsonPath('error', 'Transaction not found.');
+    }
+
+    public function test_calldata_user_isolation(): void
+    {
+        $otherUser = User::factory()->create();
+        $txHash = '0x' . str_repeat('bb', 32);
+
+        PrivacyTransaction::create([
+            'user_id'    => $otherUser->id,
+            'tx_hash'    => $txHash,
+            'operation'  => 'shield',
+            'token'      => 'USDC',
+            'amount'     => '200.00',
+            'network'    => 'polygon',
+            'to_address' => '0x' . str_repeat('ab', 20),
+            'calldata'   => '0xdeadbeef',
+            'status'     => PrivacyTransaction::STATUS_SUBMITTED,
+        ]);
+
+        config(['privacy.zk.provider' => 'railgun']);
+
+        // Current user should NOT see other user's transaction
+        $response = $this->withToken($this->token)
+            ->getJson("/api/v1/privacy/transaction-calldata/{$txHash}");
+
+        $response->assertNotFound();
+    }
+
+    public function test_update_transaction_hash_requires_auth(): void
+    {
+        $response = $this->putJson('/api/v1/privacy/transactions/some-uuid/tx-hash', [
+            'tx_hash' => '0x' . str_repeat('11', 32),
+        ]);
+
+        $response->assertUnauthorized();
+    }
+
+    public function test_update_transaction_hash_in_demo_mode(): void
+    {
+        $response = $this->withToken($this->token)
+            ->putJson('/api/v1/privacy/transactions/some-uuid/tx-hash', [
+                'tx_hash' => '0x' . str_repeat('11', 32),
+            ]);
+
+        $response->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('message', 'Transaction hash updated.');
+    }
+
+    public function test_update_transaction_hash_in_railgun_mode(): void
+    {
+        $tx = PrivacyTransaction::create([
+            'user_id'    => $this->user->id,
+            'operation'  => 'shield',
+            'token'      => 'USDC',
+            'amount'     => '100.00',
+            'network'    => 'polygon',
+            'to_address' => '0x' . str_repeat('ab', 20),
+            'calldata'   => '0xdeadbeef',
+            'status'     => PrivacyTransaction::STATUS_PENDING,
+        ]);
+
+        config(['privacy.zk.provider' => 'railgun']);
+        $newTxHash = '0x' . str_repeat('22', 32);
+
+        $response = $this->withToken($this->token)
+            ->putJson("/api/v1/privacy/transactions/{$tx->id}/tx-hash", [
+                'tx_hash' => $newTxHash,
+            ]);
+
+        $response->assertOk()
+            ->assertJsonPath('success', true);
+
+        $tx->refresh();
+        $this->assertSame($newTxHash, $tx->tx_hash);
+        $this->assertSame(PrivacyTransaction::STATUS_SUBMITTED, $tx->status);
+    }
+
+    public function test_update_transaction_hash_404_for_unknown(): void
+    {
+        config(['privacy.zk.provider' => 'railgun']);
+
+        $response = $this->withToken($this->token)
+            ->putJson('/api/v1/privacy/transactions/00000000-0000-0000-0000-000000000000/tx-hash', [
+                'tx_hash' => '0x' . str_repeat('11', 32),
+            ]);
+
+        $response->assertNotFound();
+    }
+
+    public function test_update_transaction_hash_validates_input(): void
+    {
+        $response = $this->withToken($this->token)
+            ->putJson('/api/v1/privacy/transactions/some-uuid/tx-hash', []);
+
+        $response->assertUnprocessable();
     }
 }

--- a/tests/Unit/Domain/Privacy/Models/PrivacyTransactionTest.php
+++ b/tests/Unit/Domain/Privacy/Models/PrivacyTransactionTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Privacy\Models;
+
+use App\Domain\Privacy\Models\PrivacyTransaction;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class PrivacyTransactionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+    }
+
+    public function test_fillable_fields(): void
+    {
+        $tx = new PrivacyTransaction();
+        $fillable = $tx->getFillable();
+
+        $this->assertContains('user_id', $fillable);
+        $this->assertContains('tx_hash', $fillable);
+        $this->assertContains('operation', $fillable);
+        $this->assertContains('calldata', $fillable);
+        $this->assertContains('to_address', $fillable);
+        $this->assertContains('status', $fillable);
+        $this->assertContains('recipient', $fillable);
+        $this->assertContains('metadata', $fillable);
+    }
+
+    public function test_calldata_is_encrypted_cast(): void
+    {
+        $tx = new PrivacyTransaction();
+        $casts = $tx->getCasts();
+
+        $this->assertSame('encrypted', $casts['calldata']);
+    }
+
+    public function test_metadata_is_json_cast(): void
+    {
+        $tx = new PrivacyTransaction();
+        $casts = $tx->getCasts();
+
+        $this->assertSame('json', $casts['metadata']);
+    }
+
+    public function test_status_constants(): void
+    {
+        $this->assertSame('pending', PrivacyTransaction::STATUS_PENDING);
+        $this->assertSame('submitted', PrivacyTransaction::STATUS_SUBMITTED);
+        $this->assertSame('confirmed', PrivacyTransaction::STATUS_CONFIRMED);
+        $this->assertSame('failed', PrivacyTransaction::STATUS_FAILED);
+    }
+
+    public function test_scope_for_user(): void
+    {
+        $user = User::factory()->create();
+
+        PrivacyTransaction::create([
+            'user_id'    => $user->id,
+            'operation'  => 'shield',
+            'token'      => 'USDC',
+            'amount'     => '100.00',
+            'network'    => 'polygon',
+            'to_address' => '0x' . str_repeat('ab', 20),
+            'calldata'   => '0xdeadbeef',
+            'status'     => PrivacyTransaction::STATUS_PENDING,
+        ]);
+
+        $otherUser = User::factory()->create();
+        PrivacyTransaction::create([
+            'user_id'    => $otherUser->id,
+            'operation'  => 'shield',
+            'token'      => 'USDC',
+            'amount'     => '50.00',
+            'network'    => 'polygon',
+            'to_address' => '0x' . str_repeat('cd', 20),
+            'calldata'   => '0xcafebabe',
+            'status'     => PrivacyTransaction::STATUS_PENDING,
+        ]);
+
+        $results = PrivacyTransaction::query()->forUser($user->id)->get();
+        $this->assertCount(1, $results);
+        $this->assertEquals($user->id, $results->first()->user_id);
+    }
+
+    public function test_scope_for_network(): void
+    {
+        $user = User::factory()->create();
+
+        PrivacyTransaction::create([
+            'user_id'    => $user->id,
+            'operation'  => 'shield',
+            'token'      => 'USDC',
+            'amount'     => '100.00',
+            'network'    => 'polygon',
+            'to_address' => '0x' . str_repeat('ab', 20),
+            'calldata'   => '0xdeadbeef',
+            'status'     => PrivacyTransaction::STATUS_PENDING,
+        ]);
+
+        PrivacyTransaction::create([
+            'user_id'    => $user->id,
+            'operation'  => 'shield',
+            'token'      => 'USDC',
+            'amount'     => '50.00',
+            'network'    => 'ethereum',
+            'to_address' => '0x' . str_repeat('cd', 20),
+            'calldata'   => '0xcafebabe',
+            'status'     => PrivacyTransaction::STATUS_PENDING,
+        ]);
+
+        $results = PrivacyTransaction::query()->forNetwork('polygon')->get();
+        $this->assertCount(1, $results);
+        $this->assertSame('polygon', $results->first()->network);
+    }
+
+    public function test_scope_for_tx_hash(): void
+    {
+        $user = User::factory()->create();
+        $txHash = '0x' . str_repeat('11', 32);
+
+        PrivacyTransaction::create([
+            'user_id'    => $user->id,
+            'tx_hash'    => $txHash,
+            'operation'  => 'shield',
+            'token'      => 'USDC',
+            'amount'     => '100.00',
+            'network'    => 'polygon',
+            'to_address' => '0x' . str_repeat('ab', 20),
+            'calldata'   => '0xdeadbeef',
+            'status'     => PrivacyTransaction::STATUS_SUBMITTED,
+        ]);
+
+        $results = PrivacyTransaction::query()->forTxHash($txHash)->get();
+        $this->assertCount(1, $results);
+        $this->assertSame($txHash, $results->first()->tx_hash);
+    }
+
+    public function test_to_api_response(): void
+    {
+        $user = User::factory()->create();
+
+        $tx = PrivacyTransaction::create([
+            'user_id'      => $user->id,
+            'tx_hash'      => '0x' . str_repeat('11', 32),
+            'operation'    => 'shield',
+            'token'        => 'USDC',
+            'amount'       => '100.00',
+            'network'      => 'polygon',
+            'to_address'   => '0x' . str_repeat('ab', 20),
+            'calldata'     => '0xdeadbeef',
+            'value'        => '0',
+            'gas_estimate' => '150000',
+            'status'       => PrivacyTransaction::STATUS_PENDING,
+            'recipient'    => null,
+        ]);
+
+        $response = $tx->toApiResponse();
+
+        $this->assertArrayHasKey('id', $response);
+        $this->assertArrayHasKey('tx_hash', $response);
+        $this->assertArrayHasKey('operation', $response);
+        $this->assertArrayHasKey('calldata', $response);
+        $this->assertArrayHasKey('to_address', $response);
+        $this->assertArrayHasKey('created_at', $response);
+        $this->assertSame('shield', $response['operation']);
+        $this->assertSame('USDC', $response['token']);
+        $this->assertSame('100.00', $response['amount']);
+        $this->assertSame('polygon', $response['network']);
+    }
+
+    public function test_user_relationship(): void
+    {
+        $user = User::factory()->create();
+
+        $tx = PrivacyTransaction::create([
+            'user_id'    => $user->id,
+            'operation'  => 'shield',
+            'token'      => 'USDC',
+            'amount'     => '100.00',
+            'network'    => 'polygon',
+            'to_address' => '0x' . str_repeat('ab', 20),
+            'calldata'   => '0xdeadbeef',
+            'status'     => PrivacyTransaction::STATUS_PENDING,
+        ]);
+
+        $this->assertInstanceOf(User::class, $tx->user);
+        $this->assertEquals($user->id, $tx->user->id);
+    }
+}


### PR DESCRIPTION
## Summary
- Persist EVM calldata from RAILGUN shield/unshield/transfer operations into `privacy_transactions` table with encrypted `calldata` column
- Replace the 501 stub (`GET /api/v1/privacy/transaction-calldata/{txHash}`) with full implementation supporting lookup by tx hash or UUID
- Add `PUT /api/v1/privacy/transactions/{id}/tx-hash` endpoint for mobile to report on-chain transaction hash after submission
- Wire `persistTransaction()` into all three privacy operations, returning `transaction_id` in responses

## Details
| File | Change |
|------|--------|
| `database/migrations/2026_03_01_100000_create_privacy_transactions_table.php` | New table with encrypted calldata |
| `app/Domain/Privacy/Models/PrivacyTransaction.php` | Model with `HasUuids`, `encrypted` cast, scopes, `toApiResponse()` |
| `app/Domain/Privacy/Services/RailgunPrivacyService.php` | `persistTransaction()`, `getTransactionCalldata()`, `updateTransactionHash()` |
| `app/Http/Controllers/Api/Privacy/PrivacyController.php` | Replace 501 stub, add `updateTransactionHash()`, demo mode support |
| `app/Domain/Privacy/Routes/api.php` | Add tx-hash update route |

## Security
- Calldata stored with Laravel `encrypted` cast (AES-256-CBC at rest)
- User isolation enforced on all queries via `user_id` scoping
- Input validation on tx_hash (max 66 chars)
- Generic error messages prevent information leakage

## Test plan
- [x] 12 feature tests: auth, demo mode, RAILGUN mode retrieval by hash/UUID, 404, user isolation, tx-hash update
- [x] 9 unit tests: model fillable/casts, scopes, relationship, `toApiResponse()`
- [x] PHPStan passes (0 errors)
- [x] php-cs-fixer clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)