### PR TITLE
fix: standardize inner content to FinAegis design system

### DIFF
--- a/resources/views/cgo.blade.php
+++ b/resources/views/cgo.blade.php
@@ -114,28 +114,28 @@
                 <!-- Bronze Tier -->
                 <div class="card-feature">
                     <div class="absolute -top-4 left-1/2 transform -translate-x-1/2">
-                        <span class="bg-gray-400 text-white px-4 py-1 rounded-full text-sm font-semibold">CONCEPTUAL</span>
+                        <span class="bg-slate-400 text-white px-4 py-1 rounded-full text-sm font-semibold">CONCEPTUAL</span>
                     </div>
                     <div class="text-center mb-6">
                         <h3 class="text-2xl font-bold text-slate-900 mb-2">Supporter</h3>
-                        <p class="text-4xl font-bold text-gray-400">Small</p>
-                        <p class="text-sm text-gray-500">Contributions</p>
+                        <p class="text-4xl font-bold text-slate-400">Small</p>
+                        <p class="text-sm text-slate-400">Contributions</p>
                     </div>
-                    <ul class="space-y-3 mb-8 text-gray-500">
+                    <ul class="space-y-3 mb-8 text-slate-400">
                         <li class="flex items-start">
-                            <svg class="w-5 h-5 text-gray-400 mt-1 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <svg class="w-5 h-5 text-slate-400 mt-1 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                             </svg>
                             <span>Recognition as supporter</span>
                         </li>
                         <li class="flex items-start">
-                            <svg class="w-5 h-5 text-gray-400 mt-1 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <svg class="w-5 h-5 text-slate-400 mt-1 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                             </svg>
                             <span>Development updates</span>
                         </li>
                         <li class="flex items-start">
-                            <svg class="w-5 h-5 text-gray-400 mt-1 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <svg class="w-5 h-5 text-slate-400 mt-1 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                             </svg>
                             <span>Community access</span>
@@ -147,24 +147,24 @@
                 <div class="card-feature">
                     <div class="text-center mb-6">
                         <h3 class="text-2xl font-bold text-slate-900 mb-2">Contributor</h3>
-                        <p class="text-4xl font-bold text-gray-400">Medium</p>
-                        <p class="text-sm text-gray-500">Contributions</p>
+                        <p class="text-4xl font-bold text-slate-400">Medium</p>
+                        <p class="text-sm text-slate-400">Contributions</p>
                     </div>
-                    <ul class="space-y-3 mb-8 text-gray-500">
+                    <ul class="space-y-3 mb-8 text-slate-400">
                         <li class="flex items-start">
-                            <svg class="w-5 h-5 text-gray-400 mt-1 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <svg class="w-5 h-5 text-slate-400 mt-1 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                             </svg>
                             <span>Supporter benefits</span>
                         </li>
                         <li class="flex items-start">
-                            <svg class="w-5 h-5 text-gray-400 mt-1 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <svg class="w-5 h-5 text-slate-400 mt-1 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                             </svg>
                             <span>Feature voting rights</span>
                         </li>
                         <li class="flex items-start">
-                            <svg class="w-5 h-5 text-gray-400 mt-1 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <svg class="w-5 h-5 text-slate-400 mt-1 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                             </svg>
                             <span>Roadmap input</span>
@@ -176,24 +176,24 @@
                 <div class="card-feature">
                     <div class="text-center mb-6">
                         <h3 class="text-2xl font-bold text-slate-900 mb-2">Sponsor</h3>
-                        <p class="text-4xl font-bold text-gray-400">Large</p>
-                        <p class="text-sm text-gray-500">Contributions</p>
+                        <p class="text-4xl font-bold text-slate-400">Large</p>
+                        <p class="text-sm text-slate-400">Contributions</p>
                     </div>
-                    <ul class="space-y-3 mb-8 text-gray-500">
+                    <ul class="space-y-3 mb-8 text-slate-400">
                         <li class="flex items-start">
-                            <svg class="w-5 h-5 text-gray-400 mt-1 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <svg class="w-5 h-5 text-slate-400 mt-1 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                             </svg>
                             <span>Contributor benefits</span>
                         </li>
                         <li class="flex items-start">
-                            <svg class="w-5 h-5 text-gray-400 mt-1 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <svg class="w-5 h-5 text-slate-400 mt-1 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                             </svg>
                             <span>Direct developer access</span>
                         </li>
                         <li class="flex items-start">
-                            <svg class="w-5 h-5 text-gray-400 mt-1 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <svg class="w-5 h-5 text-slate-400 mt-1 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                             </svg>
                             <span>Strategic input</span>
@@ -217,8 +217,8 @@
             </div>
 
             <div class="grid md:grid-cols-3 gap-6 max-w-4xl mx-auto">
-                <a href="https://github.com/FinAegis/core-banking-prototype-laravel" target="_blank" class="block bg-slate-50 rounded-xl p-6 hover:bg-gray-100 transition text-center">
-                    <div class="w-16 h-16 bg-gray-900 rounded-full flex items-center justify-center mx-auto mb-4">
+                <a href="https://github.com/FinAegis/core-banking-prototype-laravel" target="_blank" class="block bg-slate-50 rounded-xl p-6 hover:bg-slate-100 transition text-center">
+                    <div class="w-16 h-16 bg-slate-900 rounded-full flex items-center justify-center mx-auto mb-4">
                         <svg class="w-8 h-8 text-white" fill="currentColor" viewBox="0 0 24 24">
                             <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
                         </svg>
