### PR TITLE
refactor: Onramper API-first integration (#723)

### DIFF
--- a/app/Domain/Ramp/Clients/OnramperClient.php
+++ b/app/Domain/Ramp/Clients/OnramperClient.php
@@ -30,7 +30,7 @@ class OnramperClient
     }
 
     /**
-     * Get quotes for a fiat → crypto (or crypto → fiat) conversion.
+     * Get quotes for a fiat-crypto conversion from all aggregated providers.
      *
      * @return array<int, array<string, mixed>>
      */
@@ -63,10 +63,10 @@ class OnramperClient
     }
 
     /**
-     * Create a checkout intent (returns redirect URL for the user).
+     * Create a checkout intent via API (returns provider checkout URL).
      *
-     * @param  array<string, mixed>  $params
-     * @return array{transactionId: string, checkoutUrl: string}
+     * @param  array<string, mixed>  $params  Must include quoteId, walletAddress, redirectURL
+     * @return array<string, mixed>  Contains transactionId and checkoutUrl
      */
     public function createCheckoutIntent(array $params): array
     {
@@ -126,23 +126,7 @@ class OnramperClient
     }
 
     /**
-     * Build the Onramper widget URL for iframe embedding.
-     *
-     * @param  array<string, string|bool|int|float>  $params
-     */
-    public function buildWidgetUrl(array $params = []): string
-    {
-        $defaults = [
-            'apiKey' => $this->apiKey,
-        ];
-
-        $mergedParams = array_merge($defaults, $params);
-
-        return 'https://buy.onramper.com?' . http_build_query($mergedParams);
-    }
-
-    /**
-     * Generate HMAC-SHA256 signature for URL signing.
+     * Generate HMAC-SHA256 signature for request signing.
      */
     public function signPayload(string $payload): string
     {

--- a/app/Domain/Ramp/Contracts/RampProviderInterface.php
+++ b/app/Domain/Ramp/Contracts/RampProviderInterface.php
@@ -7,10 +7,10 @@ namespace App\Domain\Ramp\Contracts;
 interface RampProviderInterface
 {
     /**
-     * Create a ramp session (returns provider widget URL or config).
+     * Create a ramp session via checkout API (not widget).
      *
-     * @param  array{type: string, fiat_currency: string, fiat_amount: float, crypto_currency: string, wallet_address: string}  $params
-     * @return array{session_id: string, redirect_url: string|null, widget_config: array<string, mixed>|null}
+     * @param  array{type: string, fiat_currency: string, fiat_amount: float, crypto_currency: string, wallet_address: string, quote_id: string|null}  $params
+     * @return array{session_id: string, checkout_url: string|null, metadata: array<string, mixed>}
      */
     public function createSession(array $params): array;
 
@@ -29,11 +29,11 @@ interface RampProviderInterface
     public function getSupportedCurrencies(): array;
 
     /**
-     * Get a quote for a ramp transaction.
+     * Get all quotes from aggregated providers for a ramp transaction.
      *
-     * @return array{fiat_amount: float, crypto_amount: float, exchange_rate: float, fee: float, fee_currency: string}
+     * @return array<int, array{provider_name: string, quote_id: string|null, fiat_amount: float, crypto_amount: float, exchange_rate: float, fee: float, network_fee: float, fee_currency: string, payment_methods: array<string>}>
      */
-    public function getQuote(string $type, string $fiatCurrency, float $fiatAmount, string $cryptoCurrency): array;
+    public function getQuotes(string $type, string $fiatCurrency, float $fiatAmount, string $cryptoCurrency): array;
 
     /**
      * Get the webhook validator for this provider.

--- a/app/Domain/Ramp/Providers/MockRampProvider.php
+++ b/app/Domain/Ramp/Providers/MockRampProvider.php
@@ -15,9 +15,9 @@ class MockRampProvider implements RampProviderInterface
         $sessionId = 'mock_' . Str::uuid()->toString();
 
         return [
-            'session_id'    => $sessionId,
-            'redirect_url'  => null,
-            'widget_config' => [
+            'session_id'   => $sessionId,
+            'checkout_url' => null,
+            'metadata'     => [
                 'provider'   => 'mock',
                 'session_id' => $sessionId,
                 'type'       => $params['type'],
@@ -51,9 +51,8 @@ class MockRampProvider implements RampProviderInterface
         ];
     }
 
-    public function getQuote(string $type, string $fiatCurrency, float $fiatAmount, string $cryptoCurrency): array
+    public function getQuotes(string $type, string $fiatCurrency, float $fiatAmount, string $cryptoCurrency): array
     {
-        // Mock exchange rates
         $rates = [
             'USDC' => 1.0,
             'USDT' => 1.0,
@@ -62,16 +61,30 @@ class MockRampProvider implements RampProviderInterface
         ];
 
         $rate = $rates[$cryptoCurrency] ?? 1.0;
-        $fee = $fiatAmount * 0.015; // 1.5% fee
-        $netAmount = $fiatAmount - $fee;
-        $cryptoAmount = $netAmount * $rate;
 
         return [
-            'fiat_amount'   => $fiatAmount,
-            'crypto_amount' => round($cryptoAmount, 8),
-            'exchange_rate' => $rate,
-            'fee'           => round($fee, 2),
-            'fee_currency'  => $fiatCurrency,
+            [
+                'provider_name'   => 'MockProvider A',
+                'quote_id'        => 'mock_quote_a_' . Str::random(8),
+                'fiat_amount'     => $fiatAmount,
+                'crypto_amount'   => round(($fiatAmount - $fiatAmount * 0.015) * $rate, 8),
+                'exchange_rate'   => $rate,
+                'fee'             => round($fiatAmount * 0.015, 2),
+                'network_fee'     => 0.0,
+                'fee_currency'    => $fiatCurrency,
+                'payment_methods' => ['credit_card', 'bank_transfer'],
+            ],
+            [
+                'provider_name'   => 'MockProvider B',
+                'quote_id'        => 'mock_quote_b_' . Str::random(8),
+                'fiat_amount'     => $fiatAmount,
+                'crypto_amount'   => round(($fiatAmount - $fiatAmount * 0.025) * $rate, 8),
+                'exchange_rate'   => $rate,
+                'fee'             => round($fiatAmount * 0.020, 2),
+                'network_fee'     => round($fiatAmount * 0.005, 2),
+                'fee_currency'    => $fiatCurrency,
+                'payment_methods' => ['credit_card'],
+            ],
         ];
     }
 

--- a/app/Domain/Ramp/Providers/OnramperProvider.php
+++ b/app/Domain/Ramp/Providers/OnramperProvider.php
@@ -17,60 +17,35 @@ class OnramperProvider implements RampProviderInterface
 
     public function createSession(array $params): array
     {
-        $type = $params['type'];
-        $fiatCurrency = strtolower($params['fiat_currency']);
-        $cryptoCurrency = strtolower($params['crypto_currency']);
-        $amount = $params['fiat_amount'];
+        $quoteId = $params['quote_id'] ?? null;
         $walletAddress = $params['wallet_address'];
 
-        // Build widget URL with appropriate parameters
-        $widgetParams = [
-            'defaultAmount' => $amount,
+        if (! $quoteId) {
+            throw new RuntimeException('A quote_id is required. Call GET /ramp/quotes first and select a provider.');
+        }
+
+        $successUrl = config('ramp.providers.onramper.success_redirect_url', '');
+        $failureUrl = config('ramp.providers.onramper.failure_redirect_url', '');
+        $redirectUrl = $successUrl ?: ($failureUrl ?: config('app.url') . '/ramp/complete');
+
+        $result = $this->client->createCheckoutIntent([
+            'quoteId'       => $quoteId,
             'walletAddress' => $walletAddress,
-        ];
+            'redirectURL'   => $redirectUrl,
+        ]);
 
-        if ($type === 'on') {
-            $widgetParams['mode'] = 'buy';
-            $widgetParams['defaultFiat'] = strtoupper($fiatCurrency);
-            $widgetParams['defaultCrypto'] = $cryptoCurrency;
-            $widgetParams['onlyCryptos'] = $cryptoCurrency;
-        } else {
-            $widgetParams['mode'] = 'sell';
-            $widgetParams['sell_defaultFiat'] = strtoupper($fiatCurrency);
-            $widgetParams['sell_defaultCrypto'] = $cryptoCurrency;
-            $widgetParams['sell_onlyCryptos'] = $cryptoCurrency;
-        }
-
-        // Add redirect URLs if configured
-        $successUrl = config('ramp.providers.onramper.success_redirect_url');
-        $failureUrl = config('ramp.providers.onramper.failure_redirect_url');
-
-        if ($successUrl) {
-            $widgetParams['successRedirectUrl'] = $successUrl;
-        }
-        if ($failureUrl) {
-            $widgetParams['failureRedirectUrl'] = $failureUrl;
-        }
-
-        // Add a partner context for webhook correlation
-        $partnerContext = 'finaegis_' . bin2hex(random_bytes(16));
-        $widgetParams['partnerContext'] = $partnerContext;
-
-        // Sign the widget URL (required when wallet addresses are present)
-        $widgetUrl = $this->client->buildWidgetUrl($widgetParams);
-        $queryString = (string) parse_url($widgetUrl, PHP_URL_QUERY);
-        $signature = $this->client->signPayload($queryString);
-        $widgetUrl .= '&signature=' . $signature;
+        $transactionId = $result['transactionId'] ?? $result['id'] ?? ('onr_' . bin2hex(random_bytes(16)));
+        $checkoutUrl = $result['checkoutUrl'] ?? $result['checkout_url'] ?? null;
 
         return [
-            'session_id'    => $partnerContext,
-            'redirect_url'  => $widgetUrl,
-            'widget_config' => [
-                'provider'        => 'onramper',
-                'widget_url'      => $widgetUrl,
-                'partner_context' => $partnerContext,
-                'type'            => $type,
-                'mode'            => $type === 'on' ? 'buy' : 'sell',
+            'session_id'   => $transactionId,
+            'checkout_url' => $checkoutUrl,
+            'metadata'     => [
+                'provider'       => 'onramper',
+                'transaction_id' => $transactionId,
+                'checkout_url'   => $checkoutUrl,
+                'quote_id'       => $quoteId,
+                'type'           => $params['type'],
             ],
         ];
     }
@@ -94,7 +69,6 @@ class OnramperProvider implements RampProviderInterface
                 ],
             ];
         } catch (RuntimeException) {
-            // If transaction not found, it's still pending (widget not completed yet)
             return [
                 'status'        => 'pending',
                 'fiat_amount'   => null,
@@ -119,40 +93,48 @@ class OnramperProvider implements RampProviderInterface
         return $pairs;
     }
 
-    public function getQuote(string $type, string $fiatCurrency, float $fiatAmount, string $cryptoCurrency): array
+    public function getQuotes(string $type, string $fiatCurrency, float $fiatAmount, string $cryptoCurrency): array
     {
         $source = strtolower($fiatCurrency);
         $destination = strtolower($cryptoCurrency);
 
         if ($type === 'off') {
-            // Off-ramp: selling crypto for fiat — swap source/destination
             [$source, $destination] = [$destination, $source];
         }
 
-        $quotes = $this->client->getQuotes($source, $destination, $fiatAmount);
+        $rawQuotes = $this->client->getQuotes($source, $destination, $fiatAmount);
 
-        if (empty($quotes)) {
-            throw new RuntimeException('No quotes available for this currency pair.');
+        if (empty($rawQuotes)) {
+            return [];
         }
 
-        // Pick the best quote (first one — Onramper returns sorted by best rate)
-        $best = is_array($quotes[0] ?? null) ? $quotes[0] : $quotes;
+        $normalized = [];
+        foreach ($rawQuotes as $q) {
+            if (! is_array($q)) {
+                continue;
+            }
 
-        $cryptoAmount = (float) ($best['cryptoAmount'] ?? $best['payout'] ?? 0);
-        $fiatFee = (float) ($best['fee']['fiatFee'] ?? $best['totalFee'] ?? 0);
-        $networkFee = (float) ($best['fee']['networkFee'] ?? 0);
-        $totalFee = $fiatFee + $networkFee;
-        $exchangeRate = $fiatAmount > 0 ? $cryptoAmount / ($fiatAmount - $totalFee) : 0;
+            $cryptoAmount = (float) ($q['cryptoAmount'] ?? $q['payout'] ?? 0);
+            $fiatFee = (float) ($q['fee']['fiatFee'] ?? $q['fiatFee'] ?? $q['totalFee'] ?? 0);
+            $networkFee = (float) ($q['fee']['networkFee'] ?? $q['networkFee'] ?? 0);
+            $totalFee = $fiatFee + $networkFee;
+            $netFiat = $fiatAmount - $totalFee;
+            $exchangeRate = $netFiat > 0 ? $cryptoAmount / $netFiat : 0;
 
-        return [
-            'fiat_amount'   => $fiatAmount,
-            'crypto_amount' => round($cryptoAmount, 8),
-            'exchange_rate' => round($exchangeRate, 8),
-            'fee'           => round($totalFee, 2),
-            'fee_currency'  => $fiatCurrency,
-            'provider_name' => $best['provider'] ?? 'onramper',
-            'quote_id'      => $best['quoteId'] ?? null,
-        ];
+            $normalized[] = [
+                'provider_name'   => $q['provider'] ?? 'unknown',
+                'quote_id'        => $q['quoteId'] ?? $q['id'] ?? null,
+                'fiat_amount'     => $fiatAmount,
+                'crypto_amount'   => round($cryptoAmount, 8),
+                'exchange_rate'   => round($exchangeRate, 8),
+                'fee'             => round($fiatFee, 2),
+                'network_fee'     => round($networkFee, 2),
+                'fee_currency'    => $fiatCurrency,
+                'payment_methods' => (array) ($q['paymentMethods'] ?? $q['paymentMethod'] ?? []),
+            ];
+        }
+
+        return $normalized;
     }
 
     public function getWebhookValidator(): callable
@@ -165,9 +147,6 @@ class OnramperProvider implements RampProviderInterface
         return 'onramper';
     }
 
-    /**
-     * Map Onramper transaction statuses to internal statuses.
-     */
     private function mapOnramperStatus(string $status): string
     {
         return match (strtolower($status)) {

--- a/app/Domain/Ramp/Services/RampService.php
+++ b/app/Domain/Ramp/Services/RampService.php
@@ -18,23 +18,25 @@ class RampService
     }
 
     /**
-     * Get a quote for a ramp transaction.
+     * Get all quotes from aggregated providers.
      *
-     * @return array{fiat_amount: float, crypto_amount: float, exchange_rate: float, fee: float, fee_currency: string, provider: string}
+     * @return array{quotes: array<int, array<string, mixed>>, provider: string, valid_until: string}
      */
-    public function getQuote(string $type, string $fiatCurrency, float $fiatAmount, string $cryptoCurrency): array
+    public function getQuotes(string $type, string $fiatCurrency, float $fiatAmount, string $cryptoCurrency): array
     {
         $this->validateRampParams($type, $fiatCurrency, $fiatAmount, $cryptoCurrency);
 
-        $quote = $this->provider->getQuote($type, $fiatCurrency, $fiatAmount, $cryptoCurrency);
-        $quote['provider'] = $this->provider->getName();
-        $quote['valid_until'] = now()->addSeconds(60)->toIso8601String();
+        $quotes = $this->provider->getQuotes($type, $fiatCurrency, $fiatAmount, $cryptoCurrency);
 
-        return $quote;
+        return [
+            'quotes'      => $quotes,
+            'provider'    => $this->provider->getName(),
+            'valid_until' => now()->addSeconds(60)->toIso8601String(),
+        ];
     }
 
     /**
-     * Create a ramp session.
+     * Create a ramp session using a selected quote.
      */
     public function createSession(
         User $user,
@@ -43,6 +45,7 @@ class RampService
         float $fiatAmount,
         string $cryptoCurrency,
         string $walletAddress,
+        ?string $quoteId = null,
     ): RampSession {
         $this->validateRampParams($type, $fiatCurrency, $fiatAmount, $cryptoCurrency);
 
@@ -52,6 +55,7 @@ class RampService
             'fiat_amount'     => $fiatAmount,
             'crypto_currency' => $cryptoCurrency,
             'wallet_address'  => $walletAddress,
+            'quote_id'        => $quoteId,
         ]);
 
         $session = RampSession::create([
@@ -64,8 +68,8 @@ class RampService
             'status'              => RampSession::STATUS_PENDING,
             'provider_session_id' => $providerResult['session_id'],
             'metadata'            => [
-                'redirect_url'  => $providerResult['redirect_url'],
-                'widget_config' => $providerResult['widget_config'],
+                'checkout_url' => $providerResult['checkout_url'],
+                'provider'     => $providerResult['metadata'] ?? [],
             ],
         ]);
 

--- a/app/Http/Controllers/Api/V1/RampController.php
+++ b/app/Http/Controllers/Api/V1/RampController.php
@@ -21,10 +21,10 @@ class RampController extends Controller
     }
 
     #[OA\Get(
-        path: '/api/v1/ramp/quote',
-        operationId: 'v1RampQuote',
+        path: '/api/v1/ramp/quotes',
+        operationId: 'v1RampQuotes',
         tags: ['Ramp'],
-        summary: 'Get a ramp quote',
+        summary: 'Get quotes from all aggregated providers',
         security: [['sanctum' => []]],
         parameters: [
             new OA\Parameter(name: 'type', in: 'query', required: true, schema: new OA\Schema(type: 'string', enum: ['on', 'off'])),
@@ -35,23 +35,29 @@ class RampController extends Controller
     )]
     #[OA\Response(
         response: 200,
