### PR TITLE
feat: Referral System — code generation, apply, and KYC reward triggers

### DIFF
--- a/app/Domain/Referral/Listeners/CompleteReferralOnKycApproval.php
+++ b/app/Domain/Referral/Listeners/CompleteReferralOnKycApproval.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Referral\Listeners;
+
+use App\Domain\Compliance\Events\KycVerificationCompleted;
+use App\Domain\Referral\Services\ReferralService;
+use App\Models\User;
+use Exception;
+use Illuminate\Support\Facades\Log;
+
+class CompleteReferralOnKycApproval
+{
+    public function __construct(
+        private readonly ReferralService $referralService,
+    ) {
+    }
+
+    public function handle(KycVerificationCompleted $event): void
+    {
+        try {
+            $user = User::where('uuid', $event->userUuid)->first();
+
+            if (! $user) {
+                Log::warning('CompleteReferralOnKycApproval: User not found', [
+                    'user_uuid' => $event->userUuid,
+                ]);
+
+                return;
+            }
+
+            $this->referralService->completeReferral($user);
+        } catch (Exception $e) {
+            // Never throw from event listeners — log and continue
+            Log::error('CompleteReferralOnKycApproval failed', [
+                'user_uuid' => $event->userUuid,
+                'error'     => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/app/Domain/Referral/Services/ReferralService.php
+++ b/app/Domain/Referral/Services/ReferralService.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Referral\Services;
+
+use App\Domain\Relayer\Services\SponsorshipService;
+use App\Models\Referral;
+use App\Models\ReferralCode;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+class ReferralService
+{
+    public function __construct(
+        private readonly SponsorshipService $sponsorshipService,
+    ) {
+    }
+
+    /**
+     * Generate or retrieve a referral code for a user.
+     */
+    public function generateCode(User $user): ReferralCode
+    {
+        $existing = ReferralCode::where('user_id', $user->id)
+            ->where('active', true)
+            ->first();
+
+        if ($existing) {
+            return $existing;
+        }
+
+        $code = $this->createUniqueCode();
+
+        $referralCode = ReferralCode::create([
+            'user_id'  => $user->id,
+            'code'     => $code,
+            'max_uses' => 50,
+            'active'   => true,
+        ]);
+
+        // Also store on user for quick lookup
+        $user->update(['referral_code' => $code]);
+
+        Log::info('Referral code generated', [
+            'user_id' => $user->id,
+            'code'    => $code,
+        ]);
+
+        return $referralCode;
+    }
+
+    /**
+     * Apply a referral code for a new user.
+     */
+    public function applyCode(User $referee, string $code): Referral
+    {
+        // Check if user was already referred
+        $existingReferral = Referral::where('referee_id', $referee->id)->first();
+        if ($existingReferral) {
+            throw new RuntimeException('User has already been referred.');
+        }
+
+        $referralCode = ReferralCode::where('code', $code)->first();
+
+        if (! $referralCode) {
+            throw new RuntimeException('Invalid referral code.');
+        }
+
+        if (! $referralCode->canBeUsed()) {
+            throw new RuntimeException('Referral code is no longer valid.');
+        }
+
+        // Can't refer yourself
+        if ($referralCode->user_id === $referee->id) {
+            throw new RuntimeException('You cannot use your own referral code.');
+        }
+
+        return DB::transaction(function () use ($referee, $referralCode): Referral {
+            $referral = Referral::create([
+                'referrer_id'      => $referralCode->user_id,
+                'referee_id'       => $referee->id,
+                'referral_code_id' => $referralCode->id,
+                'status'           => Referral::STATUS_PENDING,
+            ]);
+
+            $referralCode->increment('uses_count');
+            $referee->update(['referred_by' => $referralCode->user_id]);
+
+            Log::info('Referral code applied', [
+                'referee_id'  => $referee->id,
+                'referrer_id' => $referralCode->user_id,
+                'code'        => $referralCode->code,
+            ]);
+
+            return $referral;
+        });
+    }
+
+    /**
+     * Complete a referral when the referee passes KYC, granting sponsorship to both parties.
+     */
+    public function completeReferral(User $referee): void
+    {
+        $referral = Referral::where('referee_id', $referee->id)
+            ->where('status', Referral::STATUS_PENDING)
+            ->first();
+
+        if (! $referral) {
+            return; // No pending referral for this user
+        }
+
+        DB::transaction(function () use ($referral): void {
+            $referral->update([
+                'status'       => Referral::STATUS_REWARDED,
+                'completed_at' => now(),
+            ]);
+
+            $referrer = User::find($referral->referrer_id);
+            $referee = User::find($referral->referee_id);
+
+            $txCount = (int) config('relayer.sponsorship.default_free_tx', 5);
+
+            // Grant sponsorship to both referrer and referee
+            if ($referrer) {
+                $this->sponsorshipService->grantSponsorship($referrer, $txCount);
+                Log::info('Referral reward granted to referrer', ['user_id' => $referrer->id, 'tx_count' => $txCount]);
+            }
+
+            if ($referee) {
+                $this->sponsorshipService->grantSponsorship($referee, $txCount);
+                Log::info('Referral reward granted to referee', ['user_id' => $referee->id, 'tx_count' => $txCount]);
+            }
+        });
+    }
+
+    /**
+     * Get referral stats for a user.
+     *
+     * @return array{total_referred: int, completed: int, pending: int, rewards_earned: int}
+     */
+    public function getUserStats(User $user): array
+    {
+        $referrals = Referral::where('referrer_id', $user->id);
+
+        return [
+            'total_referred' => (clone $referrals)->count(),
+            'completed'      => (clone $referrals)->where('status', Referral::STATUS_REWARDED)->count(),
+            'pending'        => (clone $referrals)->where('status', Referral::STATUS_PENDING)->count(),
+            'rewards_earned' => (clone $referrals)->where('status', Referral::STATUS_REWARDED)->count()
+                * (int) config('relayer.sponsorship.default_free_tx', 5),
+        ];
+    }
+
+    /**
+     * Get referrals list for a user (people they referred).
+     *
+     * @return \Illuminate\Database\Eloquent\Collection<int, Referral>
+     */
+    public function getUserReferrals(User $user): \Illuminate\Database\Eloquent\Collection
+    {
+        return Referral::where('referrer_id', $user->id)
+            ->with('referee:id,name,email')
+            ->orderBy('created_at', 'desc')
+            ->get();
+    }
+
+    private function createUniqueCode(): string
+    {
+        do {
+            $code = strtoupper(Str::random(8));
+        } while (ReferralCode::where('code', $code)->exists());
+
+        return $code;
+    }
+}

--- a/app/Http/Controllers/Api/V1/ReferralController.php
+++ b/app/Http/Controllers/Api/V1/ReferralController.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Domain\Referral\Services\ReferralService;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\V1\ReferralResource;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use OpenApi\Attributes as OA;
+use RuntimeException;
+
+class ReferralController extends Controller
+{
+    public function __construct(
+        private readonly ReferralService $referralService,
+    ) {
+    }
+
+    #[OA\Get(
+        path: '/api/v1/referrals/my-code',
+        operationId: 'v1GetReferralCode',
+        tags: ['Referrals'],
+        summary: 'Get or generate user referral code',
+        security: [['sanctum' => []]]
+    )]
+    #[OA\Response(response: 200, description: 'Referral code')]
+    public function myCode(Request $request): JsonResponse
+    {
+        $referralCode = $this->referralService->generateCode($request->user());
+
+        return response()->json([
+            'data' => [
+                'code'       => $referralCode->code,
+                'uses_count' => $referralCode->uses_count,
+                'max_uses'   => $referralCode->max_uses,
+                'active'     => $referralCode->active,
+                'expires_at' => $referralCode->expires_at?->toIso8601String(),
+            ],
+        ]);
+    }
+
+    #[OA\Post(
+        path: '/api/v1/referrals/apply',
+        operationId: 'v1ApplyReferralCode',
+        tags: ['Referrals'],
+        summary: 'Apply a referral code',
+        security: [['sanctum' => []]],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['code'],
+                properties: [
+                    new OA\Property(property: 'code', type: 'string', example: 'ABC12345'),
+                ]
+            )
+        )
+    )]
+    #[OA\Response(response: 200, description: 'Referral applied')]
+    #[OA\Response(response: 422, description: 'Validation error')]
+    public function apply(Request $request): JsonResponse
+    {
+        $request->validate([
+            'code' => 'required|string|size:8',
+        ]);
+
+        try {
+            $referral = $this->referralService->applyCode(
+                $request->user(),
+                strtoupper($request->input('code'))
+            );
+
+            return response()->json([
+                'data'    => new ReferralResource($referral->load('referee')),
+                'message' => 'Referral code applied successfully',
+            ]);
+        } catch (RuntimeException $e) {
+            return response()->json([
+                'error' => [
+                    'code'    => 'REFERRAL_ERROR',
+                    'message' => $e->getMessage(),
+                ],
+            ], 422);
+        }
+    }
+
+    #[OA\Get(
+        path: '/api/v1/referrals',
+        operationId: 'v1ListReferrals',
+        tags: ['Referrals'],
+        summary: 'List user referrals',
+        security: [['sanctum' => []]]
+    )]
+    #[OA\Response(response: 200, description: 'Referral list')]
+    public function index(Request $request): JsonResponse
+    {
+        $referrals = $this->referralService->getUserReferrals($request->user());
+
+        return response()->json([
+            'data' => ReferralResource::collection($referrals),
+        ]);
+    }
+
+    #[OA\Get(
+        path: '/api/v1/referrals/stats',
+        operationId: 'v1ReferralStats',
+        tags: ['Referrals'],
+        summary: 'Get referral stats',
+        security: [['sanctum' => []]]
+    )]
+    #[OA\Response(response: 200, description: 'Referral stats')]
+    public function stats(Request $request): JsonResponse
+    {
+        return response()->json([
+            'data' => $this->referralService->getUserStats($request->user()),
+        ]);
+    }
+}

