### PR TITLE
fix(security,mobile): WebAuthn COSE fixes, SSL pinning, GDPR async, notification WebSocket

### DIFF
--- a/app/Domain/Compliance/Routes/api.php
+++ b/app/Domain/Compliance/Routes/api.php
@@ -94,6 +94,7 @@ Route::middleware('auth:sanctum')->prefix('compliance')->group(function () {
         Route::get('/consent', [GdprController::class, 'consentStatus']);
         Route::post('/consent', [GdprController::class, 'updateConsent']);
         Route::post('/export', [GdprController::class, 'requestDataExport']);
+        Route::get('/export/{exportId}', [GdprController::class, 'getExportStatus']);
         Route::post('/delete', [GdprController::class, 'requestDeletion']);
         Route::get('/retention-policy', [GdprController::class, 'retentionPolicy']);
     });

--- a/app/Domain/Mobile/Events/Broadcast/NotificationCountUpdated.php
+++ b/app/Domain/Mobile/Events/Broadcast/NotificationCountUpdated.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Mobile\Events\Broadcast;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Broadcast event for real-time notification unread count updates.
+ *
+ * Fires on the user.{userId} private channel whenever
+ * the unread notification count changes (new notification, mark read, mark all read).
+ */
+class NotificationCountUpdated implements ShouldBroadcast
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public static string $queue = 'events';
+
+    public function __construct(
+        public readonly int $userId,
+        public readonly int $unreadCount,
+    ) {
+    }
+
+    /**
+     * @return array<int, PrivateChannel>
+     */
+    public function broadcastOn(): array
+    {
+        return [new PrivateChannel("user.{$this->userId}")];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'notification.count.updated';
+    }
+
+    /**
+     * @return array{unread_count: int}
+     */
+    public function broadcastWith(): array
+    {
+        return [
+            'unread_count' => $this->unreadCount,
+        ];
+    }
+}

--- a/app/Domain/Mobile/Routes/api.php
+++ b/app/Domain/Mobile/Routes/api.php
@@ -11,6 +11,10 @@ Route::prefix('v1/app')->name('api.app.')->group(function () {
     Route::get('/status', [MobileController::class, 'getAppStatus'])->name('status');
 });
 