-        description: 'Ramp quote',
+        description: 'Provider quotes',
         content: new OA\JsonContent(
             properties: [
                 new OA\Property(property: 'data', type: 'object', properties: [
-                    new OA\Property(property: 'fiat_amount', type: 'number', example: 100),
-                    new OA\Property(property: 'crypto_amount', type: 'number', example: 98.5),
-                    new OA\Property(property: 'exchange_rate', type: 'number', example: 1.0),
-                    new OA\Property(property: 'fee', type: 'number', example: 1.5),
-                    new OA\Property(property: 'fee_currency', type: 'string', example: 'USD'),
-                    new OA\Property(property: 'provider', type: 'string', example: 'mock'),
+                    new OA\Property(property: 'quotes', type: 'array', items: new OA\Items(type: 'object', properties: [
+                        new OA\Property(property: 'provider_name', type: 'string', example: 'Simplex'),
+                        new OA\Property(property: 'quote_id', type: 'string', example: 'q_12345'),
+                        new OA\Property(property: 'fiat_amount', type: 'number', example: 100),
+                        new OA\Property(property: 'crypto_amount', type: 'number', example: 0.0025),
+                        new OA\Property(property: 'exchange_rate', type: 'number', example: 0.000026),
+                        new OA\Property(property: 'fee', type: 'number', example: 3.5),
+                        new OA\Property(property: 'network_fee', type: 'number', example: 0.5),
+                        new OA\Property(property: 'fee_currency', type: 'string', example: 'USD'),
+                        new OA\Property(property: 'payment_methods', type: 'array', items: new OA\Items(type: 'string')),
+                    ])),
+                    new OA\Property(property: 'provider', type: 'string', example: 'onramper'),
                     new OA\Property(property: 'valid_until', type: 'string', format: 'date-time'),
                 ]),
             ]
         )
     )]
     #[OA\Response(response: 422, description: 'Validation error')]