--- a/app/Http/Resources/V1/ReferralResource.php
+++ b/app/Http/Resources/V1/ReferralResource.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\V1;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Models\Referral
+ */
+class ReferralResource extends JsonResource
+{
+    /** @return array<string, mixed> */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id'      => $this->id,
+            'referee' => $this->whenLoaded('referee', fn () => [
+                'id'   => $this->referee->id,
+                'name' => $this->referee->name,
+            ]),
+            'status'       => $this->status,
+            'completed_at' => $this->completed_at?->toIso8601String(),
+            'created_at'   => $this->created_at->toIso8601String(),
+        ];
+    }
+}

--- a/app/Models/Referral.php
+++ b/app/Models/Referral.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $referrer_id
+ * @property int $referee_id
+ * @property int $referral_code_id
+ * @property string $status
+ * @property \Carbon\Carbon|null $completed_at
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ */
+class Referral extends Model
+{
+    public const STATUS_PENDING = 'pending';
+
+    public const STATUS_COMPLETED = 'completed';
+
+    public const STATUS_REWARDED = 'rewarded';
+
+    protected $fillable = [
+        'referrer_id',
+        'referee_id',
+        'referral_code_id',
+        'status',
+        'completed_at',
+    ];
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'completed_at' => 'datetime',
+        ];
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function referrer(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'referrer_id');
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function referee(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'referee_id');
+    }
+
+    /** @return BelongsTo<ReferralCode, $this> */
+    public function referralCode(): BelongsTo
+    {
+        return $this->belongsTo(ReferralCode::class);
+    }
+}

