### PR TITLE
fix: use api + sanctum middleware for broadcasting auth (#698)

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -48,7 +48,9 @@ return Application::configure(basePath: dirname(__DIR__))
         commands: __DIR__ . '/../routes/console.php',
         health: '/up',
     )
-    ->withBroadcasting(base_path('routes/channels.php'))
+    ->withBroadcasting(base_path('routes/channels.php'), [
+        'middleware' => ['api', 'auth:sanctum'],
+    ])
     ->withMiddleware(function (Middleware $middleware) {
         // Register rate limiting middleware
         $middleware->alias([


### PR DESCRIPTION
## Summary
- Change broadcasting auth middleware from `web` (session/cookies) to `api` + `auth:sanctum` (Bearer tokens)
- Mobile apps authenticate WebSocket channels via Sanctum tokens, which requires the API middleware stack

## Problem
Broadcasting channel auth endpoint used `web` middleware by default, requiring session cookies. Mobile apps use Bearer tokens via Sanctum and couldn't authenticate WebSocket channels.

## Test plan
- [x] Mobile app can authenticate broadcasting channels with Bearer token

🤖 Generated with [Claude Code](https://claude.com/claude-code)