### PR TITLE
fix: hero subtitle colors purple-100 to slate-400

### DIFF
--- a/resources/views/ai-framework/demo.blade.php
+++ b/resources/views/ai-framework/demo.blade.php
@@ -32,7 +32,7 @@
                 Sandbox Mode &mdash; Safe to Explore
             </div>
             <h1 class="text-5xl font-bold mb-6">AI Framework Demo</h1>
-            <p class="text-xl text-purple-100 max-w-3xl mx-auto mb-8">
+            <p class="text-xl text-slate-400 max-w-3xl mx-auto mb-8">
                 Explore how AI agents interact with the FinAegis banking platform. Run natural language queries, trigger MCP tools, and see autonomous agent workflows in action.
             </p>
             <div class="flex flex-col sm:flex-row gap-4 justify-center">

--- a/resources/views/financial-institutions/apply.blade.php
+++ b/resources/views/financial-institutions/apply.blade.php
@@ -27,7 +27,7 @@
                     <h1 class="text-4xl md:text-5xl font-bold mb-6">
                         Partner Institution Application
                     </h1>
-                    <p class="text-xl text-purple-100 max-w-3xl mx-auto">
+                    <p class="text-xl text-slate-400 max-w-3xl mx-auto">
                         Join the FinAegis network and help us build the future of democratic banking
                     </p>
                 </div>

--- a/resources/views/subproducts/exchange.blade.php
+++ b/resources/views/subproducts/exchange.blade.php
@@ -24,7 +24,7 @@
                     <h1 class="text-5xl md:text-6xl font-bold mb-6">
                         FinAegis Exchange
                     </h1>
-                    <p class="text-xl md:text-2xl text-purple-100 max-w-3xl mx-auto mb-8">
+                    <p class="text-xl md:text-2xl text-slate-400 max-w-3xl mx-auto mb-8">
                         Professional trading platform for digital and traditional assets with institutional-grade infrastructure
                     </p>
                     <div class="flex flex-col sm:flex-row gap-4 justify-center">

--- a/resources/views/subproducts/lending.blade.php
+++ b/resources/views/subproducts/lending.blade.php
@@ -24,7 +24,7 @@
                     <h1 class="text-5xl md:text-6xl font-bold mb-6">
                         FinAegis Lending
                     </h1>
-                    <p class="text-xl md:text-2xl text-purple-100 max-w-3xl mx-auto mb-8">
+                    <p class="text-xl md:text-2xl text-slate-400 max-w-3xl mx-auto mb-8">
                         Connect capital with opportunity through our P2P lending marketplace
                     </p>
                 </div>

--- a/resources/views/subproducts/stablecoins.blade.php
+++ b/resources/views/subproducts/stablecoins.blade.php
@@ -24,7 +24,7 @@
                     <h1 class="text-5xl md:text-6xl font-bold mb-6">
                         FinAegis Stablecoins
                     </h1>
-                    <p class="text-xl md:text-2xl text-purple-100 max-w-3xl mx-auto mb-8">
+                    <p class="text-xl md:text-2xl text-slate-400 max-w-3xl mx-auto mb-8">
                         Issue and manage stable digital currencies with real asset backing
                     </p>
                 </div>

--- a/resources/views/subproducts/treasury.blade.php
+++ b/resources/views/subproducts/treasury.blade.php
@@ -24,7 +24,7 @@
                     <h1 class="text-5xl md:text-6xl font-bold mb-6">
                         FinAegis Treasury
                     </h1>
-                    <p class="text-xl md:text-2xl text-purple-100 max-w-3xl mx-auto mb-8">
+                    <p class="text-xl md:text-2xl text-slate-400 max-w-3xl mx-auto mb-8">
                         Enterprise-grade treasury management across multiple banks and currencies
                     </p>
                 </div>


### PR DESCRIPTION
## Summary
- Update 6 hero subtitle `text-purple-100` references to `text-slate-400` to match the `bg-fa-navy` background applied in PR #730
- Affected: AI Framework demo, financial institutions apply, subproducts (exchange, lending, stablecoins, treasury)

## Context
PR #730 migrated all `gradient-bg` sections to `bg-fa-navy` but left the hero subtitle color as `text-purple-100`, which was visually tied to the old purple gradient. This follow-up corrects those to `text-slate-400` for design consistency.

## Test plan
- [ ] Visual check: hero subtitles on all 6 pages render legibly on the dark navy background
- [ ] No purple-100 or gradient-bg references remain in any of the 12 target files

🤖 Generated with [Claude Code](https://claude.com/claude-code)