### PR TITLE
docs: v5.10.0 release documentation (#695)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ git status && git branch --show-current
 ### Version Status
 | Version | Status | Key Changes |
 |---------|--------|-------------|
+| v5.10.0 | ✅ Released | Performance Wiring & API Maturity: Wire 5 observability middleware to API group (StructuredLogging, Metrics, QueryPerformance, CachePerformance, Tracing), standardized API error responses (error codes + request_id), RFC 8594 deprecation headers for legacy endpoints, 11 integration tests + 13 new tests, 4 PRs (#691-#694) |
 | v5.9.0 | ✅ Released | OpenAPI Migration & Security Hardening: Full PHP 8 attributes migration (173 files, doctrine/annotations removed), global token expiration enforcement, scope-based authorization (EnforceMethodScope), OpenBanking 501→503 cleanup, WebAuthn COSE hardening, SSL pinning endpoint, GDPR async export, notification WebSocket broadcast, 5 PRs (#679-#683) |
 | v5.8.0 | ✅ Released | Mobile Go-Live: Rewards GraphQL (35th domain) + Filament admin, Pimlico bundler production submission, Marqeta card transactions, DB merchants, Chainalysis sanctions, recovery shard backup CRUD, WebSocket mobile channels (privacy/commerce/trustcert/user), privacy calldata persistence with encrypted storage, OpenAPI PHP 8 attributes migration, 7 PRs (#670-#676) |
 | v5.7.0 | ✅ Released | Mobile Rewards & Security Hardening: Rewards/gamification domain (quests, XP/levels, points shop, streaks with race-safe locking), WebAuthn FIDO2 hardening (rpIdHash, UV/UP flags, COSE validation, origin check), recent recipients, notification unread count, route aliases, 44 feature tests |

--- a/docs/VERSION_ROADMAP.md
+++ b/docs/VERSION_ROADMAP.md
@@ -2009,6 +2009,36 @@ The `/app` landing page rendered correctly locally but broke in production becau
 
 ---
 
-*Document Version: 5.9.0*
+## Version 5.10.0 - Performance Wiring & API Maturity ✅ RELEASED
+
+**Release Date**: March 2, 2026
+**Theme**: Performance Wiring & API Maturity
+
+### Summary
+
+Wire existing observability infrastructure to production routes and improve API maturity with standardized error responses and RFC 8594 deprecation headers.
+
+### Delivered Features
+
+| Feature | Status | Details |
+|---------|--------|---------|
+| Observability Middleware Wiring | ✅ | 5 middleware applied to API group: StructuredLogging, Metrics, QueryPerformance, CachePerformance, Tracing |
+| Middleware Aliases | ✅ | Register `metrics`, `cache.performance`, `tracing` aliases |
+| Standardized Error Responses | ✅ | All API errors include `error` code + `request_id` fields |
+| Error Code Mapping | ✅ | `VALIDATION_ERROR`, `UNAUTHENTICATED`, `FORBIDDEN`, `NOT_FOUND`, `RATE_LIMITED`, `SERVER_ERROR` |
+| RFC 8594 Deprecation Headers | ✅ | `Deprecation`, `Sunset`, `Link` headers on legacy endpoints |
+| Legacy Route Tagging | ✅ | `/api/profile` and `/api/kyc/documents` sunset 2026-09-01 |
+| Integration Tests | ✅ | 11 middleware integration tests + 5 error response tests + 8 deprecation tests |
+
+### Key Details
+- PRs #691-#694 (4 PRs)
+- Phase 1: Wire 5 existing observability middleware to API route group
+- Phase 2: Add comprehensive integration tests for middleware stack
+- Phase 3: Standardize API error responses with semantic error codes and request_id
+- Phase 4: RFC 8594 deprecation headers for legacy API endpoints
+
+---
+
+*Document Version: 5.10.0*
 *Created: January 11, 2026*
-*Updated: March 1, 2026 (v5.9.0 OpenAPI Migration & Security Hardening released)*
+*Updated: March 2, 2026 (v5.10.0 Performance Wiring & API Maturity released)*


### PR DESCRIPTION
## Summary
- Add v5.10.0 entry to CLAUDE.md version status table
- Add v5.10.0 section to VERSION_ROADMAP.md with full release details
- Update Serena memory with v5.10.0 release information

## v5.10.0 Release Summary
**Theme**: Performance Wiring & API Maturity

| PR | Feature |
|----|---------|
| #691 | Wire 5 observability middleware to API group |
| #692 | Integration tests for middleware stack |
| #693 | Standardized API error responses |
| #694 | RFC 8594 deprecation headers |

🤖 Generated with [Claude Code](https://claude.com/claude-code)