### PR TITLE
feat: Onramper integration for fiat on/off-ramp

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -229,6 +229,19 @@ FLUTTERWAVE_SETTLEMENT_NGN=FLUTTERWAVE_SETTLEMENT_NGN_ACCOUNT
 FLUTTERWAVE_SETTLEMENT_USD=FLUTTERWAVE_SETTLEMENT_USD_ACCOUNT
 FLUTTERWAVE_SETTLEMENT_KES=FLUTTERWAVE_SETTLEMENT_KES_ACCOUNT
 
+# Onramper (Fiat on/off-ramp aggregator — https://onramper.com)
+RAMP_PROVIDER=mock
+ONRAMPER_API_KEY=
+ONRAMPER_SECRET_KEY=
+ONRAMPER_BASE_URL=https://api.onramper.com
+ONRAMPER_WIDGET_URL=https://buy.onramper.com
+ONRAMPER_ENABLED=false
+ONRAMPER_SUCCESS_REDIRECT_URL=
+ONRAMPER_FAILURE_REDIRECT_URL=
+RAMP_MIN_AMOUNT=10
+RAMP_MAX_AMOUNT=10000
+RAMP_DAILY_LIMIT=50000
+
 # =============================================================================
 # CGO (Continuous Growth Offering)
 # =============================================================================

--- a/app/Domain/Ramp/Clients/OnramperClient.php
+++ b/app/Domain/Ramp/Clients/OnramperClient.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Ramp\Clients;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+class OnramperClient
+{
+    private readonly string $apiKey;
+
+    private readonly string $secretKey;
+
+    private readonly string $baseUrl;
+
+    public function __construct()
+    {
+        $config = config('ramp.providers.onramper');
+
+        $this->apiKey = (string) ($config['api_key'] ?? '');
+        $this->secretKey = (string) ($config['secret_key'] ?? '');
+        $this->baseUrl = rtrim((string) ($config['base_url'] ?? 'https://api.onramper.com'), '/');
+
+        if ($this->apiKey === '') {
+            throw new RuntimeException('Onramper API key is not configured.');
+        }
+    }
+
+    /**
+     * Get quotes for a fiat → crypto (or crypto → fiat) conversion.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function getQuotes(
+        string $sourceCurrency,
+        string $destinationCurrency,
+        float $amount,
+        ?string $paymentMethod = null,
+        ?string $country = null,
+    ): array {
+        $query = ['amount' => $amount];
+
+        if ($paymentMethod !== null) {
+            $query['paymentMethod'] = $paymentMethod;
+        }
+        if ($country !== null) {
+            $query['country'] = $country;
+        }
+
+        $response = $this->request()
+            ->get("{$this->baseUrl}/quotes/{$sourceCurrency}/{$destinationCurrency}", $query);
+
+        if (! $response->successful()) {
+            throw new RuntimeException(
+                'Onramper quote request failed: ' . ($response->json('message') ?? $response->body())
+            );
+        }
+
+        return $response->json() ?? [];
+    }
+
+    /**
+     * Create a checkout intent (returns redirect URL for the user).
+     *
+     * @param  array<string, mixed>  $params
+     * @return array{transactionId: string, checkoutUrl: string}
+     */
+    public function createCheckoutIntent(array $params): array
+    {
+        $response = $this->request()
+            ->post("{$this->baseUrl}/checkout/intent", $params);
+
+        if (! $response->successful()) {
+            throw new RuntimeException(
+                'Onramper checkout failed: ' . ($response->json('message') ?? $response->body())
+            );
+        }
+
+        return $response->json();
+    }
+
+    /**
+     * Get transaction status by ID.
+     *
+     * @return array<string, mixed>
+     */
+    public function getTransaction(string $transactionId): array
+    {
+        $response = $this->request()
+            ->get("{$this->baseUrl}/transaction/{$transactionId}");
+
+        if (! $response->successful()) {
+            throw new RuntimeException(
+                'Onramper transaction lookup failed: ' . ($response->json('message') ?? $response->body())
+            );
+        }
+
+        return $response->json();
+    }
+
+    /**
+     * Get supported assets/currencies.
+     *
+     * @return array<string, mixed>
+     */
+    public function getSupportedAssets(?string $source = null, ?string $destination = null): array
+    {
+        $query = array_filter([
+            'source'      => $source,
+            'destination' => $destination,
+        ]);
+
+        $response = $this->request()
+            ->get("{$this->baseUrl}/supported", $query);
+
+        if (! $response->successful()) {
+            throw new RuntimeException(
+                'Onramper supported assets request failed: ' . ($response->json('message') ?? $response->body())
+            );
+        }
+
+        return $response->json() ?? [];
+    }
+
+    /**
+     * Build the Onramper widget URL for iframe embedding.
+     *
+     * @param  array<string, string|bool|int|float>  $params
+     */
+    public function buildWidgetUrl(array $params = []): string
+    {
+        $defaults = [
+            'apiKey' => $this->apiKey,
+        ];
+
+        $mergedParams = array_merge($defaults, $params);
+
+        return 'https://buy.onramper.com?' . http_build_query($mergedParams);
+    }
+
+    /**
+     * Generate HMAC-SHA256 signature for URL signing.
+     */
+    public function signPayload(string $payload): string
+    {
+        return hash_hmac('sha256', $payload, $this->secretKey);
+    }
+
+    /**
+     * Verify webhook signature.
+     */
+    public function verifyWebhookSignature(string $payload, string $signature): bool
+    {
+        if ($this->secretKey === '') {
+            return false;
+        }
+
+        $computed = hash_hmac('sha256', $payload, $this->secretKey);
+
+        return hash_equals($computed, $signature);
+    }
+
+    public function getApiKey(): string
+    {
+        return $this->apiKey;
+    }
+
+    private function request(): PendingRequest
+    {
+        return Http::withHeaders([
+            'Authorization' => $this->apiKey,
+            'Accept'        => 'application/json',
+            'Content-Type'  => 'application/json',
+        ])->timeout(30);
+    }
+}

