### PR TITLE
refactor: mobile UX polish — third review pass

### DIFF
--- a/app/Domain/Ramp/Services/RampService.php
+++ b/app/Domain/Ramp/Services/RampService.php
@@ -128,6 +128,16 @@ class RampService
             return;
         }
 
+        // Idempotency: don't overwrite terminal states
+        if (in_array($session->status, [RampSession::STATUS_COMPLETED, RampSession::STATUS_FAILED], true)) {
+            Log::info('Ramp webhook skipped — session already terminal', [
+                'session_id' => $session->id,
+                'status'     => $session->status,
+            ]);
+
+            return;
+        }
+
         $status = $payload['status'] ?? 'processing';
         $session->update([
             'status'        => $status,

--- a/app/Filament/Resources/BannerResource.php
+++ b/app/Filament/Resources/BannerResource.php
@@ -57,6 +57,10 @@ class BannerResource extends Resource
                         Forms\Components\TextInput::make('action_url')
                             ->label('Action URL / Screen')
                             ->maxLength(2048),
+                        Forms\Components\TextInput::make('cta_label')
+                            ->label('CTA Button Label')
+                            ->placeholder('Auto: Learn More / View / Open')
+                            ->maxLength(50),
                     ])
                     ->columns(2),
 

--- a/app/Http/Controllers/Api/V1/ReferralController.php
+++ b/app/Http/Controllers/Api/V1/ReferralController.php
@@ -54,7 +54,7 @@ class ReferralController extends Controller
             'data' => [
                 'code'       => $code,
                 'share_link' => url("/invite/{$code}"),
-                'share_text' => "Join FinAegis with my referral code {$code} and get free transactions!",
+                'share_text' => str_replace('{code}', $code, (string) config('ramp.referral_share_text')),
                 'uses_count' => $referralCode->uses_count,
                 'max_uses'   => $referralCode->max_uses,
                 'active'     => $referralCode->active,
@@ -125,11 +125,15 @@ class ReferralController extends Controller
         $offset = max(0, (int) $request->input('offset', 0));
         $limit = min(max(1, (int) $request->input('limit', 20)), 50);
 
-        $referrals = $this->referralService->getUserReferrals($request->user(), $limit, $offset);
+        /** @var \App\Models\User $user */
+        $user = $request->user();
+        $referrals = $this->referralService->getUserReferrals($user, $limit, $offset);
+        $total = \App\Models\Referral::where('referrer_id', $user->id)->count();
 
         return response()->json([
             'data' => ReferralResource::collection($referrals),
             'meta' => [
+                'total'  => $total,
                 'offset' => $offset,
                 'limit'  => $limit,
             ],

--- a/app/Http/Resources/V1/BannerResource.php
+++ b/app/Http/Resources/V1/BannerResource.php
@@ -28,7 +28,7 @@ class BannerResource extends JsonResource
             'image_url'   => $this->image_url,
             'action_url'  => $this->action_url,
             'action_type' => $this->action_type,
-            'cta_label'   => self::CTA_LABELS[$this->action_type] ?? 'View',
+            'cta_label'   => $this->cta_label ?? self::CTA_LABELS[$this->action_type] ?? 'View',
             'position'    => $this->position,
         ];
     }

--- a/app/Http/Resources/V1/NotificationResource.php
+++ b/app/Http/Resources/V1/NotificationResource.php
@@ -63,6 +63,7 @@ class NotificationResource extends JsonResource
             'type'       => $category,
             'subtype'    => $subtype,
             'icon'       => self::SUBTYPE_ICONS[$subtype] ?? 'bell',
+            'icon_set'   => 'material',
             'title'      => $this->title,
             'body'       => $this->body,
             'data'       => $this->data,

--- a/app/Http/Resources/V1/ReferralResource.php
+++ b/app/Http/Resources/V1/ReferralResource.php
@@ -21,9 +21,10 @@ class ReferralResource extends JsonResource
                 'id'   => $this->referee->id,
                 'name' => $this->referee->name,
             ]),
-            'status'       => $this->status,
-            'completed_at' => $this->completed_at?->toIso8601String(),
-            'created_at'   => $this->created_at->toIso8601String(),
+            'status'        => $this->status,
+            'reward_amount' => (int) config('relayer.sponsorship.default_free_tx', 5),
+            'completed_at'  => $this->completed_at?->toIso8601String(),
+            'created_at'    => $this->created_at->toIso8601String(),
         ];
     }
 }

--- a/app/Models/Banner.php
+++ b/app/Models/Banner.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property string|null $image_url
  * @property string|null $action_url
  * @property string $action_type
+ * @property string|null $cta_label
  * @property int $position
  * @property bool $active
  * @property \Carbon\Carbon|null $starts_at
@@ -38,6 +39,7 @@ class Banner extends Model
         'image_url',
         'action_url',
         'action_type',
+        'cta_label',
         'position',
         'active',
         'starts_at',

