### PR TITLE
feat: GDPR export download + recovery shard blob storage

### DIFF
--- a/app/Domain/Compliance/Routes/api.php
+++ b/app/Domain/Compliance/Routes/api.php
@@ -95,6 +95,7 @@ Route::middleware('auth:sanctum')->prefix('compliance')->group(function () {
         Route::post('/consent', [GdprController::class, 'updateConsent']);
         Route::post('/export', [GdprController::class, 'requestDataExport']);
         Route::get('/export/{exportId}', [GdprController::class, 'getExportStatus']);
+        Route::get('/export/{exportId}/download', [GdprController::class, 'downloadExport']);
         Route::post('/delete', [GdprController::class, 'requestDeletion']);
         Route::get('/retention-policy', [GdprController::class, 'retentionPolicy']);
     });

--- a/app/Domain/KeyManagement/Models/RecoveryShardCloudBackup.php
+++ b/app/Domain/KeyManagement/Models/RecoveryShardCloudBackup.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string $backup_provider
  * @property string $encrypted_shard_hash
  * @property string $shard_version
+ * @property string|null $encrypted_shard
  * @property array<string, mixed>|null $metadata
  * @property \Carbon\Carbon $created_at
  * @property \Carbon\Carbon $updated_at
@@ -41,11 +42,17 @@ class RecoveryShardCloudBackup extends Model
         'backup_provider',
         'encrypted_shard_hash',
         'shard_version',
+        'encrypted_shard',
         'metadata',
     ];
 