--- a/app/Domain/Ramp/Providers/OnramperProvider.php
+++ b/app/Domain/Ramp/Providers/OnramperProvider.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Ramp\Providers;
+
+use App\Domain\Ramp\Clients\OnramperClient;
+use App\Domain\Ramp\Contracts\RampProviderInterface;
+use RuntimeException;
+
+class OnramperProvider implements RampProviderInterface
+{
+    public function __construct(
+        private readonly OnramperClient $client,
+    ) {
+    }
+
+    public function createSession(array $params): array
+    {
+        $type = $params['type'];
+        $fiatCurrency = strtolower($params['fiat_currency']);
+        $cryptoCurrency = strtolower($params['crypto_currency']);
+        $amount = $params['fiat_amount'];
+        $walletAddress = $params['wallet_address'];
+
+        // Build widget URL with appropriate parameters
+        $widgetParams = [
+            'defaultAmount' => $amount,
+            'walletAddress' => $walletAddress,
+        ];
+
+        if ($type === 'on') {
+            $widgetParams['mode'] = 'buy';
+            $widgetParams['defaultFiat'] = strtoupper($fiatCurrency);
+            $widgetParams['defaultCrypto'] = $cryptoCurrency;
+            $widgetParams['onlyCryptos'] = $cryptoCurrency;
+        } else {
+            $widgetParams['mode'] = 'sell';
+            $widgetParams['sell_defaultFiat'] = strtoupper($fiatCurrency);
+            $widgetParams['sell_defaultCrypto'] = $cryptoCurrency;
+            $widgetParams['sell_onlyCryptos'] = $cryptoCurrency;
+        }
+
+        // Add redirect URLs if configured
+        $successUrl = config('ramp.providers.onramper.success_redirect_url');
+        $failureUrl = config('ramp.providers.onramper.failure_redirect_url');
+
+        if ($successUrl) {
+            $widgetParams['successRedirectUrl'] = $successUrl;
+        }
+        if ($failureUrl) {
+            $widgetParams['failureRedirectUrl'] = $failureUrl;
+        }
+
+        // Add a partner context for webhook correlation
+        $partnerContext = 'finaegis_' . bin2hex(random_bytes(16));
+        $widgetParams['partnerContext'] = $partnerContext;
+
+        // Sign the widget URL (required when wallet addresses are present)
+        $widgetUrl = $this->client->buildWidgetUrl($widgetParams);
+        $queryString = (string) parse_url($widgetUrl, PHP_URL_QUERY);
+        $signature = $this->client->signPayload($queryString);
+        $widgetUrl .= '&signature=' . $signature;
+
+        return [
+            'session_id'    => $partnerContext,
+            'redirect_url'  => $widgetUrl,
+            'widget_config' => [
+                'provider'        => 'onramper',
+                'widget_url'      => $widgetUrl,
+                'partner_context' => $partnerContext,
+                'type'            => $type,
+                'mode'            => $type === 'on' ? 'buy' : 'sell',
+            ],
+        ];
+    }
+
+    public function getSessionStatus(string $sessionId): array
+    {
+        try {
+            $transaction = $this->client->getTransaction($sessionId);
+
+            $status = $this->mapOnramperStatus($transaction['status'] ?? 'unknown');
+
+            return [
+                'status'        => $status,
+                'fiat_amount'   => (float) ($transaction['fiatAmount'] ?? 0),
+                'crypto_amount' => (float) ($transaction['cryptoAmount'] ?? 0),
+                'metadata'      => [
+                    'provider'        => 'onramper',
+                    'onramper_id'     => $transaction['id'] ?? $sessionId,
+                    'payment_method'  => $transaction['paymentMethod'] ?? null,
+                    'onramp_provider' => $transaction['provider'] ?? null,
+                ],
+            ];
+        } catch (RuntimeException) {
+            // If transaction not found, it's still pending (widget not completed yet)
+            return [
+                'status'        => 'pending',
+                'fiat_amount'   => null,
+                'crypto_amount' => null,
+                'metadata'      => ['provider' => 'onramper'],
+            ];
+        }
+    }
+
+    public function getSupportedCurrencies(): array
+    {
+        $pairs = [];
+        $fiats = config('ramp.supported_fiat', ['USD', 'EUR', 'GBP']);
+        $cryptos = config('ramp.supported_crypto', ['USDC', 'USDT', 'ETH', 'BTC']);
+
+        foreach ($fiats as $fiat) {
+            foreach ($cryptos as $crypto) {
+                $pairs[] = ['fiat' => $fiat, 'crypto' => $crypto];
+            }
+        }
+
+        return $pairs;
+    }
+
+    public function getQuote(string $type, string $fiatCurrency, float $fiatAmount, string $cryptoCurrency): array
+    {
+        $source = strtolower($fiatCurrency);
+        $destination = strtolower($cryptoCurrency);
+
+        if ($type === 'off') {
+            // Off-ramp: selling crypto for fiat — swap source/destination
+            [$source, $destination] = [$destination, $source];
+        }
+
+        $quotes = $this->client->getQuotes($source, $destination, $fiatAmount);
+
+        if (empty($quotes)) {
+            throw new RuntimeException('No quotes available for this currency pair.');
+        }
+
+        // Pick the best quote (first one — Onramper returns sorted by best rate)
+        $best = is_array($quotes[0] ?? null) ? $quotes[0] : $quotes;
+
+        $cryptoAmount = (float) ($best['cryptoAmount'] ?? $best['payout'] ?? 0);
+        $fiatFee = (float) ($best['fee']['fiatFee'] ?? $best['totalFee'] ?? 0);
+        $networkFee = (float) ($best['fee']['networkFee'] ?? 0);
+        $totalFee = $fiatFee + $networkFee;
+        $exchangeRate = $fiatAmount > 0 ? $cryptoAmount / ($fiatAmount - $totalFee) : 0;
+
+        return [
+            'fiat_amount'   => $fiatAmount,
+            'crypto_amount' => round($cryptoAmount, 8),
+            'exchange_rate' => round($exchangeRate, 8),
+            'fee'           => round($totalFee, 2),
+            'fee_currency'  => $fiatCurrency,
+            'provider_name' => $best['provider'] ?? 'onramper',
+            'quote_id'      => $best['quoteId'] ?? null,
+        ];
+    }
+
+    public function getWebhookValidator(): callable
+    {
+        return fn (string $payload, string $signature): bool => $this->client->verifyWebhookSignature($payload, $signature);
+    }
+
+    public function getName(): string
+    {
+        return 'onramper';
+    }
+
+    /**
+     * Map Onramper transaction statuses to internal statuses.
+     */
+    private function mapOnramperStatus(string $status): string
+    {
+        return match (strtolower($status)) {
+            'completed', 'success', 'done' => 'completed',
+            'failed', 'error', 'cancelled', 'expired' => 'failed',
+            'pending', 'new', 'created' => 'pending',
+            default => 'processing',
+        };
+    }
+}