-    public function quote(Request $request): JsonResponse
+    public function quotes(Request $request): JsonResponse
     {
         $request->validate([
             'type'   => 'required|string|in:on,off',
@@ -61,14 +67,14 @@ class RampController extends Controller
         ]);
 
         try {
-            $quote = $this->rampService->getQuote(
+            $result = $this->rampService->getQuotes(
                 $request->input('type'),
                 strtoupper($request->input('fiat')),
                 (float) $request->input('amount'),
                 strtoupper($request->input('crypto'))
             );
 
-            return response()->json(['data' => $quote]);
+            return response()->json(['data' => $result]);
         } catch (RuntimeException $e) {
             return response()->json([
                 'error' => ['code' => 'QUOTE_ERROR', 'message' => $e->getMessage()],
@@ -80,7 +86,7 @@ class RampController extends Controller
         path: '/api/v1/ramp/session',
         operationId: 'v1CreateRampSession',
         tags: ['Ramp'],
-        summary: 'Create a ramp session',
+        summary: 'Create a ramp session with a selected quote',
         security: [['sanctum' => []]],
         requestBody: new OA\RequestBody(
             required: true,
@@ -92,11 +98,12 @@ class RampController extends Controller
                     new OA\Property(property: 'fiat_amount', type: 'number', example: 100),
                     new OA\Property(property: 'crypto_currency', type: 'string', example: 'USDC'),
                     new OA\Property(property: 'wallet_address', type: 'string', example: '0x...'),
+                    new OA\Property(property: 'quote_id', type: 'string', example: 'q_12345', description: 'Selected quote ID from GET /quotes'),
                 ]
             )
         )
     )]
-    #[OA\Response(response: 201, description: 'Session created')]
+    #[OA\Response(response: 201, description: 'Session created with checkout_url')]
     #[OA\Response(response: 422, description: 'Validation error')]
     public function createSession(Request $request): JsonResponse
     {
@@ -106,6 +113,7 @@ class RampController extends Controller
             'fiat_amount'     => 'required|numeric|min:1',
             'crypto_currency' => 'required|string',
             'wallet_address'  => 'required|string',
+            'quote_id'        => 'nullable|string',
         ]);
 
         try {
@@ -117,7 +125,8 @@ class RampController extends Controller
                 strtoupper($request->input('fiat_currency')),
                 (float) $request->input('fiat_amount'),
                 strtoupper($request->input('crypto_currency')),
-                $request->input('wallet_address')
+                $request->input('wallet_address'),
+                $request->input('quote_id')
             );
 
             return response()->json([

--- a/app/Http/Resources/V1/RampSessionResource.php
+++ b/app/Http/Resources/V1/RampSessionResource.php
@@ -28,9 +28,7 @@ class RampSessionResource extends JsonResource
             'crypto_amount'   => $this->crypto_amount,
             'status'          => $this->status,
             'status_label'    => ucfirst($this->status),
-            'redirect_url'    => $metadata['redirect_url'] ?? null,
-            'widget_url'      => $metadata['widget_config']['widget_url'] ?? $metadata['redirect_url'] ?? null,
-            'widget_config'   => $metadata['widget_config'] ?? null,
+            'checkout_url'    => $metadata['checkout_url'] ?? null,
             'created_at'      => $this->created_at->toIso8601String(),
             'updated_at'      => $this->updated_at->toIso8601String(),
         ];

--- a/docs/BACKEND_HANDOFF.md
+++ b/docs/BACKEND_HANDOFF.md
@@ -1,0 +1,357 @@
+# Backend Developer Handoff — Mobile API Contract Gaps
+
+> Generated from a comprehensive audit comparing all mobile service calls against the Laravel backend (core-banking-prototype-laravel). Mobile PR #202 added normalizers to handle most mismatches on the frontend side. Items below require **backend changes** to fully resolve.
+
+## Priority Legend
+- 🔴 **Critical** — Will cause user-visible failures or data loss
+- 🟡 **Medium** — Feature works partially, degraded experience
+- 🟢 **Low** — Minor inconsistency, mobile has workarounds
+
+---
+
+## 1. Wallet Service
+
+### 🟡 GET /api/v1/wallet/balances — Missing fields
+**Current response:**
+```json
+{ "token": "USDC", "network": "polygon", "balance": "1000.50", "error": null }
+```
+**Requested additions:**
+- `usd_value` (number) — USD equivalent. Mobile currently defaults to `0`.
+- `balance_formatted` (string) — Human-friendly format. Mobile falls back to raw balance.
+- `change_24h` (number, optional) — 24h price change percentage.
+
+### 🟡 GET /api/v1/wallet/state — Missing balance aggregation
+**Current response:** Returns `addresses` only.
+**Requested additions:**
+- `total_usd_value` (number) — Sum of all balances in USD.
+- `shielded_balance` (number) — Total shielded balance.
+- `balances` (array) — Same structure as `/balances` endpoint.
+
+### 🟡 GET /api/v1/wallet/tokens — Multi-network format
+**Current response:** Returns tokens with `networks[]` array and `addresses{}` object.
+**Mobile expects:** One token entry per chain (e.g., USDC on polygon and USDC on base as separate entries).
+**Note:** Mobile now handles this with normalizer. No backend change required unless you want to simplify.
+
+### 🟡 GET /api/v1/wallet/transactions — Cursor vs page pagination
+**Current:** Backend uses cursor-based (`items` + `cursor`).
+**Mobile sends:** `page` + `limit` params.
+**Note:** Mobile normalizer handles `items` → `transactions` key mapping. Consider adding page-based pagination alias or documenting cursor usage for mobile.
+
+### 🟢 POST /api/v1/transactions/{txId}/receipt — Missing fields
+**Current response:** Missing `tx_id` and `network` fields.
+**Note:** Mobile injects `txId` from the request parameter. Backend should include them for completeness.
+
+### 🟢 GET /api/v1/wallet/recent-recipients — Time format
+**Current:** Returns `last_sent_at` as ISO 8601.
+**Note:** Mobile converts to relative time ("2 days ago"). This is fine — no change needed.
+
+---
+
+## 2. Auth Service
+
+### 🟢 POST /api/auth/register — Mobile now sends correct fields
+**Fixed in PR #202:** Mobile now sends `name` (required), `password_confirmation`, etc.
+**No backend change needed.**
+
+### 🟢 POST /api/v1/auth/passkey/authenticate — Mobile now decomposes credentials
+**Fixed in PR #202:** Mobile now sends `credential_id`, `client_data_json`, `authenticator_data`, `signature`.
+**No backend change needed.**
+
+### 🟢 POST /api/auth/delete-account — Mobile now sends confirmation
+**Fixed in PR #202:** Mobile now sends `{ confirmation: "DELETE" }`.
+**No backend change needed.**
+
+---
+
+## 3. Relayer Service
+
+### 🔴 POST /api/v1/relayer/estimate-fee — Response structure mismatch
+**Current response:**
+```json
+{ "gas_price": "30", "gas_limit": "0x5208", "total_cost": "0.05", "currency": "MATIC", "sponsored": false }
+```
+**Mobile expects (GasEstimate type):**
+```json
+{
+  "call_gas_limit": "string",
+  "verification_gas_limit": "string",
+  "pre_verification_gas": "string",
+  "max_fee_per_gas": "string",
+  "max_priority_fee_per_gas": "string",
+  "paymaster_fee": "string",
+  "paymaster_fee_usd": 0.0,
+  "total_fee_usd": 0.05
+}
+```
+**Note:** Mobile normalizer maps `gas_price` → `max_fee_per_gas`, `total_cost` → `total_fee_usd`. The ERC-4337 granular fields default to "0". For proper gas estimation, backend should return `total_fee_usd` as a number.
+
+### 🟡 GET /api/v1/relayer/supported-tokens — Return format
+**Current:** Returns `[{ symbol, name, sponsored }]` (array of objects).
+**Mobile expects:** `string[]` (just symbols).
+**Note:** Mobile normalizer extracts symbols. No urgent change needed.
+
+### 🟡 GET /api/v1/relayer/paymaster-data — Structure mismatch
+**Current:** Returns `[{ paymaster_address, entry_point, sponsored_tokens, max_gas_sponsored }]`.
+**Mobile expects:** `{ paymaster_and_data, gas_token_amount }`.
+**Note:** This is a fundamental architecture difference. Mobile may need to adapt further when paymaster integration is finalized.
+
+---
+
+## 4. Commerce Service
+
+### 🟡 POST /api/v1/commerce/payment-requests — Merchant data
+**Current:** Returns `merchant_id` as a string ID.
+**Mobile expects:** Nested `merchant` object with `{ id, name, display_name, category, accepted_tokens }`.
+**Suggestion:** Include a nested `merchant` object in the response, or provide a `?include=merchant` query param.
+
+### 🟢 POST /api/v1/commerce/parse-qr — Field naming
+**Current:** Returns `asset` and `network`.
+**Mobile expects:** `token` and `chain_id`.
+**Note:** Mobile normalizer handles this. Consider standardizing on one naming convention.
+
+---
+
+## 5. Cards Service
+
+### 🟡 GET /api/v1/cards — ID field name
+**Current:** Returns `card_token` as the identifier.
+**Mobile expects:** `id` field.
+**Note:** Mobile normalizer maps `card_token` → `id`. Consider adding an `id` alias.
+
+### 🟡 POST /api/v1/cards/provision — Device ID
+**Current:** Requires `device_id` in request body.
+**Mobile:** Now includes `device_id` in provisioning request (added to type in PR #202).
+**Note:** Mobile needs to know the current device ID at provisioning time.
+
+### 🟢 GET /api/v1/cards — Expiry breakdown
+**Current:** Returns `expires_at` as ISO 8601 string.
+**Mobile expects:** `expiry_month` and `expiry_year` as separate numbers.
+**Note:** Mobile normalizer parses the date. Consider adding the breakdown fields.
+
+---
+
+## 6. Privacy Service
+
+### 🟡 GET /api/v1/privacy/balances — Token type
+**Current:** Returns `token` as string (`"USDC"`).
+**Mobile expects:** Full `Token` object `{ symbol, name, address, decimals, chain_id, is_stablecoin }`.
+**Note:** Mobile normalizer builds a stub Token from the symbol. Consider returning full token objects for richer UI.
+
+---
+
+## 7. TrustCert Service
+
+### 🟡 POST /api/v1/trustcert/check-limit — Missing upgrade info
+**Current:** Returns `{ allowed, trust_level, limit, amount, type, remaining }`.
+**Mobile expects:** `upgrade_required` field (next trust level needed).
+**Note:** Mobile derives this from `trust_level + 1`. Backend should return it explicitly.
+
+### 🟢 GET /api/v1/trustcert/requirements — Field naming
+**Current:** Uses `label` instead of `name`, limits in nested `{ daily, monthly, single }` object.
+**Note:** Mobile normalizer handles mapping. Consider adding `name` and `description` fields.
+
+---
+
+## 8. Rewards Service
+
+### 🟡 GET /api/v1/rewards/profile — Field naming
+**Current:** Returns `xp_for_next` (next level XP threshold).
+**Mobile expects:** `target_xp` (same meaning, different name).
+**Note:** Mobile normalizer maps this. Consider adding `target_xp` alias.
+
+### 🟡 POST /api/v1/rewards/quests/{id}/complete — Missing total XP
+**Current:** Returns `{ quest_id, xp_earned, points_earned, new_level, level_up }`.
+**Missing:** `new_total_xp` — the user's updated total XP after completion.
+**Suggestion:** Add `new_total_xp` to the response.
+
+### 🔴 POST /api/v1/rewards/shop/{id}/redeem — Semantic mismatch
+**Current:** Returns `{ redemption_id, points_spent, points_balance }` (points-based).
+**Mobile expects:** `{ item_id, xp_deducted, new_total_xp }` (XP-based).
+**Note:** The rewards system uses points vs XP — need to clarify which currency the shop uses. Mobile normalizer maps `points_spent` → `xp_deducted` for now, but this is semantically incorrect if points ≠ XP.
+
+### 🟢 GET /api/v1/rewards/shop — Missing fields
+**Current:** Missing `slug` and `description` on some items.
+**Note:** Mobile displays these in the shop UI. Consider ensuring all items have slugs and descriptions.
+
+---
+
+## 9. Already Resolved (No Backend Changes Needed)
+
+These were fixed entirely on the mobile side with normalizers:
+
+- ✅ Wallet addresses: `network` → `chain_id`, `deployed` → `is_deployed`
+- ✅ Transaction detail: `asset` → `token`, `from_address` → `from`
+- ✅ Compliance sanctions check: Perfect match after snake→camel conversion
+- ✅ X402 service: Fields match after snake→camel conversion
+- ✅ Smart account: `account_address` → `address`, `deployed` → `is_deployed` (PR #201)
+- ✅ Data export: Correct endpoints, downloadUrl support (PR #202)
+- ✅ Recovery shard: encryptedShard field, retrieve endpoint (PR #202)
+
+---
+
+---
+
+## 10. On/Off Ramp — Onramper API Integration (NEW)
+
+> **PR #722 + #723** — API-first Onramper integration. Mobile owns the UI (currency picker, quote comparison). Onramper is used purely as a data API — only the checkout URL opens in a browser for payment/KYC.
+
+### Provider
+**Onramper** — fiat-to-crypto aggregator (30+ providers, 190+ countries, 800+ assets).
+Docs: https://docs.onramper.com
+
+### Endpoints
+
+| Method | Endpoint | Auth | Purpose |
+|--------|----------|------|---------|
+| `GET` | `/api/v1/ramp/supported` | Bearer | Get supported currencies, modes, and limits |
+| `GET` | `/api/v1/ramp/quotes` | Bearer | Get quotes from ALL aggregated providers |
+| `POST` | `/api/v1/ramp/session` | Bearer | Create session with selected quote (returns checkout URL) |
+| `GET` | `/api/v1/ramp/session/{id}` | Bearer | Poll session status |
+| `GET` | `/api/v1/ramp/sessions` | Bearer | List user's transaction history |
+
+### Flow
+
+```
+1. GET /supported          → populate currency picker, enforce limits
+2. GET /quotes             → show ALL provider quotes (mobile renders comparison UI)
+3. User selects a quote    → mobile has the quote_id
+4. POST /session           → pass quote_id + wallet → get checkout_url
+5. Open checkout_url       → only for payment/KYC step (in-app browser)
+6. Poll GET /session/{id}  → until status = completed|failed
+```
+
+### GET /api/v1/ramp/supported
+
+```json
+{
+  "data": {
+    "provider": "onramper",
+    "fiat_currencies": ["USD", "EUR", "GBP"],
+    "crypto_currencies": ["USDC", "USDT", "ETH", "BTC"],
+    "modes": ["buy", "sell"],
+    "limits": {
+      "min_amount": 10,
+      "max_amount": 10000,
+      "daily_limit": 50000
+    }
+  }
+}
+```
+
+### GET /api/v1/ramp/quotes
+
+**Params:** `type=on|off`, `fiat=USD`, `amount=100`, `crypto=USDC`
+
+Returns quotes from **all available providers** so mobile can render a comparison UI:
+
+```json
+{
+  "data": {
+    "quotes": [
+      {
+        "provider_name": "Simplex",
+        "quote_id": "q_12345",
+        "fiat_amount": 100,
+        "crypto_amount": 0.0025,
+        "exchange_rate": 0.000026,
+        "fee": 3.50,
+        "network_fee": 0.50,
+        "fee_currency": "USD",
+        "payment_methods": ["credit_card", "bank_transfer"]
+      },
+      {
+        "provider_name": "MoonPay",
+        "quote_id": "q_67890",
+        "fiat_amount": 100,
+        "crypto_amount": 0.0024,
+        "exchange_rate": 0.000025,
+        "fee": 4.00,
+        "network_fee": 0.50,
+        "fee_currency": "USD",
+        "payment_methods": ["credit_card"]
+      }
+    ],
+    "provider": "onramper",
+    "valid_until": "2026-03-05T17:00:00+00:00"
+  }
+}
+```
+
+### POST /api/v1/ramp/session
+
+**Request:**
+```json
+{
+  "type": "on",
+  "fiat_currency": "USD",
+  "fiat_amount": 100,
+  "crypto_currency": "USDC",
+  "wallet_address": "0x1234...",
+  "quote_id": "q_12345"
+}
+```
+
+**Response (201):**
+```json
+{
+  "data": {
+    "id": "uuid",
+    "provider": "onramper",
+    "type": "on",
+    "type_label": "Buy Crypto",
+    "fiat_currency": "USD",
+    "fiat_amount": 100,
+    "crypto_currency": "USDC",
+    "crypto_amount": null,
+    "status": "pending",
+    "status_label": "Pending",
+    "checkout_url": "https://onramper.com/checkout?id=tx_789",
+    "created_at": "2026-03-05T16:00:00+00:00",
+    "updated_at": "2026-03-05T16:00:00+00:00"
+  }
+}
+```
+
+### Key Fields for Mobile
+
+| Field | Usage |
+|-------|-------|
+| `quotes[].quote_id` | Pass this to `POST /session` to select a specific provider |
+| `quotes[].provider_name` | Display name for the provider in the comparison UI |
+| `quotes[].fee` + `network_fee` | Show total cost breakdown to user |
+| `checkout_url` | **Open in in-app browser** for the payment/KYC step only. `null` in mock mode. |
+| `id` | Use to poll `GET /session/{id}` for status updates |
+| `status` | `pending` → `processing` → `completed` or `failed` |
+| `type` | `on` = buy crypto (fiat → crypto), `off` = sell crypto (crypto → fiat) |
+| `crypto_amount` | Populated after transaction completes |
+
+### Mobile Implementation Notes
+
+1. **Native quote comparison UI**: Call `GET /quotes` and render all quotes in a list/card layout. Show provider name, crypto amount, fees, and payment methods. Let the user tap to select a quote.
+
+2. **Session creation**: After the user selects a quote, call `POST /session` with the `quote_id`. The response includes `checkout_url`.
+
+3. **Checkout URL**: Open `checkout_url` in an in-app browser (not a full WebView widget). The user completes payment/KYC at the provider's checkout page. This is the only step not in your native UI.
+
+4. **Status polling**: After the browser closes, poll `GET /session/{id}` every 5-10 seconds until `status` is `completed` or `failed`. Webhooks also update status server-side.
+
+5. **Off-ramp (sell)**: Use `type: "off"` in both `/quotes` and `/session`. The user sends crypto to a provider address and receives fiat.
+
+6. **Currency picker**: Call `GET /supported` on screen load to populate fiat/crypto dropdowns and enforce min/max limits client-side before calling `/quotes`.
+
+7. **Error handling**: `/quotes` and `/session` return `422` with `{ "error": { "code": "...", "message": "..." } }` for validation errors.
+
+8. **Mock mode**: In dev/staging (`RAMP_PROVIDER=mock`), quotes return instant mock data and `checkout_url` is `null`. No browser step needed.
+
+---
+
+## Recommended Backend Priorities
+
+1. **Relayer estimate-fee response** (🔴) — Add `total_fee_usd` as number
+2. **Rewards redemption clarity** (🔴) — Clarify points vs XP, add `new_total_xp`
+3. **Wallet balances USD value** (🟡) — Add `usd_value` field
+4. **Wallet state aggregation** (🟡) — Include `total_usd_value` and `balances`
+5. **Commerce payment requests** (🟡) — Nest merchant object
+6. **Privacy balances token type** (🟡) — Return full Token objects
+7. **TrustCert check-limit** (🟡) — Add `upgrade_required`

--- a/routes/api.php
+++ b/routes/api.php
@@ -242,7 +242,7 @@ Route::prefix('v1/ramp')->name('api.v1.ramp.')
     ->middleware(['auth:sanctum'])
     ->group(function () {
         Route::get('/supported', [App\Http\Controllers\Api\V1\RampController::class, 'supported'])->middleware('api.rate_limit:query')->name('supported');
-        Route::get('/quote', [App\Http\Controllers\Api\V1\RampController::class, 'quote'])->middleware('api.rate_limit:query')->name('quote');
+        Route::get('/quotes', [App\Http\Controllers\Api\V1\RampController::class, 'quotes'])->middleware('api.rate_limit:query')->name('quotes');
         Route::post('/session', [App\Http\Controllers\Api\V1\RampController::class, 'createSession'])->name('session.create');
         Route::get('/session/{id}', [App\Http\Controllers\Api\V1\RampController::class, 'getSession'])->name('session.show');
         Route::get('/sessions', [App\Http\Controllers\Api\V1\RampController::class, 'listSessions'])->name('sessions');

--- a/tests/Feature/Api/V1/RampControllerTest.php
+++ b/tests/Feature/Api/V1/RampControllerTest.php
@@ -20,30 +20,36 @@ class RampControllerTest extends TestCase
         $this->user = User::factory()->create();
     }
 
-    public function test_quote_requires_auth(): void
+    public function test_quotes_requires_auth(): void
     {
-        $this->getJson('/api/v1/ramp/quote?type=on&fiat=USD&amount=100&crypto=USDC')
+        $this->getJson('/api/v1/ramp/quotes?type=on&fiat=USD&amount=100&crypto=USDC')
             ->assertStatus(401);
     }
 
-    public function test_get_quote_returns_pricing(): void
+    public function test_get_quotes_returns_multiple_providers(): void
     {
         Sanctum::actingAs($this->user, ['read']);
 
-        $this->getJson('/api/v1/ramp/quote?type=on&fiat=USD&amount=100&crypto=USDC')
+        $this->getJson('/api/v1/ramp/quotes?type=on&fiat=USD&amount=100&crypto=USDC')
             ->assertOk()
             ->assertJsonStructure([
-                'data' => ['fiat_amount', 'crypto_amount', 'exchange_rate', 'fee', 'fee_currency', 'provider'],
+                'data' => [
+                    'quotes' => [
+                        '*' => ['provider_name', 'quote_id', 'fiat_amount', 'crypto_amount', 'exchange_rate', 'fee', 'network_fee', 'fee_currency', 'payment_methods'],
+                    ],
+                    'provider',
+                    'valid_until',
+                ],
             ])
-            ->assertJsonPath('data.fiat_amount', 100)
-            ->assertJsonPath('data.provider', 'mock');
+            ->assertJsonPath('data.provider', 'mock')
+            ->assertJsonCount(2, 'data.quotes');
     }
 
-    public function test_get_quote_validates_currency(): void
+    public function test_get_quotes_validates_currency(): void
     {
         Sanctum::actingAs($this->user, ['read']);
 
-        $this->getJson('/api/v1/ramp/quote?type=on&fiat=XXX&amount=100&crypto=USDC')
+        $this->getJson('/api/v1/ramp/quotes?type=on&fiat=XXX&amount=100&crypto=USDC')
             ->assertStatus(422);
     }
 
@@ -60,7 +66,7 @@ class RampControllerTest extends TestCase
         ])
             ->assertStatus(201)
             ->assertJsonStructure([
-                'data' => ['id', 'provider', 'type', 'fiat_currency', 'fiat_amount', 'crypto_currency', 'status'],
+                'data' => ['id', 'provider', 'type', 'fiat_currency', 'fiat_amount', 'crypto_currency', 'status', 'checkout_url'],
             ]);
 
         $this->assertEquals('pending', $response->json('data.status'));
@@ -171,5 +177,16 @@ class RampControllerTest extends TestCase
             'wallet_address'  => '0x1234',
         ])
             ->assertStatus(422);
+    }
+
+    public function test_supported_returns_provider_info(): void
+    {
+        Sanctum::actingAs($this->user, ['read']);
+
+        $this->getJson('/api/v1/ramp/supported')
+            ->assertOk()
+            ->assertJsonStructure([
+                'data' => ['provider', 'fiat_currencies', 'crypto_currencies', 'modes', 'limits'],
+            ]);
     }
 }