@@ -227,7 +227,7 @@
                     <p class="text-slate-500">Submit PRs, fix bugs, or add features</p>
                 </a>
 
-                <a href="https://github.com/FinAegis/core-banking-prototype-laravel/issues" target="_blank" class="block bg-slate-50 rounded-xl p-6 hover:bg-gray-100 transition text-center">
+                <a href="https://github.com/FinAegis/core-banking-prototype-laravel/issues" target="_blank" class="block bg-slate-50 rounded-xl p-6 hover:bg-slate-100 transition text-center">
                     <div class="w-16 h-16 bg-blue-600 rounded-full flex items-center justify-center mx-auto mb-4">
                         <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"></path>
@@ -237,7 +237,7 @@
                     <p class="text-slate-500">Help improve by reporting bugs</p>
                 </a>
 
-                <a href="https://github.com/FinAegis/core-banking-prototype-laravel" target="_blank" class="block bg-slate-50 rounded-xl p-6 hover:bg-gray-100 transition text-center">
+                <a href="https://github.com/FinAegis/core-banking-prototype-laravel" target="_blank" class="block bg-slate-50 rounded-xl p-6 hover:bg-slate-100 transition text-center">
                     <div class="w-16 h-16 bg-yellow-500 rounded-full flex items-center justify-center mx-auto mb-4">
                         <svg class="w-8 h-8 text-white" fill="currentColor" viewBox="0 0 20 20">
                             <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/>

--- a/resources/views/developers/index.blade.php
+++ b/resources/views/developers/index.blade.php
@@ -13,9 +13,6 @@
 @push('styles')
 <link href="https://fonts.bunny.net/css?family=fira-code:400,500&display=swap" rel="stylesheet" />
 <style>
