### PR TITLE
feat: add RFC 8594 deprecation headers for legacy API endpoints (#694)

### DIFF
--- a/app/Http/Middleware/ApiDeprecationMiddleware.php
+++ b/app/Http/Middleware/ApiDeprecationMiddleware.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Adds RFC 8594 Deprecation and Sunset headers for legacy API endpoints.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc8594
+ */
+class ApiDeprecationMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  string|null  $sunset  ISO 8601 date when endpoint will be removed
+     */
+    public function handle(Request $request, Closure $next, ?string $sunset = null): Response
+    {
+        $response = $next($request);
+
+        // RFC 8594: Deprecation header indicates the endpoint is deprecated
+        $response->headers->set('Deprecation', 'true');
+
+        // Link to migration guide
+        $response->headers->set('Link', '</api/v2>; rel="successor-version"');
+
+        // Sunset header: date when the endpoint will be removed
+        if ($sunset !== null) {
+            $response->headers->set('Sunset', $sunset);
+        }
+
+        return $response;
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -85,6 +85,8 @@ return Application::configure(basePath: dirname(__DIR__))
             'tracing' => App\Http\Middleware\TracingMiddleware::class,
             // API versioning middleware (v3.4.0)
             'api.version' => App\Http\Middleware\ApiVersionMiddleware::class,
+            // API deprecation headers middleware (v5.10.0)
+            'deprecated' => App\Http\Middleware\ApiDeprecationMiddleware::class,
             // X402 Payment Protocol middleware (v5.2.0)
             'x402.payment' => App\Http\Middleware\X402PaymentGateMiddleware::class,
         ]);

--- a/routes/api.php
+++ b/routes/api.php
@@ -149,10 +149,10 @@ Route::get('/profile', function (Request $request) {
             'updated_at' => $user->updated_at,
         ],
     ]);
-})->middleware(['auth:sanctum']);
+})->middleware(['auth:sanctum', 'deprecated:2026-09-01']);
 
 // Legacy KYC documents endpoint for backward compatibility
-Route::middleware(['auth:sanctum'])->post('/kyc/documents', [KycController::class, 'upload']);
+Route::middleware(['auth:sanctum', 'deprecated:2026-09-01'])->post('/kyc/documents', [KycController::class, 'upload']);
 
 // Custodian webhook endpoints (signature verification + webhook rate limiting)
 Route::prefix('webhooks/custodian')->middleware(['api.rate_limit:webhook'])->group(function () {

--- a/tests/Feature/Api/DeprecatedEndpointHeadersTest.php
+++ b/tests/Feature/Api/DeprecatedEndpointHeadersTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+
+describe('Deprecated Endpoint Headers', function () {
+    it('legacy profile endpoint includes Deprecation header', function () {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->getJson('/api/profile');
+
+        $response->assertOk();
+        expect($response->headers->get('Deprecation'))->toBe('true');
+        expect($response->headers->get('Sunset'))->toBe('2026-09-01');
+        expect($response->headers->get('Link'))->toContain('successor-version');
+    });
+
+    it('legacy KYC documents endpoint includes Deprecation header', function () {
+        $user = User::factory()->create();
+
+        // Just verify the middleware is applied (will get validation error, but headers should be present)
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/api/kyc/documents', []);
+
+        // Even on error, deprecation headers should be present
+        expect($response->headers->get('Deprecation'))->toBe('true');
+        expect($response->headers->get('Sunset'))->toBe('2026-09-01');
+    });
+
+    it('non-deprecated endpoints do not include Deprecation header', function () {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->getJson('/api/accounts');
+
+        expect($response->headers->has('Deprecation'))->toBeFalse();
+    });
+});

--- a/tests/Unit/Http/Middleware/ApiDeprecationMiddlewareTest.php
+++ b/tests/Unit/Http/Middleware/ApiDeprecationMiddlewareTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Middleware\ApiDeprecationMiddleware;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+uses(Tests\TestCase::class);
+
+describe('ApiDeprecationMiddleware', function () {
+    it('adds Deprecation header', function () {
+        $middleware = new ApiDeprecationMiddleware();
+        $request = Request::create('/api/profile', 'GET');
+
+        $response = $middleware->handle($request, fn () => new Response('ok'));
+
+        expect($response->headers->get('Deprecation'))->toBe('true');
+    });
+
+    it('adds Link header with successor version', function () {
+        $middleware = new ApiDeprecationMiddleware();
+        $request = Request::create('/api/profile', 'GET');
+
+        $response = $middleware->handle($request, fn () => new Response('ok'));
+
+        expect($response->headers->get('Link'))->toBe('</api/v2>; rel="successor-version"');
+    });
+
+    it('adds Sunset header when date provided', function () {
+        $middleware = new ApiDeprecationMiddleware();
+        $request = Request::create('/api/profile', 'GET');
+
+        $response = $middleware->handle($request, fn () => new Response('ok'), '2026-09-01');
+
+        expect($response->headers->get('Sunset'))->toBe('2026-09-01');
+    });
+
+    it('omits Sunset header when no date provided', function () {
+        $middleware = new ApiDeprecationMiddleware();
+        $request = Request::create('/api/profile', 'GET');
+
+        $response = $middleware->handle($request, fn () => new Response('ok'));
+
+        expect($response->headers->has('Sunset'))->toBeFalse();
+    });
+
+    it('does not modify response body', function () {
+        $middleware = new ApiDeprecationMiddleware();
+        $request = Request::create('/api/profile', 'GET');
+
+        $response = $middleware->handle($request, fn () => new Response('original content'));
+
+        expect($response->getContent())->toBe('original content');
+    });
+});


### PR DESCRIPTION
## Summary
- Add `ApiDeprecationMiddleware` with RFC 8594 `Deprecation`, `Sunset`, and `Link` headers
- Register as `deprecated` alias in `bootstrap/app.php`
- Apply to legacy endpoints: `GET /api/profile` and `POST /api/kyc/documents` with Sunset date 2026-09-01
- Clients receive clear signals to migrate to `/api/v2` endpoints

## Headers added
```
Deprecation: true
Sunset: 2026-09-01
Link: </api/v2>; rel="successor-version"
```

## Test plan
- [x] 5 unit tests for middleware behavior
- [x] 3 feature tests for legacy endpoint headers
- [x] Non-deprecated endpoints confirmed to not receive headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)