--- a/config/ramp.php
+++ b/config/ramp.php
@@ -62,4 +62,15 @@ return [
         'max_fiat_amount' => (float) env('RAMP_MAX_AMOUNT', 10000.00),
         'daily_limit'     => (float) env('RAMP_DAILY_LIMIT', 50000.00),
     ],
+    /*
+    |--------------------------------------------------------------------------
+    | Referral Share Copy
+    |--------------------------------------------------------------------------
+    | Customizable by marketing. Use {code} placeholder for referral code.
+    */
+
+    'referral_share_text' => env(
+        'REFERRAL_SHARE_TEXT',
+        'Join FinAegis with my code {code} and earn free transactions!'
+    ),
 ];

--- a/database/migrations/2026_03_05_071715_add_cta_label_to_banners_table.php
+++ b/database/migrations/2026_03_05_071715_add_cta_label_to_banners_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('banners', function (Blueprint $table) {
+            $table->string('cta_label')->nullable()->after('action_type');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('banners', function (Blueprint $table) {
+            $table->dropColumn('cta_label');
+        });
+    }
+};

--- a/tests/Feature/Api/V1/BannerControllerTest.php
+++ b/tests/Feature/Api/V1/BannerControllerTest.php
@@ -37,7 +37,7 @@ class BannerControllerTest extends TestCase
             ->assertOk()
             ->assertJsonStructure([
                 'data' => [
-                    '*' => ['id', 'title', 'subtitle', 'image_url', 'action_url', 'action_type', 'position'],
+                    '*' => ['id', 'title', 'subtitle', 'image_url', 'action_url', 'action_type', 'cta_label', 'position'],
                 ],
             ]);
 
@@ -119,5 +119,33 @@ class BannerControllerTest extends TestCase
 
         $this->postJson('/api/v1/banners/99999/dismiss')
             ->assertStatus(404);
+    }
+
+    public function test_cta_label_uses_custom_value_from_db(): void
+    {
+        Sanctum::actingAs($this->user, ['read']);
+
+        Banner::create([
+            'title'       => 'Custom CTA',
+            'active'      => true,
+            'action_type' => 'url',
+            'cta_label'   => 'Shop Now',
+            'position'    => 1,
+        ]);
+        Banner::create([
+            'title'       => 'Default CTA',
+            'active'      => true,
+            'action_type' => 'screen',
+            'position'    => 2,
+        ]);
+
+        $response = $this->getJson('/api/v1/banners')->assertOk();
+
+        $data = $response->json('data');
+        $custom = collect($data)->firstWhere('title', 'Custom CTA');
+        $default = collect($data)->firstWhere('title', 'Default CTA');
+
+        $this->assertEquals('Shop Now', $custom['cta_label']);
+        $this->assertEquals('View', $default['cta_label']);
     }
 }

--- a/tests/Feature/Api/V1/ReferralControllerTest.php
+++ b/tests/Feature/Api/V1/ReferralControllerTest.php
@@ -34,11 +34,12 @@ class ReferralControllerTest extends TestCase
 
         $response = $this->getJson('/api/v1/referrals/my-code')
             ->assertOk()
-            ->assertJsonStructure(['data' => ['code', 'uses_count', 'max_uses', 'active']]);
+            ->assertJsonStructure(['data' => ['code', 'share_link', 'share_text', 'uses_count', 'max_uses', 'active', 'created_at']]);
 
         $code = $response->json('data.code');
         $this->assertEquals(8, strlen($code));
         $this->assertTrue($response->json('data.active'));
+        $this->assertStringContainsString($code, $response->json('data.share_text'));
     }
 
     public function test_get_my_code_returns_existing(): void
@@ -151,7 +152,9 @@ class ReferralControllerTest extends TestCase
 
         $this->getJson('/api/v1/referrals')
             ->assertOk()
-            ->assertJsonCount(1, 'data');
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('meta.total', 1)
+            ->assertJsonStructure(['data' => ['*' => ['id', 'status', 'reward_amount', 'created_at']]]);
     }
 
     public function test_get_stats(): void


### PR DESCRIPTION
## Summary
- **Configurable referral share text**: Moved hardcoded share copy to `config/ramp.php` with `{code}` placeholder — marketing can customize via `REFERRAL_SHARE_TEXT` env var
- **Banner CTA label**: Added `cta_label` nullable DB column (migration) so marketing can set per-banner button text (e.g. "Shop Now"), with automatic fallback defaults (Learn More / View / Open)
- **Webhook idempotency**: RampService now skips webhooks for sessions already in terminal state (completed/failed), preventing duplicate processing
- **Response enrichment**: Added `total` to referral list pagination meta, `reward_amount` to ReferralResource, `icon_set: 'material'` to NotificationResource
- **PHPStan fix**: Added `@var` annotation in ReferralController (net -1 error)
- **Tests**: Added CTA label test, enriched referral list/my-code assertions (39 tests, 168 assertions pass)

## Test plan
- [x] All 39 feature tests pass (`pest --parallel --filter`)
- [x] PHPStan: no new errors (reduced by 1)
- [x] php-cs-fixer: clean
- [x] Migration: `add_cta_label_to_banners_table` verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)