### PR TITLE
fix(security): enforce token expiration globally via api middleware group

### DIFF
--- a/app/Domain/AI/Routes/api.php
+++ b/app/Domain/AI/Routes/api.php
@@ -10,7 +10,7 @@ use App\Http\Controllers\Api\MCPToolsController;
 use Illuminate\Support\Facades\Route;
 
 // AI Agent endpoints (protected)
-Route::prefix('ai')->middleware(['auth:sanctum', 'check.token.expiration', 'api.rate_limit:private'])->group(function () {
+Route::prefix('ai')->middleware(['auth:sanctum', 'api.rate_limit:private'])->group(function () {
     Route::post('/chat', [AIAgentController::class, 'chat'])->name('api.ai.chat');
     Route::get('/conversations', [AIAgentController::class, 'conversations'])->name('api.ai.conversations');
     Route::get('/conversations/{conversationId}', [AIAgentController::class, 'getConversation'])->name('api.ai.conversation');

--- a/app/Domain/Account/Routes/api.php
+++ b/app/Domain/Account/Routes/api.php
@@ -13,7 +13,7 @@ use App\Http\Controllers\Api\TransferController;
 use Illuminate\Support\Facades\Route;
 
 // Core account, transaction, and transfer endpoints
-Route::middleware('auth:sanctum', 'check.token.expiration')->group(function () {
+Route::middleware('auth:sanctum')->group(function () {
     // Sub-product status for authenticated users
     Route::get('/sub-products/enabled', [SubProductController::class, 'enabled']);
 

--- a/app/Domain/AgentProtocol/Routes/api.php
+++ b/app/Domain/AgentProtocol/Routes/api.php
@@ -54,7 +54,7 @@ Route::prefix('agent-protocol')->name('api.agent-protocol.')->group(function () 
     });
 
     // User-authenticated endpoints (users manage their agents via sanctum)
-    Route::middleware(['auth:sanctum', 'check.token.expiration', 'api.rate_limit:private'])->group(function () {
+    Route::middleware(['auth:sanctum', 'api.rate_limit:private'])->group(function () {
         // Agent registration (users create/own agents)
         Route::post('/agents/register', [AgentIdentityController::class, 'register'])->name('agents.register');
 

--- a/app/Domain/Banking/Routes/api.php
+++ b/app/Domain/Banking/Routes/api.php
@@ -11,7 +11,7 @@ use App\Http\Controllers\Api\WorkflowMonitoringController;
 use Illuminate\Support\Facades\Route;
 
 // Banking operations endpoints
-Route::middleware('auth:sanctum', 'check.token.expiration')->group(function () {
+Route::middleware('auth:sanctum')->group(function () {
     // Batch Processing endpoints
     Route::prefix('batch-operations')->group(function () {
         Route::post('/execute', [BatchProcessingController::class, 'executeBatch']);

--- a/app/Domain/Basket/Routes/api.php
+++ b/app/Domain/Basket/Routes/api.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Route;
 // Basket endpoints
 Route::prefix('v2')->group(function () {
     // V2 accounts endpoint (requires authentication)
-    Route::middleware('auth:sanctum', 'check.token.expiration')->get('/accounts', [App\Http\Controllers\Api\AccountController::class, 'index']);
+    Route::middleware('auth:sanctum')->get('/accounts', [App\Http\Controllers\Api\AccountController::class, 'index']);
 
     // Public basket endpoints
     Route::prefix('baskets')->group(function () {
@@ -30,7 +30,7 @@ Route::prefix('v2')->group(function () {
     });
 
     // Protected basket endpoints
-    Route::middleware('auth:sanctum', 'check.token.expiration')->group(function () {
+    Route::middleware('auth:sanctum')->group(function () {
         Route::post('/baskets', [BasketController::class, 'store']);
         Route::post('/baskets/{code}/rebalance', [BasketController::class, 'rebalance']);
         Route::post('/baskets/{code}/performance/calculate', [BasketPerformanceController::class, 'calculate']);

--- a/app/Domain/CardIssuance/Routes/api.php
+++ b/app/Domain/CardIssuance/Routes/api.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Route;
 
 Route::prefix('v1/cards')->name('api.cards.')->group(function () {
     // Authenticated endpoints
-    Route::middleware(['auth:sanctum', 'check.token.expiration'])->group(function () {
+    Route::middleware(['auth:sanctum'])->group(function () {
         Route::get('/', [CardController::class, 'index'])->name('index');
         Route::post('/', [CardController::class, 'store'])
             ->middleware('transaction.rate_limit:card_provision')

--- a/app/Domain/Commerce/Routes/api.php
+++ b/app/Domain/Commerce/Routes/api.php
@@ -6,7 +6,7 @@ use App\Http\Controllers\Api\Commerce\MobileCommerceController;
 use Illuminate\Support\Facades\Route;
 
 Route::prefix('v1/commerce')->name('mobile.commerce.')
-    ->middleware(['auth:sanctum', 'check.token.expiration'])
+    ->middleware(['auth:sanctum'])
     ->group(function () {
         Route::get('/merchants', [MobileCommerceController::class, 'merchants'])
             ->middleware('api.rate_limit:query')

--- a/app/Domain/Compliance/Routes/api.php
+++ b/app/Domain/Compliance/Routes/api.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Facades\Route;
 
 // Mobile sanctions check endpoint (v5.8.0)
 Route::prefix('v1/compliance')->name('api.compliance.mobile.')
-    ->middleware(['auth:sanctum', 'check.token.expiration'])
+    ->middleware(['auth:sanctum'])
     ->group(function () {
         Route::get('/check-address', SanctionsCheckController::class)
             ->middleware('throttle:30,1')
@@ -21,7 +21,7 @@ Route::prefix('v1/compliance')->name('api.compliance.mobile.')
     });
 
 // Compliance and KYC endpoints
-Route::middleware('auth:sanctum', 'check.token.expiration')->prefix('compliance')->group(function () {
+Route::middleware('auth:sanctum')->prefix('compliance')->group(function () {
     // Compliance alerts
     Route::prefix('alerts')->group(function () {
         Route::get('/', [ComplianceAlertController::class, 'index']);

--- a/app/Domain/CrossChain/Routes/api.php
+++ b/app/Domain/CrossChain/Routes/api.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Route;
 Route::prefix('v1/crosschain')->name('api.crosschain.')->group(function () {
     Route::get('/chains', [CrossChainController::class, 'chains'])->name('chains');
 
-    Route::middleware(['auth:sanctum', 'check.token.expiration'])->group(function () {
+    Route::middleware(['auth:sanctum'])->group(function () {
         Route::post('/bridge/quote', [CrossChainController::class, 'bridgeQuote'])->name('bridge.quote');
         Route::post('/bridge/initiate', [CrossChainController::class, 'bridgeInitiate'])
             ->middleware(['transaction.rate_limit:crosschain', 'idempotency'])

--- a/app/Domain/DeFi/Routes/api.php
+++ b/app/Domain/DeFi/Routes/api.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Route;
 Route::prefix('v1/defi')->name('api.defi.')->group(function () {
     Route::get('/protocols', [DeFiController::class, 'protocols'])->name('protocols');
 
-    Route::middleware(['auth:sanctum', 'check.token.expiration'])->group(function () {
+    Route::middleware(['auth:sanctum'])->group(function () {
         Route::post('/swap/quote', [DeFiController::class, 'swapQuote'])->name('swap.quote');
         Route::post('/swap/execute', [DeFiController::class, 'swapExecute'])
             ->middleware(['transaction.rate_limit:defi', 'idempotency'])

--- a/app/Domain/Exchange/Routes/api.php
+++ b/app/Domain/Exchange/Routes/api.php
@@ -32,7 +32,7 @@ Route::middleware('api.rate_limit:public')->group(function () {
         Route::get('/orderbook/{baseCurrency}/{quoteCurrency}', [App\Http\Controllers\Api\ExchangeController::class, 'getOrderBook'])->name('orderbook');
         Route::get('/markets', [App\Http\Controllers\Api\ExchangeController::class, 'getMarkets'])->name('markets');
 
-        Route::middleware('auth:sanctum', 'check.token.expiration')->group(function () {
+        Route::middleware('auth:sanctum')->group(function () {
             Route::post('/orders', [App\Http\Controllers\Api\ExchangeController::class, 'placeOrder'])
                 ->middleware(['transaction.rate_limit:exchange_order', 'idempotency'])
                 ->name('orders.place');
@@ -48,7 +48,7 @@ Route::middleware('api.rate_limit:public')->group(function () {
         Route::get('/ticker/{base}/{quote}', [App\Http\Controllers\Api\ExternalExchangeController::class, 'ticker'])->name('ticker');
         Route::get('/orderbook/{base}/{quote}', [App\Http\Controllers\Api\ExternalExchangeController::class, 'orderBook'])->name('orderbook');
 
-        Route::middleware('auth:sanctum', 'check.token.expiration')->group(function () {
+        Route::middleware('auth:sanctum')->group(function () {
             Route::get('/arbitrage/{base}/{quote}', [App\Http\Controllers\Api\ExternalExchangeController::class, 'arbitrage'])->name('arbitrage');
         });
     });
@@ -58,7 +58,7 @@ Route::middleware('api.rate_limit:public')->group(function () {
         Route::get('/pools', [App\Http\Controllers\Api\LiquidityPoolController::class, 'index'])->name('pools.index');
         Route::get('/pools/{poolId}', [App\Http\Controllers\Api\LiquidityPoolController::class, 'show'])->name('pools.show');
 
-        Route::middleware('auth:sanctum', 'check.token.expiration')->group(function () {
+        Route::middleware('auth:sanctum')->group(function () {
             Route::post('/pools', [App\Http\Controllers\Api\LiquidityPoolController::class, 'create'])->middleware('idempotency')->name('pools.create');
             Route::post('/add', [App\Http\Controllers\Api\LiquidityPoolController::class, 'addLiquidity'])->middleware('idempotency')->name('add');
             Route::post('/remove', [App\Http\Controllers\Api\LiquidityPoolController::class, 'removeLiquidity'])->middleware('idempotency')->name('remove');
@@ -81,7 +81,7 @@ Route::middleware('api.rate_limit:public')->group(function () {
 // V1 Asset and exchange rate endpoints
 Route::prefix('v1')->middleware('api.rate_limit:public')->group(function () {
     // Versioned accounts endpoint (requires authentication)
-    Route::middleware('auth:sanctum', 'check.token.expiration')->get('/accounts', [App\Http\Controllers\Api\AccountController::class, 'index']);
+    Route::middleware('auth:sanctum')->get('/accounts', [App\Http\Controllers\Api\AccountController::class, 'index']);
 
     // Asset management endpoints
     Route::get('/assets', [AssetController::class, 'index']);
@@ -98,7 +98,7 @@ Route::prefix('v1')->middleware('api.rate_limit:public')->group(function () {
         Route::get('/{provider}/rate', [App\Http\Controllers\Api\ExchangeRateProviderController::class, 'getRate']);
         Route::get('/compare', [App\Http\Controllers\Api\ExchangeRateProviderController::class, 'compareRates']);
         Route::get('/aggregated', [App\Http\Controllers\Api\ExchangeRateProviderController::class, 'getAggregatedRate']);
-        Route::post('/refresh', [App\Http\Controllers\Api\ExchangeRateProviderController::class, 'refresh'])->middleware('auth:sanctum', 'check.token.expiration');
+        Route::post('/refresh', [App\Http\Controllers\Api\ExchangeRateProviderController::class, 'refresh'])->middleware('auth:sanctum');
         Route::get('/historical', [App\Http\Controllers\Api\ExchangeRateProviderController::class, 'historical']);
         Route::post('/validate', [App\Http\Controllers\Api\ExchangeRateProviderController::class, 'validateRate']);
     });

--- a/app/Domain/Governance/Routes/api.php
+++ b/app/Domain/Governance/Routes/api.php
@@ -8,7 +8,7 @@ use App\Http\Controllers\Api\VoteController;
 use Illuminate\Support\Facades\Route;
 
 // Governance endpoints
-Route::middleware('auth:sanctum', 'check.token.expiration')->group(function () {
+Route::middleware('auth:sanctum')->group(function () {
     // Governance endpoints (query rate limiting for reads, vote rate limiting for votes)
     Route::prefix('polls')->group(function () {
         Route::middleware('api.rate_limit:query')->group(function () {

--- a/app/Domain/Lending/Routes/api.php
+++ b/app/Domain/Lending/Routes/api.php
@@ -7,7 +7,7 @@ use App\Http\Controllers\Api\LoanController;
 use Illuminate\Support\Facades\Route;
 
 // P2P Lending endpoints
-Route::prefix('lending')->middleware(['auth:sanctum', 'check.token.expiration', 'sub_product:lending'])->group(function () {
+Route::prefix('lending')->middleware(['auth:sanctum', 'sub_product:lending'])->group(function () {
     // Loan applications
     Route::middleware('api.rate_limit:query')->group(function () {
         Route::get('/applications', [LoanApplicationController::class, 'index']);

--- a/app/Domain/Mobile/Routes/api.php
+++ b/app/Domain/Mobile/Routes/api.php
@@ -26,7 +26,7 @@ Route::prefix('mobile')->name('api.mobile.')->group(function () {
         });
 
     // Protected endpoints (require authentication)
-    Route::middleware(['auth:sanctum', 'check.token.expiration'])->group(function () {
+    Route::middleware(['auth:sanctum'])->group(function () {
         // Device management
         Route::prefix('devices')->name('devices.')->group(function () {
             Route::get('/', [MobileController::class, 'listDevices'])->name('index');
@@ -73,7 +73,7 @@ Route::prefix('mobile')->name('api.mobile.')->group(function () {
 
 // Notification endpoints (v5.6.0)
 Route::prefix('v1/notifications')->name('api.notifications.')
-    ->middleware(['auth:sanctum', 'check.token.expiration'])
+    ->middleware(['auth:sanctum'])
     ->group(function () {
         Route::get('/unread-count', [MobileController::class, 'getUnreadNotificationCount'])
             ->middleware('api.rate_limit:query')
@@ -82,7 +82,7 @@ Route::prefix('v1/notifications')->name('api.notifications.')
 
 // User preferences (v3.3.4) + data export alias (v5.6.0)
 Route::prefix('v1/user')->name('api.user.')
-    ->middleware(['auth:sanctum', 'check.token.expiration'])
+    ->middleware(['auth:sanctum'])
     ->group(function () {
         Route::get('/preferences', [UserPreferencesController::class, 'show'])->name('preferences.show');
         Route::patch('/preferences', [UserPreferencesController::class, 'update'])->name('preferences.update');

--- a/app/Domain/MobilePayment/Routes/api.php
+++ b/app/Domain/MobilePayment/Routes/api.php
@@ -11,7 +11,7 @@ use App\Http\Controllers\Api\MobilePayment\WalletReceiveController;
 use App\Http\Controllers\Api\Wallet\WalletTransferController;
 use Illuminate\Support\Facades\Route;
 
-Route::prefix('v1')->middleware(['auth:sanctum', 'check.token.expiration'])->group(function () {
+Route::prefix('v1')->middleware(['auth:sanctum'])->group(function () {
     // Payment Intents
     Route::post('/payments/intents', [PaymentIntentController::class, 'create'])
         ->middleware(['transaction.rate_limit:payment_intent', 'idempotency'])

--- a/app/Domain/Privacy/Routes/api.php
+++ b/app/Domain/Privacy/Routes/api.php
@@ -24,7 +24,7 @@ Route::prefix('v1/privacy')->name('api.privacy.')->group(function () {
     Route::get('/pool-stats', [PrivacyController::class, 'getPoolStats'])->name('pool-stats');
 
     // Authenticated endpoints
-    Route::middleware(['auth:sanctum', 'check.token.expiration', 'throttle:60,1'])->group(function () {
+    Route::middleware(['auth:sanctum', 'throttle:60,1'])->group(function () {
         Route::get('/merkle-root', [PrivacyController::class, 'getMerkleRoot'])->name('merkle-root');
         Route::post('/merkle-path', [PrivacyController::class, 'getMerklePath'])->middleware('throttle:10,1')->name('merkle-path');
         Route::post('/verify-commitment', [PrivacyController::class, 'verifyCommitment'])->middleware('throttle:10,1')->name('verify-commitment');

--- a/app/Domain/RegTech/Routes/api.php
+++ b/app/Domain/RegTech/Routes/api.php
@@ -6,7 +6,7 @@ use App\Http\Controllers\Api\RegTech\RegTechController;
 use Illuminate\Support\Facades\Route;
 
 // RegTech endpoints (regulatory compliance, MiFID II, MiCA, Travel Rule)
-Route::middleware('auth:sanctum', 'check.token.expiration', 'throttle:60,1')->prefix('regtech')->name('api.regtech.')->group(function () {
+Route::middleware('auth:sanctum', 'throttle:60,1')->prefix('regtech')->name('api.regtech.')->group(function () {
     Route::get('/compliance/summary', [RegTechController::class, 'complianceSummary'])->name('compliance.summary');
     Route::get('/adapters', [RegTechController::class, 'adapters'])->name('adapters');
     Route::get('/regulations/applicable', [RegTechController::class, 'applicableRegulations'])->name('regulations.applicable');

--- a/app/Domain/Relayer/Routes/api.php
+++ b/app/Domain/Relayer/Routes/api.php
@@ -12,7 +12,7 @@ Route::prefix('v1/relayer')->name('api.relayer.')->group(function () {
     Route::get('/networks', [RelayerController::class, 'networks'])->name('networks');
 
     // Authenticated endpoints
-    Route::middleware(['auth:sanctum', 'check.token.expiration'])->group(function () {
+    Route::middleware(['auth:sanctum'])->group(function () {
         Route::post('/sponsor', [RelayerController::class, 'sponsor'])
             ->middleware('transaction.rate_limit:relayer')
             ->name('sponsor');
@@ -30,7 +30,7 @@ Route::prefix('v1/relayer')->name('api.relayer.')->group(function () {
 });
 
 Route::prefix('v1/relayer')->name('mobile.relayer.')
-    ->middleware(['auth:sanctum', 'check.token.expiration'])
+    ->middleware(['auth:sanctum'])
     ->group(function () {
         Route::get('/status', [MobileRelayerController::class, 'status'])
             ->middleware('api.rate_limit:query')

--- a/app/Domain/Rewards/Routes/api.php
+++ b/app/Domain/Rewards/Routes/api.php
@@ -6,7 +6,7 @@ use App\Http\Controllers\Api\Rewards\RewardsController;
 use Illuminate\Support\Facades\Route;
 
 Route::prefix('v1/rewards')->name('api.rewards.')
-    ->middleware(['auth:sanctum', 'check.token.expiration'])
+    ->middleware(['auth:sanctum'])
     ->group(function () {
         Route::get('/profile', [RewardsController::class, 'profile'])
             ->middleware('api.rate_limit:query')

--- a/app/Domain/Security/Routes/api.php
+++ b/app/Domain/Security/Routes/api.php
@@ -7,7 +7,7 @@ use App\Http\Controllers\Api\TransactionMonitoringController;
 use Illuminate\Support\Facades\Route;
 
 // Risk Analysis endpoints
-Route::middleware('auth:sanctum', 'check.token.expiration')->prefix('risk')->group(function () {
+Route::middleware('auth:sanctum')->prefix('risk')->group(function () {
     // User risk endpoints
     Route::prefix('users/{userId}')->group(function () {
         Route::get('/profile', [RiskAnalysisController::class, 'getUserRiskProfile']);
@@ -27,7 +27,7 @@ Route::middleware('auth:sanctum', 'check.token.expiration')->prefix('risk')->gro
 });
 
 // Transaction Monitoring endpoints
-Route::middleware('auth:sanctum', 'check.token.expiration')->prefix('transaction-monitoring')->group(function () {
+Route::middleware('auth:sanctum')->prefix('transaction-monitoring')->group(function () {
     // Transaction monitoring
     Route::get('/', [TransactionMonitoringController::class, 'getMonitoredTransactions']);
     Route::get('/transactions/{transaction}', [TransactionMonitoringController::class, 'getTransactionDetails']);

--- a/app/Domain/Stablecoin/Routes/api.php
+++ b/app/Domain/Stablecoin/Routes/api.php
@@ -26,7 +26,7 @@ Route::prefix('v2')->group(function () {
     });
 
     // Stablecoin operations endpoints
-    Route::middleware(['auth:sanctum', 'check.token.expiration', 'sub_product:stablecoins'])->prefix('stablecoin-operations')->group(function () {
+    Route::middleware(['auth:sanctum', 'sub_product:stablecoins'])->prefix('stablecoin-operations')->group(function () {
         Route::post('/mint', [StablecoinOperationsController::class, 'mint'])->middleware('idempotency');
         Route::post('/burn', [StablecoinOperationsController::class, 'burn'])->middleware('idempotency');
         Route::post('/add-collateral', [StablecoinOperationsController::class, 'addCollateral'])->middleware('idempotency');

--- a/app/Domain/Treasury/Routes/api.php
+++ b/app/Domain/Treasury/Routes/api.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Route;
 // Treasury Management endpoints
 Route::prefix('treasury')->name('api.treasury.')->group(function () {
     // Authenticated treasury routes
-    Route::middleware('auth:sanctum', 'check.token.expiration', 'scope:treasury')->group(function () {
+    Route::middleware('auth:sanctum', 'scope:treasury')->group(function () {
         // Portfolio Management endpoints
         Route::prefix('portfolios')->name('portfolios.')->group(function () {
             Route::get('/', [PortfolioController::class, 'index'])->name('index');

--- a/app/Domain/TrustCert/Routes/api.php
+++ b/app/Domain/TrustCert/Routes/api.php
@@ -13,7 +13,7 @@ Route::prefix('v1/trustcert')->name('api.trustcert.')->group(function () {
     Route::get('/verify/{token}', [PresentationController::class, 'verify'])->name('verify');
 
     // Authenticated endpoints
-    Route::middleware(['auth:sanctum', 'check.token.expiration'])->group(function () {
+    Route::middleware(['auth:sanctum'])->group(function () {
         Route::post('/{certificateId}/present', [PresentationController::class, 'present'])->name('present');
 
         // Certificate details and PDF export
@@ -23,7 +23,7 @@ Route::prefix('v1/trustcert')->name('api.trustcert.')->group(function () {
 });
 
 Route::prefix('v1/trustcert')->name('mobile.trustcert.')
-    ->middleware(['auth:sanctum', 'check.token.expiration'])
+    ->middleware(['auth:sanctum'])
     ->group(function () {
         Route::get('/current', [MobileTrustCertController::class, 'current'])
             ->middleware('api.rate_limit:query')

--- a/app/Domain/Wallet/Routes/api.php
+++ b/app/Domain/Wallet/Routes/api.php
@@ -10,7 +10,7 @@ use App\Http\Controllers\Api\Wallet\RecoveryShardController;
 use Illuminate\Support\Facades\Route;
 
 // Blockchain wallet endpoints
-Route::prefix('blockchain-wallets')->middleware(['auth:sanctum', 'check.token.expiration', 'sub_product:blockchain'])->group(function () {
+Route::prefix('blockchain-wallets')->middleware(['auth:sanctum', 'sub_product:blockchain'])->group(function () {
     Route::middleware('api.rate_limit:query')->group(function () {
         Route::get('/', [BlockchainWalletController::class, 'index']);
         Route::get('/{walletId}', [BlockchainWalletController::class, 'show']);
@@ -35,7 +35,7 @@ Route::prefix('hardware-wallet')->name('api.hardware-wallet.')->group(function (
         ->name('supported');
 
     // Authenticated endpoints
-    Route::middleware(['auth:sanctum', 'check.token.expiration', 'sub_product:blockchain'])->group(function () {
+    Route::middleware(['auth:sanctum', 'sub_product:blockchain'])->group(function () {
         // Device registration
         Route::post('/register', [HardwareWalletController::class, 'register'])
             ->middleware('transaction.rate_limit:blockchain')
@@ -72,7 +72,7 @@ Route::prefix('multi-sig')->name('api.multi-sig.')->group(function () {
         ->name('supported');
 
     // Authenticated endpoints
-    Route::middleware(['auth:sanctum', 'check.token.expiration', 'sub_product:blockchain'])->group(function () {
+    Route::middleware(['auth:sanctum', 'sub_product:blockchain'])->group(function () {
         // Wallet management
         Route::post('/wallets', [MultiSigWalletController::class, 'createWallet'])
             ->middleware('transaction.rate_limit:blockchain')
@@ -112,7 +112,7 @@ Route::prefix('multi-sig')->name('api.multi-sig.')->group(function () {
 
 // Mobile Wallet API (v2.10.0)
 Route::prefix('v1/wallet')->name('mobile.wallet.')
-    ->middleware(['auth:sanctum', 'check.token.expiration'])
+    ->middleware(['auth:sanctum'])
     ->group(function () {
         Route::get('/tokens', [MobileWalletController::class, 'tokens'])
             ->middleware('api.rate_limit:query')

--- a/app/Domain/X402/Routes/api.php
+++ b/app/Domain/X402/Routes/api.php
@@ -14,7 +14,7 @@ Route::prefix('v1/x402')->name('api.x402.')->group(function () {
     Route::get('/supported', [X402StatusController::class, 'supported'])->name('supported');
 
     // Authenticated endpoints
-    Route::middleware(['auth:sanctum', 'check.token.expiration'])->group(function () {
+    Route::middleware(['auth:sanctum'])->group(function () {
         // Monetized endpoint management
         Route::get('/endpoints', [X402EndpointController::class, 'index'])->name('endpoints.index');
         Route::post('/endpoints', [X402EndpointController::class, 'store'])

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -98,6 +98,7 @@ return Application::configure(basePath: dirname(__DIR__))
             Illuminate\Routing\Middleware\SubstituteBindings::class,
             App\Http\Middleware\SecurityHeaders::class,
             App\Http\Middleware\ApiVersionMiddleware::class,
+            App\Http\Middleware\CheckTokenExpiration::class,
         ]);
 
         // Apply security headers to web routes

--- a/routes/api-modules.php
+++ b/routes/api-modules.php
@@ -18,7 +18,7 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::prefix('v2/modules')->name('api.modules.')->group(function () {
-    Route::middleware(['auth:sanctum', 'check.token.expiration'])->group(function () {
+    Route::middleware(['auth:sanctum'])->group(function () {
         Route::get('/', [ModuleController::class, 'index'])->name('index');
         Route::get('/health', [ModuleController::class, 'health'])->name('health');
         Route::get('/{name}', [ModuleController::class, 'show'])->name('show');
@@ -42,7 +42,7 @@ Route::prefix('v2/modules')->name('api.modules.')->group(function () {
 */
 
 Route::prefix('v2/plugins')->name('api.plugins.')->group(function () {
-    Route::middleware(['auth:sanctum', 'check.token.expiration'])->group(function () {
+    Route::middleware(['auth:sanctum'])->group(function () {
         Route::get('/', [PluginMarketplaceController::class, 'index'])->name('index');
         Route::get('/{id}', [PluginMarketplaceController::class, 'show'])->name('show');
 

--- a/routes/api-v2.php
+++ b/routes/api-v2.php
@@ -31,7 +31,7 @@ Route::prefix('auth')->middleware('api.rate_limit:auth')->group(function () {
     Route::post('/refresh', [App\Http\Controllers\Api\Auth\LoginController::class, 'refresh'])->middleware('throttle:20,1');
 
     // Protected auth endpoints
-    Route::middleware(['auth:sanctum', 'check.token.expiration'])->group(function () {
+    Route::middleware(['auth:sanctum'])->group(function () {
         Route::post('/logout', [App\Http\Controllers\Api\Auth\LoginController::class, 'logout']);
         Route::post('/logout-all', [App\Http\Controllers\Api\Auth\LoginController::class, 'logoutAll']);
         Route::get('/user', [App\Http\Controllers\Api\Auth\LoginController::class, 'user']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -65,7 +65,7 @@ Route::prefix('websocket')->name('api.websocket.')->group(function () {
 
 // WebSocket authenticated endpoints
 Route::prefix('websocket')->name('api.websocket.')
-    ->middleware(['auth:sanctum', 'check.token.expiration'])
+    ->middleware(['auth:sanctum'])
     ->group(function () {
         Route::get('/channels', [App\Http\Controllers\Api\WebSocketController::class, 'channels'])->name('channels');
     });
@@ -92,7 +92,7 @@ Route::prefix('auth')->middleware('api.rate_limit:auth')->group(function () {
     Route::post('/social/{provider}/callback', [SocialAuthController::class, 'callback']);
 
     // Protected auth endpoints
-    Route::middleware(['auth:sanctum', 'check.token.expiration'])->group(function () {
+    Route::middleware(['auth:sanctum'])->group(function () {
         Route::post('/logout', [LoginController::class, 'logout']);
         Route::post('/logout-all', [LoginController::class, 'logoutAll']);
         Route::get('/user', [LoginController::class, 'user']);
@@ -148,10 +148,10 @@ Route::get('/profile', function (Request $request) {
             'updated_at' => $user->updated_at,
         ],
     ]);
-})->middleware(['auth:sanctum', 'check.token.expiration']);
+})->middleware(['auth:sanctum']);
 
 // Legacy KYC documents endpoint for backward compatibility
-Route::middleware(['auth:sanctum', 'check.token.expiration'])->post('/kyc/documents', [KycController::class, 'upload']);
+Route::middleware(['auth:sanctum'])->post('/kyc/documents', [KycController::class, 'upload']);
 
 // Custodian webhook endpoints (signature verification + webhook rate limiting)
 Route::prefix('webhooks/custodian')->middleware(['api.rate_limit:webhook'])->group(function () {
@@ -175,7 +175,7 @@ Route::prefix('webhooks/ondato')->middleware(['api.rate_limit:webhook'])->group(
 });
 
 // Extended monitoring endpoints with authentication
-Route::prefix('monitoring')->middleware(['auth:sanctum', 'check.token.expiration'])->group(function () {
+Route::prefix('monitoring')->middleware(['auth:sanctum'])->group(function () {
     Route::get('/metrics-json', [App\Http\Controllers\Api\MonitoringController::class, 'metrics']);
     Route::get('/traces', [App\Http\Controllers\Api\MonitoringController::class, 'traces']);
     Route::get('/trace/{traceId}', [App\Http\Controllers\Api\MonitoringController::class, 'trace']);
@@ -192,7 +192,7 @@ Route::prefix('monitoring')->middleware(['auth:sanctum', 'check.token.expiration
 });
 
 // v5.0.0 — Live Dashboard
-Route::prefix('v1/monitoring/live-dashboard')->middleware(['auth:sanctum', 'check.token.expiration'])->group(function () {
+Route::prefix('v1/monitoring/live-dashboard')->middleware(['auth:sanctum'])->group(function () {
     Route::get('/', [App\Http\Controllers\Api\V1\LiveDashboardController::class, 'index']);
     Route::get('/domain-health', [App\Http\Controllers\Api\V1\LiveDashboardController::class, 'domainHealth']);
     Route::get('/event-throughput', [App\Http\Controllers\Api\V1\LiveDashboardController::class, 'eventThroughput']);
@@ -201,7 +201,7 @@ Route::prefix('v1/monitoring/live-dashboard')->middleware(['auth:sanctum', 'chec
 });
 
 // Admin dashboard endpoint (with 2FA requirement)
-Route::prefix('admin')->middleware(['auth:sanctum', 'check.token.expiration', 'require.2fa.admin'])->group(function () {
+Route::prefix('admin')->middleware(['auth:sanctum', 'require.2fa.admin'])->group(function () {
     Route::get('/dashboard', function () {
         return response()->json([
             'message' => 'Admin dashboard',
@@ -221,7 +221,7 @@ Route::prefix('v1/auth/passkey')
 
 // Passkey registration (requires auth) - v1 path
 Route::prefix('v1/auth/passkey')
-    ->middleware(['auth:sanctum', 'check.token.expiration', 'throttle:5,1'])
+    ->middleware(['auth:sanctum', 'throttle:5,1'])
     ->name('mobile.auth.passkey.authed.')
     ->group(function () {
         Route::post('/register-challenge', [PasskeyController::class, 'challenge'])->name('register-challenge');

--- a/routes/api/regulatory.php
+++ b/routes/api/regulatory.php
@@ -17,7 +17,7 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::middleware(['auth:sanctum', 'check.token.expiration'])->group(function () {
+Route::middleware(['auth:sanctum'])->group(function () {
     // Regulatory Reporting
     Route::prefix('regulatory')->group(function () {
         Route::get('/reports', [RegulatoryReportingController::class, 'getReports']);


### PR DESCRIPTION
## Summary
- Move `CheckTokenExpiration` from per-route middleware to the global `api` middleware group in `bootstrap/app.php`
- All API routes (including domain routes loaded via `ModuleRouteLoader`) now enforce token expiration automatically
- Remove 48 redundant per-route `check.token.expiration` middleware registrations across 29 route files
- Fix `test_token_expiration_is_enforced` security test to assert 401 for expired tokens (was a known permissive assertion)

## Test plan
- [x] `AuthenticationSecurityTest::test_token_expiration_is_enforced` now properly asserts 401
- [x] `AuthorizationSecurityTest` — all 10 tests pass
- [x] Verify no route files still reference `check.token.expiration` middleware (only alias definition remains in `bootstrap/app.php`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)