### PR TITLE
fix: update stale version numbers and domain counts across website

### DIFF
--- a/resources/views/about.blade.php
+++ b/resources/views/about.blade.php
@@ -61,7 +61,7 @@
                 </div>
                 <h1 class="text-5xl font-bold text-gray-900 mb-6">About FinAegis</h1>
                 <p class="text-xl text-gray-600 max-w-3xl mx-auto">
-                    Open-source core banking infrastructure built with Laravel—42 domain modules covering everything from democratic currency governance to AI agent commerce.
+                    Open-source core banking infrastructure built with Laravel—43 domain modules covering everything from democratic currency governance to AI agent commerce.
                 </p>
             </div>
         </div>
@@ -236,7 +236,7 @@
                 <div class="timeline-item mb-12">
                     <h3 class="text-xl font-bold text-gray-900 mb-2">GraphQL API</h3>
                     <p class="text-gray-600">
-                        Lighthouse-powered GraphQL covering 34 domains with real-time subscriptions, N+1 safe DataLoaders, and cursor-based pagination alongside REST/OpenAPI.
+                        Lighthouse-powered GraphQL covering 35 domains with real-time subscriptions, N+1 safe DataLoaders, and cursor-based pagination alongside REST/OpenAPI.
                     </p>
                 </div>
                 <div class="timeline-item mb-12">
@@ -305,7 +305,7 @@
                     <div class="bg-white rounded-xl shadow-lg p-6">
                         <h4 class="text-xl font-bold text-gray-900 mb-3">For Founders</h4>
                         <p class="text-gray-600 mb-4">
-                            Build your fintech product on battle-tested infrastructure. 42 domain modules, MIT licensed, ready to customize.
+                            Build your fintech product on battle-tested infrastructure. 43 domain modules, MIT licensed, ready to customize.
                         </p>
                         <a href="{{ route('developers') }}" class="text-indigo-600 font-semibold hover:text-indigo-700">
                             View Documentation →

--- a/resources/views/developers/api-docs.blade.php
+++ b/resources/views/developers/api-docs.blade.php
@@ -1250,8 +1250,8 @@ curl -H "Authorization: Bearer your_api_key" \
                         <h2 class="text-3xl font-bold text-gray-900 mb-8">GraphQL API</h2>
 
                         <div class="prose prose-lg max-w-none mb-8">
-                            <p>Schema-first GraphQL API powered by Lighthouse PHP. Provides queries, mutations, and subscriptions across 34 domain schemas with DataLoader-optimized resolvers and WebSocket-based real-time subscriptions.</p>
-                            <p class="text-sm text-gray-500">34 domain schemas &middot; Queries, Mutations, Subscriptions</p>
+                            <p>Schema-first GraphQL API powered by Lighthouse PHP. Provides queries, mutations, and subscriptions across 35 domain schemas with DataLoader-optimized resolvers and WebSocket-based real-time subscriptions.</p>
+                            <p class="text-sm text-gray-500">35 domain schemas &middot; Queries, Mutations, Subscriptions</p>
                         </div>
 
                         <div class="space-y-8">
@@ -1263,7 +1263,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                         <span class="ml-2 font-mono text-sm">/graphql</span>
                                     </div>
                                 </div>
-                                <p class="text-gray-600 mb-4">Execute a GraphQL query or mutation against the unified schema. Supports all 34 domain schemas including Account, AgentProtocol, Basket, Batch, CardIssuance, Cgo, Compliance, CrossChain, DeFi, Exchange, FinancialInstitution, Product, Regulatory, User, Wallet, and more.</p>
+                                <p class="text-gray-600 mb-4">Execute a GraphQL query or mutation against the unified schema. Supports all 35 domain schemas including Account, AgentProtocol, Basket, Batch, CardIssuance, Cgo, Compliance, CrossChain, DeFi, Exchange, FinancialInstitution, Product, Regulatory, User, Wallet, and more.</p>
                                 <x-code-block language="bash">
 curl -X POST \
   -H "Authorization: Bearer your_api_key" \
