### PR TITLE
docs: update roadmap documents for v5.9.0 release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ git status && git branch --show-current
 ### Version Status
 | Version | Status | Key Changes |
 |---------|--------|-------------|
+| v5.9.0 | ✅ Released | OpenAPI Migration & Security Hardening: Full PHP 8 attributes migration (173 files, doctrine/annotations removed), global token expiration enforcement, scope-based authorization (EnforceMethodScope), OpenBanking 501→503 cleanup, WebAuthn COSE hardening, SSL pinning endpoint, GDPR async export, notification WebSocket broadcast, 5 PRs (#679-#683) |
 | v5.8.0 | ✅ Released | Mobile Go-Live: Rewards GraphQL (35th domain) + Filament admin, Pimlico bundler production submission, Marqeta card transactions, DB merchants, Chainalysis sanctions, recovery shard backup CRUD, WebSocket mobile channels (privacy/commerce/trustcert/user), privacy calldata persistence with encrypted storage, OpenAPI PHP 8 attributes migration, 7 PRs (#670-#676) |
 | v5.7.0 | ✅ Released | Mobile Rewards & Security Hardening: Rewards/gamification domain (quests, XP/levels, points shop, streaks with race-safe locking), WebAuthn FIDO2 hardening (rpIdHash, UV/UP flags, COSE validation, origin check), recent recipients, notification unread count, route aliases, 44 feature tests |
 | v5.6.0 | ✅ Released | RAILGUN Privacy Protocol: Node.js bridge service (@railgun-community/wallet SDK), RailgunBridgeClient HTTP client, RailgunMerkleTreeService/ZkProverService, RailgunPrivacyService orchestrator (shield/unshield/transfer), RailgunWallet/ShieldedBalance models, PrivacyController integration, 57 tests, chains: Ethereum/Polygon/Arbitrum/BSC |

--- a/docs/VERSION_ROADMAP.md
+++ b/docs/VERSION_ROADMAP.md
@@ -1982,6 +1982,33 @@ The `/app` landing page rendered correctly locally but broke in production becau
 
 ---
 
-*Document Version: 5.8.0*
+## v5.9.0 — OpenAPI Migration & Security Hardening ✅ COMPLETED
+
+**Released**: March 1, 2026
+
+### Delivered
+
+| Feature | Status | Description |
+|---------|--------|-------------|
+| Token Expiration Enforcement | ✅ | Global `CheckTokenExpiration` middleware in api group |
+| Scope-Based Authorization | ✅ | `EnforceMethodScope` middleware: GET→read, POST/PUT/PATCH→write, DELETE→delete |
+| OpenBanking Cleanup | ✅ | 501 stubs replaced with 503 Service Unavailable |
+| OpenAPI PHP 8 Migration | ✅ | 173 files migrated from `@OA\` docblocks to `#[OA\]` attributes |
+| Doctrine Annotations Removed | ✅ | `doctrine/annotations` dependency removed from composer.json |
+| WebAuthn COSE Hardening | ✅ | Fixed null bypass in algorithm/curve validation, removed unsupported RS256 |
+| SSL Pinning Endpoint | ✅ | `GET /api/v1/mobile/ssl-pins` for certificate pinning |
+| GDPR Async Export | ✅ | 202 Accepted + `ProcessGdprDataExport` job + status polling |
+| Notification WebSocket | ✅ | `NotificationCountUpdated` broadcast on `user.{userId}` channel |
+
+### Key Details
+- PRs #679-#683 (5 PRs: 3 security + 1 migration + 1 mobile feedback)
+- Phase 1: Security Hardening — global token expiration, method-based scope enforcement, OpenBanking stub cleanup
+- Phase 2: OpenAPI Migration — custom `bin/migrate-openapi-v2.php` script, batch conversion, `doctrine/annotations` removed
+- Phase 3: Mobile Feedback — WebAuthn COSE fixes, SSL pinning, GDPR async, notification real-time count
+- Mobile developer feedback triaged: 4 items fixed, 4 already resolved in v5.8.0, 4 not actionable
+
+---
+
+*Document Version: 5.9.0*
 *Created: January 11, 2026*
-*Updated: March 1, 2026 (v5.8.0 Mobile Go-Live released)*
+*Updated: March 1, 2026 (v5.9.0 OpenAPI Migration & Security Hardening released)*


### PR DESCRIPTION
## Summary
- Add v5.9.0 entry to CLAUDE.md version status table
- Add v5.9.0 section to docs/VERSION_ROADMAP.md with full feature list
- Update document version markers to 5.9.0

## Test plan
- [x] Documentation only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)