### PR TITLE
feat: app landing, developer hub, feature pages & AI framework content refresh

### DIFF
--- a/resources/views/about.blade.php
+++ b/resources/views/about.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'About FinAegis - Open Source Core Banking Infrastructure',
-        'description' => 'FinAegis is an open-source core banking platform with 42 DDD domains, event sourcing, CQRS, and the Global Currency Unit. Built with Laravel for fintech developers.',
+        'description' => 'FinAegis is an open-source core banking platform with 43 DDD domains, event sourcing, CQRS, and the Global Currency Unit. Built with Laravel for fintech developers.',
         'keywords' => 'FinAegis about, open source banking, core banking platform, GCU, event sourcing, CQRS, Laravel banking, DDD, fintech infrastructure',
     ])
 
@@ -74,7 +74,7 @@
                 <div>
                     <h2 class="text-4xl font-bold text-gray-900 mb-6">What Is FinAegis?</h2>
                     <p class="text-lg text-gray-600 mb-4">
-                        FinAegis is a core banking platform built with Laravel, implementing event sourcing, CQRS, domain-driven design, and AI agent integration across 42 bounded contexts.
+                        FinAegis is a core banking platform built with Laravel, implementing event sourcing, CQRS, domain-driven design, and AI agent integration across 43 bounded contexts.
                     </p>
                     <p class="text-lg text-gray-600 mb-4">
                         At its heart is the <strong>Global Currency Unit (GCU)</strong>—a democratically governed basket currency where users vote on composition from six global reserve assets.