-    .gradient-bg {
-        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    }
     .dev-gradient {
         background: linear-gradient(135deg, #0c1222 0%, #131b2e 50%, #1e293b 100%);
     }
@@ -149,13 +146,13 @@
                         Open source banking infrastructure with comprehensive APIs, SDKs, and documentation.
                     </p>
                     <div class="flex flex-col sm:flex-row gap-4 justify-center">
-                        <a href="#quickstart" class="group bg-white text-gray-900 px-8 py-4 rounded-lg text-lg font-semibold hover:bg-gray-100 transition shadow-lg hover:shadow-xl inline-flex items-center justify-center">
+                        <a href="#quickstart" class="group bg-white text-slate-900 px-8 py-4 rounded-lg text-lg font-semibold hover:bg-gray-100 transition shadow-lg hover:shadow-xl inline-flex items-center justify-center">
                             <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
                             </svg>
                             Quick Start
                         </a>
-                        <a href="{{ route('developers.show', 'api-docs') }}" class="group border-2 border-white text-white px-8 py-4 rounded-lg text-lg font-semibold hover:bg-white hover:text-gray-900 transition inline-flex items-center justify-center">
+                        <a href="{{ route('developers.show', 'api-docs') }}" class="group border-2 border-white text-white px-8 py-4 rounded-lg text-lg font-semibold hover:bg-white hover:text-slate-900 transition inline-flex items-center justify-center">
                             <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
                             </svg>
@@ -187,11 +184,11 @@
         </section>
 
         <!-- Quick Start Section -->
-        <section id="quickstart" class="py-20 bg-gray-50">
+        <section id="quickstart" class="py-20 bg-slate-50">
             <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                 <div class="text-center mb-16">
-                    <h2 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4">Quick Start Guide</h2>
-                    <p class="text-xl text-gray-600 max-w-3xl mx-auto">
+                    <h2 class="font-display text-3xl md:text-4xl font-bold text-slate-900 mb-4">Quick Start Guide</h2>
+                    <p class="text-xl text-slate-500 max-w-3xl mx-auto">
                         Get up and running with FinAegis in three simple steps
                     </p>
                 </div>
@@ -202,7 +199,7 @@
                         <div class="text-center mb-6">
                             <div class="w-20 h-20 bg-gradient-to-br from-indigo-500 to-purple-600 text-white rounded-full flex items-center justify-center text-2xl font-bold mx-auto shadow-lg">1</div>
                             <h3 class="text-xl font-semibold mt-4 mb-2">Clone Repository</h3>
-                            <p class="text-gray-600">Get the source code from GitHub</p>
+                            <p class="text-slate-500">Get the source code from GitHub</p>
                         </div>
                         <div class="code-container flex-1">
                             <div class="code-header">
@@ -233,7 +230,7 @@
                         <div class="text-center mb-6">
                             <div class="w-20 h-20 bg-gradient-to-br from-purple-500 to-pink-600 text-white rounded-full flex items-center justify-center text-2xl font-bold mx-auto shadow-lg">2</div>
                             <h3 class="text-xl font-semibold mt-4 mb-2">Install & Configure</h3>
-                            <p class="text-gray-600">Set up your development environment</p>
+                            <p class="text-slate-500">Set up your development environment</p>
                         </div>
                         <div class="code-container flex-1">
                             <div class="code-header">
@@ -266,7 +263,7 @@
                         <div class="text-center mb-6">
                             <div class="w-20 h-20 bg-gradient-to-br from-pink-500 to-orange-600 text-white rounded-full flex items-center justify-center text-2xl font-bold mx-auto shadow-lg">3</div>
                             <h3 class="text-xl font-semibold mt-4 mb-2">Start Building</h3>
-                            <p class="text-gray-600">Create your first API request</p>
+                            <p class="text-slate-500">Create your first API request</p>
                         </div>
                         <div class="code-container flex-1">
                             <div class="code-header">
@@ -300,8 +297,8 @@
         <section class="py-20 bg-white">
             <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                 <div class="text-center mb-16">
-                    <h2 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4">API Overview</h2>
-                    <p class="text-xl text-gray-600 max-w-3xl mx-auto">
+                    <h2 class="font-display text-3xl md:text-4xl font-bold text-slate-900 mb-4">API Overview</h2>
+                    <p class="text-xl text-slate-500 max-w-3xl mx-auto">
                         RESTful API built on modern standards with comprehensive documentation
                     </p>
                 </div>
@@ -318,7 +315,7 @@
                                 </div>
                                 <h3 class="text-xl font-semibold">Authentication</h3>
                             </div>
-                            <p class="text-gray-600 mb-6">
+                            <p class="text-slate-500 mb-6">
                                 Secure API authentication using Bearer tokens. Get your API key from the dashboard after registration.
                             </p>
                             <div class="code-container">
@@ -368,24 +365,24 @@
                                 </div>
                                 <h3 class="text-xl font-semibold">Rate Limiting</h3>
                             </div>
-                            <p class="text-gray-600 mb-6">
+                            <p class="text-slate-500 mb-6">
                                 API requests are limited to ensure fair usage and platform stability.
                             </p>
-                            <div class="bg-gray-50 rounded-lg p-6 space-y-4">
+                            <div class="bg-slate-50 rounded-lg p-6 space-y-4">
                                 <div class="flex items-center justify-between">
-                                    <span class="text-gray-700 font-medium">Per Hour</span>
+                                    <span class="text-slate-600 font-medium">Per Hour</span>
                                     <span class="text-2xl font-bold text-indigo-600">1,000</span>
                                 </div>
                                 <div class="flex items-center justify-between">
-                                    <span class="text-gray-700 font-medium">Per Day</span>
+                                    <span class="text-slate-600 font-medium">Per Day</span>
                                     <span class="text-2xl font-bold text-indigo-600">10,000</span>
                                 </div>
                                 <div class="flex items-center justify-between">
-                                    <span class="text-gray-700 font-medium">Burst Rate</span>
+                                    <span class="text-slate-600 font-medium">Burst Rate</span>
                                     <span class="text-2xl font-bold text-indigo-600">100/min</span>
                                 </div>
                             </div>
-                            <p class="text-sm text-gray-500 mt-4">
+                            <p class="text-sm text-slate-400 mt-4">
                                 Rate limit headers are included in all API responses for monitoring.
                             </p>
                         </div>
@@ -401,8 +398,8 @@
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01"></path>
                             </svg>
                         </div>
-                        <h4 class="text-lg font-semibold text-gray-900 mb-2">API Versioning</h4>
-                        <p class="text-gray-600 text-sm">
+                        <h4 class="text-lg font-semibold text-slate-900 mb-2">API Versioning</h4>
+                        <p class="text-slate-500 text-sm">
                             All endpoints are versioned (v1, v2) to ensure backward compatibility as we evolve the API.
                         </p>
                     </div>
@@ -414,8 +411,8 @@
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
                             </svg>
                         </div>
-                        <h4 class="text-lg font-semibold text-gray-900 mb-2">Webhooks</h4>
-                        <p class="text-gray-600 text-sm">
+                        <h4 class="text-lg font-semibold text-slate-900 mb-2">Webhooks</h4>
+                        <p class="text-slate-500 text-sm">
                             Real-time event notifications for transactions, account updates, and system events.
                         </p>
                     </div>
@@ -427,8 +424,8 @@
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"></path>
                             </svg>
                         </div>
-                        <h4 class="text-lg font-semibold text-gray-900 mb-2">Official SDKs</h4>
-                        <p class="text-gray-600 text-sm">
+                        <h4 class="text-lg font-semibold text-slate-900 mb-2">Official SDKs</h4>
+                        <p class="text-slate-500 text-sm">
                             Native SDKs for JavaScript, Python, PHP, and more are in development.
                         </p>
                     </div>
@@ -436,8 +433,8 @@
 
                 <!-- Platform API Area Cards -->
                 <div class="mt-16">
-                    <h3 class="text-2xl font-bold text-gray-900 mb-2 text-center">Platform API Areas</h3>
-                    <p class="text-gray-600 text-center mb-8">Explore the full breadth of the FinAegis platform across 43 DDD domains</p>
+                    <h3 class="text-2xl font-bold text-slate-900 mb-2 text-center">Platform API Areas</h3>
+                    <p class="text-slate-500 text-center mb-8">Explore the full breadth of the FinAegis platform across 43 DDD domains</p>
                     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
 
                         <!-- CrossChain -->
@@ -450,11 +447,11 @@
                                         </svg>
                                     </div>
                                     <div>
-                                        <h4 class="text-lg font-semibold text-gray-900">CrossChain</h4>
-                                        <span class="text-xs text-gray-500">7 routes</span>
+                                        <h4 class="text-lg font-semibold text-slate-900">CrossChain</h4>
+                                        <span class="text-xs text-slate-400">7 routes</span>
                                     </div>
                                 </div>
-                                <p class="text-gray-600 text-sm mb-3">Bridge protocols (Wormhole, LayerZero, Axelar), cross-chain swaps, fee comparison, and multi-chain portfolio tracking.</p>
+                                <p class="text-slate-500 text-sm mb-3">Bridge protocols (Wormhole, LayerZero, Axelar), cross-chain swaps, fee comparison, and multi-chain portfolio tracking.</p>
                                 <span class="text-cyan-600 text-sm font-medium group-hover:text-cyan-700">View endpoints &rarr;</span>
                             </div>
                         </a>
@@ -469,11 +466,11 @@
                                         </svg>
                                     </div>
                                     <div>
-                                        <h4 class="text-lg font-semibold text-gray-900">DeFi</h4>
-                                        <span class="text-xs text-gray-500">8 routes</span>
+                                        <h4 class="text-lg font-semibold text-slate-900">DeFi</h4>
+                                        <span class="text-xs text-slate-400">8 routes</span>
                                     </div>
                                 </div>
-                                <p class="text-gray-600 text-sm mb-3">DEX aggregation (Uniswap, Curve), lending (Aave), staking (Lido), yield optimization, flash loans, and portfolio management.</p>
+                                <p class="text-slate-500 text-sm mb-3">DEX aggregation (Uniswap, Curve), lending (Aave), staking (Lido), yield optimization, flash loans, and portfolio management.</p>
                                 <span class="text-emerald-600 text-sm font-medium group-hover:text-emerald-700">View endpoints &rarr;</span>
                             </div>
                         </a>
@@ -488,11 +485,11 @@
                                         </svg>
                                     </div>
                                     <div>
-                                        <h4 class="text-lg font-semibold text-gray-900">RegTech</h4>
-                                        <span class="text-xs text-gray-500">12 routes</span>
+                                        <h4 class="text-lg font-semibold text-slate-900">RegTech</h4>
+                                        <span class="text-xs text-slate-400">12 routes</span>
                                     </div>
                                 </div>
-                                <p class="text-gray-600 text-sm mb-3">MiFID II reporting, MiCA compliance, Travel Rule enforcement, jurisdiction adapters, and regulatory orchestration.</p>
+                                <p class="text-slate-500 text-sm mb-3">MiFID II reporting, MiCA compliance, Travel Rule enforcement, jurisdiction adapters, and regulatory orchestration.</p>
                                 <span class="text-amber-600 text-sm font-medium group-hover:text-amber-700">View endpoints &rarr;</span>
                             </div>
                         </a>
@@ -507,11 +504,11 @@
                                         </svg>
                                     </div>
                                     <div>
-                                        <h4 class="text-lg font-semibold text-gray-900">Mobile Payment</h4>
-                                        <span class="text-xs text-gray-500">25+ routes</span>
+                                        <h4 class="text-lg font-semibold text-slate-900">Mobile Payment</h4>
+                                        <span class="text-xs text-slate-400">25+ routes</span>
                                     </div>
                                 </div>
-                                <p class="text-gray-600 text-sm mb-3">Payment intents, receipts, activity feeds, receive addresses, P2P transfers, passkey auth, and biometric JWT.</p>
+                                <p class="text-slate-500 text-sm mb-3">Payment intents, receipts, activity feeds, receive addresses, P2P transfers, passkey auth, and biometric JWT.</p>
                                 <span class="text-violet-600 text-sm font-medium group-hover:text-violet-700">View endpoints &rarr;</span>
                             </div>
                         </a>
@@ -526,11 +523,11 @@
                                         </svg>
                                     </div>
                                     <div>
-                                        <h4 class="text-lg font-semibold text-gray-900">Partner / BaaS</h4>
-                                        <span class="text-xs text-gray-500">24 routes</span>
+                                        <h4 class="text-lg font-semibold text-slate-900">Partner / BaaS</h4>
+                                        <span class="text-xs text-slate-400">24 routes</span>
                                     </div>
                                 </div>
-                                <p class="text-gray-600 text-sm mb-3">Banking-as-a-Service partner onboarding, SDK generation, white-label configuration, and tenant provisioning.</p>
+                                <p class="text-slate-500 text-sm mb-3">Banking-as-a-Service partner onboarding, SDK generation, white-label configuration, and tenant provisioning.</p>
                                 <span class="text-rose-600 text-sm font-medium group-hover:text-rose-700">View endpoints &rarr;</span>
                             </div>
                         </a>
@@ -545,12 +542,12 @@
                                         </svg>
                                     </div>
                                     <div>
-                                        <h4 class="text-lg font-semibold text-gray-900">AI Query</h4>
-                                        <span class="text-xs text-gray-500">2 routes</span>
+                                        <h4 class="text-lg font-semibold text-slate-900">AI Query</h4>
+                                        <span class="text-xs text-slate-400">2 routes</span>
                                     </div>
                                 </div>
-                                <p class="text-gray-600 text-sm mb-3">Natural language transaction queries and AI-powered financial insights via the intelligent query interface.</p>
-                                <span class="text-gray-600 text-sm font-medium group-hover:text-gray-800">View endpoints &rarr;</span>
+                                <p class="text-slate-500 text-sm mb-3">Natural language transaction queries and AI-powered financial insights via the intelligent query interface.</p>
+                                <span class="text-slate-500 text-sm font-medium group-hover:text-slate-800">View endpoints &rarr;</span>
                             </div>
                         </a>
 
@@ -565,11 +562,11 @@
                                         </svg>
                                     </div>
                                     <div>
-                                        <h4 class="text-lg font-semibold text-gray-900">GraphQL API</h4>
-                                        <span class="text-xs text-gray-500">35 domains</span>
+                                        <h4 class="text-lg font-semibold text-slate-900">GraphQL API</h4>
+                                        <span class="text-xs text-slate-400">35 domains</span>
                                     </div>
                                 </div>
-                                <p class="text-gray-600 text-sm mb-3">Schema-first GraphQL via Lighthouse PHP with queries, mutations, subscriptions, and DataLoaders across 35 domain schemas.</p>
+                                <p class="text-slate-500 text-sm mb-3">Schema-first GraphQL via Lighthouse PHP with queries, mutations, subscriptions, and DataLoaders across 35 domain schemas.</p>
                                 <span class="text-sky-600 text-sm font-medium group-hover:text-sky-700">View endpoints &rarr;</span>
                             </div>
                         </a>
@@ -584,11 +581,11 @@
                                         </svg>
                                     </div>
                                     <div>
-                                        <h4 class="text-lg font-semibold text-gray-900">Event Streaming</h4>
-                                        <span class="text-xs text-gray-500">5 endpoints</span>
+                                        <h4 class="text-lg font-semibold text-slate-900">Event Streaming</h4>
+                                        <span class="text-xs text-slate-400">5 endpoints</span>
                                     </div>
                                 </div>
-                                <p class="text-gray-600 text-sm mb-3">Redis Streams-based event publishing, consumer groups, live metrics dashboard with projector lag and throughput monitoring.</p>
+                                <p class="text-slate-500 text-sm mb-3">Redis Streams-based event publishing, consumer groups, live metrics dashboard with projector lag and throughput monitoring.</p>
                                 <span class="text-lime-600 text-sm font-medium group-hover:text-lime-700">View endpoints &rarr;</span>
                             </div>
                         </a>
@@ -603,11 +600,11 @@
                                         </svg>
                                     </div>
                                     <div>
-                                        <h4 class="text-lg font-semibold text-gray-900">x402 Protocol</h4>
-                                        <span class="text-xs text-gray-500">15+ endpoints</span>
+                                        <h4 class="text-lg font-semibold text-slate-900">x402 Protocol</h4>
+                                        <span class="text-xs text-slate-400">15+ endpoints</span>
                                     </div>
                                 </div>
-                                <p class="text-gray-600 text-sm mb-3">HTTP-native micropayments. Monetize APIs with USDC on Base. GraphQL + REST with AI agent payment support.</p>
+                                <p class="text-slate-500 text-sm mb-3">HTTP-native micropayments. Monetize APIs with USDC on Base. GraphQL + REST with AI agent payment support.</p>
                                 <span class="text-emerald-600 text-sm font-medium group-hover:text-emerald-700">View endpoints &rarr;</span>
                             </div>
                         </a>
@@ -621,8 +618,8 @@
         <section class="py-20 bg-white">
             <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                 <div class="text-center mb-16">
-                    <h2 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4">Developer Resources</h2>
-                    <p class="text-xl text-gray-600 max-w-3xl mx-auto">
+                    <h2 class="font-display text-3xl md:text-4xl font-bold text-slate-900 mb-4">Developer Resources</h2>
+                    <p class="text-xl text-slate-500 max-w-3xl mx-auto">
                         Everything you need to build amazing financial applications
                     </p>
                 </div>
@@ -641,7 +638,7 @@
                                 </svg>
                                 API Documentation
                             </h3>
-                            <p class="text-gray-600 mb-4">Complete reference for all API endpoints</p>
+                            <p class="text-slate-500 mb-4">Complete reference for all API endpoints</p>
                             <span class="text-indigo-600 font-medium group-hover:text-indigo-700">Explore API →</span>
                         </div>
                     </a>
@@ -659,7 +656,7 @@
                                 </svg>
                                 SDKs & Libraries
                             </h3>
-                            <p class="text-gray-600 mb-4">Official SDKs for popular languages</p>
+                            <p class="text-slate-500 mb-4">Official SDKs for popular languages</p>
                             <span class="text-purple-600 font-medium group-hover:text-purple-700">View SDKs →</span>
                         </div>
                     </a>
@@ -677,7 +674,7 @@
                                 </svg>
                                 Code Examples
                             </h3>
-                            <p class="text-gray-600 mb-4">Real-world integration examples</p>
+                            <p class="text-slate-500 mb-4">Real-world integration examples</p>
                             <span class="text-green-600 font-medium group-hover:text-green-700">See Examples →</span>
                         </div>
                     </a>
@@ -742,8 +739,8 @@
         <section id="partner-auth" class="py-20 bg-white">
             <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                 <div class="text-center mb-16">
-                    <h2 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4">Partner API Authentication</h2>
-                    <p class="text-xl text-gray-600 max-w-3xl mx-auto">
+                    <h2 class="font-display text-3xl md:text-4xl font-bold text-slate-900 mb-4">Partner API Authentication</h2>
+                    <p class="text-xl text-slate-500 max-w-3xl mx-auto">
                         BaaS partners and third-party integrators use dedicated Partner API keys with scoped permissions
                     </p>
                 </div>
@@ -760,25 +757,25 @@
                                 </div>
                                 <h3 class="text-xl font-semibold">Partner API Keys</h3>
                             </div>
-                            <p class="text-gray-600 mb-6">
+                            <p class="text-slate-500 mb-6">
                                 Partner keys provide scoped access to BaaS endpoints, tenant provisioning, SDK generation, and white-label configuration. Keys are issued during partner onboarding.
                             </p>
-                            <div class="bg-gray-50 rounded-lg p-6 space-y-3">
+                            <div class="bg-slate-50 rounded-lg p-6 space-y-3">
                                 <div class="flex items-center justify-between">
-                                    <span class="text-gray-700 font-medium">Key Prefix</span>
-                                    <code class="text-sm bg-gray-200 px-2 py-1 rounded">fpk_</code>
+                                    <span class="text-slate-600 font-medium">Key Prefix</span>
+                                    <code class="text-sm bg-slate-200 px-2 py-1 rounded">fpk_</code>
                                 </div>
                                 <div class="flex items-center justify-between">
-                                    <span class="text-gray-700 font-medium">Scopes</span>
-                                    <span class="text-sm text-gray-600">baas, tenants, sdk, config</span>
+                                    <span class="text-slate-600 font-medium">Scopes</span>
+                                    <span class="text-sm text-slate-500">baas, tenants, sdk, config</span>
                                 </div>
                                 <div class="flex items-center justify-between">
-                                    <span class="text-gray-700 font-medium">Rate Limit</span>
-                                    <span class="text-sm text-gray-600">5,000 req/hour</span>
+                                    <span class="text-slate-600 font-medium">Rate Limit</span>
+                                    <span class="text-sm text-slate-500">5,000 req/hour</span>
                                 </div>
                                 <div class="flex items-center justify-between">
-                                    <span class="text-gray-700 font-medium">IP Whitelist</span>
-                                    <span class="text-sm text-gray-600">Required</span>
+                                    <span class="text-slate-600 font-medium">IP Whitelist</span>
+                                    <span class="text-sm text-slate-500">Required</span>
                                 </div>
                             </div>
                         </div>
@@ -795,8 +792,8 @@
                                 </div>
                                 <h3 class="text-xl font-semibold">Partner Request Example</h3>
                             </div>
-                            <p class="text-gray-600 mb-6">
-                                Include the Partner API key in the <code class="bg-gray-100 px-1 rounded">X-Partner-Key</code> header alongside your standard Bearer token.
+                            <p class="text-slate-500 mb-6">
+                                Include the Partner API key in the <code class="bg-slate-100 px-1 rounded">X-Partner-Key</code> header alongside your standard Bearer token.
                             </p>
                             <div class="code-container">
                                 <div class="code-header">
@@ -830,17 +827,17 @@
         </section>
 
         <!-- CTA -->
-        <section class="py-20 bg-gray-50">
+        <section class="py-20 bg-slate-50">
             <div class="max-w-4xl mx-auto text-center px-4 sm:px-6 lg:px-8">
-                <h2 class="text-3xl md:text-4xl font-bold text-gray-900 mb-6">Ready to Build?</h2>
-                <p class="text-xl text-gray-600 mb-8">
+                <h2 class="font-display text-3xl md:text-4xl font-bold text-slate-900 mb-6">Ready to Build?</h2>
+                <p class="text-xl text-slate-500 mb-8">
                     Join our developer community and start building the future of finance
                 </p>
                 <div class="flex flex-col sm:flex-row gap-4 justify-center">
-                    <a href="{{ route('register') }}" class="bg-indigo-600 text-white px-8 py-4 rounded-lg text-lg font-semibold hover:bg-indigo-700 transition shadow-lg hover:shadow-xl">
+                    <a href="{{ route('register') }}" class="btn-primary !py-4 !px-10 !text-base !rounded-lg">
                         Get API Key
                     </a>
-                    <a href="https://github.com/FinAegis/core-banking-prototype-laravel" target="_blank" class="border-2 border-indigo-600 text-indigo-600 px-8 py-4 rounded-lg text-lg font-semibold hover:bg-indigo-50 transition">
+                    <a href="https://github.com/FinAegis/core-banking-prototype-laravel" target="_blank" class="btn-outline-dark !py-4 !px-10 !text-base !rounded-lg">
                         View on GitHub
                     </a>
                 </div>
@@ -848,11 +845,11 @@
         </section>
 
         <!-- Code Examples Section -->
-        <section class="py-20 bg-gray-50">
+        <section class="py-20 bg-slate-50">
             <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                 <div class="text-center mb-16">
-                    <h2 class="text-3xl md:text-4xl font-bold text-gray-900 mb-4">Code Examples</h2>
-                    <p class="text-xl text-gray-600 max-w-3xl mx-auto">
+                    <h2 class="font-display text-3xl md:text-4xl font-bold text-slate-900 mb-4">Code Examples</h2>
+                    <p class="text-xl text-slate-500 max-w-3xl mx-auto">
                         Real-world examples to get you started quickly
                     </p>
                 </div>
@@ -861,8 +858,8 @@
                     <!-- Create Account Example -->
                     <div class="bg-white rounded-xl shadow-lg border border-gray-200 overflow-hidden">
                         <div class="p-6 border-b border-gray-200">
-                            <h3 class="text-lg font-semibold text-gray-900">Create a New Account</h3>
-                            <p class="text-gray-600 text-sm mt-1">Initialize a new bank account with initial deposit</p>
+                            <h3 class="text-lg font-semibold text-slate-900">Create a New Account</h3>
+                            <p class="text-slate-500 text-sm mt-1">Initialize a new bank account with initial deposit</p>
                         </div>
                         <div class="code-container">
                             <div class="code-header">
@@ -903,8 +900,8 @@
                     <!-- Transfer Funds Example -->
                     <div class="bg-white rounded-xl shadow-lg border border-gray-200 overflow-hidden">
                         <div class="p-6 border-b border-gray-200">
-                            <h3 class="text-lg font-semibold text-gray-900">Transfer Funds</h3>
-                            <p class="text-gray-600 text-sm mt-1">Execute a transfer between two accounts</p>
+                            <h3 class="text-lg font-semibold text-slate-900">Transfer Funds</h3>
+                            <p class="text-slate-500 text-sm mt-1">Execute a transfer between two accounts</p>
                         </div>
                         <div class="code-container">
                             <div class="code-header">
@@ -950,8 +947,8 @@
                     <!-- GCU Exchange Example -->
                     <div class="bg-white rounded-xl shadow-lg border border-gray-200 overflow-hidden">
                         <div class="p-6 border-b border-gray-200">
-                            <h3 class="text-lg font-semibold text-gray-900">Exchange to GCU</h3>
-                            <p class="text-gray-600 text-sm mt-1">Convert traditional currency to Global Currency Units</p>
+                            <h3 class="text-lg font-semibold text-slate-900">Exchange to GCU</h3>
+                            <p class="text-slate-500 text-sm mt-1">Convert traditional currency to Global Currency Units</p>
                         </div>
                         <div class="code-container">
                             <div class="code-header">
@@ -998,8 +995,8 @@
                     <!-- Webhook Example -->
                     <div class="bg-white rounded-xl shadow-lg border border-gray-200 overflow-hidden">
                         <div class="p-6 border-b border-gray-200">
-                            <h3 class="text-lg font-semibold text-gray-900">Handle Webhooks</h3>
-                            <p class="text-gray-600 text-sm mt-1">Process real-time transaction notifications</p>
+                            <h3 class="text-lg font-semibold text-slate-900">Handle Webhooks</h3>
+                            <p class="text-slate-500 text-sm mt-1">Process real-time transaction notifications</p>
                         </div>
                         <div class="code-container">
                             <div class="code-header">

--- a/resources/views/support/faq.blade.php
+++ b/resources/views/support/faq.blade.php
@@ -91,19 +91,19 @@
                 <button class="category-filter active px-4 py-2 rounded-full bg-indigo-600 text-white transition" data-category="all">
                     All Questions
                 </button>
-                <button class="category-filter px-4 py-2 rounded-full bg-slate-200 text-slate-600 hover:bg-gray-300 transition" data-category="getting-started">
+                <button class="category-filter px-4 py-2 rounded-full bg-slate-200 text-slate-600 hover:bg-slate-300 transition" data-category="getting-started">
                     Getting Started
                 </button>
-                <button class="category-filter px-4 py-2 rounded-full bg-slate-200 text-slate-600 hover:bg-gray-300 transition" data-category="gcu">
+                <button class="category-filter px-4 py-2 rounded-full bg-slate-200 text-slate-600 hover:bg-slate-300 transition" data-category="gcu">
                     GCU
                 </button>
-                <button class="category-filter px-4 py-2 rounded-full bg-slate-200 text-slate-600 hover:bg-gray-300 transition" data-category="platform">
+                <button class="category-filter px-4 py-2 rounded-full bg-slate-200 text-slate-600 hover:bg-slate-300 transition" data-category="platform">
                     Platform Status
                 </button>
-                <button class="category-filter px-4 py-2 rounded-full bg-slate-200 text-slate-600 hover:bg-gray-300 transition" data-category="technical">
+                <button class="category-filter px-4 py-2 rounded-full bg-slate-200 text-slate-600 hover:bg-slate-300 transition" data-category="technical">
                     Technical
                 </button>
-                <button class="category-filter px-4 py-2 rounded-full bg-slate-200 text-slate-600 hover:bg-gray-300 transition" data-category="future">
+                <button class="category-filter px-4 py-2 rounded-full bg-slate-200 text-slate-600 hover:bg-slate-300 transition" data-category="future">
                     Future Features
                 </button>
             </div>

--- a/resources/views/support/guides.blade.php
+++ b/resources/views/support/guides.blade.php
@@ -12,12 +12,8 @@
 
 @push('styles')
 <style>
-    .guide-card {
+    .card-feature {
         transition: all 0.3s ease;
-    }
-    .guide-card:hover {
-        transform: translateY(-4px);
-        box-shadow: 0 12px 24px rgba(0,0,0,0.1);
     }
 </style>
 @endpush
@@ -38,7 +34,7 @@
                         <div class="relative">
                             <input type="text" id="guide-search" placeholder="Search guides..."
                                 class="w-full px-6 py-3 rounded-lg text-slate-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-white pl-12">
-                            <svg class="absolute left-4 top-3.5 w-5 h-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <svg class="absolute left-4 top-3.5 w-5 h-5 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
                             </svg>
                         </div>
@@ -217,9 +213,9 @@
                             <p class="text-slate-500 mb-4">How to contribute to FinAegis:</p>
                             <ol class="list-decimal list-inside text-slate-500 space-y-2">
                                 <li>Fork the repository on GitHub</li>
-                                <li>Create a feature branch (<code class="bg-gray-100 px-2 py-1 rounded">git checkout -b feature/your-feature</code>)</li>
+                                <li>Create a feature branch (<code class="bg-slate-100 px-2 py-1 rounded">git checkout -b feature/your-feature</code>)</li>
                                 <li>Make your changes and test thoroughly</li>
-                                <li>Run tests (<code class="bg-gray-100 px-2 py-1 rounded">./vendor/bin/pest</code>)</li>
+                                <li>Run tests (<code class="bg-slate-100 px-2 py-1 rounded">./vendor/bin/pest</code>)</li>
                                 <li>Commit with clear messages</li>
                                 <li>Push to your fork and create a pull request</li>
                             </ol>
@@ -254,7 +250,7 @@
                             <p class="text-slate-500 mb-4">Testing the REST API:</p>
                             <ol class="list-decimal list-inside text-slate-500 space-y-2">
                                 <li>Register for an account to get API access</li>
-                                <li>Use the API documentation at <code class="bg-gray-100 px-2 py-1 rounded">/developers/api-docs</code></li>
+                                <li>Use the API documentation at <code class="bg-slate-100 px-2 py-1 rounded">/developers/api-docs</code></li>
                                 <li>Test with tools like Postman or curl</li>
                                 <li>All API responses use simulated data</li>
                             </ol>

--- a/resources/views/support/index.blade.php
+++ b/resources/views/support/index.blade.php
@@ -12,14 +12,6 @@
 
 @push('styles')
 <style>
-    .support-card {
-        transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
-    }
-    .support-card:hover {
-        transform: translateY(-3px);
-        box-shadow: 0 12px 30px rgba(0,0,0,0.08);
-        border-color: #3b82f6;
-    }
     .status-badge {
         animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
     }
@@ -205,7 +197,7 @@
                 </div>
                 
                 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 max-w-5xl mx-auto">
-                    <a href="{{ route('developers') }}" class="bg-slate-50 rounded-lg p-6 text-center hover:bg-gray-100 transition">
+                    <a href="{{ route('developers') }}" class="bg-slate-50 rounded-lg p-6 text-center hover:bg-slate-100 transition">
                         <svg class="w-8 h-8 text-indigo-600 mx-auto mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"></path>
                         </svg>
@@ -213,7 +205,7 @@
                         <p class="text-sm text-slate-500 mt-1">REST API reference</p>
                     </a>
                     
-                    <a href="{{ route('developers.show', 'examples') }}" class="bg-slate-50 rounded-lg p-6 text-center hover:bg-gray-100 transition">
+                    <a href="{{ route('developers.show', 'examples') }}" class="bg-slate-50 rounded-lg p-6 text-center hover:bg-slate-100 transition">
                         <svg class="w-8 h-8 text-purple-600 mx-auto mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
                         </svg>
@@ -221,7 +213,7 @@
                         <p class="text-sm text-slate-500 mt-1">Code samples</p>
                     </a>
                     
-                    <a href="{{ route('developers.show', 'postman') }}" class="bg-slate-50 rounded-lg p-6 text-center hover:bg-gray-100 transition">
+                    <a href="{{ route('developers.show', 'postman') }}" class="bg-slate-50 rounded-lg p-6 text-center hover:bg-slate-100 transition">
                         <svg class="w-8 h-8 text-orange-600 mx-auto mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"></path>
                         </svg>
@@ -229,7 +221,7 @@
                         <p class="text-sm text-slate-500 mt-1">Collection download</p>
                     </a>
                     
-                    <a href="https://github.com/FinAegis/core-banking-prototype-laravel" class="bg-slate-50 rounded-lg p-6 text-center hover:bg-gray-100 transition">
+                    <a href="https://github.com/FinAegis/core-banking-prototype-laravel" class="bg-slate-50 rounded-lg p-6 text-center hover:bg-slate-100 transition">
                         <svg class="w-8 h-8 text-slate-600 mx-auto mb-3" fill="currentColor" viewBox="0 0 24 24">
                             <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
                         </svg>


### PR DESCRIPTION
## Summary
- Standardize 5 remaining pages to use the FinAegis design system classes (card-feature, btn-primary, btn-outline, font-display, text-slate-*, bg-fa-navy CTAs)
- Replace gradient-bg CTA sections with dark navy pattern (bg-fa-navy + bg-dot-pattern)
- Remove orphaned .support-card / .guide-card / .gradient-bg CSS definitions
- 3 of the 8 target files (features/index, features/gcu, support/contact) were already compliant

## Files changed
| File | Changes |
|------|---------|
| `support/index.blade.php` | card-feature cards, dark navy CTA, btn-secondary GitHub button, hover:bg-slate-100, font-display headings |
| `support/faq.blade.php` | text-slate-* colors, hover:bg-slate-300 filters, btn-primary + btn-outline-dark help buttons |
| `support/guides.blade.php` | card-feature for guide cards + content cards, font-display heading, btn-primary + btn-outline-dark |
| `cgo.blade.php` | card-feature tiers, dark navy CTA, font-display headings, text-slate-* throughout |
| `developers/index.blade.php` | font-display headings, text-slate-* colors, btn-primary + btn-outline-dark CTA, removed .gradient-bg style |

## Test plan
- [ ] Visually inspect all 5 updated pages
- [ ] Verify CTA buttons render correctly with btn-primary and btn-outline classes
- [ ] Confirm card-feature styling (white card with thin border) applies
- [ ] Check font-display renders Plus Jakarta Sans on section headings

🤖 Generated with [Claude Code](https://claude.com/claude-code)