### PR TITLE
feat: standardize API error responses with error codes and request_id (#693)

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -144,6 +144,45 @@ return Application::configure(basePath: dirname(__DIR__))
             return $request->expectsJson();
         });
 
+        // Standardize API error responses (v5.10.0)
+        $exceptions->respond(function (Symfony\Component\HttpFoundation\Response $response, Throwable $e, Illuminate\Http\Request $request) {
+            if (! $response instanceof Illuminate\Http\JsonResponse) {
+                return $response;
+            }
+
+            $isApi = $request->is('api/*') || str_starts_with($request->getHost(), 'api.') || $request->expectsJson();
+            if (! $isApi) {
+                return $response;
+            }
+
+            $data = $response->getData(true);
+
+            // Map exception types to error codes
+            $errorCode = match (true) {
+                $e instanceof Illuminate\Validation\ValidationException => 'VALIDATION_ERROR',
+                $e instanceof Illuminate\Auth\AuthenticationException => 'UNAUTHENTICATED',
+                $e instanceof Illuminate\Auth\Access\AuthorizationException => 'FORBIDDEN',
+                $e instanceof Illuminate\Database\Eloquent\ModelNotFoundException => 'NOT_FOUND',
+                $e instanceof Symfony\Component\HttpKernel\Exception\NotFoundHttpException => 'NOT_FOUND',
+                $e instanceof Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException => 'METHOD_NOT_ALLOWED',
+                $e instanceof Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException => 'RATE_LIMITED',
+                $e instanceof Symfony\Component\HttpKernel\Exception\HttpException => 'HTTP_ERROR',
+                default => 'SERVER_ERROR',
+            };
+
+            // Add standardized fields without overwriting existing ones
+            if (! isset($data['error'])) {
+                $data['error'] = $errorCode;
+            }
+            if (! isset($data['request_id'])) {
+                $data['request_id'] = $request->header('X-Request-ID');
+            }
+
+            $response->setData($data);
+
+            return $response;
+        });
+
         // Don't report certain exceptions in demo environment
         $exceptions->dontReport([
             Illuminate\Auth\AuthenticationException::class,

--- a/tests/Feature/Api/StandardizedErrorResponseTest.php
+++ b/tests/Feature/Api/StandardizedErrorResponseTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+
+describe('Standardized API Error Responses', function () {
+    it('includes error code on validation errors', function () {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/api/accounts', []);
+
+        $response->assertStatus(422);
+        $response->assertJsonStructure(['message', 'errors', 'error', 'request_id']);
+        $response->assertJson(['error' => 'VALIDATION_ERROR']);
+    });
+
+    it('includes error code on 404 responses', function () {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->getJson('/api/accounts/00000000-0000-0000-0000-000000000000');
+
+        $response->assertStatus(404);
+        $json = $response->json();
+        expect($json)->toHaveKey('error');
+        expect($json)->toHaveKey('request_id');
+    });
+
+    it('includes error code on unauthenticated requests', function () {
+        $response = $this->getJson('/api/accounts');
+
+        $response->assertStatus(401);
+        $json = $response->json();
+        expect($json)->toHaveKey('error');
+        expect($json['error'])->toBe('UNAUTHENTICATED');
+    });
+
+    it('preserves existing error codes from controllers', function () {
+        $user = User::factory()->create();
+        Laravel\Sanctum\Sanctum::actingAs($user, ['delete']);
+
+        $account = \App\Domain\Account\Models\Account::factory()->forUser($user)->create([
+            'frozen' => true,
+        ]);
+
+        $response = $this->deleteJson("/api/accounts/{$account->uuid}");
+
+        // Controller returns its own error code which should not be overwritten
+        $json = $response->json();
+        expect($json)->toHaveKey('error');
+        expect($json['error'])->toBe('ACCOUNT_FROZEN');
+    });
+
+    it('includes request_id from X-Request-ID header', function () {
+        $response = $this->getJson('/api/accounts', [
+            'X-Request-ID' => 'test-req-12345',
+        ]);
+
+        $response->assertStatus(401);
+        $json = $response->json();
+        expect($json['request_id'])->toBe('test-req-12345');
+    });
+});


### PR DESCRIPTION
## Summary
- Add exception `respond` callback in `bootstrap/app.php` that enriches all API JSON error responses with consistent `error` code and `request_id` fields
- Maps exception types to semantic error codes: `VALIDATION_ERROR`, `UNAUTHENTICATED`, `FORBIDDEN`, `NOT_FOUND`, `METHOD_NOT_ALLOWED`, `RATE_LIMITED`, `HTTP_ERROR`, `SERVER_ERROR`
- Preserves existing controller-set `error` codes without overwriting (backward compatible)
- `request_id` is sourced from the `X-Request-ID` header (set by StructuredLoggingMiddleware from PR #691)

## Error response format
```json
{
  "message": "The given data was invalid.",
  "errors": { "field": ["Error detail"] },
  "error": "VALIDATION_ERROR",
  "request_id": "uuid-from-middleware"
}
```

## Test plan
- [x] 5 new tests for error response standardization
- [x] API feature tests show identical pass/fail (79 failed / 534 passed — all failures pre-existing)
- [x] Controller error codes preserved (not overwritten by handler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)