--- a/resources/views/ai-framework/demo.blade.php
+++ b/resources/views/ai-framework/demo.blade.php
@@ -1,0 +1,168 @@
+@extends('layouts.public')
+
+@section('title', 'AI Framework Demo - FinAegis')
+
+@section('seo')
+    @include('partials.seo', [
+        'title' => 'AI Framework Demo - Interactive AI Agent Playground',
+        'description' => 'Try the FinAegis AI Agent Framework in action. Explore MCP tools, transaction queries, x402 agent payments, and autonomous financial workflows.',
+        'keywords' => 'AI demo, MCP tools, AI agent payments, transaction query, x402, financial AI, agent framework demo',
+    ])
+@endsection
+
+@push('styles')
+<style>
+    .gradient-bg {
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    }
+    .demo-card {
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+    .demo-card:hover {
+        transform: translateY(-3px);
+        box-shadow: 0 8px 25px rgba(0,0,0,0.1);
+    }
+</style>
+@endpush
+
+@section('content')
+
+    <!-- Hero -->
+    <section class="gradient-bg text-white py-20">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+            <div class="inline-flex items-center px-4 py-2 bg-white/10 backdrop-blur-sm rounded-full text-sm mb-6">
+                <span class="w-2 h-2 bg-green-400 rounded-full mr-2 animate-pulse"></span>
+                Sandbox Mode &mdash; Safe to Explore
+            </div>
+            <h1 class="text-5xl font-bold mb-6">AI Framework Demo</h1>
+            <p class="text-xl text-purple-100 max-w-3xl mx-auto mb-8">
+                Explore how AI agents interact with the FinAegis banking platform. Run natural language queries, trigger MCP tools, and see autonomous agent workflows in action.
+            </p>
+            <div class="flex flex-col sm:flex-row gap-4 justify-center">
+                <a href="{{ route('register') }}" class="bg-white text-indigo-600 px-8 py-4 rounded-lg text-lg font-semibold hover:bg-gray-100 transition shadow-lg hover:shadow-xl">
+                    Try the Demo
+                </a>
+                <a href="{{ route('ai-framework.docs') }}" class="border-2 border-white text-white px-8 py-4 rounded-lg text-lg font-semibold hover:bg-white hover:text-indigo-600 transition">
+                    Read the Docs
+                </a>
+            </div>
+        </div>
+    </section>
+
+    <!-- Demo Scenarios -->
+    <section class="py-20 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="text-center mb-16">
+                <h2 class="text-4xl font-bold text-gray-900 mb-4">What You Can Try</h2>
+                <p class="text-xl text-gray-600 max-w-3xl mx-auto">
+                    Each scenario demonstrates a real capability of the AI Agent Framework
+                </p>
+            </div>
+
+            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+                <!-- Transaction Query -->
+                <div class="demo-card bg-white border border-gray-200 rounded-xl p-8">
+                    <div class="w-14 h-14 bg-blue-100 rounded-lg flex items-center justify-center mb-6">
+                        <svg class="w-8 h-8 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+                        </svg>
+                    </div>
+                    <h3 class="text-xl font-semibold mb-3">Natural Language Queries</h3>
+                    <p class="text-gray-600 mb-4">
+                        Ask questions like "Show my largest transactions this month" or "What's my portfolio allocation?" The AI translates to structured queries.
+                    </p>
+                    <code class="text-sm text-blue-600 bg-blue-50 px-3 py-1 rounded">TransactionQueryTool</code>
+                </div>
+
+                <!-- MCP Tools -->
+                <div class="demo-card bg-white border border-gray-200 rounded-xl p-8">
+                    <div class="w-14 h-14 bg-purple-100 rounded-lg flex items-center justify-center mb-6">
+                        <svg class="w-8 h-8 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"></path>
+                        </svg>
+                    </div>
+                    <h3 class="text-xl font-semibold mb-3">MCP Tool Integration</h3>
+                    <p class="text-gray-600 mb-4">
+                        See how Claude and other LLMs use Model Context Protocol tools to interact with banking APIs, check balances, and execute transfers.
+                    </p>
+                    <code class="text-sm text-purple-600 bg-purple-50 px-3 py-1 rounded">X402PaymentTool</code>
+                </div>
+
+                <!-- x402 Agent Payments -->
+                <div class="demo-card bg-white border border-gray-200 rounded-xl p-8">
+                    <div class="w-14 h-14 bg-emerald-100 rounded-lg flex items-center justify-center mb-6">
+                        <svg class="w-8 h-8 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z"></path>
+                        </svg>
+                    </div>
+                    <h3 class="text-xl font-semibold mb-3">Agent Micropayments</h3>
+                    <p class="text-gray-600 mb-4">
+                        Watch autonomous agents pay for API calls using the x402 protocol. USDC-based pay-per-request with spending limits and settlement tracking.
+                    </p>
+                    <code class="text-sm text-emerald-600 bg-emerald-50 px-3 py-1 rounded">AgentPaymentIntegrationService</code>
+                </div>
+
+                <!-- A2A Protocol -->
+                <div class="demo-card bg-white border border-gray-200 rounded-xl p-8">
+                    <div class="w-14 h-14 bg-orange-100 rounded-lg flex items-center justify-center mb-6">
+                        <svg class="w-8 h-8 text-orange-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"></path>
+                        </svg>
+                    </div>
+                    <h3 class="text-xl font-semibold mb-3">Agent-to-Agent (A2A)</h3>
+                    <p class="text-gray-600 mb-4">
+                        Google A2A protocol for multi-agent collaboration. See agents discover capabilities, negotiate tasks, and execute financial workflows together.
+                    </p>
+                    <code class="text-sm text-orange-600 bg-orange-50 px-3 py-1 rounded">AgentProtocol Domain</code>
+                </div>
+
+                <!-- Spending Controls -->
+                <div class="demo-card bg-white border border-gray-200 rounded-xl p-8">
+                    <div class="w-14 h-14 bg-red-100 rounded-lg flex items-center justify-center mb-6">
+                        <svg class="w-8 h-8 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"></path>
+                        </svg>
+                    </div>
+                    <h3 class="text-xl font-semibold mb-3">Spending Limits</h3>
+                    <p class="text-gray-600 mb-4">
+                        Configure per-agent spending caps, daily/monthly limits, and approval workflows. Safety rails for autonomous financial agents.
+                    </p>
+                    <code class="text-sm text-red-600 bg-red-50 px-3 py-1 rounded">X402PricingService</code>
+                </div>
+
+                <!-- GraphQL + REST -->
+                <div class="demo-card bg-white border border-gray-200 rounded-xl p-8">
+                    <div class="w-14 h-14 bg-cyan-100 rounded-lg flex items-center justify-center mb-6">
+                        <svg class="w-8 h-8 text-cyan-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4"></path>
+                        </svg>
+                    </div>
+                    <h3 class="text-xl font-semibold mb-3">Full API Access</h3>
+                    <p class="text-gray-600 mb-4">
+                        Agents have access to the complete FinAegis API surface: 1,250+ REST endpoints and 35 GraphQL domain schemas with real-time subscriptions.
+                    </p>
+                    <code class="text-sm text-cyan-600 bg-cyan-50 px-3 py-1 rounded">REST + GraphQL</code>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- CTA -->
+    <section class="py-16 bg-gray-50">
+        <div class="max-w-4xl mx-auto text-center px-4">
+            <h2 class="text-3xl font-bold text-gray-900 mb-4">Ready to Build with AI Agents?</h2>
+            <p class="text-lg text-gray-600 mb-8">
+                Register for the sandbox to start experimenting, or read the documentation to understand the architecture.
+            </p>
+            <div class="flex flex-col sm:flex-row gap-4 justify-center">
+                <a href="{{ route('register') }}" class="bg-indigo-600 text-white px-8 py-4 rounded-lg text-lg font-semibold hover:bg-indigo-700 transition shadow-lg hover:shadow-xl">
+                    Start Building
+                </a>
+                <a href="{{ route('ai-framework.docs') }}" class="border-2 border-indigo-600 text-indigo-600 px-8 py-4 rounded-lg text-lg font-semibold hover:bg-indigo-50 transition">
+                    Documentation
+                </a>
+            </div>
+        </div>
+    </section>
+
+@endsection

--- a/resources/views/ai-framework/docs.blade.php
+++ b/resources/views/ai-framework/docs.blade.php
@@ -1,0 +1,218 @@
+@extends('layouts.public')
+
+@section('title', 'AI Framework Documentation - FinAegis')
+
+@section('seo')
+    @include('partials.seo', [
+        'title' => 'AI Framework Documentation - Architecture & Integration Guide',
+        'description' => 'Technical documentation for the FinAegis AI Agent Framework. Learn about MCP tools, A2A protocol, x402 agent payments, spending controls, and integration patterns.',
+        'keywords' => 'AI framework docs, MCP integration, A2A protocol, agent payments, x402, financial AI documentation, LLM integration',
+    ])
+@endsection
+
+@push('styles')
+<style>
+    .gradient-bg {
+        background: linear-gradient(135deg, #1e3a5f 0%, #2d1b69 100%);
+    }
+    .doc-section {
+        scroll-margin-top: 100px;
+    }
+</style>
+@endpush
+
+@section('content')
+
+    <!-- Hero -->
+    <section class="gradient-bg text-white py-16">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center gap-2 text-sm text-gray-300 mb-4">
+                <a href="{{ route('ai-framework') }}" class="hover:text-white">AI Framework</a>
+                <span>/</span>
+                <span class="text-white">Documentation</span>
+            </div>
+            <h1 class="text-4xl font-bold mb-4">AI Framework Documentation</h1>
+            <p class="text-xl text-gray-300 max-w-3xl">
+                Architecture guide, integration patterns, and API reference for the FinAegis AI Agent Framework.
+            </p>
+        </div>
+    </section>
+
+    <!-- Content -->
+    <section class="py-16 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="lg:grid lg:grid-cols-4 lg:gap-12">
+
+                <!-- Sidebar Navigation -->
+                <nav class="hidden lg:block lg:col-span-1">
+                    <div class="sticky top-24 space-y-1">
+                        <h3 class="text-sm font-semibold text-gray-500 uppercase tracking-wider mb-3">On this page</h3>
+                        <a href="#overview" class="block text-gray-600 hover:text-indigo-600 py-1 text-sm">Overview</a>
+                        <a href="#architecture" class="block text-gray-600 hover:text-indigo-600 py-1 text-sm">Architecture</a>
+                        <a href="#mcp-tools" class="block text-gray-600 hover:text-indigo-600 py-1 text-sm">MCP Tools</a>
+                        <a href="#a2a-protocol" class="block text-gray-600 hover:text-indigo-600 py-1 text-sm">A2A Protocol</a>
+                        <a href="#x402-payments" class="block text-gray-600 hover:text-indigo-600 py-1 text-sm">x402 Agent Payments</a>
+                        <a href="#spending-controls" class="block text-gray-600 hover:text-indigo-600 py-1 text-sm">Spending Controls</a>
+                        <a href="#transaction-query" class="block text-gray-600 hover:text-indigo-600 py-1 text-sm">Transaction Query</a>
+                    </div>
+                </nav>
+
+                <!-- Main Content -->
+                <div class="lg:col-span-3 prose prose-lg max-w-none">
+
+                    <!-- Overview -->
+                    <section id="overview" class="doc-section mb-16">
+                        <h2 class="text-3xl font-bold text-gray-900 mb-6">Overview</h2>
+                        <p>
+                            The FinAegis AI Framework enables autonomous agents to interact with the full banking platform. It provides Model Context Protocol (MCP) tools for LLM integration, Google A2A protocol for agent-to-agent communication, and x402-based micropayments for pay-per-request API access.
+                        </p>
+                        <div class="bg-blue-50 border border-blue-200 rounded-lg p-6 not-prose mt-6">
+                            <h4 class="font-semibold text-blue-900 mb-2">Key Capabilities</h4>
+                            <ul class="space-y-2 text-blue-800">
+                                <li class="flex items-start">
+                                    <svg class="w-5 h-5 text-blue-500 mr-2 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                                    <span><strong>MCP Tools:</strong> TransactionQueryTool, X402PaymentTool for direct LLM integration</span>
+                                </li>
+                                <li class="flex items-start">
+                                    <svg class="w-5 h-5 text-blue-500 mr-2 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                                    <span><strong>A2A Protocol:</strong> Google Agent-to-Agent for multi-agent collaboration</span>
+                                </li>
+                                <li class="flex items-start">
+                                    <svg class="w-5 h-5 text-blue-500 mr-2 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                                    <span><strong>x402 Payments:</strong> Autonomous USDC micropayments with spending limits</span>
+                                </li>
+                                <li class="flex items-start">
+                                    <svg class="w-5 h-5 text-blue-500 mr-2 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                                    <span><strong>Full API Surface:</strong> 1,250+ REST endpoints and 35 GraphQL domains</span>
+                                </li>
+                            </ul>
+                        </div>
+                    </section>
+
+                    <!-- Architecture -->
+                    <section id="architecture" class="doc-section mb-16">
+                        <h2 class="text-3xl font-bold text-gray-900 mb-6">Architecture</h2>
+                        <p>
+                            The AI Framework spans three domain modules: <code>AgentProtocol</code> for A2A communication, <code>X402</code> for payment gating, and <code>AI</code> for MCP tool definitions.
+                        </p>
+                        <div class="bg-gray-900 rounded-lg p-6 font-mono text-sm text-gray-300 not-prose mt-4">
+<pre>app/
+├── Domain/
+│   ├── AgentProtocol/     # Google A2A protocol implementation
+│   │   ├── Services/      # AgentPaymentIntegrationService
+│   │   └── Models/        # AgentCard, AgentTask
+│   ├── X402/              # HTTP 402 payment gate
+│   │   ├── Services/      # Settlement, Verification, Pricing
+│   │   └── Middleware/     # X402PaymentGateMiddleware
+│   └── AI/                # MCP tool definitions
+│       └── Tools/         # TransactionQueryTool, X402PaymentTool
+└── Infrastructure/
+    └── AI/                # Provider adapters</pre>
+                        </div>
+                    </section>
+
+                    <!-- MCP Tools -->
+                    <section id="mcp-tools" class="doc-section mb-16">
+                        <h2 class="text-3xl font-bold text-gray-900 mb-6">MCP Tools</h2>
+                        <p>
+                            FinAegis implements Model Context Protocol tools that LLMs like Claude can use to interact with the banking platform. Tools are registered as MCP-compatible endpoints.
+                        </p>
+                        <h3>TransactionQueryTool</h3>
+                        <p>
+                            Translates natural language questions about transactions, balances, and portfolios into structured database queries. Supports filtering by date range, amount, asset type, and counterparty.
+                        </p>
+                        <h3>X402PaymentTool</h3>
+                        <p>
+                            Enables agents to make USDC payments for API access using the x402 protocol. Handles payment negotiation, execution, and verification in a single tool call.
+                        </p>
+                    </section>
+
+                    <!-- A2A Protocol -->
+                    <section id="a2a-protocol" class="doc-section mb-16">
+                        <h2 class="text-3xl font-bold text-gray-900 mb-6">A2A Protocol</h2>
+                        <p>
+                            The Agent-to-Agent (A2A) protocol, based on Google's specification, enables agents to discover each other's capabilities, negotiate tasks, and collaborate on multi-step financial workflows.
+                        </p>
+                        <h3>Agent Cards</h3>
+                        <p>
+                            Each agent publishes a capability card describing its skills, input/output schemas, and pricing. Other agents can discover these cards and delegate appropriate tasks.
+                        </p>
+                        <h3>Task Lifecycle</h3>
+                        <p>
+                            Tasks follow a lifecycle: <code>created → assigned → in_progress → completed</code>. Agents report progress and intermediate results through the A2A message channel.
+                        </p>
+                    </section>
+
+                    <!-- x402 Payments -->
+                    <section id="x402-payments" class="doc-section mb-16">
+                        <h2 class="text-3xl font-bold text-gray-900 mb-6">x402 Agent Payments</h2>
+                        <p>
+                            The x402 protocol enables HTTP-native micropayments. When an agent hits a payment-gated endpoint, it receives a <code>402 Payment Required</code> response with pricing details. The agent then submits a USDC payment and retries the request.
+                        </p>
+                        <div class="bg-gray-900 rounded-lg p-6 font-mono text-sm text-gray-300 not-prose mt-4">
+<pre><span class="text-gray-500"># 1. Agent calls a gated endpoint</span>
+<span class="text-green-400">GET</span> /api/v2/premium/data
+<span class="text-yellow-400">→ 402 Payment Required</span>
+<span class="text-gray-500"># X-Payment-Required: {"amount": "0.01", "currency": "USDC", "network": "base"}</span>
+
+<span class="text-gray-500"># 2. Agent submits payment</span>
+<span class="text-green-400">POST</span> /api/v2/x402/pay
+<span class="text-gray-500"># {"endpoint": "/api/v2/premium/data", "tx_hash": "0x..."}</span>
+
+<span class="text-gray-500"># 3. Agent retries with payment proof</span>
+<span class="text-green-400">GET</span> /api/v2/premium/data
+<span class="text-gray-500"># X-Payment-Proof: 0x...</span>
+<span class="text-green-400">→ 200 OK</span></pre>
+                        </div>
+                    </section>
+
+                    <!-- Spending Controls -->
+                    <section id="spending-controls" class="doc-section mb-16">
+                        <h2 class="text-3xl font-bold text-gray-900 mb-6">Spending Controls</h2>
+                        <p>
+                            Safety rails for autonomous agents. Configure per-agent daily and monthly spending limits, per-request caps, and approval thresholds. The <code>X402PricingService</code> enforces limits before any payment is authorized.
+                        </p>
+                        <ul>
+                            <li>Per-agent daily and monthly spending caps</li>
+                            <li>Per-request maximum amount</li>
+                            <li>Approval workflows for high-value transactions</li>
+                            <li>Real-time spending dashboards</li>
+                        </ul>
+                    </section>
+
+                    <!-- Transaction Query -->
+                    <section id="transaction-query" class="doc-section mb-16">
+                        <h2 class="text-3xl font-bold text-gray-900 mb-6">Transaction Query</h2>
+                        <p>
+                            The <code>TransactionQueryTool</code> enables natural language interaction with transaction data. Agents can ask questions and receive structured results.
+                        </p>
+                        <div class="bg-gray-50 border rounded-lg p-6 not-prose mt-4">
+                            <h4 class="font-semibold text-gray-900 mb-3">Example Queries</h4>
+                            <ul class="space-y-2 text-gray-700 text-sm">
+                                <li><code class="bg-gray-200 px-2 py-1 rounded">"Show my top 5 transactions this week"</code></li>
+                                <li><code class="bg-gray-200 px-2 py-1 rounded">"What's my total spending on DeFi protocols?"</code></li>
+                                <li><code class="bg-gray-200 px-2 py-1 rounded">"List all cross-chain bridge transactions over $100"</code></li>
+                                <li><code class="bg-gray-200 px-2 py-1 rounded">"Calculate my portfolio allocation by asset class"</code></li>
+                            </ul>
+                        </div>
+                    </section>
+
+                    <!-- CTA -->
+                    <div class="bg-indigo-50 border border-indigo-200 rounded-xl p-8 not-prose text-center">
+                        <h3 class="text-2xl font-bold text-indigo-900 mb-3">Start Building</h3>
+                        <p class="text-indigo-700 mb-6">Ready to integrate AI agents with FinAegis? Start with the sandbox.</p>
+                        <div class="flex flex-col sm:flex-row gap-4 justify-center">
+                            <a href="{{ route('ai-framework.demo') }}" class="bg-indigo-600 text-white px-6 py-3 rounded-lg font-semibold hover:bg-indigo-700 transition">
+                                Try the Demo
+                            </a>
+                            <a href="{{ route('developers.show', 'api-docs') }}" class="border-2 border-indigo-600 text-indigo-600 px-6 py-3 rounded-lg font-semibold hover:bg-indigo-100 transition">
+                                API Reference
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+@endsection

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -370,7 +370,7 @@
 
                         {{-- App Store Badges --}}
                         <div class="pt-1 border-t border-white/5">
-                            <p class="text-[11px] uppercase tracking-widest text-slate-600 font-semibold mb-4">Coming soon to mobile</p>
+                            <p class="text-[11px] uppercase tracking-widest text-slate-600 font-semibold mb-4">Available on mobile</p>
                             <div class="flex gap-3 justify-center lg:justify-start" id="store-badges">
                                 <div class="store-badge">
                                     <div class="bg-[#111827] border border-white/5 rounded-xl py-2 px-4 flex items-center gap-3 h-12">
@@ -713,11 +713,11 @@
                 {{-- Capabilities grid --}}
                 <div class="mt-16 grid grid-cols-2 md:grid-cols-4 gap-4 max-w-3xl mx-auto">
                     <div class="text-center p-4 rounded-xl bg-white/[0.02] border border-white/5">
-                        <div class="text-2xl font-bold text-white">42</div>
+                        <div class="text-2xl font-bold text-white">43</div>
                         <div class="text-[11px] text-slate-500 mt-1">Banking Domains</div>
                     </div>
                     <div class="text-center p-4 rounded-xl bg-white/[0.02] border border-white/5">
-                        <div class="text-2xl font-bold text-white">1,200+</div>
+                        <div class="text-2xl font-bold text-white">1,250+</div>
                         <div class="text-[11px] text-slate-500 mt-1">API Endpoints</div>
                     </div>
                     <div class="text-center p-4 rounded-xl bg-white/[0.02] border border-white/5">

--- a/resources/views/developers/api-docs.blade.php
+++ b/resources/views/developers/api-docs.blade.php
@@ -61,7 +61,7 @@
                         <h2 class="text-3xl font-bold text-gray-900 mb-8">Getting Started</h2>
                         
                         <div class="prose prose-lg max-w-none">
-                            <p>The FinAegis API provides programmatic access to our multi-asset banking platform spanning 42 DDD domains with over 1,200 routes. Our API is organized around REST principles with predictable, resource-oriented URLs. Domains include core banking, CrossChain bridging, DeFi protocols, RegTech compliance, Mobile Payment, Partner BaaS, and AI-powered queries.</p>
+                            <p>The FinAegis API provides programmatic access to our multi-asset banking platform spanning 43 DDD domains with over 1,250 routes. Our API is organized around REST principles with predictable, resource-oriented URLs. Domains include core banking, CrossChain bridging, DeFi protocols, RegTech compliance, Mobile Payment, Partner BaaS, and AI-powered queries.</p>
                             
                             <h3>Base URL</h3>
                             <x-code-block language="plaintext">

--- a/resources/views/developers/index.blade.php
+++ b/resources/views/developers/index.blade.php
@@ -437,7 +437,7 @@
                 <!-- Platform API Area Cards -->
                 <div class="mt-16">
                     <h3 class="text-2xl font-bold text-gray-900 mb-2 text-center">Platform API Areas</h3>
-                    <p class="text-gray-600 text-center mb-8">Explore the full breadth of the FinAegis platform across 42 DDD domains</p>
+                    <p class="text-gray-600 text-center mb-8">Explore the full breadth of the FinAegis platform across 43 DDD domains</p>
                     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
 
                         <!-- CrossChain -->
@@ -690,7 +690,7 @@
             <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                 <div class="grid grid-cols-2 md:grid-cols-5 gap-8 text-center">
                     <div>
-                        <div class="text-4xl md:text-5xl font-bold mb-2">1,200+</div>
+                        <div class="text-4xl md:text-5xl font-bold mb-2">1,250+</div>
                         <p class="text-indigo-200 flex items-center justify-center">
                             <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>

--- a/resources/views/features/index.blade.php
+++ b/resources/views/features/index.blade.php
@@ -38,7 +38,7 @@
     <section class="pt-16 bg-gray-50">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
             <div class="text-center">
-                <h1 class="text-5xl font-bold text-gray-900 mb-6">42 Domain Modules. One Platform.</h1>
+                <h1 class="text-5xl font-bold text-gray-900 mb-6">43 Domain Modules. One Platform.</h1>
                 <p class="text-xl text-gray-600 max-w-3xl mx-auto">
                     Every building block a modern fintech needs—from democratic currency governance to AI agent commerce, cross-chain DeFi, and privacy-preserving identity.
                 </p>

--- a/resources/views/platform/index.blade.php
+++ b/resources/views/platform/index.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'FinAegis Platform - Open Banking for Developers',
-        'description' => 'FinAegis Platform - Open-source core banking infrastructure with 42 DDD domains, event sourcing, REST + GraphQL APIs, and cross-chain DeFi. MIT licensed.',
+        'description' => 'FinAegis Platform - Open-source core banking infrastructure with 43 DDD domains, event sourcing, REST + GraphQL APIs, and cross-chain DeFi. MIT licensed.',
         'keywords' => 'FinAegis platform, banking infrastructure, open source banking, developer API, MIT license, core banking API, fintech development, DDD, event sourcing',
     ])
 
