### PR TITLE
feat: wire observability middleware to API group (#691)

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -77,8 +77,12 @@ return Application::configure(basePath: dirname(__DIR__))
             'tenant' => App\Http\Middleware\InitializeTenancyByTeam::class,
             // Performance monitoring middleware
             'query.performance' => App\Http\Middleware\QueryPerformanceMiddleware::class,
+            'metrics'           => App\Http\Middleware\MetricsMiddleware::class,
+            'cache.performance' => App\Http\Middleware\CachePerformance::class,
             // Structured logging middleware (v3.3.0)
             'structured.logging' => App\Http\Middleware\StructuredLoggingMiddleware::class,
+            // Distributed tracing middleware (v3.3.0)
+            'tracing' => App\Http\Middleware\TracingMiddleware::class,
             // API versioning middleware (v3.4.0)
             'api.version' => App\Http\Middleware\ApiVersionMiddleware::class,
             // X402 Payment Protocol middleware (v5.2.0)
@@ -100,6 +104,12 @@ return Application::configure(basePath: dirname(__DIR__))
             App\Http\Middleware\ApiVersionMiddleware::class,
             App\Http\Middleware\CheckTokenExpiration::class,
             App\Http\Middleware\EnforceMethodScope::class,
+            // Observability middleware stack (v5.10.0)
+            App\Http\Middleware\StructuredLoggingMiddleware::class,
+            App\Http\Middleware\MetricsMiddleware::class,
+            App\Http\Middleware\QueryPerformanceMiddleware::class,
+            App\Http\Middleware\CachePerformance::class,
+            App\Http\Middleware\TracingMiddleware::class,
         ]);
 
         // Apply security headers to web routes


### PR DESCRIPTION
## Summary
- Register missing middleware aliases: `metrics` → MetricsMiddleware, `cache.performance` → CachePerformance, `tracing` → TracingMiddleware
- Apply all 5 existing observability middleware to the `api` middleware group in order: StructuredLogging → Metrics → QueryPerformance → CachePerformance → Tracing
- All middleware have config-based enable/disable flags and are safe to apply globally

## Details
These 5 middleware were fully implemented and tested but never wired to any routes:

| Middleware | Alias | Behavior |
|------------|-------|----------|
| StructuredLoggingMiddleware | `structured.logging` | Adds X-Request-ID, trace context to logs |
| MetricsMiddleware | `metrics` | Records HTTP request metrics to cache |
| QueryPerformanceMiddleware | `query.performance` | Slow query + N+1 detection (opt-in via `PERFORMANCE_QUERY_LOGGING`) |
| CachePerformance | `cache.performance` | Cache hit rate tracking + headers |
| TracingMiddleware | `tracing` | OpenTelemetry distributed tracing (opt-in via `TRACING_ENABLED`) |

## Test plan
- [x] All 26 middleware unit tests pass
- [x] API feature tests show identical results with/without changes (79 failed / 534 passed — all failures pre-existing)
- [x] No regressions introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)