+    protected $hidden = [
+        'encrypted_shard',
+    ];
+
     protected $casts = [
-        'metadata' => 'array',
+        'metadata'        => 'array',
+        'encrypted_shard' => 'encrypted',
     ];
 
     /**

--- a/app/Domain/Mobile/Routes/api.php
+++ b/app/Domain/Mobile/Routes/api.php
@@ -95,4 +95,12 @@ Route::prefix('v1/user')->name('api.user.')
         Route::post('/data-export', [App\Http\Controllers\Api\GdprController::class, 'requestDataExport'])
             ->middleware('api.rate_limit:mutation')
             ->name('data-export');
+
+        // Data export status polling (mobile expects GET /api/v1/user/data-export/{exportId})
+        Route::get('/data-export/{exportId}', [App\Http\Controllers\Api\GdprController::class, 'getExportStatus'])
+            ->name('data-export.status');
+
+        // Data export download (signed URL)
+        Route::get('/data-export/{exportId}/download', [App\Http\Controllers\Api\GdprController::class, 'downloadExport'])
+            ->name('data-export.download');
     });

--- a/app/Domain/Wallet/Routes/api.php
+++ b/app/Domain/Wallet/Routes/api.php
@@ -151,6 +151,8 @@ Route::prefix('v1/wallet')->name('mobile.wallet.')
             ->name('recovery-shard-backup.store');
         Route::get('/recovery-shard-backup', [RecoveryShardController::class, 'show'])
             ->name('recovery-shard-backup.show');
+        Route::get('/recovery-shard-backup/retrieve', [RecoveryShardController::class, 'retrieve'])
+            ->name('recovery-shard-backup.retrieve');
         Route::delete('/recovery-shard-backup', [RecoveryShardController::class, 'destroy'])
             ->name('recovery-shard-backup.destroy');
     });

--- a/app/Http/Controllers/Api/GdprController.php
+++ b/app/Http/Controllers/Api/GdprController.php
@@ -11,6 +11,7 @@ use Exception;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
 use OpenApi\Attributes as OA;
 
 #[OA\Tag(
@@ -208,10 +209,73 @@ class GdprController extends Controller
             ], 404);
         }
 
-        return response()->json(array_merge(
+        $response = array_merge(
             ['export_id' => $exportId],
             (array) $status,
-        ));
+        );
+
+        // Regenerate a fresh signed download URL if export is completed
+        if (($response['status'] ?? '') === 'completed' && ! empty($response['file_path'])) {
+            $response['download_url'] = \Illuminate\Support\Facades\URL::signedRoute(
+                'api.user.data-export.download',
+                ['exportId' => $exportId],
+                now()->addHour(),
+            );
+            unset($response['file_path']);
+        }
+
+        return response()->json($response);
+    }
+
+    #[OA\Get(
+        path: '/api/v1/user/data-export/{exportId}/download',
+        operationId: 'downloadGdprExport',
+        tags: ['GDPR'],
+        summary: 'Download completed GDPR data export',
+        description: 'Download the exported data as a JSON file. Requires a valid signed URL.',
+        security: [['sanctum' => []]],
+        parameters: [
+        new OA\Parameter(name: 'exportId', in: 'path', required: true, description: 'Export request ID', schema: new OA\Schema(type: 'string', format: 'uuid')),
+        ]
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'JSON file download',
+        content: new OA\JsonContent(type: 'object')
+    )]
+    #[OA\Response(
+        response: 403,
+        description: 'Invalid or expired signature'
+    )]
+    #[OA\Response(
+        response: 404,
+        description: 'Export file not found'
+    )]
+    public function downloadExport(Request $request, string $exportId): JsonResponse|\Symfony\Component\HttpFoundation\Response
+    {
+        if (! $request->hasValidSignature()) {
+            return response()->json(['error' => 'Invalid or expired download link.'], 403);
+        }
+
+        $cacheKey = "gdpr_export:{$exportId}";
+        $status = \Illuminate\Support\Facades\Cache::get($cacheKey);
+
+        if ($status === null || ($status['status'] ?? '') !== 'completed') {
+            return response()->json(['error' => 'Export not found or not yet completed.'], 404);
+        }
+
+        $filePath = $status['file_path'] ?? "gdpr-exports/{$exportId}.json.enc";
+
+        if (! Storage::disk('local')->exists($filePath)) {
+            return response()->json(['error' => 'Export file not found or expired.'], 404);
+        }
+
+        $decrypted = decrypt((string) Storage::disk('local')->get($filePath));
+
+        return response($decrypted, 200, [
+            'Content-Type'        => 'application/json',
+            'Content-Disposition' => "attachment; filename=\"gdpr-export-{$exportId}.json\"",
+        ]);
     }
 
         #[OA\Post(

--- a/app/Http/Controllers/Api/Wallet/RecoveryShardController.php
+++ b/app/Http/Controllers/Api/Wallet/RecoveryShardController.php
@@ -52,8 +52,19 @@ class RecoveryShardController extends Controller
             'backup_provider'      => ['required', 'string', 'in:icloud,google_drive,manual'],
             'encrypted_shard_hash' => ['required', 'string', 'max:255'],
             'shard_version'        => ['required', 'string', 'max:50'],
+            'encrypted_shard'      => ['nullable', 'string', 'max:65535'],
             'metadata'             => ['nullable', 'array'],
         ]);
+
+        $updateData = [
+            'encrypted_shard_hash' => $validated['encrypted_shard_hash'],
+            'shard_version'        => $validated['shard_version'],
+            'metadata'             => $validated['metadata'] ?? null,
+        ];
+
+        if (array_key_exists('encrypted_shard', $validated)) {
+            $updateData['encrypted_shard'] = $validated['encrypted_shard'];
+        }
 
         $backup = RecoveryShardCloudBackup::updateOrCreate(
             [
@@ -61,11 +72,7 @@ class RecoveryShardController extends Controller
                 'device_id'       => $validated['device_id'],
                 'backup_provider' => $validated['backup_provider'],
             ],
-            [
-                'encrypted_shard_hash' => $validated['encrypted_shard_hash'],
-                'shard_version'        => $validated['shard_version'],
-                'metadata'             => $validated['metadata'] ?? null,
-            ],
+            $updateData,
         );
 
         return response()->json([
@@ -185,6 +192,72 @@ class RecoveryShardController extends Controller
         return response()->json([
             'success' => true,
             'message' => 'Recovery shard backup deleted.',
+        ]);
+    }
+
+        #[OA\Get(
+            path: '/api/v1/wallet/recovery-shard-backup/retrieve',
+            operationId: 'retrieveRecoveryShardBackup',
+            summary: 'Retrieve the encrypted shard blob for a specific device and provider',
+            tags: ['Recovery Shard Backup'],
+            security: [['sanctum' => []]],
+            parameters: [
+        new OA\Parameter(name: 'device_id', in: 'query', required: true, schema: new OA\Schema(type: 'string')),
+        new OA\Parameter(name: 'backup_provider', in: 'query', required: true, schema: new OA\Schema(type: 'string', enum: ['icloud', 'google_drive', 'manual'])),
+        ]
+        )]
+    #[OA\Response(
+        response: 200,
+        description: 'Encrypted shard retrieved',
+        content: new OA\JsonContent(properties: [
+        new OA\Property(property: 'success', type: 'boolean', example: true),
+        new OA\Property(property: 'data', type: 'object', properties: [
+        new OA\Property(property: 'encrypted_shard', type: 'string', description: 'Base64-encoded encrypted shard blob'),
+        new OA\Property(property: 'shard_version', type: 'string', example: 'v1'),
+        new OA\Property(property: 'encrypted_shard_hash', type: 'string', example: 'sha256hash...'),
+        ]),
+        ])
+    )]
+    #[OA\Response(
+        response: 404,
+        description: 'Backup not found'
+    )]
+    #[OA\Response(
+        response: 422,
+        description: 'Validation error'
+    )]
+    public function retrieve(Request $request): JsonResponse
+    {
+        /** @var \App\Models\User $user */
+        $user = $request->user();
+
+        $validated = $request->validate([
+            'device_id'       => ['required', 'string'],
+            'backup_provider' => ['required', 'string', 'in:icloud,google_drive,manual'],
+        ]);
+
+        $backup = RecoveryShardCloudBackup::where('user_id', $user->id)
+            ->where('device_id', $validated['device_id'])
+            ->where('backup_provider', $validated['backup_provider'])
+            ->first();
+
+        if (! $backup || $backup->encrypted_shard === null) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'SHARD_NOT_FOUND',
+                    'message' => 'No encrypted shard found for the specified device and provider.',
+                ],
+            ], 404);
+        }
+
+        return response()->json([
+            'success' => true,
+            'data'    => [
+                'encrypted_shard'      => $backup->encrypted_shard,
+                'shard_version'        => $backup->shard_version,
+                'encrypted_shard_hash' => $backup->encrypted_shard_hash,
+            ],
         ]);
     }
 }

