### PR TITLE
feat: homepage content refresh for v5.11.0

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'FinAegis - Open Source Core Banking Infrastructure',
-        'description' => 'Open-source core banking infrastructure with 42 DDD domains, event sourcing, cross-chain DeFi, privacy-preserving identity, RegTech compliance, AI analytics, and HTTP-native micropayments. Built with Laravel.',
+        'description' => 'Open-source core banking infrastructure with 43 DDD domains, event sourcing, cross-chain DeFi, privacy-preserving identity, RegTech compliance, AI analytics, and HTTP-native micropayments. Built with Laravel.',
         'keywords' => 'FinAegis, open source banking, core banking infrastructure, GCU, event sourcing, DeFi, cross-chain, RegTech, banking API, Laravel fintech',
     ])
 
@@ -101,7 +101,7 @@
                                 What Is FinAegis?
                             </h2>
                             <p class="text-lg mb-6 text-indigo-100">
-                                A production-grade core banking platform built with Laravel and domain-driven design. 42 bounded contexts, event sourcing, CQRS, and every integration pattern a modern fintech needs—from cross-chain bridges to AI agent commerce.
+                                A production-grade core banking platform built with Laravel and domain-driven design. 43 bounded contexts, event sourcing, CQRS, and every integration pattern a modern fintech needs—from cross-chain bridges to AI agent commerce.
                             </p>
                             <div class="space-y-4 mb-8">
                                 <div class="flex items-start">
@@ -120,7 +120,7 @@
                                     <svg class="w-6 h-6 text-green-400 mr-3 flex-shrink-0 mt-1" fill="currentColor" viewBox="0 0 20 20">
                                         <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
                                     </svg>
-                                    <span>RegTech compliance, mobile payments & Banking-as-a-Service</span>
+                                    <span>RegTech compliance, mobile payments, rewards & Banking-as-a-Service</span>
                                 </div>
                             </div>
                             <div class="bg-white/10 backdrop-blur rounded-lg p-4">
@@ -316,7 +316,7 @@
                         </div>
                         <h3 class="text-xl font-semibold mb-3">Privacy & Identity</h3>
                         <p class="text-gray-600 mb-4">
-                            Prove compliance without exposing data. ZK-KYC proofs, W3C verifiable credentials, soulbound tokens, and Shamir key management.
+                            Prove compliance without exposing data. ZK-KYC proofs, RAILGUN shielded transfers, W3C verifiable credentials, soulbound tokens, and Shamir key management.
                         </p>
                         <span class="text-teal-600 font-medium hover:text-teal-700">
                             Learn more →
@@ -401,6 +401,22 @@
                             v5.2.0
                         </span>
                     </div>
+
+                    <!-- Rewards & Gamification -->
+                    <div class="feature-card bg-white border border-gray-200 rounded-xl p-8 block hover:border-rose-500 transition-all">
+                        <div class="w-14 h-14 bg-rose-100 rounded-lg flex items-center justify-center mb-6">
+                            <svg class="w-8 h-8 text-rose-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"></path>
+                            </svg>
+                        </div>
+                        <h3 class="text-xl font-semibold mb-3">Rewards & Gamification</h3>
+                        <p class="text-gray-600 mb-4">
+                            Drive engagement with quests, XP levels, a points shop, and daily streaks. Race-safe locking ensures fair reward distribution at scale.
+                        </p>
+                        <span class="text-rose-600 font-medium">
+                            v5.7.0
+                        </span>
+                    </div>
                 </div>
 
                 <div class="text-center mt-12">
@@ -420,7 +436,7 @@
                 <div class="text-center mb-16">
                     <h2 class="text-4xl font-bold text-gray-900 mb-4">Platform Architecture</h2>
                     <p class="text-xl text-gray-600 max-w-3xl mx-auto">
-                        42 bounded contexts built with domain-driven design, event sourcing, and CQRS. Each module implements specific financial system patterns you can use independently.
+                        43 bounded contexts built with domain-driven design, event sourcing, and CQRS. Each module implements specific financial system patterns you can use independently.
                     </p>
                 </div>
 


### PR DESCRIPTION
## Summary
- Update all stale domain counts in SEO meta and content sections (42 → 43)
- Add Rewards & Gamification feature card (v5.7.0: quests, XP, points shop, streaks)
- Update Privacy & Identity card to mention RAILGUN shielded transfers
- Update capability bullets to include rewards

## Test plan
- [x] `php artisan view:cache` compiles
- [x] No remaining stale "42" references (only SVG coordinates)
- [ ] Visual inspection of homepage layout with new card

🤖 Generated with [Claude Code](https://claude.com/claude-code)