### PR TITLE
fix: add default ERC-4337 factory addresses to relayer config

### DIFF
--- a/config/relayer.php
+++ b/config/relayer.php
@@ -139,9 +139,9 @@ return [
     'smart_accounts' => [
         // Factory contract addresses per network (SimpleAccountFactory or custom)
         'factory_addresses' => [
-            'polygon'  => env('POLYGON_FACTORY_ADDRESS'),
-            'base'     => env('BASE_FACTORY_ADDRESS'),
-            'arbitrum' => env('ARBITRUM_FACTORY_ADDRESS'),
+            'polygon'  => env('POLYGON_FACTORY_ADDRESS', '0x9406Cc6185a346906296840746125a0E44976454'),
+            'base'     => env('BASE_FACTORY_ADDRESS', '0x9406Cc6185a346906296840746125a0E44976454'),
+            'arbitrum' => env('ARBITRUM_FACTORY_ADDRESS', '0x9406Cc6185a346906296840746125a0E44976454'),
         ],
 
         // Paymaster contract addresses per network


### PR DESCRIPTION
## Summary
- `POST /api/v1/relayer/account` was returning **400** because `POLYGON_FACTORY_ADDRESS`, `BASE_FACTORY_ADDRESS`, and `ARBITRUM_FACTORY_ADDRESS` env vars were unset
- `ProductionSmartAccountFactory::getSupportedNetworks()` filtered out all null entries → `validateNetwork()` rejected every network
- Adds the standard ERC-4337 v0.6 SimpleAccountFactory address (`0x9406Cc6185a346906296840746125a0E44976454`) as config defaults so dev environments work without explicit env vars
- Production environments should still set these explicitly in `.env` (already documented in `.env.production.example`)

## Root cause
```
config('relayer.smart_accounts.factory_addresses') 
→ ['polygon' => null, 'base' => null, 'arbitrum' => null]
→ array_filter(..., fn($addr) => !empty($addr)) 
→ [] (empty)
→ supportsNetwork('polygon') → false
→ SmartAccountException::invalidNetwork('polygon') → HTTP 400
```

## Test plan
- [x] 143 relayer tests pass (551 assertions)
- [x] Config verified via `php artisan tinker`
- [ ] Mobile app: retry `POST /api/v1/relayer/account` — should return 200
- [ ] Mobile app: `GET /api/v1/wallet/addresses` should return real smart account addresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)