--- a/tests/Unit/Domain/Ramp/OnramperClientTest.php
+++ b/tests/Unit/Domain/Ramp/OnramperClientTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\Domain\Ramp;
 
 use App\Domain\Ramp\Clients\OnramperClient;
 use Illuminate\Support\Facades\Http;
+use RuntimeException;
 use Tests\TestCase;
 
 class OnramperClientTest extends TestCase
@@ -18,9 +19,8 @@ class OnramperClientTest extends TestCase
 
         config([
             'ramp.providers.onramper.api_key'    => 'pk_test_12345',
-            'ramp.providers.onramper.secret_key'  => 'sk_test_secret',
-            'ramp.providers.onramper.base_url'    => 'https://api.onramper.com',
-            'ramp.providers.onramper.widget_url'  => 'https://buy.onramper.com',
+            'ramp.providers.onramper.secret_key' => 'sk_test_secret',
+            'ramp.providers.onramper.base_url'   => 'https://api.onramper.com',
         ]);
 
         $this->client = new OnramperClient();
@@ -30,7 +30,7 @@ class OnramperClientTest extends TestCase
     {
         config(['ramp.providers.onramper.api_key' => '']);
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('API key is not configured');
 
         new OnramperClient();
@@ -77,7 +77,7 @@ class OnramperClientTest extends TestCase
             'api.onramper.com/quotes/*' => Http::response(['message' => 'Invalid pair'], 400),
         ]);
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Onramper quote request failed');
 
         $this->client->getQuotes('xxx', 'yyy', 100.0);