@@ -180,7 +180,7 @@
                                 <div class="text-sm text-gray-500">License</div>
                             </div>
                             <div>
-                                <div class="text-2xl font-bold text-blue-400 code-font">42</div>
+                                <div class="text-2xl font-bold text-blue-400 code-font">43</div>
                                 <div class="text-sm text-gray-500">Domains</div>
                             </div>
                             <div>


### PR DESCRIPTION
## Summary
Covers plan items PR #4-#7: App landing page, developer hub, feature pages, platform, about, and AI framework.

### App Landing Page
- Domain count 42 → 43, route count 1,200+ → 1,250+
- "Coming soon to mobile" → "Available on mobile"

### Developer Hub & API Docs
- Remaining 42 → 43 domain counts and 1,200 → 1,250 route counts
- Stats section and API areas updated

### Feature Pages & Platform
- features/index hero heading: 42 → 43 Domain Modules
- platform/index SEO meta and stats counter
- about.blade.php SEO meta and body text

### AI Framework (new views)
- **demo.blade.php**: Interactive demo page showcasing MCP tools, A2A protocol, x402 payments, spending controls
- **docs.blade.php**: Technical documentation with architecture overview, code structure, API patterns

## Test plan
- [x] `php artisan view:cache` — all templates compile
- [x] Zero remaining stale "42 domain", "34 domain", "v5.4", "1,200" references
- [x] New AI framework routes (`/ai-framework/demo`, `/ai-framework/docs`) resolve to views
- [ ] Visual inspection of all updated pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)