### PR TITLE
refactor: mobile UX/security polish for investor feedback features

### DIFF
--- a/app/Domain/Ramp/Providers/MockRampProvider.php
+++ b/app/Domain/Ramp/Providers/MockRampProvider.php
@@ -6,6 +6,7 @@ namespace App\Domain\Ramp\Providers;
 
 use App\Domain\Ramp\Contracts\RampProviderInterface;
 use Illuminate\Support\Str;
+use RuntimeException;
 
 class MockRampProvider implements RampProviderInterface
 {
@@ -76,7 +77,11 @@ class MockRampProvider implements RampProviderInterface
 
     public function getWebhookValidator(): callable
     {
-        return fn (string $payload, string $signature): bool => true;
+        if (app()->environment('production')) {
+            throw new RuntimeException('Mock ramp provider must not be used in production.');
+        }
+
+        return fn (string $payload, string $signature): bool => $signature !== '';
     }
 
     public function getName(): string

--- a/app/Domain/Ramp/Services/RampService.php
+++ b/app/Domain/Ramp/Services/RampService.php
@@ -28,6 +28,7 @@ class RampService
 
         $quote = $this->provider->getQuote($type, $fiatCurrency, $fiatAmount, $cryptoCurrency);
         $quote['provider'] = $this->provider->getName();
+        $quote['valid_until'] = now()->addSeconds(60)->toIso8601String();
 
         return $quote;
     }

--- a/app/Domain/Referral/Listeners/CompleteReferralOnKycApproval.php
+++ b/app/Domain/Referral/Listeners/CompleteReferralOnKycApproval.php
@@ -6,6 +6,7 @@ namespace App\Domain\Referral\Listeners;
 
 use App\Domain\Compliance\Events\KycVerificationCompleted;
 use App\Domain\Referral\Services\ReferralService;
+use App\Models\Referral;
 use App\Models\User;
 use Exception;
 use Illuminate\Support\Facades\Log;
@@ -24,6 +25,19 @@ class CompleteReferralOnKycApproval
 
             if (! $user) {
                 Log::warning('CompleteReferralOnKycApproval: User not found', [
+                    'user_uuid' => $event->userUuid,
+                ]);
+
+                return;
+            }
+
+            // Idempotency: skip if already rewarded (guards against duplicate events)
+            $alreadyRewarded = Referral::where('referee_id', $user->id)
+                ->where('status', Referral::STATUS_REWARDED)
+                ->exists();
+
+            if ($alreadyRewarded) {
+                Log::info('CompleteReferralOnKycApproval: Already rewarded, skipping', [
                     'user_uuid' => $event->userUuid,
                 ]);
 

--- a/app/Domain/Referral/Services/ReferralService.php
+++ b/app/Domain/Referral/Services/ReferralService.php
@@ -138,33 +138,41 @@ class ReferralService
     }
 
     /**
-     * Get referral stats for a user.
+     * Get referral stats for a user (single aggregated query).
      *
-     * @return array{total_referred: int, completed: int, pending: int, rewards_earned: int}
+     * @return array{total_referred: int, completed: int, pending: int, rewards_earned: int, reward_per_referral: int}
      */
     public function getUserStats(User $user): array
     {
-        $referrals = Referral::where('referrer_id', $user->id);
+        $stats = Referral::where('referrer_id', $user->id)
+            ->selectRaw('COUNT(*) as total')
+            ->selectRaw('SUM(CASE WHEN status = ? THEN 1 ELSE 0 END) as completed', [Referral::STATUS_REWARDED])
+            ->selectRaw('SUM(CASE WHEN status = ? THEN 1 ELSE 0 END) as pending', [Referral::STATUS_PENDING])
+            ->first();
+
+        $rewardPerReferral = (int) config('relayer.sponsorship.default_free_tx', 5);
 
         return [
-            'total_referred' => (clone $referrals)->count(),
-            'completed'      => (clone $referrals)->where('status', Referral::STATUS_REWARDED)->count(),
-            'pending'        => (clone $referrals)->where('status', Referral::STATUS_PENDING)->count(),
-            'rewards_earned' => (clone $referrals)->where('status', Referral::STATUS_REWARDED)->count()
-                * (int) config('relayer.sponsorship.default_free_tx', 5),
+            'total_referred'      => (int) $stats->total,
+            'completed'           => (int) $stats->completed,
+            'pending'             => (int) $stats->pending,
+            'rewards_earned'      => (int) $stats->completed * $rewardPerReferral,
+            'reward_per_referral' => $rewardPerReferral,
         ];
     }
 
     /**
-     * Get referrals list for a user (people they referred).
+     * Get referrals list for a user (people they referred), paginated.
      *
      * @return \Illuminate\Database\Eloquent\Collection<int, Referral>
      */