@@ -132,21 +132,6 @@ class OnramperClientTest extends TestCase
 
         $this->assertArrayHasKey('crypto', $assets);
         $this->assertArrayHasKey('fiat', $assets);
-    }
-
-    public function test_build_widget_url(): void
-    {
-        $url = $this->client->buildWidgetUrl([
-            'mode'          => 'buy',
-            'defaultFiat'   => 'USD',
-            'defaultCrypto' => 'btc',
-            'defaultAmount' => 100,
-        ]);
-
-        $this->assertStringStartsWith('https://buy.onramper.com?', $url);
-        $this->assertStringContainsString('apiKey=pk_test_12345', $url);
-        $this->assertStringContainsString('mode=buy', $url);
-        $this->assertStringContainsString('defaultFiat=USD', $url);
     }
 
     public function test_sign_payload(): void

--- a/tests/Unit/Domain/Ramp/OnramperProviderTest.php
+++ b/tests/Unit/Domain/Ramp/OnramperProviderTest.php
@@ -8,6 +8,7 @@ use App\Domain\Ramp\Clients\OnramperClient;
 use App\Domain\Ramp\Providers\OnramperProvider;
 use Mockery;
 use Mockery\MockInterface;
+use RuntimeException;
 use Tests\TestCase;
 
 class OnramperProviderTest extends TestCase