--- a/app/Models/ReferralCode.php
+++ b/app/Models/ReferralCode.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property int $id
+ * @property int $user_id
+ * @property string $code
+ * @property int $uses_count
+ * @property int $max_uses
+ * @property bool $active
+ * @property \Carbon\Carbon|null $expires_at
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ *
+ * @method static Builder<static> usable()
+ */
+class ReferralCode extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'code',
+        'uses_count',
+        'max_uses',
+        'active',
+        'expires_at',
+    ];
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'uses_count' => 'integer',
+            'max_uses'   => 'integer',
+            'active'     => 'boolean',
+            'expires_at' => 'datetime',
+        ];
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /** @return HasMany<Referral, $this> */
+    public function referrals(): HasMany
+    {
+        return $this->hasMany(Referral::class);
+    }
+
+    /**
+     * @param Builder<static> $query
+     * @return Builder<static>
+     */
+    public function scopeUsable(Builder $query): Builder
+    {
+        return $query->where('active', true)
+            ->whereColumn('uses_count', '<', 'max_uses')
+            ->where(function (Builder $q) {
+                $q->whereNull('expires_at')->orWhere('expires_at', '>', now());
+            });
+    }
+
+    public function canBeUsed(): bool
+    {
+        if (! $this->active) {
+            return false;
+        }
+
+        if ($this->uses_count >= $this->max_uses) {
+            return false;
+        }
+
+        if ($this->expires_at !== null && $this->expires_at->isPast()) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -80,6 +80,8 @@ class User extends Authenticatable implements FilamentUser
         'free_tx_until',
         'sponsored_tx_used',
         'sponsored_tx_limit',
+        'referral_code',
+        'referred_by',
     ];
 
     /**
@@ -289,5 +291,25 @@ class User extends Authenticatable implements FilamentUser
             'uuid', // Local key on users table
             'uuid' // Local key on accounts table
         );
+    }
+
+    /**
+     * Get the user who referred this user.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<User, $this>
+     */
+    public function referrer(): \Illuminate\Database\Eloquent\Relations\BelongsTo
+    {
+        return $this->belongsTo(self::class, 'referred_by');
+    }
+
+    /**
+     * Get users referred by this user.
+     *
+     * @return HasMany<Referral, $this>
+     */
+    public function referrals(): HasMany
+    {
+        return $this->hasMany(Referral::class, 'referrer_id');
     }
 }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -4,9 +4,11 @@ namespace App\Providers;
 
 use App\Domain\Account\Events\MoneyTransferred;
 use App\Domain\Account\Listeners\CreateAccountForNewUser;
