### PR TITLE
feat: Banners API with Filament admin for promotional carousel

### DIFF
--- a/app/Filament/Resources/BannerResource.php
+++ b/app/Filament/Resources/BannerResource.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\BannerResource\Pages;
+use App\Models\Banner;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class BannerResource extends Resource
+{
+    protected static ?string $model = Banner::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-megaphone';
+
+    protected static ?string $navigationGroup = 'Marketing';
+
+    protected static ?int $navigationSort = 1;
+
+    public static function getNavigationBadge(): ?string
+    {
+        return (string) (static::getModel()::where('active', true)->count() ?: null);
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\Section::make('Banner Content')
+                    ->schema([
+                        Forms\Components\TextInput::make('title')
+                            ->required()
+                            ->maxLength(255),
+                        Forms\Components\TextInput::make('subtitle')
+                            ->maxLength(255),
+                        Forms\Components\TextInput::make('image_url')
+                            ->label('Image URL')
+                            ->url()
+                            ->maxLength(2048),
+                    ]),
+
+                Forms\Components\Section::make('Action')
+                    ->schema([
+                        Forms\Components\Select::make('action_type')
+                            ->options([
+                                'url'      => 'External URL',
+                                'screen'   => 'App Screen',
+                                'deeplink' => 'Deep Link',
+                            ])
+                            ->default('url')
+                            ->required(),
+                        Forms\Components\TextInput::make('action_url')
+                            ->label('Action URL / Screen')
+                            ->maxLength(2048),
+                    ])
+                    ->columns(2),
+
+                Forms\Components\Section::make('Display Settings')
+                    ->schema([
+                        Forms\Components\TextInput::make('position')
+                            ->numeric()
+                            ->default(0)
+                            ->required(),
+                        Forms\Components\Toggle::make('active')
+                            ->default(true),
+                        Forms\Components\DateTimePicker::make('starts_at')
+                            ->label('Visible From'),
+                        Forms\Components\DateTimePicker::make('ends_at')
+                            ->label('Visible Until'),
+                    ])
+                    ->columns(2),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('id')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('title')
+                    ->searchable()
+                    ->sortable()
+                    ->limit(40),
+                Tables\Columns\BadgeColumn::make('action_type')
+                    ->colors([
+                        'primary' => 'url',
+                        'success' => 'screen',
+                        'warning' => 'deeplink',
+                    ]),
+                Tables\Columns\TextColumn::make('position')
+                    ->sortable(),
+                Tables\Columns\IconColumn::make('active')
+                    ->boolean(),
+                Tables\Columns\TextColumn::make('starts_at')
+                    ->dateTime()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('ends_at')
+                    ->dateTime()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->defaultSort('position')
+            ->filters([
+                Tables\Filters\TernaryFilter::make('active'),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index'  => Pages\ListBanners::route('/'),
+            'create' => Pages\CreateBanner::route('/create'),
+            'edit'   => Pages\EditBanner::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/BannerResource/Pages/CreateBanner.php
+++ b/app/Filament/Resources/BannerResource/Pages/CreateBanner.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\BannerResource\Pages;
+
+use App\Filament\Resources\BannerResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateBanner extends CreateRecord
+{
+    protected static string $resource = BannerResource::class;
+
+    protected function getRedirectUrl(): string
+    {
+        return $this->getResource()::getUrl('index');
+    }
+}

--- a/app/Filament/Resources/BannerResource/Pages/EditBanner.php
+++ b/app/Filament/Resources/BannerResource/Pages/EditBanner.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\BannerResource\Pages;
+
+use App\Filament\Resources\BannerResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditBanner extends EditRecord
+{
+    protected static string $resource = BannerResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/BannerResource/Pages/ListBanners.php
+++ b/app/Filament/Resources/BannerResource/Pages/ListBanners.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\BannerResource\Pages;
+
+use App\Filament\Resources\BannerResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListBanners extends ListRecords
+{
+    protected static string $resource = BannerResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/V1/BannerController.php
+++ b/app/Http/Controllers/Api/V1/BannerController.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\V1\BannerResource;
+use App\Models\Banner;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use OpenApi\Attributes as OA;
+
+class BannerController extends Controller
+{
+    #[OA\Get(
+        path: '/api/v1/banners',
+        operationId: 'v1ListBanners',
+        tags: ['Banners'],
+        summary: 'List active banners for current user',
+        security: [['sanctum' => []]]
+    )]
+    #[OA\Response(response: 200, description: 'Active banners')]
+    public function index(Request $request): JsonResponse
+    {
+        $userId = $request->user()->id;
+
+        $banners = Banner::currentlyVisible()
+            ->notDismissedBy($userId)
+            ->orderBy('position')
+            ->orderBy('created_at', 'desc')
+            ->get();
+
+        return response()->json([
+            'data' => BannerResource::collection($banners),
+        ]);
+    }
+
+    #[OA\Post(
+        path: '/api/v1/banners/{id}/dismiss',
+        operationId: 'v1DismissBanner',
+        tags: ['Banners'],
+        summary: 'Dismiss a banner for the current user',
+        security: [['sanctum' => []]],
+        parameters: [
+            new OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),
+        ]
+    )]
+    #[OA\Response(response: 200, description: 'Banner dismissed')]
+    #[OA\Response(response: 404, description: 'Banner not found')]
+    public function dismiss(Request $request, int $id): JsonResponse
+    {
+        $banner = Banner::find($id);
+
+        if (! $banner) {
+            return response()->json([
+                'error' => [
+                    'code'    => 'NOT_FOUND',
+                    'message' => 'Banner not found',
+                ],
+            ], 404);
+        }
+
+        $banner->dismiss($request->user()->id);
+
+        return response()->json([
+            'message' => 'Banner dismissed',
+        ]);
+    }
+}

--- a/app/Http/Resources/V1/BannerResource.php
+++ b/app/Http/Resources/V1/BannerResource.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\V1;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Models\Banner
+ */
+class BannerResource extends JsonResource
+{
+    /** @return array<string, mixed> */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id'          => $this->id,
+            'title'       => $this->title,
+            'subtitle'    => $this->subtitle,
+            'image_url'   => $this->image_url,
+            'action_url'  => $this->action_url,
+            'action_type' => $this->action_type,
+            'position'    => $this->position,
+            'starts_at'   => $this->starts_at?->toIso8601String(),
+            'ends_at'     => $this->ends_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Models/Banner.php
+++ b/app/Models/Banner.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $id
+ * @property string $title
+ * @property string|null $subtitle
+ * @property string|null $image_url
+ * @property string|null $action_url
+ * @property string $action_type
+ * @property int $position
+ * @property bool $active
+ * @property \Carbon\Carbon|null $starts_at
+ * @property \Carbon\Carbon|null $ends_at
+ * @property array<string, mixed>|null $target_audience
+ * @property array<int>|null $dismissed_by
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ *
+ * @method static Builder<static> active()
+ * @method static Builder<static> currentlyVisible()
+ * @method static Builder<static> notDismissedBy(int $userId)
+ */
+class Banner extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'title',
+        'subtitle',
+        'image_url',
+        'action_url',
+        'action_type',
+        'position',
+        'active',
+        'starts_at',
+        'ends_at',
+        'target_audience',
+        'dismissed_by',
+    ];
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'active'          => 'boolean',
+            'position'        => 'integer',
+            'starts_at'       => 'datetime',
+            'ends_at'         => 'datetime',
+            'target_audience' => 'array',
+            'dismissed_by'    => 'array',
+        ];
+    }
+
+    /**
+     * @param Builder<static> $query
+     * @return Builder<static>
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('active', true);
+    }
+
+    /**
+     * @param Builder<static> $query
+     * @return Builder<static>
+     */
+    public function scopeCurrentlyVisible(Builder $query): Builder
+    {
+        $now = now();
+
+        return $query->active()
+            ->where(function (Builder $q) use ($now) {
+                $q->whereNull('starts_at')->orWhere('starts_at', '<=', $now);
+            })
+            ->where(function (Builder $q) use ($now) {
+                $q->whereNull('ends_at')->orWhere('ends_at', '>=', $now);
+            });
+    }
+
+    /**
+     * @param Builder<static> $query
+     * @return Builder<static>
+     */
+    public function scopeNotDismissedBy(Builder $query, int $userId): Builder
+    {
+        return $query->where(function (Builder $q) use ($userId) {
+            $q->whereNull('dismissed_by')
+                ->orWhereJsonDoesntContain('dismissed_by', $userId);
+        });
+    }
+
+    public function isDismissedBy(int $userId): bool
+    {
+        return in_array($userId, $this->dismissed_by ?? [], true);
+    }
+
+    public function dismiss(int $userId): void
+    {
+        $dismissed = $this->dismissed_by ?? [];
+        if (! in_array($userId, $dismissed, true)) {
+            $dismissed[] = $userId;
+            $this->update(['dismissed_by' => $dismissed]);
+        }
+    }
+}

