### PR TITLE
fix: ramp design consistency — constants, null safety, modes, tests (#725)

### DIFF
--- a/app/Domain/Ramp/Clients/OnramperClient.php
+++ b/app/Domain/Ramp/Clients/OnramperClient.php
@@ -79,7 +79,7 @@ class OnramperClient
             );
         }
 
-        return $response->json();
+        return $response->json() ?? [];
     }
 
     /**
@@ -98,7 +98,7 @@ class OnramperClient
             );
         }
 
-        return $response->json();
+        return $response->json() ?? [];
     }
 
     /**

--- a/app/Domain/Ramp/Providers/OnramperProvider.php
+++ b/app/Domain/Ramp/Providers/OnramperProvider.php
@@ -6,6 +6,7 @@ namespace App\Domain\Ramp\Providers;
 
 use App\Domain\Ramp\Clients\OnramperClient;
 use App\Domain\Ramp\Contracts\RampProviderInterface;
+use App\Models\RampSession;
 use RuntimeException;
 
 class OnramperProvider implements RampProviderInterface
@@ -69,7 +70,7 @@ class OnramperProvider implements RampProviderInterface
             ];
         } catch (RuntimeException) {
             return [
-                'status'        => 'pending',
+                'status'        => RampSession::STATUS_PENDING,
                 'fiat_amount'   => null,
                 'crypto_amount' => null,
                 'metadata'      => ['provider' => 'onramper'],
@@ -149,10 +150,10 @@ class OnramperProvider implements RampProviderInterface
     private function mapOnramperStatus(string $status): string
     {
         return match (strtolower($status)) {
-            'completed', 'success', 'done' => 'completed',
-            'failed', 'error', 'cancelled', 'expired' => 'failed',
-            'pending', 'new', 'created' => 'pending',
-            default => 'processing',
+            'completed', 'success', 'done' => RampSession::STATUS_COMPLETED,
+            'failed', 'error', 'cancelled', 'expired' => RampSession::STATUS_FAILED,
+            'pending', 'new', 'created' => RampSession::STATUS_PENDING,
+            default => RampSession::STATUS_PROCESSING,
         };
     }
 }

--- a/app/Http/Controllers/Api/V1/RampController.php
+++ b/app/Http/Controllers/Api/V1/RampController.php
@@ -207,7 +207,10 @@ class RampController extends Controller
                     new OA\Property(property: 'provider', type: 'string', example: 'onramper'),
                     new OA\Property(property: 'fiat_currencies', type: 'array', items: new OA\Items(type: 'string'), example: '["USD","EUR","GBP"]'),
                     new OA\Property(property: 'crypto_currencies', type: 'array', items: new OA\Items(type: 'string'), example: '["USDC","USDT","ETH","BTC"]'),
-                    new OA\Property(property: 'modes', type: 'array', items: new OA\Items(type: 'string'), example: '["buy","sell"]'),
+                    new OA\Property(property: 'modes', type: 'array', items: new OA\Items(type: 'object', properties: [
+                        new OA\Property(property: 'type', type: 'string', example: 'on'),
+                        new OA\Property(property: 'label', type: 'string', example: 'Buy Crypto'),
+                    ])),
                 ]),
             ]
         )
@@ -219,8 +222,11 @@ class RampController extends Controller
                 'provider'          => config('ramp.default_provider'),
                 'fiat_currencies'   => config('ramp.supported_fiat'),
                 'crypto_currencies' => config('ramp.supported_crypto'),
-                'modes'             => ['buy', 'sell'],
-                'limits'            => [
+                'modes'             => [
+                    ['type' => 'on', 'label' => 'Buy Crypto'],
+                    ['type' => 'off', 'label' => 'Sell Crypto'],
+                ],
+                'limits' => [
                     'min_amount'  => config('ramp.limits.min_fiat_amount'),
                     'max_amount'  => config('ramp.limits.max_fiat_amount'),
                     'daily_limit' => config('ramp.limits.daily_limit'),

--- a/tests/Feature/Api/V1/RampControllerTest.php
+++ b/tests/Feature/Api/V1/RampControllerTest.php
@@ -59,25 +59,29 @@ class RampControllerTest extends TestCase
     {
         Sanctum::actingAs($this->user, ['read', 'write']);
 
+        $wallet = '0x1234567890abcdef1234567890abcdef12345678';
+
         $response = $this->postJson('/api/v1/ramp/session', [
             'type'            => 'on',
             'fiat_currency'   => 'USD',
             'fiat_amount'     => 100,
             'crypto_currency' => 'USDC',
-            'wallet_address'  => '0x1234567890abcdef1234567890abcdef12345678',
+            'wallet_address'  => $wallet,
         ])
             ->assertStatus(201)
             ->assertJsonStructure([
-                'data' => ['id', 'provider', 'type', 'fiat_currency', 'fiat_amount', 'crypto_currency', 'status', 'checkout_url'],
+                'data' => ['id', 'provider', 'type', 'fiat_currency', 'fiat_amount', 'crypto_currency', 'status', 'checkout_url', 'wallet_address'],
             ]);
 
         $this->assertEquals('pending', $response->json('data.status'));
         $this->assertEquals('mock', $response->json('data.provider'));
+        $this->assertEquals($wallet, $response->json('data.wallet_address'));
 
         $this->assertDatabaseHas('ramp_sessions', [
-            'user_id'  => $this->user->id,
-            'provider' => 'mock',
-            'type'     => 'on',
+            'user_id'        => $this->user->id,
+            'provider'       => 'mock',
+            'type'           => 'on',
+            'wallet_address' => $wallet,
         ]);
     }
 
@@ -165,6 +169,91 @@ class RampControllerTest extends TestCase
 
         $session->refresh();
         $this->assertEquals('completed', $session->status);
+    }
+
+    public function test_webhook_skips_terminal_session(): void
+    {
+        $session = RampSession::create([
+            'user_id'             => $this->user->id,
+            'provider'            => 'mock',
+            'type'                => 'on',
+            'fiat_currency'       => 'USD',
+            'fiat_amount'         => 100,
+            'crypto_currency'     => 'USDC',
+            'status'              => 'completed',
+            'provider_session_id' => 'mock_terminal_test',
+            'metadata'            => [],
+        ]);
+
+        $this->postJson('/api/v1/ramp/webhook/mock', [
+            'session_id'    => 'mock_terminal_test',
+            'status'        => 'failed',
+            'crypto_amount' => 0,
+        ], ['X-Webhook-Signature' => 'valid'])
+            ->assertOk();
+
+        $session->refresh();
+        $this->assertEquals('completed', $session->status);
+    }
+
+    public function test_webhook_rejects_provider_mismatch(): void
+    {
+        $session = RampSession::create([
+            'user_id'             => $this->user->id,
+            'provider'            => 'onramper',
+            'type'                => 'on',
+            'fiat_currency'       => 'USD',
+            'fiat_amount'         => 100,
+            'crypto_currency'     => 'USDC',
+            'status'              => 'pending',
+            'provider_session_id' => 'mismatch_test',
+            'metadata'            => [],
+        ]);
+
+        $this->postJson('/api/v1/ramp/webhook/mock', [
+            'session_id' => 'mismatch_test',
+            'status'     => 'completed',
+        ], ['X-Webhook-Signature' => 'valid'])
+            ->assertOk();
+
+        $session->refresh();
+        $this->assertEquals('pending', $session->status);
+    }
+
+    public function test_webhook_normalizes_status(): void
+    {
+        $session = RampSession::create([
+            'user_id'             => $this->user->id,
+            'provider'            => 'mock',
+            'type'                => 'on',
+            'fiat_currency'       => 'USD',
+            'fiat_amount'         => 100,
+            'crypto_currency'     => 'USDC',
+            'status'              => 'pending',
+            'provider_session_id' => 'normalize_test',
+            'metadata'            => [],
+        ]);
+
+        $this->postJson('/api/v1/ramp/webhook/mock', [
+            'session_id' => 'normalize_test',
+            'status'     => 'success',
+        ], ['X-Webhook-Signature' => 'valid'])
+            ->assertOk();
+
+        $session->refresh();
+        $this->assertEquals('completed', $session->status);
+    }
+
+    public function test_supported_returns_modes_with_types(): void
+    {
+        Sanctum::actingAs($this->user, ['read']);
+
+        $this->getJson('/api/v1/ramp/supported')
+            ->assertOk()
+            ->assertJsonPath('data.modes.0.type', 'on')
+            ->assertJsonPath('data.modes.0.label', 'Buy Crypto')
+            ->assertJsonPath('data.modes.1.type', 'off')
+            ->assertJsonPath('data.modes.1.label', 'Sell Crypto');
     }
 
     public function test_create_session_validates_amount_limits(): void


### PR DESCRIPTION
## Summary
Third review pass focusing on design consistency across the ramp stack — ensuring all "inner pages" follow the same patterns.

### Consistency fixes
- **Status constants**: `OnramperProvider::mapOnramperStatus()` now uses `RampSession::STATUS_*` constants instead of raw strings — matches `RampService::normalizeWebhookStatus()` pattern
- **Null safety**: `OnramperClient::createCheckoutIntent()` and `getTransaction()` now have `?? []` null guards — matches the existing `getQuotes()` pattern
- **API modes**: `supported()` endpoint returns `[{type: 'on', label: 'Buy Crypto'}, ...]` instead of `['buy', 'sell']` — matches the `type: on|off` parameter used in `/quotes` and `/session`

### Test coverage (4 new tests → 38 total)
- Webhook terminal idempotency: completed session stays completed when webhook sends 'failed'
- Webhook provider mismatch: onramper session not updated by mock provider webhook
- Webhook status normalization: 'success' → 'completed'
- Supported modes structure validation
- Create session now verifies `wallet_address` persistence and response

## Test plan
- [x] 38 ramp tests passing (was 34)
- [x] PHPStan Level 8 clean
- [x] php-cs-fixer clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)