@@ -1572,7 +1572,7 @@ if (response.status === 402) {
                                 <li><a href="#mobile-payment" class="text-violet-600 hover:text-violet-800 flex justify-between"><span>Mobile Payment</span><span class="text-gray-400">25+ routes</span></a></li>
                                 <li><a href="#partner-baas" class="text-rose-600 hover:text-rose-800 flex justify-between"><span>Partner BaaS</span><span class="text-gray-400">24 routes</span></a></li>
                                 <li><a href="#ai" class="text-gray-600 hover:text-gray-800 flex justify-between"><span>AI Query</span><span class="text-gray-400">2 routes</span></a></li>
-                                <li><a href="#graphql" class="text-sky-600 hover:text-sky-800 flex justify-between"><span>GraphQL</span><span class="text-gray-400">34 domains</span></a></li>
+                                <li><a href="#graphql" class="text-sky-600 hover:text-sky-800 flex justify-between"><span>GraphQL</span><span class="text-gray-400">35 domains</span></a></li>
                                 <li><a href="#event-streaming" class="text-lime-600 hover:text-lime-800 flex justify-between"><span>Event Streaming</span><span class="text-gray-400">5 endpoints</span></a></li>
                                 <li><a href="#x402" class="text-emerald-600 hover:text-emerald-800 flex justify-between"><span>x402 Protocol</span><span class="text-gray-400">15+ endpoints</span></a></li>
                             </ul>

--- a/resources/views/developers/index.blade.php
+++ b/resources/views/developers/index.blade.php
@@ -140,7 +140,7 @@
                 <div class="text-center">
                     <div class="inline-flex items-center px-4 py-2 bg-white/10 backdrop-blur-sm rounded-full text-sm mb-6">
                         <span class="w-2 h-2 bg-green-400 rounded-full mr-2 animate-pulse"></span>
-                        <span>v5.4 Documentation — 42 Domains, 1,200+ Routes, GraphQL + REST + x402</span>
+                        <span>v5.11 Documentation — 43 Domains, 1,250+ Routes, GraphQL + REST + x402</span>
                     </div>
                     <h1 class="text-5xl md:text-7xl font-bold mb-6 bg-clip-text text-transparent bg-gradient-to-r from-white to-blue-200">
                         Built for Developers
@@ -180,8 +180,8 @@
                     <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                     </svg>
-                    <span class="font-medium">v5.4 Released:</span>
-                    <span class="ml-2">42 DDD domains, 1,200+ API routes, GraphQL (34 domains), x402 Protocol, Ondato KYC, Chainalysis, Marqeta, Event Streaming, Plugin Marketplace, and more.</span>
+                    <span class="font-medium">v5.11 Released:</span>
+                    <span class="ml-2">43 DDD domains, 1,250+ API routes, GraphQL (35 domains), x402 Protocol, Rewards Gamification, RAILGUN Privacy, Ondato KYC, Chainalysis, Marqeta, Event Streaming, Plugin Marketplace, and more.</span>
                 </div>
             </div>
         </section>
@@ -566,10 +566,10 @@
                                     </div>
                                     <div>
                                         <h4 class="text-lg font-semibold text-gray-900">GraphQL API</h4>
-                                        <span class="text-xs text-gray-500">34 domains</span>
+                                        <span class="text-xs text-gray-500">35 domains</span>
                                     </div>
                                 </div>
-                                <p class="text-gray-600 text-sm mb-3">Schema-first GraphQL via Lighthouse PHP with queries, mutations, subscriptions, and DataLoaders across 34 domain schemas.</p>
+                                <p class="text-gray-600 text-sm mb-3">Schema-first GraphQL via Lighthouse PHP with queries, mutations, subscriptions, and DataLoaders across 35 domain schemas.</p>
                                 <span class="text-sky-600 text-sm font-medium group-hover:text-sky-700">View endpoints &rarr;</span>
                             </div>
                         </a>

--- a/resources/views/developers/sdks.blade.php
+++ b/resources/views/developers/sdks.blade.php
@@ -186,7 +186,7 @@
                     <div class="flex flex-wrap items-center justify-center gap-3 mb-6">
                         <span class="inline-flex items-center px-4 py-2 bg-green-500/20 backdrop-blur-sm rounded-full text-sm">
                             <span class="w-2 h-2 bg-green-400 rounded-full mr-2"></span>
-                            <span>REST API v5.2</span>
+                            <span>REST API v5.11</span>
                         </span>
                         <span class="inline-flex items-center px-4 py-2 bg-green-500/20 backdrop-blur-sm rounded-full text-sm">
                             <span class="w-2 h-2 bg-green-400 rounded-full mr-2"></span>
@@ -639,8 +639,8 @@ curl -X POST https://api.finaegis.org/api/v1/partner/sdk/generate \
         "language": "go",
         "version": "5.0.0",
         "package_name": "github.com/finaegis/sdk-go",
-        "download_url": "https://sdk.finaegis.org/packages/go/finaegis-sdk-go-5.2.0.tar.gz",
-        "install_command": "go get github.com/finaegis/sdk-go@v5.2.0"
+        "download_url": "https://sdk.finaegis.org/packages/go/finaegis-sdk-go-5.11.0.tar.gz",
+        "install_command": "go get github.com/finaegis/sdk-go@v5.11.0"
       },
       {
         "language": "php",
@@ -678,7 +678,7 @@ curl -X POST https://api.finaegis.org/api/v1/partner/sdk/generate \
                         <div>
                             <p class="text-sm font-medium text-gray-700 mb-2">Go</p>
                             <div class="bg-gray-900 rounded-lg p-4 font-mono text-green-400 text-sm">
-                                <code>go get github.com/finaegis/sdk-go@v5.2.0</code>
+                                <code>go get github.com/finaegis/sdk-go@v5.11.0</code>
                             </div>
                         </div>
                         <div>

--- a/resources/views/features/index.blade.php
+++ b/resources/views/features/index.blade.php
@@ -261,7 +261,7 @@
                     </div>
                     <h3 class="text-xl font-semibold mb-3">Developer APIs</h3>
                     <p class="text-gray-600 mb-4">
-                        Full REST coverage with OpenAPI specs, GraphQL across 34 domains with real-time subscriptions, and configurable webhooks.
+                        Full REST coverage with OpenAPI specs, GraphQL across 35 domains with real-time subscriptions, and configurable webhooks.
                     </p>
                     <a href="{{ route('features.show', 'api') }}" class="text-blue-600 font-medium hover:text-blue-700">
                         View docs →
@@ -405,7 +405,7 @@
                     </div>
                     <h3 class="text-xl font-semibold mb-3">GraphQL API</h3>
                     <p class="text-gray-600 mb-4">
-                        Lighthouse-powered GraphQL covering 34 domains with real-time subscriptions, N+1 safe DataLoaders, and cursor-based pagination.
+                        Lighthouse-powered GraphQL covering 35 domains with real-time subscriptions, N+1 safe DataLoaders, and cursor-based pagination.
                     </p>
                     <a href="{{ route('features.show', 'api') }}" class="text-pink-600 font-medium hover:text-pink-700">
                         View API &rarr;

--- a/resources/views/platform/index.blade.php
+++ b/resources/views/platform/index.blade.php
@@ -478,7 +478,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-bold mb-2">GraphQL API</h3>
-                        <p class="text-pink-100 text-sm mb-4">34 domains, subscriptions, DataLoaders, and real-time queries</p>
+                        <p class="text-pink-100 text-sm mb-4">35 domains, subscriptions, DataLoaders, and real-time queries</p>
                         <a href="{{ route('features') }}" class="text-white font-semibold hover:underline">Learn more &rarr;</a>
                     </div>
 

--- a/resources/views/support/contact.blade.php
+++ b/resources/views/support/contact.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'Contact Us - FinAegis Support',
-        'description' => 'Contact the FinAegis team for technical support, partnership inquiries, or to report issues. Community support for our open-source core banking platform with 42 domain modules.',
+        'description' => 'Contact the FinAegis team for technical support, partnership inquiries, or to report issues. Community support for our open-source core banking platform with 43 domain modules.',
     ])
 @endsection
 