--- a/database/migrations/2026_03_04_214329_create_banners_table.php
+++ b/database/migrations/2026_03_04_214329_create_banners_table.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('banners', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->string('subtitle')->nullable();
+            $table->string('image_url')->nullable();
+            $table->string('action_url')->nullable();
+            $table->string('action_type')->default('url'); // url, screen, deeplink
+            $table->integer('position')->default(0);
+            $table->boolean('active')->default(true);
+            $table->timestamp('starts_at')->nullable();
+            $table->timestamp('ends_at')->nullable();
+            $table->json('target_audience')->nullable();
+            $table->json('dismissed_by')->nullable(); // array of user IDs
+            $table->timestamps();
+
+            $table->index(['active', 'starts_at', 'ends_at']);
+            $table->index('position');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('banners');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -229,6 +229,14 @@ Route::prefix('v1/auth/passkey')
         Route::post('/register', [PasskeyController::class, 'register'])->name('register');
     });
 
+// v5.13.0 — Banners (promotional carousel)
+Route::prefix('v1/banners')->name('api.v1.banners.')
+    ->middleware(['auth:sanctum'])
+    ->group(function () {
+        Route::get('/', [App\Http\Controllers\Api\V1\BannerController::class, 'index'])->name('index');
+        Route::post('/{id}/dismiss', [App\Http\Controllers\Api\V1\BannerController::class, 'dismiss'])->name('dismiss');
+    });
+
 /*
 |--------------------------------------------------------------------------
 | External Route Includes

--- a/tests/Feature/Api/V1/BannerControllerTest.php
+++ b/tests/Feature/Api/V1/BannerControllerTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\Banner;
+use App\Models\User;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class BannerControllerTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+    }
+
+    public function test_list_banners_requires_auth(): void
+    {
+        $this->getJson('/api/v1/banners')
+            ->assertStatus(401);
+    }
+
+    public function test_list_banners_returns_active_visible_banners(): void
+    {
+        Sanctum::actingAs($this->user, ['read']);
+
+        Banner::create(['title' => 'Active Banner', 'active' => true, 'position' => 1]);
+        Banner::create(['title' => 'Inactive Banner', 'active' => false, 'position' => 2]);
+
+        $response = $this->getJson('/api/v1/banners')
+            ->assertOk()
+            ->assertJsonStructure([
+                'data' => [
+                    '*' => ['id', 'title', 'subtitle', 'image_url', 'action_url', 'action_type', 'position'],
+                ],
+            ]);
+
+        $this->assertCount(1, $response->json('data'));
+        $this->assertEquals('Active Banner', $response->json('data.0.title'));
+    }
+
+    public function test_list_banners_filters_by_date_range(): void
+    {
+        Sanctum::actingAs($this->user, ['read']);
+
+        Banner::create([
+            'title'     => 'Future Banner',
+            'active'    => true,
+            'starts_at' => now()->addDay(),
+            'position'  => 1,
+        ]);
+        Banner::create([
+            'title'   => 'Expired Banner',
+            'active'  => true,
+            'ends_at' => now()->subDay(),
+            'position' => 2,
+        ]);
+        Banner::create([
+            'title'     => 'Current Banner',
+            'active'    => true,
+            'starts_at' => now()->subDay(),
+            'ends_at'   => now()->addDay(),
+            'position'  => 3,
+        ]);
+
+        $response = $this->getJson('/api/v1/banners')
+            ->assertOk();
+
+        $this->assertCount(1, $response->json('data'));
+        $this->assertEquals('Current Banner', $response->json('data.0.title'));
+    }
+
+    public function test_list_banners_excludes_dismissed(): void
+    {
+        Sanctum::actingAs($this->user, ['read']);
+
+        Banner::create([
+            'title'        => 'Dismissed',
+            'active'       => true,
+            'dismissed_by' => [$this->user->id],
+            'position'     => 1,
+        ]);
+        Banner::create(['title' => 'Visible', 'active' => true, 'position' => 2]);
+
+        $response = $this->getJson('/api/v1/banners')
+            ->assertOk();
+
+        $this->assertCount(1, $response->json('data'));
+        $this->assertEquals('Visible', $response->json('data.0.title'));
+    }
+
+    public function test_dismiss_banner(): void
+    {
+        Sanctum::actingAs($this->user, ['read', 'write']);
+
+        $banner = Banner::create(['title' => 'Dismissable', 'active' => true, 'position' => 1]);
+
+        $this->postJson("/api/v1/banners/{$banner->id}/dismiss")
+            ->assertOk()
+            ->assertJsonPath('message', 'Banner dismissed');
+
+        $banner->refresh();
+        $this->assertTrue($banner->isDismissedBy($this->user->id));
+
+        // Verify it no longer appears in listing
+        $response = $this->getJson('/api/v1/banners')->assertOk();
+        $this->assertCount(0, $response->json('data'));
+    }
+
+    public function test_dismiss_nonexistent_banner_returns_404(): void
+    {
+        Sanctum::actingAs($this->user, ['read', 'write']);
+
+        $this->postJson('/api/v1/banners/99999/dismiss')
+            ->assertStatus(404);
+    }
+}


### PR DESCRIPTION
## Summary
- **Banner model** with scopes for active/visible/dismissed filtering and JSON-based dismiss tracking
- **2 API endpoints**: `GET /api/v1/banners` (list active for user) and `POST /api/v1/banners/{id}/dismiss`
- **Filament admin panel** under Marketing group with full CRUD, date pickers, action type selector
- Migration with composite index for efficient date-range queries

## Endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/v1/banners` | Active banners for user (date-filtered, not dismissed) |
| POST | `/api/v1/banners/{id}/dismiss` | Dismiss a banner |

## Test plan
- [x] 6 feature tests (auth, active filtering, date range, dismiss, 404)
- [ ] Filament admin CRUD manual verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)