--- a/app/Domain/Ramp/Services/RampService.php
+++ b/app/Domain/Ramp/Services/RampService.php
@@ -107,11 +107,11 @@ class RampService
     {
         $validator = $this->provider->getWebhookValidator();
 
-        if (! $validator(json_encode($payload), $signature)) {
+        if (! $validator((string) json_encode($payload), $signature)) {
             throw new RuntimeException('Invalid webhook signature');
         }
 
-        $sessionId = $payload['session_id'] ?? $payload['id'] ?? null;
+        $sessionId = $payload['session_id'] ?? $payload['partnerContext'] ?? $payload['id'] ?? null;
         if (! $sessionId) {
             Log::warning('Ramp webhook missing session_id', ['provider' => $provider]);
 

--- a/app/Http/Controllers/Api/V1/RampController.php
+++ b/app/Http/Controllers/Api/V1/RampController.php
@@ -109,8 +109,10 @@ class RampController extends Controller
         ]);
 
         try {
+            /** @var \App\Models\User $user */
+            $user = $request->user();
             $session = $this->rampService->createSession(
-                $request->user(),
+                $user,
                 $request->input('type'),
                 strtoupper($request->input('fiat_currency')),
                 (float) $request->input('fiat_amount'),
@@ -142,8 +144,10 @@ class RampController extends Controller
     #[OA\Response(response: 404, description: 'Not found')]
     public function getSession(Request $request, string $id): JsonResponse
     {
+        /** @var \App\Models\User $user */
+        $user = $request->user();
         $session = RampSession::where('id', $id)
-            ->where('user_id', $request->user()->id)
+            ->where('user_id', $user->id)
             ->first();
 
         if (! $session) {
@@ -169,10 +173,50 @@ class RampController extends Controller
     #[OA\Response(response: 200, description: 'Session list')]
     public function listSessions(Request $request): JsonResponse
     {
-        $sessions = $this->rampService->getUserSessions($request->user());
+        /** @var \App\Models\User $user */
+        $user = $request->user();
+        $sessions = $this->rampService->getUserSessions($user);
 
         return response()->json([
             'data' => RampSessionResource::collection($sessions),
+        ]);
+    }
+
+    #[OA\Get(
+        path: '/api/v1/ramp/supported',
+        operationId: 'v1RampSupported',
+        tags: ['Ramp'],
+        summary: 'Get supported currencies and provider info',
+        security: [['sanctum' => []]]
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Supported currencies',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'data', type: 'object', properties: [
+                    new OA\Property(property: 'provider', type: 'string', example: 'onramper'),
+                    new OA\Property(property: 'fiat_currencies', type: 'array', items: new OA\Items(type: 'string'), example: '["USD","EUR","GBP"]'),
+                    new OA\Property(property: 'crypto_currencies', type: 'array', items: new OA\Items(type: 'string'), example: '["USDC","USDT","ETH","BTC"]'),
+                    new OA\Property(property: 'modes', type: 'array', items: new OA\Items(type: 'string'), example: '["buy","sell"]'),
+                ]),
+            ]
+        )
+    )]
+    public function supported(): JsonResponse
+    {
+        return response()->json([
+            'data' => [
+                'provider'          => config('ramp.default_provider'),
+                'fiat_currencies'   => config('ramp.supported_fiat'),
+                'crypto_currencies' => config('ramp.supported_crypto'),
+                'modes'             => ['buy', 'sell'],
+                'limits'            => [
+                    'min_amount'  => config('ramp.limits.min_fiat_amount'),
+                    'max_amount'  => config('ramp.limits.max_fiat_amount'),
+                    'daily_limit' => config('ramp.limits.daily_limit'),
+                ],
+            ],
         ]);
     }
 }