+use App\Domain\Compliance\Events\KycVerificationCompleted;
 use App\Domain\Mobile\Listeners\LogMobileAuditEventListener;
 use App\Domain\Mobile\Listeners\SendSecurityAlertListener;
 use App\Domain\Mobile\Listeners\SendTransactionPushNotificationListener;
+use App\Domain\Referral\Listeners\CompleteReferralOnKycApproval;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 
@@ -23,6 +25,9 @@ class EventServiceProvider extends ServiceProvider
         ],
         MoneyTransferred::class => [
             SendTransactionPushNotificationListener::class,
+        ],
+        KycVerificationCompleted::class => [
+            CompleteReferralOnKycApproval::class,
         ],
     ];
 

--- a/database/migrations/2026_03_04_220000_create_referral_codes_table.php
+++ b/database/migrations/2026_03_04_220000_create_referral_codes_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('referral_codes', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('code', 8)->unique();
+            $table->unsignedInteger('uses_count')->default(0);
+            $table->unsignedInteger('max_uses')->default(50);
+            $table->boolean('active')->default(true);
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['code', 'active']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('referral_codes');
+    }
+};

--- a/database/migrations/2026_03_04_220001_create_referrals_table.php
+++ b/database/migrations/2026_03_04_220001_create_referrals_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('referrals', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('referrer_id')->constrained('users')->onDelete('cascade');
+            $table->foreignId('referee_id')->constrained('users')->onDelete('cascade');
+            $table->foreignId('referral_code_id')->constrained()->onDelete('cascade');
+            $table->string('status')->default('pending'); // pending, completed, rewarded
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamps();
+
+            $table->unique('referee_id'); // Each user can only be referred once
+            $table->index(['referrer_id', 'status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('referrals');
+    }
+};

--- a/database/migrations/2026_03_04_220002_add_referral_fields_to_users_table.php
+++ b/database/migrations/2026_03_04_220002_add_referral_fields_to_users_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('referral_code', 8)->nullable()->after('sponsored_tx_limit');
+            $table->foreignId('referred_by')->nullable()->after('referral_code')
+                ->constrained('users')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropForeign(['referred_by']);
+            $table->dropColumn(['referral_code', 'referred_by']);
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -237,6 +237,16 @@ Route::prefix('v1/banners')->name('api.v1.banners.')
         Route::post('/{id}/dismiss', [App\Http\Controllers\Api\V1\BannerController::class, 'dismiss'])->name('dismiss');
     });
 
