### PR TITLE
feat: v1 Notifications API — paginated list with type filtering

### DIFF
--- a/app/Domain/Mobile/Routes/api.php
+++ b/app/Domain/Mobile/Routes/api.php
@@ -75,13 +75,21 @@ Route::prefix('mobile')->name('api.mobile.')->group(function () {
     });
 });
 
-// Notification endpoints (v5.6.0)
-Route::prefix('v1/notifications')->name('api.notifications.')
+// Notification endpoints — v1 (v5.13.0)
+Route::prefix('v1/notifications')->name('api.v1.notifications.')
     ->middleware(['auth:sanctum'])
     ->group(function () {
-        Route::get('/unread-count', [MobileController::class, 'getUnreadNotificationCount'])
+        Route::get('/', [App\Http\Controllers\Api\V1\NotificationController::class, 'index'])
+            ->name('index');
+        Route::get('/unread-count', [App\Http\Controllers\Api\V1\NotificationController::class, 'unreadCount'])
             ->middleware('api.rate_limit:query')
             ->name('unread-count');
+        Route::get('/{id}', [App\Http\Controllers\Api\V1\NotificationController::class, 'show'])
+            ->name('show');
+        Route::post('/read-all', [App\Http\Controllers\Api\V1\NotificationController::class, 'markAllRead'])
+            ->name('read-all');
+        Route::post('/{id}/read', [App\Http\Controllers\Api\V1\NotificationController::class, 'markRead'])
+            ->name('read');
     });
 
 // User preferences (v3.3.4) + data export alias (v5.6.0)

