### PR TITLE
fix: add broadcasting/* to CORS allowed paths (#697)

### DIFF
--- a/config/cors.php
+++ b/config/cors.php
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'paths' => ['api/*', 'v1/*', 'v2/*', 'auth/*', 'sanctum/csrf-cookie'],
+    'paths' => ['api/*', 'v1/*', 'v2/*', 'auth/*', 'broadcasting/*', 'sanctum/csrf-cookie'],
 
     'allowed_methods' => ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
 


### PR DESCRIPTION
## Summary
- Add `broadcasting/*` to CORS allowed paths in `config/cors.php`
- Enables cross-origin WebSocket/Pusher channel authentication from the mobile app

🤖 Generated with [Claude Code](https://claude.com/claude-code)