@@ -31,7 +32,7 @@ class OnramperProviderTest extends TestCase
         $this->assertEquals('onramper', $this->provider->getName());
     }
 
-    public function test_get_quote_returns_best_quote(): void
+    public function test_get_quotes_returns_all_provider_quotes(): void
     {
         $this->client->shouldReceive('getQuotes')
             ->with('usd', 'btc', 100.0)
@@ -42,7 +43,6 @@ class OnramperProviderTest extends TestCase
                     'quoteId'      => 'q_12345',
                     'fiatAmount'   => 100,
                     'cryptoAmount' => 0.0025,
-                    'exchangeRate' => 40000,
                     'fee'          => ['fiatFee' => 3.5, 'networkFee' => 0.5],
                 ],
                 [
@@ -50,22 +50,26 @@ class OnramperProviderTest extends TestCase
                     'quoteId'      => 'q_67890',
                     'fiatAmount'   => 100,
                     'cryptoAmount' => 0.0024,
-                    'exchangeRate' => 39500,
                     'fee'          => ['fiatFee' => 4.0, 'networkFee' => 0.5],
                 ],
             ]);
 
-        $quote = $this->provider->getQuote('on', 'USD', 100.0, 'BTC');
+        $quotes = $this->provider->getQuotes('on', 'USD', 100.0, 'BTC');
 