+Route::prefix('v1/mobile')->name('api.mobile.v1.')->group(function () {
+    Route::get('/ssl-pins', [MobileController::class, 'getSslPins'])->name('ssl-pins');
+});
+
 Route::prefix('mobile')->name('api.mobile.')->group(function () {
     // Public endpoints (no auth required)
     Route::get('/config', [MobileController::class, 'getConfig'])->name('config');

--- a/app/Domain/Mobile/Services/PasskeyAuthenticationService.php
+++ b/app/Domain/Mobile/Services/PasskeyAuthenticationService.php
@@ -269,8 +269,7 @@ class PasskeyAuthenticationService
                 'displayName' => $user->name ?? $user->email,
             ],
             'pubKeyCredParams' => [
-                ['type' => 'public-key', 'alg' => -7],   // ES256 (ECDSA w/ SHA-256)
-                ['type' => 'public-key', 'alg' => -257],  // RS256 (RSASSA-PKCS1-v1_5 w/ SHA-256)
+                ['type' => 'public-key', 'alg' => -7],   // ES256 (ECDSA w/ SHA-256) — only supported algorithm
             ],
             'timeout'                => (int) config('mobile.webauthn.timeout', 60000),
             'authenticatorSelection' => [
@@ -750,14 +749,14 @@ class PasskeyAuthenticationService
             throw new RuntimeException('Unsupported COSE key type: ' . ($kty ?? 'null') . '. Only EC2 (kty=2) is supported.');
         }
 
-        // Validate algorithm: must be ES256 (alg=-7)
-        if ($alg !== null && $alg !== -7) {
-            throw new RuntimeException('Unsupported COSE algorithm: ' . $alg . '. Only ES256 (alg=-7) is supported.');
+        // Validate algorithm: must be ES256 (alg=-7), reject null (must be explicitly set)
+        if ($alg === null || $alg !== -7) {
+            throw new RuntimeException('Unsupported COSE algorithm: ' . ($alg ?? 'null') . '. Only ES256 (alg=-7) is supported.');
         }
 
-        // Validate curve: must be P-256 (crv=1)
-        if ($crv !== null && $crv !== 1) {
-            throw new RuntimeException('Unsupported COSE curve: ' . $crv . '. Only P-256 (crv=1) is supported.');
+        // Validate curve: must be P-256 (crv=1), reject null (must be explicitly set)
+        if ($crv === null || $crv !== 1) {
+            throw new RuntimeException('Unsupported COSE curve: ' . ($crv ?? 'null') . '. Only P-256 (crv=1) is supported.');
         }
 
         if ($xCoord === null || $yCoord === null) {

--- a/app/Jobs/ProcessGdprDataExport.php
+++ b/app/Jobs/ProcessGdprDataExport.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Domain\Compliance\Services\GdprService;
+use App\Models\User;
+use Exception;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Process a GDPR data export request asynchronously.
+ *
+ * Collects all user data sections and stores the result in cache
+ * for retrieval via the export status endpoint.
+ */
+class ProcessGdprDataExport implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public int $backoff = 60;
+
+    public function __construct(
+        private readonly int $userId,
+        private readonly string $exportId,
+    ) {
+        $this->onQueue('default');
+    }
+
+    public function handle(GdprService $gdprService): void
+    {
+        $user = User::find($this->userId);
+
+        if (! $user) {
+            Log::warning('GDPR export: user not found', ['user_id' => $this->userId, 'export_id' => $this->exportId]);
+            Cache::put($this->cacheKey(), [
+                'status' => 'failed',
+                'error'  => 'User not found',
+            ], now()->addHours(24));
+
+            return;
+        }
+
+        try {
+            Cache::put($this->cacheKey(), [
+                'status'     => 'processing',
+                'started_at' => now()->toIso8601String(),
+            ], now()->addHours(24));
+
+            $data = $gdprService->exportUserData($user);
+
+            Cache::put($this->cacheKey(), [
+                'status'       => 'completed',
+                'sections'     => array_keys($data),
+                'completed_at' => now()->toIso8601String(),
+            ], now()->addHours(24));
+
+            Log::info('GDPR data export completed', [
+                'user_id'   => $this->userId,
+                'export_id' => $this->exportId,
+                'sections'  => array_keys($data),
+            ]);
+        } catch (Exception $e) {
+            Log::error('GDPR data export failed', [
+                'user_id'   => $this->userId,
+                'export_id' => $this->exportId,
+                'error'     => $e->getMessage(),
+            ]);
+
+            Cache::put($this->cacheKey(), [
+                'status' => 'failed',
+                'error'  => 'Export processing failed',
+            ], now()->addHours(24));
+
+            throw $e;
+        }
+    }
+
+    private function cacheKey(): string
+    {
+        return "gdpr_export:{$this->exportId}";
+    }
+}

--- a/config/mobile.php
+++ b/config/mobile.php
@@ -251,6 +251,23 @@ return [
     |
     */
 
+    /*
+    |--------------------------------------------------------------------------
+    | SSL Certificate Pinning
+    |--------------------------------------------------------------------------
+    |
+    | SHA-256 hashes of the server's public key certificates for mobile
+    | certificate pinning. Mobile clients use these to validate the server
+    | identity and prevent MITM attacks.
+    |
+    */
+
+    'ssl_pins' => array_filter(explode(',', (string) env('MOBILE_SSL_PINS', ''))),
+
+    'ssl_pin_max_age' => env('MOBILE_SSL_PIN_MAX_AGE', 86400),
+
+    'ssl_pin_include_subdomains' => env('MOBILE_SSL_PIN_INCLUDE_SUBDOMAINS', true),
+
     'android_channels' => [
         'default' => [
             'id'          => 'finaegis_default',

--- a/tests/Feature/Api/CardIssuance/CardDetailTest.php
+++ b/tests/Feature/Api/CardIssuance/CardDetailTest.php
@@ -20,7 +20,7 @@ class CardDetailTest extends TestCase
         Cache::flush();
 
         $this->user = User::factory()->create();
-        $this->token = $this->user->createToken('test-token', ['read', 'write'])->plainTextToken;
+        $this->token = $this->user->createToken('test-token', ['read', 'write', 'delete'])->plainTextToken;
     }
 
     public function test_store_card_requires_authentication(): void

--- a/tests/Feature/Api/Mobile/BulkDeviceRemovalTest.php
+++ b/tests/Feature/Api/Mobile/BulkDeviceRemovalTest.php
@@ -20,7 +20,7 @@ class BulkDeviceRemovalTest extends TestCase
         Cache::flush();
 
         $this->user = User::factory()->create();
-        $this->token = $this->user->createToken('test-token', ['read', 'write'])->plainTextToken;
+        $this->token = $this->user->createToken('test-token', ['read', 'write', 'delete'])->plainTextToken;
     }
 
     public function test_bulk_remove_devices_requires_auth(): void

--- a/tests/Feature/Api/MobileControllerTest.php
+++ b/tests/Feature/Api/MobileControllerTest.php
@@ -21,7 +21,7 @@ class MobileControllerTest extends TestCase
         parent::setUp();
 
         $this->user = User::factory()->create();
-        $this->token = $this->user->createToken('test-token', ['read', 'write'])->plainTextToken;
+        $this->token = $this->user->createToken('test-token', ['read', 'write', 'delete'])->plainTextToken;
     }
 
     public function test_can_get_mobile_config_without_auth(): void

--- a/tests/Feature/Api/Privacy/DelegatedProofControllerTest.php
+++ b/tests/Feature/Api/Privacy/DelegatedProofControllerTest.php
@@ -24,7 +24,7 @@ class DelegatedProofControllerTest extends TestCase
         Queue::fake();
 
         $this->user = User::factory()->create();
-        $this->token = $this->user->createToken('test-token', ['read', 'write'])->plainTextToken;
+        $this->token = $this->user->createToken('test-token', ['read', 'write', 'delete'])->plainTextToken;
     }
 
     public function test_get_supported_types_returns_proof_types(): void

--- a/tests/Feature/Api/Wallet/RecoveryShardBackupTest.php
+++ b/tests/Feature/Api/Wallet/RecoveryShardBackupTest.php
@@ -21,7 +21,7 @@ class RecoveryShardBackupTest extends TestCase
         Cache::flush();
 
         $this->user = User::factory()->create();
-        $this->token = $this->user->createToken('test-token', ['read', 'write'])->plainTextToken;
+        $this->token = $this->user->createToken('test-token', ['read', 'write', 'delete'])->plainTextToken;
     }
 
     // --- Store ---


### PR DESCRIPTION
## Summary
Addresses mobile developer feedback with 4 security/functionality fixes:

- **WebAuthn COSE validation hardening**: Fixed null bypass in algorithm/curve validation; removed unsupported RS256 from `pubKeyCredParams` (only ES256 is implemented)
- **SSL pinning endpoint**: Added `GET /api/v1/mobile/ssl-pins` for certificate pinning with configurable SHA-256 hashes
- **GDPR export async**: Changed from synchronous 200 to async 202 with `ProcessGdprDataExport` job and status polling endpoint
- **Notification unread count WebSocket**: Added `NotificationCountUpdated` broadcast event on `user.{userId}` channel, fired on send/markAsRead/markAllAsRead

### Mobile Feedback Triage
| Feedback | Status | Action |
|----------|--------|--------|
| WebSocket channels missing | Already fixed v5.8.0 | None |
| Card transactions empty | Already fixed v5.8.0 | None |
| Privacy calldata route | Already exists | None |
| WebAuthn COSE validation | **Fixed** | Reject null alg/crv, remove RS256 |
| SSL pinning endpoint | **Added** | New endpoint + config |
| GDPR export never completes | **Fixed** | Async job + status polling |
| Notification count not real-time | **Fixed** | WebSocket broadcast |
| Fee estimation static | Expected in demo | None |
| Smart account timeout | Not reproducible | None |
| Rewards mocked data | Not true (DB-backed) | None |
| Force update endpoint | Already exists | None |
| Recent recipients | Works correctly | None |

Also fixes 5 test files for `EnforceMethodScope` delete scope compatibility (from PR #680).

## Test plan
- [x] PHPStan passes with 0 errors
- [x] php-cs-fixer clean
- [x] All 15 mobile API tests pass
- [x] 301/303 security tests pass (2 pre-existing CSRF failures)
- [x] 544 mobile/GDPR/notification tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)