--- a/app/Http/Controllers/Api/V1/NotificationController.php
+++ b/app/Http/Controllers/Api/V1/NotificationController.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Domain\Mobile\Models\MobilePushNotification;
+use App\Domain\Mobile\Services\PushNotificationService;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\V1\NotificationResource;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use OpenApi\Attributes as OA;
+
+class NotificationController extends Controller
+{
+    /**
+     * Type category → raw notification_type prefix mapping for filtering.
+     *
+     * @var array<string, array<string>>
+     */
+    private const TYPE_FILTER_MAP = [
+        'transaction' => ['transaction.', 'balance.'],
+        'security'    => ['security.'],
+        'system'      => ['system.', 'kyc.', 'general'],
+        'promo'       => ['promo.', 'marketing.', 'price.'],
+    ];
+
+    public function __construct(
+        private readonly PushNotificationService $pushService,
+    ) {
+    }
+
+    #[OA\Get(
+        path: '/api/v1/notifications',
+        operationId: 'v1ListNotifications',
+        tags: ['Notifications'],
+        summary: 'List paginated notifications',
+        security: [['sanctum' => []]],
+        parameters: [
+            new OA\Parameter(name: 'offset', in: 'query', required: false, schema: new OA\Schema(type: 'integer', default: 0)),
+            new OA\Parameter(name: 'limit', in: 'query', required: false, schema: new OA\Schema(type: 'integer', default: 20, maximum: 100)),
+            new OA\Parameter(name: 'type', in: 'query', required: false, schema: new OA\Schema(type: 'string', enum: ['transaction', 'security', 'system', 'promo'])),
+        ]
+    )]
+    #[OA\Response(response: 200, description: 'Paginated notification list')]
+    public function index(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $offset = max(0, (int) $request->input('offset', 0));
+        $limit = min(max(1, (int) $request->input('limit', 20)), 100);
+        $typeFilter = $request->input('type');
+
+        $query = MobilePushNotification::where('user_id', $user->id)
+            ->orderBy('created_at', 'desc');
+
+        if ($typeFilter && isset(self::TYPE_FILTER_MAP[$typeFilter])) {
+            $prefixes = self::TYPE_FILTER_MAP[$typeFilter];
+            $query->where(function ($q) use ($prefixes) {
+                foreach ($prefixes as $prefix) {
+                    if (str_ends_with($prefix, '.')) {
+                        $q->orWhere('notification_type', 'like', $prefix . '%');
+                    } else {
+                        $q->orWhere('notification_type', $prefix);
+                    }
+                }
+            });
+        }
+
+        $total = $query->count();
+        $notifications = $query->skip($offset)->take($limit)->get();
+
+        return response()->json([
+            'data' => NotificationResource::collection($notifications),
+            'meta' => [
+                'total'        => $total,
+                'offset'       => $offset,
+                'limit'        => $limit,
+                'unread_count' => $this->pushService->getUnreadCount($user),
+            ],
+        ]);
+    }
+
+    #[OA\Get(
+        path: '/api/v1/notifications/{id}',
+        operationId: 'v1ShowNotification',
+        tags: ['Notifications'],
+        summary: 'Get a single notification',
+        security: [['sanctum' => []]],
+        parameters: [
+            new OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'string')),
+        ]
+    )]
+    #[OA\Response(response: 200, description: 'Notification detail')]
+    #[OA\Response(response: 404, description: 'Not found')]
+    public function show(Request $request, string $id): JsonResponse
+    {
+        $notification = MobilePushNotification::where('id', $id)
+            ->where('user_id', $request->user()->id)
+            ->first();
+
+        if (! $notification) {
+            return response()->json([
+                'error' => [
+                    'code'    => 'NOT_FOUND',
+                    'message' => 'Notification not found',
+                ],
+            ], 404);
+        }
+
+        return response()->json([
+            'data' => new NotificationResource($notification),
+        ]);
+    }
+
+    #[OA\Post(
+        path: '/api/v1/notifications/{id}/read',
+        operationId: 'v1MarkNotificationRead',
+        tags: ['Notifications'],
+        summary: 'Mark a notification as read',
+        security: [['sanctum' => []]],
+        parameters: [
+            new OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'string')),
+        ]
+    )]
+    #[OA\Response(response: 200, description: 'Marked as read')]
+    #[OA\Response(response: 404, description: 'Not found')]
+    public function markRead(Request $request, string $id): JsonResponse
+    {
+        $notification = MobilePushNotification::where('id', $id)
+            ->where('user_id', $request->user()->id)
+            ->first();
+
+        if (! $notification) {
+            return response()->json([
+                'error' => [
+                    'code'    => 'NOT_FOUND',
+                    'message' => 'Notification not found',
+                ],
+            ], 404);
+        }
+
+        $this->pushService->markAsRead($notification);
+        $notification->refresh();
+
+        return response()->json([
+            'data'    => new NotificationResource($notification),
+            'message' => 'Notification marked as read',
+        ]);
+    }
+
+    #[OA\Post(
+        path: '/api/v1/notifications/read-all',
+        operationId: 'v1MarkAllNotificationsRead',
+        tags: ['Notifications'],
+        summary: 'Mark all notifications as read',
+        security: [['sanctum' => []]]
+    )]
+    #[OA\Response(response: 200, description: 'All marked as read')]
+    public function markAllRead(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $count = $this->pushService->markAllAsRead($user);
+
+        return response()->json([
+            'data' => [
+                'count' => $count,
+            ],
+            'message' => "{$count} notifications marked as read",
+        ]);
+    }
+
+    #[OA\Get(
+        path: '/api/v1/notifications/unread-count',
+        operationId: 'v1NotificationUnreadCount',
+        tags: ['Notifications'],
+        summary: 'Get unread notification count',
+        security: [['sanctum' => []]]
+    )]
+    #[OA\Response(response: 200, description: 'Unread count')]
+    public function unreadCount(Request $request): JsonResponse
+    {
+        return response()->json([
+            'data' => [
+                'unread_count' => $this->pushService->getUnreadCount($request->user()),
+            ],
+        ]);
+    }
+}