+// v5.13.0 — Referral System
+Route::prefix('v1/referrals')->name('api.v1.referrals.')
+    ->middleware(['auth:sanctum'])
+    ->group(function () {
+        Route::get('/my-code', [App\Http\Controllers\Api\V1\ReferralController::class, 'myCode'])->name('my-code');
+        Route::post('/apply', [App\Http\Controllers\Api\V1\ReferralController::class, 'apply'])->name('apply');
+        Route::get('/stats', [App\Http\Controllers\Api\V1\ReferralController::class, 'stats'])->name('stats');
+        Route::get('/', [App\Http\Controllers\Api\V1\ReferralController::class, 'index'])->name('index');
+    });
+
 // v5.13.0 — Gas Sponsorship status
 Route::prefix('v1/sponsorship')->name('api.v1.sponsorship.')
     ->middleware(['auth:sanctum'])

--- a/tests/Feature/Api/V1/ReferralControllerTest.php
+++ b/tests/Feature/Api/V1/ReferralControllerTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\Referral;
+use App\Models\ReferralCode;
+use App\Models\User;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class ReferralControllerTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        config(['relayer.sponsorship.enabled' => true, 'relayer.sponsorship.default_free_tx' => 5]);
+    }
+
+    public function test_get_my_code_requires_auth(): void
+    {
+        $this->getJson('/api/v1/referrals/my-code')
+            ->assertStatus(401);
+    }
+
+    public function test_get_my_code_generates_code(): void
+    {
+        Sanctum::actingAs($this->user, ['read']);
+
+        $response = $this->getJson('/api/v1/referrals/my-code')
+            ->assertOk()
+            ->assertJsonStructure(['data' => ['code', 'uses_count', 'max_uses', 'active']]);
+
+        $code = $response->json('data.code');
+        $this->assertEquals(8, strlen($code));
+        $this->assertTrue($response->json('data.active'));
+    }
+
+    public function test_get_my_code_returns_existing(): void
+    {
+        Sanctum::actingAs($this->user, ['read']);
+
+        $existing = ReferralCode::create([
+            'user_id'  => $this->user->id,
+            'code'     => 'TEST1234',
+            'max_uses' => 50,
+        ]);
+
+        $this->getJson('/api/v1/referrals/my-code')
+            ->assertOk()
+            ->assertJsonPath('data.code', 'TEST1234');
+    }
+
+    public function test_apply_code_creates_referral(): void
+    {
+        $referrer = User::factory()->create();
+        $referralCode = ReferralCode::create([
+            'user_id'  => $referrer->id,
+            'code'     => 'REF12345',
+            'max_uses' => 50,
+        ]);
+
+        Sanctum::actingAs($this->user, ['read', 'write']);
+
+        $this->postJson('/api/v1/referrals/apply', ['code' => 'REF12345'])
+            ->assertOk()
+            ->assertJsonPath('message', 'Referral code applied successfully');
+
+        $this->assertDatabaseHas('referrals', [
+            'referrer_id' => $referrer->id,
+            'referee_id'  => $this->user->id,
+            'status'      => 'pending',
+        ]);
+
+        $this->user->refresh();
+        $this->assertEquals($referrer->id, $this->user->referred_by);
+    }
+
+    public function test_apply_own_code_fails(): void
+    {
+        $referralCode = ReferralCode::create([
+            'user_id'  => $this->user->id,
+            'code'     => 'MYOWN123',
+            'max_uses' => 50,
+        ]);
+
+        Sanctum::actingAs($this->user, ['read', 'write']);
+
+        $this->postJson('/api/v1/referrals/apply', ['code' => 'MYOWN123'])
+            ->assertStatus(422)
+            ->assertJsonPath('error.message', 'You cannot use your own referral code.');
+    }
+
+    public function test_apply_invalid_code_fails(): void
+    {
+        Sanctum::actingAs($this->user, ['read', 'write']);
+
+        $this->postJson('/api/v1/referrals/apply', ['code' => 'INVALID1'])
+            ->assertStatus(422)
+            ->assertJsonPath('error.message', 'Invalid referral code.');
+    }
+
+    public function test_apply_code_twice_fails(): void
+    {
+        $referrer = User::factory()->create();
+        ReferralCode::create([
+            'user_id'  => $referrer->id,
+            'code'     => 'FIRST123',
+            'max_uses' => 50,
+        ]);
+
+        $referrer2 = User::factory()->create();
+        ReferralCode::create([
+            'user_id'  => $referrer2->id,
+            'code'     => 'SECND123',
+            'max_uses' => 50,
+        ]);
+
+        Sanctum::actingAs($this->user, ['read', 'write']);
+
+        $this->postJson('/api/v1/referrals/apply', ['code' => 'FIRST123'])
+            ->assertOk();
+
+        $this->postJson('/api/v1/referrals/apply', ['code' => 'SECND123'])
+            ->assertStatus(422)
+            ->assertJsonPath('error.message', 'User has already been referred.');
+    }
+
+    public function test_list_referrals(): void
+    {
+        Sanctum::actingAs($this->user, ['read']);
+
+        $referee = User::factory()->create();
+        $code = ReferralCode::create([
+            'user_id'  => $this->user->id,
+            'code'     => 'LIST1234',
+            'max_uses' => 50,
+        ]);
+        Referral::create([
+            'referrer_id'      => $this->user->id,
+            'referee_id'       => $referee->id,
+            'referral_code_id' => $code->id,
+            'status'           => 'pending',
+        ]);
+
+        $this->getJson('/api/v1/referrals')
+            ->assertOk()
+            ->assertJsonCount(1, 'data');
+    }
+
+    public function test_get_stats(): void
+    {
+        Sanctum::actingAs($this->user, ['read']);
+
+        $code = ReferralCode::create([
+            'user_id'  => $this->user->id,
+            'code'     => 'STAT1234',
+            'max_uses' => 50,
+        ]);
+
+        // Create 2 referrals (1 rewarded, 1 pending)
+        $referee1 = User::factory()->create();
+        Referral::create([
+            'referrer_id'      => $this->user->id,
+            'referee_id'       => $referee1->id,
+            'referral_code_id' => $code->id,
+            'status'           => 'rewarded',
+            'completed_at'     => now(),
+        ]);
+        $referee2 = User::factory()->create();
+        Referral::create([
+            'referrer_id'      => $this->user->id,
+            'referee_id'       => $referee2->id,
+            'referral_code_id' => $code->id,
+            'status'           => 'pending',
+        ]);
+
+        $this->getJson('/api/v1/referrals/stats')
+            ->assertOk()
+            ->assertJsonPath('data.total_referred', 2)
+            ->assertJsonPath('data.completed', 1)
+            ->assertJsonPath('data.pending', 1)
+            ->assertJsonPath('data.rewards_earned', 5);
+    }
+}


### PR DESCRIPTION
## Summary
- **ReferralCode/Referral models** with unique 8-char code generation and self-referral protection
- **ReferralService** orchestrates code generation, application, and KYC-triggered reward completion
- **KYC integration**: `CompleteReferralOnKycApproval` listener on `KycVerificationCompleted` event grants both referrer and referee free sponsored transactions via `SponsorshipService`
- **User model** extended with `referral_code`, `referred_by` fields + relationships

## Endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/v1/referrals/my-code` | Get or generate referral code |
| POST | `/api/v1/referrals/apply` | Apply referral code `{code}` |
| GET | `/api/v1/referrals` | List referrals (who you referred) |
| GET | `/api/v1/referrals/stats` | Stats (total, completed, rewards) |

## Dependencies
- Builds on PR #714 (Gas Sponsorship) for `SponsorshipService::grantSponsorship()`

## Test plan
- [x] 9 feature tests (auth, code gen, apply, self-ref block, double-apply, list, stats)
- [ ] Manual test: KYC completion triggers referral reward

🤖 Generated with [Claude Code](https://claude.com/claude-code)