-    public function getUserReferrals(User $user): \Illuminate\Database\Eloquent\Collection
+    public function getUserReferrals(User $user, int $limit = 20, int $offset = 0): \Illuminate\Database\Eloquent\Collection
     {
         return Referral::where('referrer_id', $user->id)
-            ->with('referee:id,name,email')
+            ->with('referee:id,name')
             ->orderBy('created_at', 'desc')
+            ->skip($offset)
+            ->take($limit)
             ->get();
     }
 

--- a/app/Http/Controllers/Api/V1/RampController.php
+++ b/app/Http/Controllers/Api/V1/RampController.php
@@ -45,6 +45,7 @@ class RampController extends Controller
                     new OA\Property(property: 'fee', type: 'number', example: 1.5),
                     new OA\Property(property: 'fee_currency', type: 'string', example: 'USD'),
                     new OA\Property(property: 'provider', type: 'string', example: 'mock'),
+                    new OA\Property(property: 'valid_until', type: 'string', format: 'date-time'),
                 ]),
             ]
         )

--- a/app/Http/Controllers/Api/V1/ReferralController.php
+++ b/app/Http/Controllers/Api/V1/ReferralController.php
@@ -33,10 +33,13 @@ class ReferralController extends Controller
             properties: [
                 new OA\Property(property: 'data', type: 'object', properties: [
                     new OA\Property(property: 'code', type: 'string', example: 'ABC12345'),
+                    new OA\Property(property: 'share_link', type: 'string', example: 'https://finaegis.com/invite/ABC12345'),
+                    new OA\Property(property: 'share_text', type: 'string'),
                     new OA\Property(property: 'uses_count', type: 'integer', example: 3),
                     new OA\Property(property: 'max_uses', type: 'integer', example: 50),
                     new OA\Property(property: 'active', type: 'boolean', example: true),
                     new OA\Property(property: 'expires_at', type: 'string', format: 'date-time', nullable: true),
+                    new OA\Property(property: 'created_at', type: 'string', format: 'date-time'),
                 ]),
             ]
         )
@@ -45,13 +48,18 @@ class ReferralController extends Controller
     {
         $referralCode = $this->referralService->generateCode($request->user());
 
+        $code = $referralCode->code;
+
         return response()->json([
             'data' => [
-                'code'       => $referralCode->code,
+                'code'       => $code,
+                'share_link' => url("/invite/{$code}"),
+                'share_text' => "Join FinAegis with my referral code {$code} and get free transactions!",
                 'uses_count' => $referralCode->uses_count,
                 'max_uses'   => $referralCode->max_uses,
                 'active'     => $referralCode->active,
                 'expires_at' => $referralCode->expires_at?->toIso8601String(),
+                'created_at' => $referralCode->created_at->toIso8601String(),
             ],
         ]);
     }
@@ -105,15 +113,26 @@ class ReferralController extends Controller
         operationId: 'v1ListReferrals',
         tags: ['Referrals'],
         summary: 'List user referrals',
-        security: [['sanctum' => []]]
+        security: [['sanctum' => []]],
+        parameters: [
+            new OA\Parameter(name: 'offset', in: 'query', required: false, schema: new OA\Schema(type: 'integer', default: 0)),
+            new OA\Parameter(name: 'limit', in: 'query', required: false, schema: new OA\Schema(type: 'integer', default: 20, maximum: 50)),
+        ]
     )]
     #[OA\Response(response: 200, description: 'Referral list')]
     public function index(Request $request): JsonResponse
     {
-        $referrals = $this->referralService->getUserReferrals($request->user());
+        $offset = max(0, (int) $request->input('offset', 0));
+        $limit = min(max(1, (int) $request->input('limit', 20)), 50);
+
+        $referrals = $this->referralService->getUserReferrals($request->user(), $limit, $offset);
 
         return response()->json([
             'data' => ReferralResource::collection($referrals),
+            'meta' => [
+                'offset' => $offset,
+                'limit'  => $limit,
+            ],
         ]);
     }
 
@@ -134,6 +153,7 @@ class ReferralController extends Controller
                     new OA\Property(property: 'completed', type: 'integer', example: 3),
                     new OA\Property(property: 'pending', type: 'integer', example: 2),
                     new OA\Property(property: 'rewards_earned', type: 'integer', example: 15),