--- a/resources/views/support/faq.blade.php
+++ b/resources/views/support/faq.blade.php
@@ -13,7 +13,7 @@
     $faqData = [
         [
             'question' => 'What is the current status of FinAegis?',
-            'answer' => 'FinAegis v5.4.0 is a fully-featured open-source core banking platform with 42 domain modules. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
+            'answer' => 'FinAegis v5.11.0 is a fully-featured open-source core banking platform with 43 domain modules. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
         ],
         [
             'question' => 'Can I use real money on the platform?',
@@ -21,7 +21,7 @@
         ],
         [
             'question' => 'How do I get started?',
-            'answer' => 'Register for a free account to explore the sandbox, or clone the repository from GitHub to self-host. You can explore all 42 domain modules, test the APIs, and provide feedback through our support channels.'
+            'answer' => 'Register for a free account to explore the sandbox, or clone the repository from GitHub to self-host. You can explore all 43 domain modules, test the APIs, and provide feedback through our support channels.'
         ],
         [
             'question' => 'What is the Global Currency Unit (GCU)?',
@@ -128,11 +128,11 @@
                     </button>
                     <div class="faq-answer px-6 py-4 bg-white rounded-b-lg">
                         <p class="text-gray-600">
-                            FinAegis is a fully-featured open-source core banking platform at v5.4.0. The sandbox environment lets you:
+                            FinAegis is a fully-featured open-source core banking platform at v5.11.0. The sandbox environment lets you:
                         </p>
                         <ul class="list-disc list-inside mt-2 text-gray-600 space-y-1">
-                            <li>Explore 42 domain modules including DeFi, cross-chain, and privacy</li>
-                            <li>Test 143+ REST API endpoints and a 34-domain GraphQL API</li>
+                            <li>Explore 43 domain modules including DeFi, cross-chain, privacy, and rewards</li>
+                            <li>Test 143+ REST API endpoints and a 35-domain GraphQL API</li>
                             <li>Try KYC/AML compliance flows, card issuing, and mobile payments</li>
                             <li>All transactions use test data &mdash; no real funds are involved</li>
                             <li>Community feedback drives the roadmap forward</li>
@@ -344,7 +344,7 @@
                             We have an exciting roadmap ahead:
                         </p>
                         <ul class="list-disc list-inside mt-2 text-gray-600 space-y-1">
-                            <li><strong>Delivered:</strong> 42 domain modules, 143+ API endpoints, GraphQL, event sourcing</li>
+                            <li><strong>Delivered:</strong> 43 domain modules, 143+ API endpoints, GraphQL, event sourcing</li>
                             <li><strong>Delivered:</strong> Mobile app backend, passkey auth, card issuing, KYC/AML</li>
                             <li><strong>Delivered:</strong> Cross-chain bridges, DeFi connectors, X402 micropayments</li>
                             <li><strong>Upcoming:</strong> GCU voting system, production bank integrations</li>

--- a/resources/views/support/guides.blade.php
+++ b/resources/views/support/guides.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'Support Guides - FinAegis',
-        'description' => 'FinAegis platform guides and documentation. Learn how to use, deploy, and contribute to our open-source core banking platform with 42 domain modules.',
+        'description' => 'FinAegis platform guides and documentation. Learn how to use, deploy, and contribute to our open-source core banking platform with 43 domain modules.',
         'keywords' => 'FinAegis guides, documentation, tutorials, open source banking, core banking platform',
     ])
 @endsection

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -58,7 +58,7 @@
                         Developers Deserve
                     </h1>
                     <p class="text-xl md:text-2xl mb-8 text-purple-100 max-w-4xl mx-auto">