--- a/app/Jobs/ProcessGdprDataExport.php
+++ b/app/Jobs/ProcessGdprDataExport.php
@@ -14,6 +14,8 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\URL;
 
 /**
  * Process a GDPR data export request asynchronously.
@@ -61,10 +63,23 @@ class ProcessGdprDataExport implements ShouldQueue
 
             $data = $gdprService->exportUserData($user);
 
+            // Write encrypted export to disk for download
+            $filePath = "gdpr-exports/{$this->exportId}.json.enc";
+            $jsonData = json_encode($data, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
+            Storage::disk('local')->put($filePath, encrypt($jsonData));
+
+            $downloadUrl = URL::signedRoute(
+                'api.user.data-export.download',
+                ['exportId' => $this->exportId],
+                now()->addHour(),
+            );
+
             Cache::put($this->cacheKey(), [
                 'status'       => 'completed',
                 'sections'     => array_keys($data),
                 'completed_at' => now()->toIso8601String(),
+                'file_path'    => $filePath,
+                'download_url' => $downloadUrl,
             ], now()->addHours(24));
 
             Log::info('GDPR data export completed', [

--- a/database/migrations/2026_03_02_100000_add_encrypted_shard_to_recovery_shard_cloud_backups.php
+++ b/database/migrations/2026_03_02_100000_add_encrypted_shard_to_recovery_shard_cloud_backups.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('recovery_shard_cloud_backups', function (Blueprint $table) {
+            $table->binary('encrypted_shard')->nullable()->after('shard_version');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('recovery_shard_cloud_backups', function (Blueprint $table) {
+            $table->dropColumn('encrypted_shard');
+        });
+    }
+};

--- a/tests/Feature/Api/GdprExportDownloadTest.php
+++ b/tests/Feature/Api/GdprExportDownloadTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Domain\Compliance\Services\GdprService;
+use App\Jobs\ProcessGdprDataExport;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\URL;
+use Tests\TestCase;
+
+class GdprExportDownloadTest extends TestCase
+{
+    protected User $user;
+
+    protected string $token;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+        Storage::fake('local');
+
+        $this->user = User::factory()->create();
+        $this->token = $this->user->createToken('test-token', ['read', 'write'])->plainTextToken;
+    }
+
+    // --- GET /api/v1/user/data-export/{exportId} status polling ---
+
+    public function test_get_export_status_via_mobile_route(): void
+    {
+        $exportId = 'test-export-001';
+        Cache::put("gdpr_export:{$exportId}", [
+            'status'     => 'processing',
+            'started_at' => now()->toIso8601String(),
+        ], now()->addHours(24));
+
+        $response = $this->withToken($this->token)
+            ->getJson("/api/v1/user/data-export/{$exportId}");
+
+        $response->assertOk()
+            ->assertJsonPath('export_id', $exportId)
+            ->assertJsonPath('status', 'processing');
+    }
+
+    public function test_get_export_status_returns_404_when_not_found(): void
+    {
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/user/data-export/nonexistent');
+
+        $response->assertNotFound()
+            ->assertJsonPath('error', 'Export request not found or expired');
+    }
+
+    public function test_get_export_status_includes_download_url_when_completed(): void
+    {
+        $exportId = 'test-export-dl';
+        $filePath = "gdpr-exports/{$exportId}.json.enc";
+
+        Storage::disk('local')->put($filePath, encrypt(json_encode(['profile' => ['name' => 'Test']])));
+
+        Cache::put("gdpr_export:{$exportId}", [
+            'status'       => 'completed',
+            'sections'     => ['profile'],
+            'completed_at' => now()->toIso8601String(),
+            'file_path'    => $filePath,
+        ], now()->addHours(24));
+
+        $response = $this->withToken($this->token)
+            ->getJson("/api/v1/user/data-export/{$exportId}");
+
+        $response->assertOk()
+            ->assertJsonPath('status', 'completed')
+            ->assertJsonStructure(['download_url'])
+            ->assertJsonMissing(['file_path']);
+    }
+
+    public function test_get_export_status_requires_authentication(): void
+    {
+        $response = $this->getJson('/api/v1/user/data-export/some-id');
+
+        $response->assertUnauthorized();
+    }
+
+    // --- Download endpoint ---
+
+    public function test_download_export_returns_json_file(): void
+    {
+        $exportId = 'test-download';
+        $exportData = ['profile' => ['name' => 'John', 'email' => 'john@example.com']];
+        $filePath = "gdpr-exports/{$exportId}.json.enc";
+
+        Storage::disk('local')->put($filePath, encrypt(json_encode($exportData)));
+
+        Cache::put("gdpr_export:{$exportId}", [
+            'status'    => 'completed',
+            'sections'  => ['profile'],
+            'file_path' => $filePath,
+        ], now()->addHours(24));
+
+        $signedUrl = URL::signedRoute(
+            'api.user.data-export.download',
+            ['exportId' => $exportId],
+            now()->addHour(),
+        );
+
+        $response = $this->withToken($this->token)->get($signedUrl);
+
+        $response->assertOk()
+            ->assertHeader('Content-Type', 'application/json')
+            ->assertHeader('Content-Disposition', "attachment; filename=\"gdpr-export-{$exportId}.json\"");
+
+        $this->assertEquals($exportData, json_decode($response->getContent(), true));
+    }
+
+    public function test_download_with_invalid_signature_returns_403(): void
+    {
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/user/data-export/some-id/download?signature=invalid');
+
+        $response->assertStatus(403);
+    }
+
+    public function test_download_returns_404_when_export_not_completed(): void
+    {
+        $exportId = 'test-pending';
+        Cache::put("gdpr_export:{$exportId}", [
+            'status' => 'processing',
+        ], now()->addHours(24));
+
+        $signedUrl = URL::signedRoute(
+            'api.user.data-export.download',
+            ['exportId' => $exportId],
+            now()->addHour(),
+        );
+
+        $response = $this->withToken($this->token)->get($signedUrl);
+
+        $response->assertNotFound();
+    }
+
+    public function test_download_returns_404_when_file_missing(): void
+    {
+        $exportId = 'test-missing-file';
+        Cache::put("gdpr_export:{$exportId}", [
+            'status'    => 'completed',
+            'file_path' => "gdpr-exports/{$exportId}.json.enc",
+        ], now()->addHours(24));
+
+        $signedUrl = URL::signedRoute(
+            'api.user.data-export.download',
+            ['exportId' => $exportId],
+            now()->addHour(),
+        );
+
+        $response = $this->withToken($this->token)->get($signedUrl);
+
+        $response->assertNotFound();
+    }
+
+    // --- Export file is encrypted at rest ---
+
+    public function test_export_file_is_encrypted_at_rest(): void
+    {
+        $exportId = 'test-encrypted';
+        $exportData = ['profile' => ['name' => 'Sensitive User']];
+        $filePath = "gdpr-exports/{$exportId}.json.enc";
+
+        $encrypted = encrypt(json_encode($exportData));
+        Storage::disk('local')->put($filePath, $encrypted);
+
+        $rawContent = Storage::disk('local')->get($filePath);
+
+        // Raw file should not contain the plaintext
+        $this->assertStringNotContainsString('Sensitive User', $rawContent);
+
+        // But decrypting should yield the original data
+        $decrypted = json_decode(decrypt($rawContent), true);
+        $this->assertEquals($exportData, $decrypted);
+    }
+
+    // --- Job integration ---
+
+    public function test_job_writes_file_and_sets_cache_with_download_url(): void
+    {
+        $this->mock(GdprService::class, function ($mock) {
+            $mock->shouldReceive('exportUserData')
+                ->once()
+                ->andReturn([
+                    'profile'      => ['name' => 'Test User'],
+                    'transactions' => [],
+                ]);
+        });
+
+        $exportId = 'job-test-export';
+        $job = new ProcessGdprDataExport($this->user->id, $exportId);
+        $job->handle(app(GdprService::class));
+
+        // File should exist
+        $this->assertTrue(Storage::disk('local')->exists("gdpr-exports/{$exportId}.json.enc"));
+
+        // Cache should have completed status with download_url
+        $cached = Cache::get("gdpr_export:{$exportId}");
+        $this->assertEquals('completed', $cached['status']);
+        $this->assertArrayHasKey('download_url', $cached);
+        $this->assertArrayHasKey('file_path', $cached);
+        $this->assertEquals(['profile', 'transactions'], $cached['sections']);
+    }
+
+    // --- Route existence ---
+
+    public function test_mobile_data_export_routes_exist(): void
+    {
+        $routes = app('router')->getRoutes();
+        $this->assertNotNull($routes->getByName('api.user.data-export'));
+        $this->assertNotNull($routes->getByName('api.user.data-export.status'));
+        $this->assertNotNull($routes->getByName('api.user.data-export.download'));
+    }
+}

--- a/tests/Feature/Api/Wallet/RecoveryShardBlobTest.php
+++ b/tests/Feature/Api/Wallet/RecoveryShardBlobTest.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\Wallet;
+
+use App\Domain\KeyManagement\Models\RecoveryShardCloudBackup;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class RecoveryShardBlobTest extends TestCase
+{
+    protected User $user;
+
+    protected string $token;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+
+        $this->user = User::factory()->create();
+        $this->token = $this->user->createToken('test-token', ['read', 'write', 'delete'])->plainTextToken;
+    }
+
+    // --- Store with encrypted_shard ---
+
+    public function test_store_with_encrypted_shard_saves_blob(): void
+    {
+        $shardData = base64_encode('encrypted-shard-binary-data');
+
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/wallet/recovery-shard-backup', [
+                'device_id'            => 'device_001',
+                'backup_provider'      => 'icloud',
+                'encrypted_shard_hash' => hash('sha256', $shardData),
+                'shard_version'        => 'v1',
+                'encrypted_shard'      => $shardData,
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.device_id', 'device_001');
+
+        // Verify the shard was stored (encrypted at rest via model cast)
+        $backup = RecoveryShardCloudBackup::where('user_id', $this->user->id)
+            ->where('device_id', 'device_001')
+            ->first();
+
+        $this->assertNotNull($backup);
+        $this->assertEquals($shardData, $backup->encrypted_shard);
+    }
+
+    public function test_store_without_encrypted_shard_still_works(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/wallet/recovery-shard-backup', [
+                'device_id'            => 'device_002',
+                'backup_provider'      => 'google_drive',
+                'encrypted_shard_hash' => 'sha256_hash',
+                'shard_version'        => 'v1',
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('success', true);
+
+        $backup = RecoveryShardCloudBackup::where('user_id', $this->user->id)
+            ->where('device_id', 'device_002')
+            ->first();
+
+        $this->assertNotNull($backup);
+        $this->assertNull($backup->encrypted_shard);
+    }
+
+    public function test_store_validates_encrypted_shard_max_length(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/wallet/recovery-shard-backup', [
+                'device_id'            => 'device_001',
+                'backup_provider'      => 'icloud',
+                'encrypted_shard_hash' => 'hash',
+                'shard_version'        => 'v1',
+                'encrypted_shard'      => str_repeat('x', 65536),
+            ]);
+
+        $response->assertUnprocessable();
+    }
+
+    // --- Retrieve endpoint ---
+
+    public function test_retrieve_returns_encrypted_shard(): void
+    {
+        $shardData = base64_encode('my-secret-shard');
+
+        RecoveryShardCloudBackup::create([
+            'user_id'              => $this->user->id,
+            'device_id'            => 'device_001',
+            'backup_provider'      => 'icloud',
+            'encrypted_shard_hash' => hash('sha256', $shardData),
+            'shard_version'        => 'v1',
+            'encrypted_shard'      => $shardData,
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/wallet/recovery-shard-backup/retrieve?device_id=device_001&backup_provider=icloud');
+
+        $response->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.encrypted_shard', $shardData)
+            ->assertJsonPath('data.shard_version', 'v1')
+            ->assertJsonPath('data.encrypted_shard_hash', hash('sha256', $shardData));
+    }
+
+    public function test_retrieve_returns_404_when_no_backup(): void
+    {
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/wallet/recovery-shard-backup/retrieve?device_id=nonexistent&backup_provider=icloud');
+
+        $response->assertNotFound()
+            ->assertJsonPath('success', false)
+            ->assertJsonPath('error.code', 'SHARD_NOT_FOUND');
+    }
+
+    public function test_retrieve_returns_404_when_no_shard_blob(): void
+    {
+        // Backup exists but without encrypted_shard (metadata-only)
+        RecoveryShardCloudBackup::create([
+            'user_id'              => $this->user->id,
+            'device_id'            => 'device_meta',
+            'backup_provider'      => 'manual',
+            'encrypted_shard_hash' => 'some_hash',
+            'shard_version'        => 'v1',
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/wallet/recovery-shard-backup/retrieve?device_id=device_meta&backup_provider=manual');
+
+        $response->assertNotFound()
+            ->assertJsonPath('error.code', 'SHARD_NOT_FOUND');
+    }
+
+    public function test_retrieve_requires_authentication(): void
+    {
+        $response = $this->getJson('/api/v1/wallet/recovery-shard-backup/retrieve?device_id=d&backup_provider=icloud');
+
+        $response->assertUnauthorized();
+    }
+
+    public function test_retrieve_validates_required_params(): void
+    {
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/wallet/recovery-shard-backup/retrieve');
+
+        $response->assertUnprocessable();
+    }
+
+    public function test_retrieve_does_not_return_other_users_shard(): void
+    {
+        $otherUser = User::factory()->create();
+
+        RecoveryShardCloudBackup::create([
+            'user_id'              => $otherUser->id,
+            'device_id'            => 'device_001',
+            'backup_provider'      => 'icloud',
+            'encrypted_shard_hash' => 'hash',
+            'shard_version'        => 'v1',
+            'encrypted_shard'      => base64_encode('other-user-shard'),
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/wallet/recovery-shard-backup/retrieve?device_id=device_001&backup_provider=icloud');
+
+        $response->assertNotFound();
+    }
+
+    // --- $hidden test ---
+
+    public function test_encrypted_shard_is_hidden_in_default_serialization(): void
+    {
+        $shardData = base64_encode('hidden-shard');
+
+        $backup = RecoveryShardCloudBackup::create([
+            'user_id'              => $this->user->id,
+            'device_id'            => 'device_hidden',
+            'backup_provider'      => 'icloud',
+            'encrypted_shard_hash' => 'hash',
+            'shard_version'        => 'v1',
+            'encrypted_shard'      => $shardData,
+        ]);
+
+        $json = $backup->toArray();
+
+        $this->assertArrayNotHasKey('encrypted_shard', $json);
+    }
+
+    // --- Show (list) endpoint does NOT leak encrypted_shard ---
+
+    public function test_show_list_does_not_include_encrypted_shard(): void
+    {
+        RecoveryShardCloudBackup::create([
+            'user_id'              => $this->user->id,
+            'device_id'            => 'device_list',
+            'backup_provider'      => 'icloud',
+            'encrypted_shard_hash' => 'hash',
+            'shard_version'        => 'v1',
+            'encrypted_shard'      => base64_encode('should-not-appear'),
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/wallet/recovery-shard-backup');
+
+        $response->assertOk()
+            ->assertJsonMissing(['encrypted_shard']);
+    }
+
+    // --- Route existence ---
+
+    public function test_retrieve_route_exists(): void
+    {
+        $routes = app('router')->getRoutes();
+        $this->assertNotNull($routes->getByName('mobile.wallet.recovery-shard-backup.retrieve'));
+    }
+}


### PR DESCRIPTION
## Summary

- **GDPR data export download**: Export job now writes encrypted JSON to disk and provides signed download URLs. Added `GET /api/v1/user/data-export/{exportId}` status polling route and `GET /api/v1/user/data-export/{exportId}/download` signed download endpoint.
- **Recovery shard blob storage**: Added `encrypted_shard` BLOB column (with Laravel `encrypted` cast for at-rest encryption), updated `store()` to accept optional shard blob, added `GET /api/v1/wallet/recovery-shard-backup/retrieve` endpoint for retrieving stored shards.
- 23 new feature tests across both features, all existing tests pass with no regressions.

### Mobile Developer Handoff

1. **Data export status**: `GET /api/v1/user/data-export/{exportId}` now works
2. **Data export download**: When status is `completed`, response includes `download_url`. Signed, expires in 1 hour.
3. **Recovery shard backup**: `POST /api/v1/wallet/recovery-shard-backup` now accepts optional `encrypted_shard` (base64). `GET /api/v1/wallet/recovery-shard-backup/retrieve?device_id=xxx&backup_provider=icloud` returns the stored shard.

## Test plan

- [x] 11 GDPR export download tests pass
- [x] 12 recovery shard blob tests pass
- [x] 15 existing recovery shard backup tests pass (no regressions)
- [ ] Run full CI pipeline
- [ ] Verify migration runs cleanly on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)