--- a/app/Http/Controllers/Api/V1/RampWebhookController.php
+++ b/app/Http/Controllers/Api/V1/RampWebhookController.php
@@ -32,7 +32,11 @@ class RampWebhookController extends Controller
     #[OA\Response(response: 400, description: 'Invalid signature')]
     public function handle(Request $request, string $provider): JsonResponse
     {
-        $signature = $request->header('X-Webhook-Signature', '');
+        // Provider-specific signature header resolution
+        $signature = match ($provider) {
+            'onramper' => $request->header('X-Onramper-Webhook-Signature', ''),
+            default    => $request->header('X-Webhook-Signature', ''),
+        };
 
         try {
             $this->rampService->handleWebhook(

--- a/app/Http/Resources/V1/RampSessionResource.php
+++ b/app/Http/Resources/V1/RampSessionResource.php
@@ -29,6 +29,7 @@ class RampSessionResource extends JsonResource
             'status'          => $this->status,
             'status_label'    => ucfirst($this->status),
             'redirect_url'    => $metadata['redirect_url'] ?? null,
+            'widget_url'      => $metadata['widget_config']['widget_url'] ?? $metadata['redirect_url'] ?? null,
             'widget_config'   => $metadata['widget_config'] ?? null,
             'created_at'      => $this->created_at->toIso8601String(),
             'updated_at'      => $this->updated_at->toIso8601String(),

--- a/app/Providers/RampServiceProvider.php
+++ b/app/Providers/RampServiceProvider.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Domain\Ramp\Clients\OnramperClient;
 use App\Domain\Ramp\Contracts\RampProviderInterface;
 use App\Domain\Ramp\Providers\MockRampProvider;
+use App\Domain\Ramp\Providers\OnramperProvider;
 use App\Domain\Ramp\Services\RampService;
 use Illuminate\Support\ServiceProvider;
 
@@ -18,11 +20,16 @@ class RampServiceProvider extends ServiceProvider
             'ramp'
         );
 
-        $this->app->bind(RampProviderInterface::class, function () {
+        $this->app->singleton(OnramperClient::class, function () {
+            return new OnramperClient();
+        });
+
+        $this->app->bind(RampProviderInterface::class, function ($app) {
             $provider = config('ramp.default_provider', 'mock');
 
             return match ($provider) {
-                default => new MockRampProvider(),
+                'onramper' => new OnramperProvider($app->make(OnramperClient::class)),
+                default    => new MockRampProvider(),
             };
         });
 

--- a/config/ramp.php
+++ b/config/ramp.php
@@ -23,22 +23,15 @@ return [
             'enabled' => true,
         ],
 
-        'moonpay' => [
-            'driver'      => 'moonpay',
-            'api_key'     => env('MOONPAY_API_KEY'),
-            'secret_key'  => env('MOONPAY_SECRET_KEY'),
-            'webhook_key' => env('MOONPAY_WEBHOOK_KEY'),
-            'base_url'    => env('MOONPAY_BASE_URL', 'https://api.moonpay.com'),
-            'enabled'     => (bool) env('MOONPAY_ENABLED', false),
-        ],
-
-        'transak' => [
-            'driver'      => 'transak',
-            'api_key'     => env('TRANSAK_API_KEY'),
-            'api_secret'  => env('TRANSAK_API_SECRET'),
-            'webhook_key' => env('TRANSAK_WEBHOOK_KEY'),
-            'base_url'    => env('TRANSAK_BASE_URL', 'https://api.transak.com'),
-            'enabled'     => (bool) env('TRANSAK_ENABLED', false),
+        'onramper' => [
+            'driver'               => 'onramper',
+            'api_key'              => env('ONRAMPER_API_KEY'),
+            'secret_key'           => env('ONRAMPER_SECRET_KEY'),
+            'base_url'             => env('ONRAMPER_BASE_URL', 'https://api.onramper.com'),
+            'widget_url'           => env('ONRAMPER_WIDGET_URL', 'https://buy.onramper.com'),
+            'success_redirect_url' => env('ONRAMPER_SUCCESS_REDIRECT_URL'),
+            'failure_redirect_url' => env('ONRAMPER_FAILURE_REDIRECT_URL'),
+            'enabled'              => (bool) env('ONRAMPER_ENABLED', false),
         ],
     ],
 
@@ -62,6 +55,7 @@ return [
         'max_fiat_amount' => (float) env('RAMP_MAX_AMOUNT', 10000.00),
         'daily_limit'     => (float) env('RAMP_DAILY_LIMIT', 50000.00),
     ],
+
     /*
     |--------------------------------------------------------------------------
     | Referral Share Copy

--- a/routes/api.php
+++ b/routes/api.php
@@ -241,6 +241,7 @@ Route::prefix('v1/banners')->name('api.v1.banners.')
 Route::prefix('v1/ramp')->name('api.v1.ramp.')
     ->middleware(['auth:sanctum'])
     ->group(function () {
+        Route::get('/supported', [App\Http\Controllers\Api\V1\RampController::class, 'supported'])->middleware('api.rate_limit:query')->name('supported');
         Route::get('/quote', [App\Http\Controllers\Api\V1\RampController::class, 'quote'])->middleware('api.rate_limit:query')->name('quote');
         Route::post('/session', [App\Http\Controllers\Api\V1\RampController::class, 'createSession'])->name('session.create');
         Route::get('/session/{id}', [App\Http\Controllers\Api\V1\RampController::class, 'getSession'])->name('session.show');

--- a/tests/Unit/Domain/Ramp/OnramperClientTest.php
+++ b/tests/Unit/Domain/Ramp/OnramperClientTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Ramp;
+
+use App\Domain\Ramp\Clients\OnramperClient;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class OnramperClientTest extends TestCase
+{
+    private OnramperClient $client;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'ramp.providers.onramper.api_key'    => 'pk_test_12345',
+            'ramp.providers.onramper.secret_key'  => 'sk_test_secret',
+            'ramp.providers.onramper.base_url'    => 'https://api.onramper.com',
+            'ramp.providers.onramper.widget_url'  => 'https://buy.onramper.com',
+        ]);
+
+        $this->client = new OnramperClient();
+    }
+
+    public function test_constructor_throws_without_api_key(): void
+    {
+        config(['ramp.providers.onramper.api_key' => '']);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('API key is not configured');
+
+        new OnramperClient();
+    }
+
+    public function test_get_quotes_calls_api(): void
+    {
+        Http::fake([
+            'api.onramper.com/quotes/usd/btc*' => Http::response([
+                ['provider' => 'Simplex', 'cryptoAmount' => 0.0025, 'fee' => ['fiatFee' => 3.5]],
+            ]),
+        ]);
+
+        $quotes = $this->client->getQuotes('usd', 'btc', 100.0);
+
+        $this->assertCount(1, $quotes);
+        $this->assertEquals('Simplex', $quotes[0]['provider']);
+
+        Http::assertSent(function ($request) {
+            return str_contains($request->url(), '/quotes/usd/btc')
+                && $request->hasHeader('Authorization', 'pk_test_12345');
+        });
+    }
+
+    public function test_get_quotes_with_optional_params(): void
+    {
+        Http::fake([
+            'api.onramper.com/quotes/*' => Http::response([]),
+        ]);
+
+        $this->client->getQuotes('eur', 'eth', 200.0, 'creditCard', 'DE');
+
+        Http::assertSent(function ($request) {
+            $url = $request->url();
+
+            return str_contains($url, 'paymentMethod=creditCard')
+                && str_contains($url, 'country=DE');
+        });
+    }
+
+    public function test_get_quotes_throws_on_failure(): void
+    {
+        Http::fake([
+            'api.onramper.com/quotes/*' => Http::response(['message' => 'Invalid pair'], 400),
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Onramper quote request failed');
+
+        $this->client->getQuotes('xxx', 'yyy', 100.0);
+    }
+
+    public function test_create_checkout_intent(): void
+    {
+        Http::fake([
+            'api.onramper.com/checkout/intent' => Http::response([
+                'transactionId' => 'tx_789',
+                'checkoutUrl'   => 'https://onramper.com/checkout?id=tx_789',
+            ]),
+        ]);
+
+        $result = $this->client->createCheckoutIntent([
+            'quoteId'       => 'q_12345',
+            'redirectURL'   => 'https://finaegis.org/ramp/complete',
+            'walletAddress' => '0xabc',
+        ]);
+
+        $this->assertEquals('tx_789', $result['transactionId']);
+        $this->assertStringContainsString('checkout', $result['checkoutUrl']);
+    }
+
+    public function test_get_transaction(): void
+    {
+        Http::fake([
+            'api.onramper.com/transaction/tx_789' => Http::response([
+                'id'           => 'tx_789',
+                'status'       => 'completed',
+                'fiatAmount'   => 100.0,
+                'cryptoAmount' => 0.0025,
+            ]),
+        ]);
+
+        $tx = $this->client->getTransaction('tx_789');
+
+        $this->assertEquals('completed', $tx['status']);
+        $this->assertEquals(0.0025, $tx['cryptoAmount']);
+    }
+
+    public function test_get_supported_assets(): void
+    {
+        Http::fake([
+            'api.onramper.com/supported*' => Http::response([
+                'crypto' => ['BTC', 'ETH', 'USDC'],
+                'fiat'   => ['USD', 'EUR'],
+            ]),
+        ]);
+
+        $assets = $this->client->getSupportedAssets();
+
+        $this->assertArrayHasKey('crypto', $assets);
+        $this->assertArrayHasKey('fiat', $assets);
+    }
+
+    public function test_build_widget_url(): void
+    {
+        $url = $this->client->buildWidgetUrl([
+            'mode'          => 'buy',
+            'defaultFiat'   => 'USD',
+            'defaultCrypto' => 'btc',
+            'defaultAmount' => 100,
+        ]);
+
+        $this->assertStringStartsWith('https://buy.onramper.com?', $url);
+        $this->assertStringContainsString('apiKey=pk_test_12345', $url);
+        $this->assertStringContainsString('mode=buy', $url);
+        $this->assertStringContainsString('defaultFiat=USD', $url);
+    }
+
+    public function test_sign_payload(): void
+    {
+        $payload = 'apiKey=pk_test_12345&walletAddress=0xabc';
+        $signature = $this->client->signPayload($payload);
+
+        $expected = hash_hmac('sha256', $payload, 'sk_test_secret');
+        $this->assertEquals($expected, $signature);
+    }
+
+    public function test_verify_webhook_signature_valid(): void
+    {
+        $payload = '{"id":"tx_1","status":"completed"}';
+        $signature = hash_hmac('sha256', $payload, 'sk_test_secret');
+
+        $this->assertTrue($this->client->verifyWebhookSignature($payload, $signature));
+    }
+
+    public function test_verify_webhook_signature_invalid(): void
+    {
+        $payload = '{"id":"tx_1","status":"completed"}';
+
+        $this->assertFalse($this->client->verifyWebhookSignature($payload, 'invalid_signature'));
+    }
+
+    public function test_verify_webhook_signature_rejects_empty_secret(): void
+    {
+        config(['ramp.providers.onramper.secret_key' => '']);
+        $client = new OnramperClient();
+
+        $this->assertFalse($client->verifyWebhookSignature('payload', 'sig'));
+    }
+
+    public function test_get_api_key(): void
+    {
+        $this->assertEquals('pk_test_12345', $this->client->getApiKey());
+    }
+}

--- a/tests/Unit/Domain/Ramp/OnramperProviderTest.php
+++ b/tests/Unit/Domain/Ramp/OnramperProviderTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\Ramp;
+
+use App\Domain\Ramp\Clients\OnramperClient;
+use App\Domain\Ramp\Providers\OnramperProvider;
+use Mockery;
+use Mockery\MockInterface;
+use Tests\TestCase;
+
+class OnramperProviderTest extends TestCase
+{
+    private OnramperClient&MockInterface $client;
+
+    private OnramperProvider $provider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var OnramperClient&MockInterface $client */
+        $client = Mockery::mock(OnramperClient::class);
+        $this->client = $client;
+        $this->provider = new OnramperProvider($this->client);
+    }
+
+    public function test_get_name_returns_onramper(): void
+    {
+        $this->assertEquals('onramper', $this->provider->getName());
+    }
+
+    public function test_get_quote_returns_best_quote(): void
+    {
+        $this->client->shouldReceive('getQuotes')
+            ->with('usd', 'btc', 100.0)
+            ->once()
+            ->andReturn([
+                [
+                    'provider'     => 'Simplex',
+                    'quoteId'      => 'q_12345',
+                    'fiatAmount'   => 100,
+                    'cryptoAmount' => 0.0025,
+                    'exchangeRate' => 40000,
+                    'fee'          => ['fiatFee' => 3.5, 'networkFee' => 0.5],
+                ],
+                [
+                    'provider'     => 'MoonPay',
+                    'quoteId'      => 'q_67890',
+                    'fiatAmount'   => 100,
+                    'cryptoAmount' => 0.0024,
+                    'exchangeRate' => 39500,
+                    'fee'          => ['fiatFee' => 4.0, 'networkFee' => 0.5],
+                ],
+            ]);
+
+        $quote = $this->provider->getQuote('on', 'USD', 100.0, 'BTC');
+
+        $this->assertEquals(100.0, $quote['fiat_amount']);
+        $this->assertEquals(0.0025, $quote['crypto_amount']);
+        $this->assertEquals(4.0, $quote['fee']);
+        $this->assertEquals('USD', $quote['fee_currency']);
+        $this->assertEquals('Simplex', $quote['provider_name']);
+        $this->assertEquals('q_12345', $quote['quote_id']);
+    }
+
+    public function test_get_quote_off_ramp_swaps_currencies(): void
+    {
+        $this->client->shouldReceive('getQuotes')
+            ->with('btc', 'usd', 0.005)
+            ->once()
+            ->andReturn([
+                [
+                    'provider'     => 'Transak',
+                    'cryptoAmount' => 195.0,
+                    'fee'          => ['fiatFee' => 2.0, 'networkFee' => 0.5],
+                ],
+            ]);
+
+        $quote = $this->provider->getQuote('off', 'USD', 0.005, 'BTC');
+
+        $this->assertEquals(0.005, $quote['fiat_amount']);
+        $this->assertEquals(195.0, $quote['crypto_amount']);
+    }
+
+    public function test_get_quote_throws_when_no_quotes(): void
+    {
+        $this->client->shouldReceive('getQuotes')
+            ->once()
+            ->andReturn([]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('No quotes available');
+
+        $this->provider->getQuote('on', 'USD', 100.0, 'BTC');
+    }
+
+    public function test_create_session_returns_widget_url(): void
+    {
+        $this->client->shouldReceive('buildWidgetUrl')
+            ->once()
+            ->andReturn('https://buy.onramper.com?apiKey=pk_test&mode=buy&defaultFiat=USD&defaultCrypto=usdc');
+
+        $this->client->shouldReceive('signPayload')
+            ->once()
+            ->andReturn('abc123signature');
+
+        $result = $this->provider->createSession([
+            'type'            => 'on',
+            'fiat_currency'   => 'USD',
+            'fiat_amount'     => 100.0,
+            'crypto_currency' => 'USDC',
+            'wallet_address'  => '0x1234',
+        ]);
+
+        $this->assertArrayHasKey('session_id', $result);
+        $this->assertStringStartsWith('finaegis_', $result['session_id']);
+        $this->assertStringContainsString('buy.onramper.com', $result['redirect_url']);
+        $this->assertStringContainsString('signature=abc123signature', $result['redirect_url']);
+        $this->assertEquals('onramper', $result['widget_config']['provider']);
+        $this->assertEquals('buy', $result['widget_config']['mode']);
+    }
+
+    public function test_create_session_off_ramp_uses_sell_mode(): void
+    {
+        $this->client->shouldReceive('buildWidgetUrl')
+            ->withArgs(function (array $params) {
+                return $params['mode'] === 'sell'
+                    && isset($params['sell_defaultFiat'])
+                    && isset($params['sell_defaultCrypto']);
+            })
+            ->once()
+            ->andReturn('https://buy.onramper.com?mode=sell');
+
+        $this->client->shouldReceive('signPayload')
+            ->once()
+            ->andReturn('sig');
+
+        $result = $this->provider->createSession([
+            'type'            => 'off',
+            'fiat_currency'   => 'EUR',
+            'fiat_amount'     => 50.0,
+            'crypto_currency' => 'ETH',
+            'wallet_address'  => '0xabc',
+        ]);
+
+        $this->assertEquals('sell', $result['widget_config']['mode']);
+    }
+
+    public function test_get_session_status_maps_completed(): void
+    {
+        $this->client->shouldReceive('getTransaction')
+            ->with('tx_123')
+            ->once()
+            ->andReturn([
+                'id'            => 'tx_123',
+                'status'        => 'completed',
+                'fiatAmount'    => 100.0,
+                'cryptoAmount'  => 98.5,
+                'paymentMethod' => 'creditCard',
+                'provider'      => 'Simplex',
+            ]);
+
+        $result = $this->provider->getSessionStatus('tx_123');
+
+        $this->assertEquals('completed', $result['status']);
+        $this->assertEquals(100.0, $result['fiat_amount']);
+        $this->assertEquals(98.5, $result['crypto_amount']);
+        $this->assertEquals('Simplex', $result['metadata']['onramp_provider']);
+    }
+
+    public function test_get_session_status_maps_failed(): void
+    {
+        $this->client->shouldReceive('getTransaction')
+            ->with('tx_456')
+            ->once()
+            ->andReturn(['status' => 'failed']);
+
+        $result = $this->provider->getSessionStatus('tx_456');
+
+        $this->assertEquals('failed', $result['status']);
+    }
+
+    public function test_get_session_status_returns_pending_on_error(): void
+    {
+        $this->client->shouldReceive('getTransaction')
+            ->with('tx_notfound')
+            ->once()
+            ->andThrow(new \RuntimeException('Transaction not found'));
+
+        $result = $this->provider->getSessionStatus('tx_notfound');
+
+        $this->assertEquals('pending', $result['status']);
+    }
+
+    public function test_get_supported_currencies_returns_pairs(): void
+    {
+        $currencies = $this->provider->getSupportedCurrencies();
+
+        $this->assertNotEmpty($currencies);
+        $this->assertArrayHasKey('fiat', $currencies[0]);
+        $this->assertArrayHasKey('crypto', $currencies[0]);
+    }
+
+    public function test_webhook_validator_delegates_to_client(): void
+    {
+        $this->client->shouldReceive('verifyWebhookSignature')
+            ->with('{"id":"tx_1"}', 'valid_sig')
+            ->once()
+            ->andReturn(true);
+
+        $validator = $this->provider->getWebhookValidator();
+
+        $this->assertTrue($validator('{"id":"tx_1"}', 'valid_sig'));
+    }
+
+    public function test_webhook_validator_rejects_invalid_signature(): void
+    {
+        $this->client->shouldReceive('verifyWebhookSignature')
+            ->with('{"id":"tx_1"}', 'bad_sig')
+            ->once()
+            ->andReturn(false);
+
+        $validator = $this->provider->getWebhookValidator();
+
+        $this->assertFalse($validator('{"id":"tx_1"}', 'bad_sig'));
+    }
+}


### PR DESCRIPTION
## Summary

- Full **Onramper** integration replacing MoonPay/Transak stubs as the fiat on/off-ramp aggregator
- `OnramperClient` — HTTP wrapper for Onramper REST API (quotes, checkout, transactions, supported assets)
- `OnramperProvider` — implements `RampProviderInterface` with widget URL generation, HMAC signing, and status mapping
- New `GET /api/v1/ramp/supported` endpoint for currency/limit discovery by mobile clients

## Architecture

```
RampController → RampService → OnramperProvider → OnramperClient → Onramper API
                                                                 → Widget URL (iframe)
```

| Component | Purpose |
|-----------|---------|
| `OnramperClient` | HTTP client: quotes, checkout intent, transaction status, widget URL builder, HMAC signing |
| `OnramperProvider` | Provider interface impl: maps Onramper API to internal session/quote/webhook contracts |
| `config/ramp.php` | Onramper config (api_key, secret_key, base_url, widget_url, redirect URLs) |
| `RampWebhookController` | Routes `X-Onramper-Webhook-Signature` header for HMAC verification |

## API Endpoints

| Method | Endpoint | New? |
|--------|----------|------|
| GET | `/api/v1/ramp/supported` | **Yes** — returns currencies, modes, limits |
| GET | `/api/v1/ramp/quote` | Updated — proxies to Onramper quotes API |
| POST | `/api/v1/ramp/session` | Updated — returns Onramper widget URL |
| GET | `/api/v1/ramp/session/{id}` | Updated — polls Onramper transaction status |
| GET | `/api/v1/ramp/sessions` | Unchanged |
| POST | `/api/v1/ramp/webhook/{provider}` | Updated — Onramper signature header |

## Config

```env
RAMP_PROVIDER=onramper          # Switch from mock to onramper
ONRAMPER_API_KEY=pk_prod_...    # From Onramper dashboard
ONRAMPER_SECRET_KEY=sk_...      # For HMAC signing
ONRAMPER_ENABLED=true
```

## Test plan

- [x] 25 new tests (13 OnramperClient + 12 OnramperProvider)
- [x] All 34 ramp tests pass (9 existing feature + 25 new unit)
- [x] PHPStan Level 8 — 0 errors
- [x] php-cs-fixer — clean
- [x] Route list verified (6 endpoints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)