-                        42 domain modules covering everything from <a href="{{ route('features.show', 'gcu') }}" class="text-white underline hover:text-purple-100">democratic currency governance</a> to cross-chain DeFi, privacy-preserving identity, AI-driven analytics, and HTTP-native micropayments. Open source. MIT licensed.
+                        43 domain modules covering everything from <a href="{{ route('features.show', 'gcu') }}" class="text-white underline hover:text-purple-100">democratic currency governance</a> to cross-chain DeFi, privacy-preserving identity, AI-driven analytics, and HTTP-native micropayments. Open source. MIT licensed.
                     </p>
                     <p class="mb-8">
                         <a href="{{ route('about') }}" class="text-purple-200 hover:text-white underline">Why we built this →</a>
@@ -176,7 +176,7 @@
                 <div class="text-center mb-16">
                     <h2 class="text-4xl font-bold text-gray-900 mb-4">Built-In Capabilities</h2>
                     <p class="text-xl text-gray-600 max-w-3xl mx-auto">
-                        42 domain modules spanning payments, lending, compliance, DeFi, privacy, mobile wallets, AI analytics, and more
+                        43 domain modules spanning payments, lending, compliance, DeFi, privacy, mobile wallets, AI analytics, and more
                     </p>
                 </div>
 
@@ -268,7 +268,7 @@
                         </div>
                         <h3 class="text-xl font-semibold mb-3">REST, GraphQL & OpenAPI</h3>
                         <p class="text-gray-600 mb-4">
-                            Full REST coverage with OpenAPI specs, GraphQL across 34 domains with real-time subscriptions, and configurable webhooks.
+                            Full REST coverage with OpenAPI specs, GraphQL across 35 domains with real-time subscriptions, and configurable webhooks.
                         </p>
                         <span class="text-blue-600 font-medium hover:text-blue-700">
                             View docs →
@@ -723,7 +723,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-semibold mb-3">REST & GraphQL APIs</h3>
-                        <p class="text-gray-600">OpenAPI/Swagger docs, GraphQL (34 domains), webhooks, and comprehensive test coverage</p>
+                        <p class="text-gray-600">OpenAPI/Swagger docs, GraphQL (35 domains), webhooks, and comprehensive test coverage</p>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- Update domain count: 42 → 43 (Rewards module added in v5.7.0)
- Update GraphQL count: 34 → 35 domains (Rewards GraphQL added in v5.8.0)
- Update version references: v5.4.0 → v5.11.0 in FAQ and developer hub
- Update SDK version references: v5.2 → v5.11
- Update route count: 1,200+ → 1,250+ (actual: 1,259)
- 10 blade files modified across welcome, about, support, features, developers, platform

## Test plan
- [x] `php artisan view:cache` compiles all templates
- [x] `grep` verification: zero remaining stale references
- [ ] Visual inspection of updated pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)