### PR TITLE
fix: ramp integration review — security hardening & cleanup (#724)

### DIFF
--- a/app/Domain/Ramp/Providers/MockRampProvider.php
+++ b/app/Domain/Ramp/Providers/MockRampProvider.php
@@ -10,6 +10,13 @@ use RuntimeException;
 
 class MockRampProvider implements RampProviderInterface
 {
+    public function __construct()
+    {
+        if (app()->environment('production')) {
+            throw new RuntimeException('Mock ramp provider must not be used in production.');
+        }
+    }
+
     public function createSession(array $params): array
     {
         $sessionId = 'mock_' . Str::uuid()->toString();
@@ -90,10 +97,6 @@ class MockRampProvider implements RampProviderInterface
 
     public function getWebhookValidator(): callable
     {
-        if (app()->environment('production')) {
-            throw new RuntimeException('Mock ramp provider must not be used in production.');
-        }
-
         return fn (string $payload, string $signature): bool => $signature !== '';
     }
 

--- a/app/Domain/Ramp/Providers/OnramperProvider.php
+++ b/app/Domain/Ramp/Providers/OnramperProvider.php
@@ -24,9 +24,8 @@ class OnramperProvider implements RampProviderInterface
             throw new RuntimeException('A quote_id is required. Call GET /ramp/quotes first and select a provider.');
         }
 
-        $successUrl = config('ramp.providers.onramper.success_redirect_url', '');
-        $failureUrl = config('ramp.providers.onramper.failure_redirect_url', '');
-        $redirectUrl = $successUrl ?: ($failureUrl ?: config('app.url') . '/ramp/complete');
+        $redirectUrl = config('ramp.providers.onramper.success_redirect_url')
+            ?: config('app.url') . '/ramp/complete';
 
         $result = $this->client->createCheckoutIntent([
             'quoteId'       => $quoteId,

--- a/app/Domain/Ramp/Services/RampService.php
+++ b/app/Domain/Ramp/Services/RampService.php
@@ -65,6 +65,7 @@ class RampService
             'fiat_currency'       => $fiatCurrency,
             'fiat_amount'         => $fiatAmount,
             'crypto_currency'     => $cryptoCurrency,
+            'wallet_address'      => $walletAddress,
             'status'              => RampSession::STATUS_PENDING,
             'provider_session_id' => $providerResult['session_id'],
             'metadata'            => [
@@ -132,6 +133,17 @@ class RampService
             return;
         }
 
+        // Verify the webhook provider matches the session provider
+        if ($session->provider !== $provider) {
+            Log::warning('Ramp webhook provider mismatch', [
+                'expected'   => $session->provider,
+                'received'   => $provider,
+                'session_id' => $session->id,
+            ]);
+
+            return;
+        }
+
         // Idempotency: don't overwrite terminal states
         if (in_array($session->status, [RampSession::STATUS_COMPLETED, RampSession::STATUS_FAILED], true)) {
             Log::info('Ramp webhook skipped — session already terminal', [
@@ -142,7 +154,7 @@ class RampService
             return;
         }
 
-        $status = $payload['status'] ?? 'processing';
+        $status = $this->normalizeWebhookStatus($payload['status'] ?? 'processing');
         $session->update([
             'status'        => $status,
             'crypto_amount' => $payload['crypto_amount'] ?? $session->crypto_amount,
@@ -190,5 +202,18 @@ class RampService
         if ($fiatAmount < $min || $fiatAmount > $max) {
             throw new RuntimeException("Amount must be between \${$min} and \${$max}.");
         }
+    }
+
+    /**
+     * Normalize webhook status to known session status constants.
+     */
+    private function normalizeWebhookStatus(string $status): string
+    {
+        return match (strtolower($status)) {
+            'completed', 'success', 'done' => RampSession::STATUS_COMPLETED,
+            'failed', 'error', 'cancelled', 'expired' => RampSession::STATUS_FAILED,
+            'pending', 'new', 'created' => RampSession::STATUS_PENDING,
+            default => RampSession::STATUS_PROCESSING,
+        };
     }
 }

--- a/app/Http/Controllers/Api/V1/RampWebhookController.php
+++ b/app/Http/Controllers/Api/V1/RampWebhookController.php
@@ -41,7 +41,7 @@ class RampWebhookController extends Controller
         try {
             $this->rampService->handleWebhook(
                 $provider,
-                $request->all(),
+                (array) $request->json()->all(),
                 $signature
             );
 

--- a/app/Http/Controllers/Api/V1/ReferralController.php
+++ b/app/Http/Controllers/Api/V1/ReferralController.php
@@ -46,7 +46,9 @@ class ReferralController extends Controller
     )]
     public function myCode(Request $request): JsonResponse
     {
-        $referralCode = $this->referralService->generateCode($request->user());
+        /** @var \App\Models\User $user */
+        $user = $request->user();
+        $referralCode = $this->referralService->generateCode($user);
 
         $code = $referralCode->code;
 
@@ -54,7 +56,7 @@ class ReferralController extends Controller
             'data' => [
                 'code'       => $code,
                 'share_link' => url("/invite/{$code}"),
-                'share_text' => str_replace('{code}', $code, (string) config('ramp.referral_share_text')),
+                'share_text' => str_replace('{code}', $code, (string) config('referral.share_text')),
                 'uses_count' => $referralCode->uses_count,
                 'max_uses'   => $referralCode->max_uses,
                 'active'     => $referralCode->active,
@@ -89,8 +91,10 @@ class ReferralController extends Controller
         ]);
 
         try {
+            /** @var \App\Models\User $user */
+            $user = $request->user();
             $referral = $this->referralService->applyCode(
-                $request->user(),
+                $user,
                 strtoupper($request->input('code'))
             );
 
@@ -164,8 +168,11 @@ class ReferralController extends Controller
     )]
     public function stats(Request $request): JsonResponse
     {
+        /** @var \App\Models\User $user */
+        $user = $request->user();
+
         return response()->json([
-            'data' => $this->referralService->getUserStats($request->user()),
+            'data' => $this->referralService->getUserStats($user),
         ]);
     }
 }

--- a/app/Http/Resources/V1/RampSessionResource.php
+++ b/app/Http/Resources/V1/RampSessionResource.php
@@ -26,6 +26,7 @@ class RampSessionResource extends JsonResource
             'fiat_amount'     => $this->fiat_amount,
             'crypto_currency' => $this->crypto_currency,
             'crypto_amount'   => $this->crypto_amount,
+            'wallet_address'  => $this->wallet_address,
             'status'          => $this->status,
             'status_label'    => ucfirst($this->status),
             'checkout_url'    => $metadata['checkout_url'] ?? null,

--- a/app/Models/RampSession.php
+++ b/app/Models/RampSession.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property float|null $fiat_amount
  * @property string $crypto_currency
  * @property float|null $crypto_amount
+ * @property string|null $wallet_address
  * @property string $status
  * @property string|null $provider_session_id
  * @property array<string, mixed>|null $metadata
@@ -43,6 +44,7 @@ class RampSession extends Model
         'fiat_amount',
         'crypto_currency',
         'crypto_amount',
+        'wallet_address',
         'status',
         'provider_session_id',
         'metadata',

--- a/config/ramp.php
+++ b/config/ramp.php
@@ -28,9 +28,7 @@ return [
             'api_key'              => env('ONRAMPER_API_KEY'),
             'secret_key'           => env('ONRAMPER_SECRET_KEY'),
             'base_url'             => env('ONRAMPER_BASE_URL', 'https://api.onramper.com'),
-            'widget_url'           => env('ONRAMPER_WIDGET_URL', 'https://buy.onramper.com'),
             'success_redirect_url' => env('ONRAMPER_SUCCESS_REDIRECT_URL'),
-            'failure_redirect_url' => env('ONRAMPER_FAILURE_REDIRECT_URL'),
             'enabled'              => (bool) env('ONRAMPER_ENABLED', false),
         ],
     ],
@@ -56,15 +54,4 @@ return [
         'daily_limit'     => (float) env('RAMP_DAILY_LIMIT', 50000.00),
     ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Referral Share Copy
-    |--------------------------------------------------------------------------
-    | Customizable by marketing. Use {code} placeholder for referral code.
-    */
-
-    'referral_share_text' => env(
-        'REFERRAL_SHARE_TEXT',
-        'Join FinAegis with my code {code} and earn free transactions!'
-    ),
 ];

--- a/config/referral.php
+++ b/config/referral.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'share_text' => env(
+        'REFERRAL_SHARE_TEXT',
+        'Join FinAegis with my code {code} and earn free transactions!'
+    ),
+];

--- a/database/migrations/2026_03_04_221000_create_ramp_sessions_table.php
+++ b/database/migrations/2026_03_04_221000_create_ramp_sessions_table.php
@@ -12,7 +12,7 @@ return new class () extends Migration {
         Schema::create('ramp_sessions', function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->foreignId('user_id')->constrained()->onDelete('cascade');
-            $table->string('provider'); // mock, moonpay, transak
+            $table->string('provider'); // mock, onramper
             $table->string('type'); // on, off
             $table->string('fiat_currency', 3);
             $table->decimal('fiat_amount', 16, 2)->nullable();

--- a/database/migrations/2026_03_05_120000_add_wallet_address_to_ramp_sessions_table.php
+++ b/database/migrations/2026_03_05_120000_add_wallet_address_to_ramp_sessions_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('ramp_sessions', function (Blueprint $table) {
+            $table->string('wallet_address')->nullable()->after('crypto_amount');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('ramp_sessions', function (Blueprint $table) {
+            $table->dropColumn('wallet_address');
+        });
+    }
+};

--- a/tests/Feature/Api/V1/RampControllerTest.php
+++ b/tests/Feature/Api/V1/RampControllerTest.php
@@ -14,6 +14,8 @@ class RampControllerTest extends TestCase
 {
     use LazilyRefreshDatabase;
 
+    protected User $user;
+
     protected function setUp(): void
     {
         parent::setUp();


### PR DESCRIPTION
## Summary
Professional code review of the Onramper ramp integration (PR #722 + #723). Fixes 3 security issues, 5 architectural issues, and 2 code quality issues.

### Security fixes
- **Webhook provider mismatch**: Validates that webhook provider matches session provider — prevents cross-provider session updates
- **Webhook status injection**: Raw payload status is now normalized through `normalizeWebhookStatus()` instead of being trusted directly
- **Webhook body parsing**: Uses `$request->json()->all()` instead of `$request->all()` to exclude query params from webhook payload

### Architectural fixes
- **wallet_address persistence**: New migration adds `wallet_address` column to `ramp_sessions` — previously accepted but never stored
- **Config cleanup**: Removed dead `widget_url` and `failure_redirect_url` keys from ramp config
- **Config misplacement**: Moved `referral_share_text` from `config/ramp.php` to `config/referral.php`
- **Redirect fallback**: Fixed illogical fallback to `failure_redirect_url` when `success_redirect_url` is empty
- **MockRampProvider**: Production guard moved to constructor (was only on `getWebhookValidator()`)

### Code quality
- Fixed 4 PHPStan errors in `ReferralController` (`User|null` types, `env()` outside config)
- Declared `$user` property in `RampControllerTest` (PHP 8.2 dynamic property deprecation)
- Updated migration comment `moonpay/transak` → `onramper`

## Test plan
- [x] 34 ramp tests passing
- [x] 9 referral tests passing (verifying config move)
- [x] PHPStan Level 8 clean
- [x] php-cs-fixer clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)