--- a/app/Http/Resources/V1/NotificationResource.php
+++ b/app/Http/Resources/V1/NotificationResource.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\V1;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Domain\Mobile\Models\MobilePushNotification
+ */
+class NotificationResource extends JsonResource
+{
+    /**
+     * Simplified type category mapping.
+     *
+     * @var array<string, string>
+     */
+    private const TYPE_MAP = [
+        'transaction.received'      => 'transaction',
+        'transaction.sent'          => 'transaction',
+        'transaction.failed'        => 'transaction',
+        'balance.low'               => 'transaction',
+        'security.login'            => 'security',
+        'security.device_added'     => 'security',
+        'security.password_changed' => 'security',
+        'kyc.status_changed'        => 'system',
+        'system.maintenance'        => 'system',
+        'system.update'             => 'system',
+        'price.alert'               => 'promo',
+        'general'                   => 'system',
+    ];
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id'         => $this->id,
+            'type'       => $this->mapType($this->notification_type),
+            'title'      => $this->title,
+            'body'       => $this->body,
+            'data'       => $this->data,
+            'read'       => $this->read_at !== null,
+            'created_at' => $this->created_at->toIso8601String(),
+        ];
+    }
+
+    /**
+     * Map raw notification_type to simplified category.
+     */
+    private function mapType(string $rawType): string
+    {
+        if (isset(self::TYPE_MAP[$rawType])) {
+            return self::TYPE_MAP[$rawType];
+        }
+
+        // promo.* and marketing.* → promo
+        if (str_starts_with($rawType, 'promo.') || str_starts_with($rawType, 'marketing.')) {
+            return 'promo';
+        }
+
+        // security.* → security
+        if (str_starts_with($rawType, 'security.')) {
+            return 'security';
+        }
+
+        // transaction.* → transaction
+        if (str_starts_with($rawType, 'transaction.')) {
+            return 'transaction';
+        }
+
+        // system.* → system
+        if (str_starts_with($rawType, 'system.')) {
+            return 'system';
+        }
+
+        return 'system';
+    }
+}