+                    new OA\Property(property: 'reward_per_referral', type: 'integer', example: 5),
                 ]),
             ]
         )

--- a/app/Http/Controllers/Api/V1/SponsorshipController.php
+++ b/app/Http/Controllers/Api/V1/SponsorshipController.php
@@ -32,8 +32,11 @@ class SponsorshipController extends Controller
                 new OA\Property(property: 'data', type: 'object', properties: [
                     new OA\Property(property: 'eligible', type: 'boolean', example: true),
                     new OA\Property(property: 'remaining_free_tx', type: 'integer', example: 3),
-                    new OA\Property(property: 'free_until', type: 'string', format: 'date-time', nullable: true),
+                    new OA\Property(property: 'total_limit', type: 'integer', example: 5),
                     new OA\Property(property: 'total_sponsored', type: 'integer', example: 2),
+                    new OA\Property(property: 'progress_pct', type: 'number', example: 40),
+                    new OA\Property(property: 'free_until', type: 'string', format: 'date-time', nullable: true),
+                    new OA\Property(property: 'expires_in_days', type: 'integer', nullable: true, example: 25),
                 ]),
             ]
         )
@@ -44,12 +47,20 @@ class SponsorshipController extends Controller
         $eligible = $this->sponsorshipService->isEligible($user);
         $remaining = $this->sponsorshipService->getRemainingFreeTx($user);
 
+        $limit = $user->sponsored_tx_limit;
+        $expiresInDays = $user->free_tx_until?->isFuture()
+            ? (int) now()->diffInDays($user->free_tx_until, false)
+            : null;
+
         return response()->json([
             'data' => [
                 'eligible'          => $eligible,
                 'remaining_free_tx' => $remaining,
-                'free_until'        => $user->free_tx_until?->toIso8601String(),
+                'total_limit'       => $limit,
                 'total_sponsored'   => $user->sponsored_tx_used,
+                'progress_pct'      => $limit > 0 ? round(($user->sponsored_tx_used / $limit) * 100) : 0,
+                'free_until'        => $user->free_tx_until?->toIso8601String(),
+                'expires_in_days'   => $expiresInDays,
             ],
         ]);
     }

--- a/app/Http/Resources/V1/BannerResource.php
+++ b/app/Http/Resources/V1/BannerResource.php
@@ -12,6 +12,12 @@ use Illuminate\Http\Resources\Json\JsonResource;
  */
 class BannerResource extends JsonResource
 {
+    private const CTA_LABELS = [
+        'url'      => 'Learn More',
+        'screen'   => 'View',
+        'deeplink' => 'Open',
+    ];
+
     /** @return array<string, mixed> */
     public function toArray(Request $request): array
     {
@@ -22,9 +28,8 @@ class BannerResource extends JsonResource
             'image_url'   => $this->image_url,
             'action_url'  => $this->action_url,
             'action_type' => $this->action_type,
+            'cta_label'   => self::CTA_LABELS[$this->action_type] ?? 'View',
             'position'    => $this->position,
-            'starts_at'   => $this->starts_at?->toIso8601String(),
-            'ends_at'     => $this->ends_at?->toIso8601String(),
         ];
     }
 }