-        $this->assertEquals(100.0, $quote['fiat_amount']);
-        $this->assertEquals(0.0025, $quote['crypto_amount']);
-        $this->assertEquals(4.0, $quote['fee']);
-        $this->assertEquals('USD', $quote['fee_currency']);
-        $this->assertEquals('Simplex', $quote['provider_name']);
-        $this->assertEquals('q_12345', $quote['quote_id']);
+        $this->assertCount(2, $quotes);
+        $this->assertEquals('Simplex', $quotes[0]['provider_name']);
+        $this->assertEquals('q_12345', $quotes[0]['quote_id']);
+        $this->assertEquals(100.0, $quotes[0]['fiat_amount']);
+        $this->assertEquals(0.0025, $quotes[0]['crypto_amount']);
+        $this->assertEquals(3.5, $quotes[0]['fee']);
+        $this->assertEquals(0.5, $quotes[0]['network_fee']);
+        $this->assertEquals('USD', $quotes[0]['fee_currency']);
+
+        $this->assertEquals('MoonPay', $quotes[1]['provider_name']);
+        $this->assertEquals('q_67890', $quotes[1]['quote_id']);
     }
 
-    public function test_get_quote_off_ramp_swaps_currencies(): void
+    public function test_get_quotes_off_ramp_swaps_currencies(): void
     {
         $this->client->shouldReceive('getQuotes')
             ->with('btc', 'usd', 0.005)
@@ -78,33 +82,35 @@ class OnramperProviderTest extends TestCase
                 ],
             ]);
 