--- a/tests/Feature/Api/V1/NotificationControllerTest.php
+++ b/tests/Feature/Api/V1/NotificationControllerTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Domain\Mobile\Models\MobilePushNotification;
+use App\Models\User;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class NotificationControllerTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+    }
+
+    private function createNotification(array $overrides = []): MobilePushNotification
+    {
+        return MobilePushNotification::create(array_merge([
+            'user_id'           => $this->user->id,
+            'notification_type' => MobilePushNotification::TYPE_TRANSACTION_RECEIVED,
+            'title'             => 'Test Notification',
+            'body'              => 'Test body content',
+            'data'              => ['amount' => '100'],
+            'status'            => MobilePushNotification::STATUS_SENT,
+        ], $overrides));
+    }
+
+    public function test_list_notifications_requires_auth(): void
+    {
+        $this->getJson('/api/v1/notifications')
+            ->assertStatus(401);
+    }
+
+    public function test_list_notifications_returns_paginated_results(): void
+    {
+        Sanctum::actingAs($this->user, ['read']);
+
+        // Create 5 notifications
+        for ($i = 0; $i < 5; $i++) {
+            $this->createNotification(['title' => "Notification {$i}"]);
+        }
+
+        $response = $this->getJson('/api/v1/notifications?offset=0&limit=3')
+            ->assertOk()
+            ->assertJsonStructure([
+                'data' => [
+                    '*' => ['id', 'type', 'title', 'body', 'data', 'read', 'created_at'],
+                ],
+                'meta' => ['total', 'offset', 'limit', 'unread_count'],
+            ]);
+
+        $data = $response->json();
+        $this->assertCount(3, $data['data']);
+        $this->assertEquals(5, $data['meta']['total']);
+        $this->assertEquals(0, $data['meta']['offset']);
+        $this->assertEquals(3, $data['meta']['limit']);
+    }
+
+    public function test_list_notifications_filters_by_type(): void
+    {
+        Sanctum::actingAs($this->user, ['read']);
+
+        $this->createNotification(['notification_type' => 'transaction.received']);
+        $this->createNotification(['notification_type' => 'transaction.sent']);
+        $this->createNotification(['notification_type' => 'security.login']);
+
+        $response = $this->getJson('/api/v1/notifications?type=transaction')
+            ->assertOk();
+
+        $data = $response->json();
+        $this->assertCount(2, $data['data']);
+        foreach ($data['data'] as $notification) {
+            $this->assertEquals('transaction', $notification['type']);
+        }
+    }
+
+    public function test_list_notifications_maps_types_correctly(): void
+    {
+        Sanctum::actingAs($this->user, ['read']);
+
+        $this->createNotification(['notification_type' => 'transaction.received']);
+        $this->createNotification(['notification_type' => 'security.login']);
+        $this->createNotification(['notification_type' => 'general']);
+        $this->createNotification(['notification_type' => 'price.alert']);
+
+        $response = $this->getJson('/api/v1/notifications')
+            ->assertOk();
+
+        $types = collect($response->json('data'))->pluck('type')->sort()->values()->all();
+        $this->assertEquals(['promo', 'security', 'system', 'transaction'], $types);
+    }
+
+    public function test_show_notification_returns_single(): void
+    {
+        Sanctum::actingAs($this->user, ['read']);
+
+        $notification = $this->createNotification(['title' => 'Specific One']);
+
+        $this->getJson("/api/v1/notifications/{$notification->id}")
+            ->assertOk()
+            ->assertJsonPath('data.title', 'Specific One')
+            ->assertJsonPath('data.read', false);
+    }
+
+    public function test_show_notification_returns_404_for_other_user(): void
+    {
+        Sanctum::actingAs($this->user, ['read']);
+
+        $otherUser = User::factory()->create();
+        $notification = $this->createNotification(['user_id' => $otherUser->id]);
+
+        $this->getJson("/api/v1/notifications/{$notification->id}")
+            ->assertStatus(404);
+    }
+
+    public function test_mark_read_marks_notification_as_read(): void
+    {
+        Sanctum::actingAs($this->user, ['read', 'write']);
+
+        $notification = $this->createNotification();
+        $this->assertNull($notification->read_at);
+
+        $this->postJson("/api/v1/notifications/{$notification->id}/read")
+            ->assertOk()
+            ->assertJsonPath('data.read', true)
+            ->assertJsonPath('message', 'Notification marked as read');
+
+        $notification->refresh();
+        $this->assertNotNull($notification->read_at);
+    }
+
+    public function test_mark_all_read_marks_all_as_read(): void
+    {
+        Sanctum::actingAs($this->user, ['read', 'write']);
+
+        $this->createNotification();
+        $this->createNotification();
+        $this->createNotification(['read_at' => now(), 'status' => 'read']);
+
+        $response = $this->postJson('/api/v1/notifications/read-all')
+            ->assertOk();
+
+        $this->assertEquals(2, $response->json('data.count'));
+    }
+
+    public function test_unread_count_returns_correct_count(): void
+    {
+        Sanctum::actingAs($this->user, ['read']);
+
+        $this->createNotification();
+        $this->createNotification();
+        $this->createNotification(['read_at' => now(), 'status' => 'read']);
+
+        $this->getJson('/api/v1/notifications/unread-count')
+            ->assertOk()
+            ->assertJsonPath('data.unread_count', 2);
+    }
+
+    public function test_list_notifications_default_limit_is_20(): void
+    {
+        Sanctum::actingAs($this->user, ['read']);
+
+        for ($i = 0; $i < 25; $i++) {
+            $this->createNotification();
+        }
+
+        $response = $this->getJson('/api/v1/notifications')
+            ->assertOk();
+
+        $this->assertCount(20, $response->json('data'));
+        $this->assertEquals(25, $response->json('meta.total'));
+    }
+}


### PR DESCRIPTION
## Summary
- **New controller** `NotificationController` at `/api/v1/notifications` with 5 endpoints (list, show, mark read, mark all read, unread count)
- **New resource** `NotificationResource` with simplified type categories (`transaction`, `security`, `system`, `promo`)
- **Backward compatible** — existing `/api/mobile/notifications/` routes unchanged
- Replaces old unread-count route with new controller while keeping same path

## Endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/v1/notifications` | Paginated list (offset/limit, type filter) |
| GET | `/api/v1/notifications/{id}` | Single notification |
| POST | `/api/v1/notifications/{id}/read` | Mark one read |
| POST | `/api/v1/notifications/read-all` | Mark all read |
| GET | `/api/v1/notifications/unread-count` | Unread count |

## Test plan
- [x] 10 feature tests covering auth, pagination, type filtering, mark read, unread count
- [ ] Verify `/api/mobile/notifications/` backward compat still works
- [ ] Mobile team integration test

🤖 Generated with [Claude Code](https://claude.com/claude-code)