--- a/app/Http/Resources/V1/NotificationResource.php
+++ b/app/Http/Resources/V1/NotificationResource.php
@@ -33,13 +33,36 @@ class NotificationResource extends JsonResource
     ];
 
     /**
+     * Subtype extraction from raw notification_type (part after the dot).
+     */
+    private const SUBTYPE_ICONS = [
+        'received'         => 'arrow_down',
+        'sent'             => 'arrow_up',
+        'failed'           => 'alert_circle',
+        'low'              => 'trending_down',
+        'login'            => 'shield',
+        'device_added'     => 'smartphone',
+        'password_changed' => 'lock',
+        'status_changed'   => 'badge_check',
+        'maintenance'      => 'wrench',
+        'update'           => 'refresh',
+        'alert'            => 'bell',
+    ];
+
+    /**
      * @return array<string, mixed>
      */
     public function toArray(Request $request): array
     {
+        $rawType = $this->notification_type;
+        $category = $this->mapType($rawType);
+        $subtype = str_contains($rawType, '.') ? substr($rawType, strrpos($rawType, '.') + 1) : null;
+
         return [
             'id'         => $this->id,
-            'type'       => $this->mapType($this->notification_type),
+            'type'       => $category,
+            'subtype'    => $subtype,
+            'icon'       => self::SUBTYPE_ICONS[$subtype] ?? 'bell',
             'title'      => $this->title,
             'body'       => $this->body,
             'data'       => $this->data,

--- a/app/Http/Resources/V1/RampSessionResource.php
+++ b/app/Http/Resources/V1/RampSessionResource.php
@@ -15,18 +15,23 @@ class RampSessionResource extends JsonResource
     /** @return array<string, mixed> */
     public function toArray(Request $request): array
     {
+        $metadata = $this->metadata ?? [];
+
         return [
             'id'              => $this->id,
             'provider'        => $this->provider,
             'type'            => $this->type,
+            'type_label'      => $this->type === 'on' ? 'Buy Crypto' : 'Sell Crypto',
             'fiat_currency'   => $this->fiat_currency,
             'fiat_amount'     => $this->fiat_amount,
             'crypto_currency' => $this->crypto_currency,
             'crypto_amount'   => $this->crypto_amount,
             'status'          => $this->status,
-            'redirect_url'    => $this->metadata['redirect_url'] ?? null,
-            'widget_config'   => $this->metadata['widget_config'] ?? null,
+            'status_label'    => ucfirst($this->status),
+            'redirect_url'    => $metadata['redirect_url'] ?? null,
+            'widget_config'   => $metadata['widget_config'] ?? null,
             'created_at'      => $this->created_at->toIso8601String(),
+            'updated_at'      => $this->updated_at->toIso8601String(),
         ];
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -241,7 +241,7 @@ Route::prefix('v1/banners')->name('api.v1.banners.')
 Route::prefix('v1/ramp')->name('api.v1.ramp.')
     ->middleware(['auth:sanctum'])
     ->group(function () {
-        Route::get('/quote', [App\Http\Controllers\Api\V1\RampController::class, 'quote'])->name('quote');
+        Route::get('/quote', [App\Http\Controllers\Api\V1\RampController::class, 'quote'])->middleware('api.rate_limit:query')->name('quote');
         Route::post('/session', [App\Http\Controllers\Api\V1\RampController::class, 'createSession'])->name('session.create');
         Route::get('/session/{id}', [App\Http\Controllers\Api\V1\RampController::class, 'getSession'])->name('session.show');
         Route::get('/sessions', [App\Http\Controllers\Api\V1\RampController::class, 'listSessions'])->name('sessions');


### PR DESCRIPTION
## Summary

Professional mobile designer / UX / copywriter / marketing / SEO / AI review of PRs #712-#717 with actionable refactoring applied.

### Critical Security Fixes
- **MockRampProvider**: Production environment guard (`throw` if `app()->environment('production')`) + require non-empty webhook signatures instead of always-true validator
- **CompleteReferralOnKycApproval**: Idempotency guard — check if referral already rewarded before granting double sponsorship on duplicate KYC events

### Mobile UX Enhancements
- **Notifications**: Added `subtype` (received/sent/failed/login/etc.) and `icon` (arrow_down/shield/wrench/bell) fields for mobile list rendering differentiation
- **Banners**: Added `cta_label` ("Learn More"/"View"/"Open") for mobile button text; removed `starts_at`/`ends_at` from response (redundant — already server-filtered)
- **Ramp Sessions**: Added `type_label` ("Buy Crypto"/"Sell Crypto"), `status_label`, `updated_at` for mobile display
- **Referrals**: Added `share_link`, `share_text`, `created_at` to my-code response for native share sheet integration
- **Sponsorship**: Added `progress_pct`, `total_limit`, `expires_in_days` for progress bar UI rendering
- **Ramp Quotes**: Added `valid_until` (60s TTL) so mobile knows when to refresh quote

### Performance
- `ReferralService::getUserStats()` — Replaced 4 `clone` queries with single aggregated SQL (`SUM(CASE WHEN...)`)
- `ReferralService::getUserReferrals()` — Added pagination (offset/limit, default 20, max 50)
- Removed `email` from referee eager load (GDPR-clean)
- Added `api.rate_limit:query` middleware to ramp quote endpoint

### New response field: `reward_per_referral`
Stats endpoint now includes how many free TX each referral earns, so mobile can display "Earn 5 free transactions per friend!"

## Test plan

- [x] All 49 investor feedback tests pass (167 assertions)
- [x] Code style clean (php-cs-fixer)
- [x] No new files, all changes are refinements to existing code

🤖 Generated with [Claude Code](https://claude.com/claude-code)