-        $quote = $this->provider->getQuote('off', 'USD', 0.005, 'BTC');
+        $quotes = $this->provider->getQuotes('off', 'USD', 0.005, 'BTC');
 
-        $this->assertEquals(0.005, $quote['fiat_amount']);
-        $this->assertEquals(195.0, $quote['crypto_amount']);
+        $this->assertCount(1, $quotes);
+        $this->assertEquals('Transak', $quotes[0]['provider_name']);
     }
 
-    public function test_get_quote_throws_when_no_quotes(): void
+    public function test_get_quotes_returns_empty_when_no_quotes(): void
     {
         $this->client->shouldReceive('getQuotes')
             ->once()
             ->andReturn([]);
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('No quotes available');
+        $quotes = $this->provider->getQuotes('on', 'USD', 100.0, 'BTC');
 
-        $this->provider->getQuote('on', 'USD', 100.0, 'BTC');
+        $this->assertEmpty($quotes);
     }
 
-    public function test_create_session_returns_widget_url(): void
+    public function test_create_session_calls_checkout_intent(): void
     {
-        $this->client->shouldReceive('buildWidgetUrl')
+        $this->client->shouldReceive('createCheckoutIntent')
             ->once()
-            ->andReturn('https://buy.onramper.com?apiKey=pk_test&mode=buy&defaultFiat=USD&defaultCrypto=usdc');
-
-        $this->client->shouldReceive('signPayload')
-            ->once()
-            ->andReturn('abc123signature');
+            ->withArgs(function (array $params) {
+                return $params['quoteId'] === 'q_12345'
+                    && $params['walletAddress'] === '0x1234';
+            })
+            ->andReturn([
+                'transactionId' => 'tx_789',
+                'checkoutUrl'   => 'https://onramper.com/checkout?id=tx_789',
+            ]);
 
         $result = $this->provider->createSession([
             'type'            => 'on',
@@ -112,40 +118,27 @@ class OnramperProviderTest extends TestCase
             'fiat_amount'     => 100.0,
             'crypto_currency' => 'USDC',
             'wallet_address'  => '0x1234',
+            'quote_id'        => 'q_12345',
         ]);
 
-        $this->assertArrayHasKey('session_id', $result);
-        $this->assertStringStartsWith('finaegis_', $result['session_id']);
-        $this->assertStringContainsString('buy.onramper.com', $result['redirect_url']);
-        $this->assertStringContainsString('signature=abc123signature', $result['redirect_url']);
-        $this->assertEquals('onramper', $result['widget_config']['provider']);
-        $this->assertEquals('buy', $result['widget_config']['mode']);
+        $this->assertEquals('tx_789', $result['session_id']);
+        $this->assertEquals('https://onramper.com/checkout?id=tx_789', $result['checkout_url']);
+        $this->assertEquals('onramper', $result['metadata']['provider']);
+        $this->assertEquals('q_12345', $result['metadata']['quote_id']);
     }
 
-    public function test_create_session_off_ramp_uses_sell_mode(): void
+    public function test_create_session_throws_without_quote_id(): void
     {
-        $this->client->shouldReceive('buildWidgetUrl')
-            ->withArgs(function (array $params) {
-                return $params['mode'] === 'sell'
-                    && isset($params['sell_defaultFiat'])
-                    && isset($params['sell_defaultCrypto']);
-            })
-            ->once()
-            ->andReturn('https://buy.onramper.com?mode=sell');
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('quote_id is required');
 
-        $this->client->shouldReceive('signPayload')
-            ->once()
-            ->andReturn('sig');
-
-        $result = $this->provider->createSession([
-            'type'            => 'off',
-            'fiat_currency'   => 'EUR',
-            'fiat_amount'     => 50.0,
-            'crypto_currency' => 'ETH',
-            'wallet_address'  => '0xabc',
+        $this->provider->createSession([
+            'type'            => 'on',
+            'fiat_currency'   => 'USD',
+            'fiat_amount'     => 100.0,
+            'crypto_currency' => 'USDC',
+            'wallet_address'  => '0x1234',
         ]);
-
-        $this->assertEquals('sell', $result['widget_config']['mode']);
     }
 
     public function test_get_session_status_maps_completed(): void
@@ -187,7 +180,7 @@ class OnramperProviderTest extends TestCase
         $this->client->shouldReceive('getTransaction')
             ->with('tx_notfound')
             ->once()
-            ->andThrow(new \RuntimeException('Transaction not found'));
+            ->andThrow(new RuntimeException('Transaction not found'));
 
         $result = $this->provider->getSessionStatus('tx_notfound');
 


### PR DESCRIPTION
## Summary
- Replaces widget/iframe approach with API-first Onramper integration
- Mobile owns the UI: `GET /quotes` returns ALL provider quotes for native comparison rendering
- `POST /session` accepts `quote_id` from selected quote, returns `checkout_url` for payment/KYC step only
- Removes `buildWidgetUrl()`, `widget_url`, `widget_config` — replaced by `checkout_url`
- Updates `RampProviderInterface`: `getQuote()` → `getQuotes()` (multi-provider)
- All 34 ramp tests updated and passing, PHPStan clean

## Test plan
- [x] 12 unit tests (OnramperProviderTest) — multi-quote, checkout intent, status mapping
- [x] 12 unit tests (OnramperClientTest) — API calls, webhook verification
- [x] 10 feature tests (RampControllerTest) — quotes endpoint, session CRUD, webhooks
- [x] PHPStan Level 8 clean
- [x] php-cs-fixer clean
- [x] BACKEND_HANDOFF.md Section 10 updated with API-first flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)