### PR TITLE
refactor: migrate inner pages to FinAegis design system v2

### DIFF
--- a/resources/views/compliance.blade.php
+++ b/resources/views/compliance.blade.php
@@ -4,495 +4,369 @@
 
 @section('seo')
     @include('partials.seo', [
-        'title' => 'Compliance - FinAegis',
-        'description' => 'FinAegis compliance-ready architecture. Built to meet EU regulatory standards and integrate with licensed financial institutions.',
-        'keywords' => 'FinAegis, compliance, regulation, PSD2, EMD2, MiCA, KYC, AML, GDPR, security',
+        'title' => 'Compliance-Ready Architecture - FinAegis',
+        'description' => 'FinAegis compliance-ready architecture. Built to meet EU regulatory standards with PSD2, EMD2, MiCA, KYC/AML, GDPR, and Travel Rule adapters.',
+        'keywords' => 'FinAegis, compliance, regulation, PSD2, EMD2, MiCA, KYC, AML, GDPR, security, Travel Rule, MiFID II',
     ])
+
+    <x-schema type="breadcrumb" :data="[
+        ['name' => 'Home', 'url' => url('/')],
+        ['name' => 'Compliance', 'url' => url('/compliance')]
+    ]" />
 @endsection
 
 @section('content')
-    <div class="bg-white">
-        <!-- Header -->
-        <div class="bg-gradient-to-r from-blue-600 to-purple-600">
-            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
+    <!-- Hero Section -->
+    <section class="bg-fa-navy relative overflow-hidden">
+        <div class="absolute inset-0 bg-grid-pattern"></div>
+        <div class="absolute top-1/3 left-1/4 w-80 h-80 bg-blue-500/8 rounded-full blur-[100px]"></div>
+        <div class="absolute bottom-1/4 right-1/4 w-64 h-64 bg-teal-500/6 rounded-full blur-[100px]"></div>
+        <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20 lg:py-24">
+            <div class="text-center">
+                <div class="inline-flex items-center justify-center w-16 h-16 bg-white/[0.04] border border-white/[0.08] rounded-2xl mb-6">
+                    <svg class="w-8 h-8 text-teal-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
+                </div>
+                <h1 class="font-display text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">Compliance-Ready <span class="text-gradient">Architecture</span></h1>
+                <p class="text-lg text-slate-400 max-w-2xl mx-auto">
+                    Built for EU regulatory compliance from day one. PSD2, EMD2, MiCA, KYC/AML, GDPR, and MiFID II adapters with jurisdiction-aware routing.
+                </p>
+            </div>
+        </div>
+        <div class="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-blue-500/20 to-transparent"></div>
+    </section>
+
+    <!-- Regulatory Strategy Notice -->
+    <section class="py-6 bg-white border-b border-slate-100">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="card-stat flex items-start gap-3 border-l-4 border-teal-400 bg-teal-50/50">
+                <svg class="w-5 h-5 text-teal-600 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                </svg>
+                <div>
+                    <h3 class="font-display text-sm font-semibold text-slate-900">Designed for EU Regulatory Compliance</h3>
+                    <p class="text-sm text-slate-600 mt-0.5">
+                        Our platform architecture supports EMI licensing requirements and integrates with licensed partners for compliant operations across the European Union.
+                    </p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Primary Regulations -->
+    <section class="py-24 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="text-center mb-14 animate-on-scroll">
+                <h2 class="font-display text-3xl md:text-4xl font-bold text-slate-900 mb-4">Regulatory Framework Support</h2>
+                <p class="text-lg text-slate-500">Comprehensive adapters for EU financial regulations</p>
+            </div>
+
+            @php
+                $regulations = [
+                    ['title' => 'PSD2 Compatible', 'desc' => 'Architecture designed to support Payment Services Directive 2 requirements when operating with licensed partners.', 'color' => 'blue', 'icon' => 'M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z', 'items' => ['Strong Customer Authentication (SCA)', 'Open Banking API standards', 'Account Information Services (AIS)', 'Payment Initiation Services (PIS)']],
+                    ['title' => 'EMD2 Ready', 'desc' => 'Platform architecture prepared for Electronic Money Directive 2 compliance requirements.', 'color' => 'teal', 'icon' => 'M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z', 'items' => ['Support for fund safeguarding', 'Customer fund segregation', 'E-money redemption workflows', 'Operational resilience features']],
+                    ['title' => 'MiCA Compatible', 'desc' => 'Infrastructure designed with Markets in Crypto-Assets regulation in mind for digital asset operations.', 'color' => 'amber', 'icon' => 'M13 7h8m0 0v8m0-8l-8 8-4-4-6 6', 'items' => ['Asset-referenced token framework', 'E-money token compliance', 'Reserve asset management', 'Stability mechanism requirements']],
+                    ['title' => 'KYC/AML Framework', 'desc' => 'Multi-tier identity verification with Ondato integration and Chainalysis sanctions screening.', 'color' => 'blue', 'icon' => 'M10 6H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V8a2 2 0 00-2-2h-5m-4 0V5a2 2 0 114 0v1m-4 0a2 2 0 104 0m-5 8a2 2 0 100-4 2 2 0 000 4zm0 0c1.306 0 2.417.835 2.83 2M9 14a3.001 3.001 0 00-2.83 2M15 11h3m-3 4h2', 'items' => ['National ID & passport verification', 'Liveness check & selfie matching', 'PEP & sanctions screening', 'Automated risk scoring']],
+                    ['title' => 'GDPR Enhanced', 'desc' => 'Full data protection framework with ROPA, DPIA, breach notification, and consent management v2.', 'color' => 'teal', 'icon' => 'M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z', 'items' => ['Full data portability & export', 'Right to deletion & anonymization', 'Automated retention policies', 'Granular consent management']],
+                    ['title' => 'MiFID II & Travel Rule', 'desc' => 'Financial instruments reporting and crypto transfer data requirements with jurisdiction adapters.', 'color' => 'slate', 'icon' => 'M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3', 'items' => ['Transaction reporting adapters', 'Jurisdiction-aware routing', 'Travel Rule VASP compliance', 'Regulatory report generation']],
+                ];
+            @endphp
+
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                @foreach($regulations as $i => $reg)
+                <div class="card-feature !p-6 animate-on-scroll stagger-{{ ($i % 6) + 1 }}">
+                    <div class="flex items-center gap-3 mb-4">
+                        <div class="icon-box bg-{{ $reg['color'] }}-50">
+                            <svg class="w-5 h-5 text-{{ $reg['color'] }}-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="{{ $reg['icon'] }}"/></svg>
+                        </div>
+                        <h3 class="font-display text-lg font-bold text-slate-900">{{ $reg['title'] }}</h3>
+                    </div>
+                    <p class="text-sm text-slate-500 mb-4 leading-relaxed">{{ $reg['desc'] }}</p>
+                    <ul class="space-y-2 text-sm text-slate-600">
+                        @foreach($reg['items'] as $item)
+                        <li class="list-check">{{ $item }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+                @endforeach
+            </div>
+        </div>
+    </section>
+
+    <!-- KYC Tiers -->
+    <section class="py-24 bg-slate-50/50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="text-center mb-14 animate-on-scroll">
+                <h2 class="font-display text-3xl md:text-4xl font-bold text-slate-900 mb-4">KYC/AML System Architecture</h2>
+                <p class="text-lg text-slate-500">Multi-tier verification with progressive access levels</p>
+            </div>
+
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6 animate-on-scroll stagger-1">
+                @php
+                    $tiers = [
+                        ['level' => '1', 'name' => 'Basic Verification', 'color' => 'blue', 'limit' => '10,000', 'checks' => ['National ID verification', 'Selfie with liveness check', 'Automated risk scoring']],
+                        ['level' => '2', 'name' => 'Enhanced Verification', 'color' => 'teal', 'limit' => '50,000', 'checks' => ['Passport verification', 'Proof of address', 'PEP & sanctions screening']],
+                        ['level' => '3', 'name' => 'Full Verification', 'color' => 'amber', 'limit' => 'Unlimited', 'checks' => ['All previous checks', 'Source of funds verification', 'Enhanced due diligence']],
+                    ];
+                @endphp
+
+                @foreach($tiers as $tier)
+                <div class="card-feature !p-6">
+                    <div class="flex items-center justify-between mb-5">
+                        <h3 class="font-display text-lg font-bold text-slate-900">{{ $tier['name'] }}</h3>
+                        <span class="badge badge-{{ $tier['color'] === 'amber' ? 'warning' : ($tier['color'] === 'teal' ? 'success' : 'info') }}">Level {{ $tier['level'] }}</span>
+                    </div>
+                    <ul class="space-y-2.5 text-sm text-slate-600 mb-6">
+                        @foreach($tier['checks'] as $check)
+                        <li class="list-check">{{ $check }}</li>
+                        @endforeach
+                    </ul>
+                    <div class="pt-4 border-t border-slate-100">
+                        <div class="text-xs text-slate-500 uppercase tracking-wider mb-1">Daily Limit</div>
+                        <div class="font-display text-2xl font-bold text-slate-900">{{ $tier['limit'] === 'Unlimited' ? $tier['limit'] : '€' . $tier['limit'] }}</div>
+                    </div>
+                </div>
+                @endforeach
+            </div>
+        </div>
+    </section>
+
+    <!-- AML Framework -->
+    <section class="py-24 bg-white">
+        <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="text-center mb-14 animate-on-scroll">
+                <h2 class="font-display text-3xl md:text-4xl font-bold text-slate-900 mb-4">Anti-Money Laundering Framework</h2>
+                <p class="text-lg text-slate-500">Real-time monitoring with automated regulatory reporting</p>
+            </div>
+
+            <div class="card-feature !p-8 animate-on-scroll stagger-1">
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-10">
+                    <div>
+                        <h3 class="font-display text-lg font-bold text-slate-900 mb-5">Real-Time Transaction Monitoring</h3>
+                        <ul class="space-y-4">
+                            @php
+                                $monitoring = [
+                                    ['title' => 'Pattern Detection', 'desc' => 'Structuring, velocity, and unusual patterns'],
+                                    ['title' => 'Threshold Monitoring', 'desc' => '€10,000 CTR threshold tracking'],
+                                    ['title' => 'Risk Scoring', 'desc' => 'ML-based transaction risk assessment'],
+                                ];
+                            @endphp
+                            @foreach($monitoring as $item)
+                            <li class="flex items-start gap-3">
+                                <div class="icon-box bg-blue-50 mt-0.5">
+                                    <svg class="w-4 h-4 text-blue-600" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/></svg>
+                                </div>
+                                <div>
+                                    <div class="font-display text-sm font-semibold text-slate-900">{{ $item['title'] }}</div>
+                                    <div class="text-xs text-slate-500">{{ $item['desc'] }}</div>
+                                </div>
+                            </li>
+                            @endforeach
+                        </ul>
+                    </div>
+                    <div>
+                        <h3 class="font-display text-lg font-bold text-slate-900 mb-5">Automated Regulatory Reporting</h3>
+                        <ul class="space-y-4">
+                            @php
+                                $reporting = [
+                                    ['title' => 'Currency Transaction Reports (CTR)', 'desc' => 'Daily automated generation'],
+                                    ['title' => 'Suspicious Activity Reports (SAR)', 'desc' => 'Monthly candidate identification'],
+                                    ['title' => 'Compliance Dashboards', 'desc' => 'Real-time metrics and alerts'],
+                                ];
+                            @endphp
+                            @foreach($reporting as $item)
+                            <li class="flex items-start gap-3">
+                                <div class="icon-box bg-teal-50 mt-0.5">
+                                    <svg class="w-4 h-4 text-teal-600" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/></svg>
+                                </div>
+                                <div>
+                                    <div class="font-display text-sm font-semibold text-slate-900">{{ $item['title'] }}</div>
+                                    <div class="text-xs text-slate-500">{{ $item['desc'] }}</div>
+                                </div>
+                            </li>
+                            @endforeach
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- GDPR & Data Protection -->
+    <section class="py-24 bg-slate-50/50">
+        <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="text-center mb-14 animate-on-scroll">
+                <span class="badge badge-success mb-4">Implemented v3.5.0</span>
+                <h2 class="font-display text-3xl md:text-4xl font-bold text-slate-900 mb-4">GDPR & Data Protection</h2>
+                <p class="text-lg text-slate-500">Full European data protection compliance</p>
+            </div>
+
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-6 animate-on-scroll stagger-1">
+                @php
+                    $gdpr = [
+                        ['title' => 'Data Export', 'desc' => 'Full data portability support', 'icon' => 'M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z'],
+                        ['title' => 'Right to Deletion', 'desc' => 'Secure data anonymization', 'icon' => 'M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16'],
+                        ['title' => 'Retention Policies', 'desc' => 'Automated data lifecycle', 'icon' => 'M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z'],
+                        ['title' => 'Consent Management', 'desc' => 'Granular privacy controls', 'icon' => 'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z'],
+                    ];
+                @endphp
+
+                @foreach($gdpr as $item)
+                <div class="card-feature text-center !p-6">
+                    <div class="icon-box-lg bg-blue-50 mx-auto mb-4">
+                        <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="{{ $item['icon'] }}"/></svg>
+                    </div>
+                    <h4 class="font-display text-sm font-bold text-slate-900 mb-1">{{ $item['title'] }}</h4>
+                    <p class="text-xs text-slate-500">{{ $item['desc'] }}</p>
+                </div>
+                @endforeach
+            </div>
+        </div>
+    </section>
+
+    <!-- Banking Integration Examples -->
+    <section class="py-24 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="text-center mb-14 animate-on-scroll">
+                <h2 class="font-display text-3xl md:text-4xl font-bold text-slate-900 mb-4">Example Banking Integrations</h2>
+                <p class="text-lg text-slate-500">Reference implementations demonstrating integration patterns</p>
+            </div>
+
+            <div class="card-stat flex items-start gap-3 border-l-4 border-amber-400 bg-amber-50/50 mb-8 animate-on-scroll">
+                <svg class="w-5 h-5 text-amber-600 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+                </svg>
+                <p class="text-sm text-slate-600">
+                    <strong>Disclaimer:</strong> These are example integrations demonstrating technical capabilities, not active partnerships or endorsements.
+                </p>
+            </div>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-5 animate-on-scroll stagger-1">
+                @php
+                    $integrations = [
+                        ['name' => 'Paysera Connector', 'type' => 'EMI Integration Example', 'items' => ['API integration ready', 'Multi-currency support', 'SEPA payments', 'PSD2 compatible APIs']],
+                        ['name' => 'Deutsche Bank API', 'type' => 'Banking Integration Demo', 'items' => ['Corporate API access', 'Multi-currency accounts', 'SWIFT connectivity', 'SEPA Instant support']],
+                        ['name' => 'Santander Module', 'type' => 'Open Banking Sample', 'items' => ['Open Banking APIs', 'Account aggregation', 'Payment initiation', 'Real-time balances']],
+                        ['name' => 'Custom Integrations', 'type' => 'Your Bank Here', 'items' => ['Modular architecture', 'Standard interfaces', 'Webhook support', 'Easy integration']],
+                    ];
+                @endphp
+
+                @foreach($integrations as $int)
+                <div class="card-feature !p-5">
+                    <span class="badge badge-info mb-3">Example</span>
+                    <h4 class="font-display text-base font-bold text-slate-900 mb-1">{{ $int['name'] }}</h4>
+                    <p class="text-xs text-slate-500 mb-3">{{ $int['type'] }}</p>
+                    <ul class="space-y-1.5 text-xs text-slate-500">
+                        @foreach($int['items'] as $item)
+                        <li class="list-check">{{ $item }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+                @endforeach
+            </div>
+
+            <p class="text-center text-sm text-slate-500 mt-6 animate-on-scroll">
+                These reference implementations demonstrate integration patterns. No partnerships or endorsements are implied.
+            </p>
+        </div>
+    </section>
+
+    <!-- API Endpoints -->
+    <section class="py-24 bg-slate-50/50">
+        <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="text-center mb-14 animate-on-scroll">
+                <h2 class="font-display text-3xl md:text-4xl font-bold text-slate-900 mb-4">Compliance API Endpoints</h2>
+                <p class="text-lg text-slate-500">Programmatic access to compliance features</p>
+            </div>
+
+            <div class="card-feature !p-0 overflow-hidden animate-on-scroll stagger-1">
+                <div class="px-6 py-4 bg-slate-50 border-b border-slate-200">
+                    <p class="text-sm text-slate-600">
+                        <strong class="text-slate-900">Note:</strong> For api.finaegis.org, endpoints are available without the /api prefix.
+                    </p>
+                </div>
+                <div class="grid grid-cols-1 md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-slate-100">
+                    @php
+                        $endpoints = [
+                            ['title' => 'KYC Endpoints', 'routes' => ['GET /api/compliance/kyc/status', 'GET /api/compliance/kyc/requirements', 'POST /api/compliance/kyc/submit', 'POST /api/compliance/kyc/documents']],
+                            ['title' => 'GDPR Endpoints', 'routes' => ['GET /api/compliance/gdpr/consent', 'POST /api/compliance/gdpr/consent', 'POST /api/compliance/gdpr/export', 'POST /api/compliance/gdpr/delete']],
+                            ['title' => 'Regulatory Reporting', 'routes' => ['POST /api/regulatory/reports/ctr', 'POST /api/regulatory/reports/sar-candidates', 'GET /api/regulatory/reports', 'GET /api/regulatory/metrics']],
+                            ['title' => 'Bank Health & Alerting', 'routes' => ['POST /api/bank-health/check', 'GET /api/bank-health/status', 'GET /api/bank-health/alerts/stats', 'PUT /api/bank-health/alerts/config']],
+                        ];
+                    @endphp
+                    @foreach($endpoints as $group)
+                    <div class="p-6">
+                        <h4 class="font-display text-sm font-bold text-slate-900 mb-3">{{ $group['title'] }}</h4>
+                        <ul class="space-y-2 text-xs text-slate-600 font-mono">
+                            @foreach($group['routes'] as $route)
+                            <li>{{ $route }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                    @endforeach
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Security Standards -->
+    <section class="py-20 bg-fa-navy relative overflow-hidden">
+        <div class="absolute inset-0 bg-dot-pattern"></div>
+        <div class="relative max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="text-center mb-12 animate-on-scroll">
+                <h2 class="font-display text-3xl md:text-4xl font-bold text-white mb-4">Security Architecture</h2>
+                <p class="text-slate-400">Industry-standard security practices</p>
+            </div>
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-6 animate-on-scroll stagger-1">
+                @php
+                    $standards = [
+                        ['label' => 'OWASP', 'desc' => 'Security Guidelines'],
+                        ['label' => 'AES-256', 'desc' => 'Data Encryption'],
+                        ['label' => 'OAuth 2.0', 'desc' => 'API Security'],
+                        ['label' => 'bcrypt', 'desc' => 'Password Hashing'],
+                    ];
+                @endphp
+                @foreach($standards as $std)
                 <div class="text-center">
-                    <h1 class="text-4xl font-bold text-white sm:text-5xl lg:text-6xl">
-                        Compliance-Ready Architecture
-                    </h1>
-                    <p class="mt-6 text-xl text-blue-100 max-w-3xl mx-auto">
-                        Built for EU regulatory compliance from day one. PSD2, EMD2, MiCA, KYC/AML, GDPR, and MiFID II adapters with jurisdiction-aware routing.
-                    </p>
+                    <div class="font-display text-xl font-bold text-white mb-1">{{ $std['label'] }}</div>
+                    <div class="text-sm text-slate-400">{{ $std['desc'] }}</div>
                 </div>
+                @endforeach
+            </div>
+
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-6 mt-12 animate-on-scroll stagger-2">
+                @php
+                    $metrics = [
+                        ['label' => 'Real-time', 'desc' => 'Transaction Logging'],
+                        ['label' => 'Automated', 'desc' => 'Risk Scoring'],
+                        ['label' => 'Built-in', 'desc' => 'Audit Trail'],
+                        ['label' => 'Flexible', 'desc' => 'KYC Workflows'],
+                    ];
+                @endphp
+                @foreach($metrics as $m)
+                <div class="card-dark text-center !p-5">
+                    <div class="font-display text-lg font-bold text-white mb-1">{{ $m['label'] }}</div>
+                    <div class="text-xs text-slate-400">{{ $m['desc'] }}</div>
+                </div>
+                @endforeach
             </div>
         </div>
+    </section>
 
-        <!-- Regulatory Strategy -->
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-            <div class="text-center mb-16">
-                <h2 class="text-3xl font-bold text-gray-900">Designed for EU Regulatory Compliance</h2>
-                <p class="mt-4 text-lg text-gray-600 max-w-3xl mx-auto">
-                    Our platform architecture is built to support EMI licensing requirements and can integrate with licensed partners for compliant operations across the European Union.
-                </p>
-            </div>
-
-            <!-- Primary Regulations -->
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-16">
-                
-                <!-- PSD2 Compliance -->
-                <div class="bg-white border border-gray-200 rounded-lg p-6 hover:shadow-lg transition duration-200">
-                    <div class="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center mb-4">
-                        <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"></path>
-                        </svg>
-                    </div>
-                    <h3 class="text-xl font-bold text-gray-900 mb-3">PSD2 Compatible</h3>
-                    <p class="text-gray-600 mb-4">Architecture designed to support Payment Services Directive 2 requirements when operating with licensed partners.</p>
-                    <ul class="text-sm text-gray-600 space-y-1">
-                        <li>• Strong Customer Authentication (SCA)</li>
-                        <li>• Open Banking API standards</li>
-                        <li>• Account Information Services (AIS)</li>
-                        <li>• Payment Initiation Services (PIS)</li>
-                    </ul>
-                </div>
-
-                <!-- EMD2 Framework -->
-                <div class="bg-white border border-gray-200 rounded-lg p-6 hover:shadow-lg transition duration-200">
-                    <div class="w-12 h-12 bg-green-100 rounded-lg flex items-center justify-center mb-4">
-                        <svg class="w-6 h-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                        </svg>
-                    </div>
-                    <h3 class="text-xl font-bold text-gray-900 mb-3">EMD2 Ready</h3>
-                    <p class="text-gray-600 mb-4">Platform architecture prepared for Electronic Money Directive 2 compliance requirements.</p>
-                    <ul class="text-sm text-gray-600 space-y-1">
-                        <li>• Support for fund safeguarding</li>
-                        <li>• Customer fund segregation</li>
-                        <li>• E-money redemption workflows</li>
-                        <li>• Operational resilience features</li>
-                    </ul>
-                </div>
-
-                <!-- MiCA Ready -->
-                <div class="bg-white border border-gray-200 rounded-lg p-6 hover:shadow-lg transition duration-200">
-                    <div class="w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center mb-4">
-                        <svg class="w-6 h-6 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"></path>
-                        </svg>
-                    </div>
-                    <h3 class="text-xl font-bold text-gray-900 mb-3">MiCA Compatible Design</h3>
-                    <p class="text-gray-600 mb-4">Infrastructure designed with Markets in Crypto-Assets regulation in mind for future digital asset operations.</p>
-                    <ul class="text-sm text-gray-600 space-y-1">
-                        <li>• Asset-referenced token framework</li>
-                        <li>• E-money token compliance</li>
-                        <li>• Reserve asset management</li>
-                        <li>• Stability mechanism requirements</li>
-                    </ul>
-                </div>
-            </div>
-
-            <!-- KYC Implementation -->
-            <div class="bg-gray-50 rounded-lg p-8 mb-16">
-                <h3 class="text-2xl font-bold text-gray-900 mb-6">KYC/AML System Architecture</h3>
-                <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-                    
-                    <!-- Basic KYC -->
-                    <div class="bg-white rounded-lg p-6 border border-gray-200">
-                        <div class="flex items-center justify-between mb-4">
-                            <h4 class="text-lg font-semibold text-gray-900">Basic Verification</h4>
-                            <span class="bg-blue-100 text-blue-700 text-sm px-3 py-1 rounded-full">Level 1</span>
-                        </div>
-                        <ul class="space-y-2 text-gray-600 mb-4">
-                            <li class="flex items-start">
-                                <svg class="w-5 h-5 text-green-500 mt-0.5 mr-2" fill="currentColor" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
-                                </svg>
-                                National ID verification
-                            </li>
-                            <li class="flex items-start">
-                                <svg class="w-5 h-5 text-green-500 mt-0.5 mr-2" fill="currentColor" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
-                                </svg>
-                                Selfie with liveness check
-                            </li>
-                            <li class="flex items-start">
-                                <svg class="w-5 h-5 text-green-500 mt-0.5 mr-2" fill="currentColor" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
-                                </svg>
-                                Automated risk scoring
-                            </li>
-                        </ul>
-                        <div class="pt-4 border-t border-gray-200">
-                            <div class="text-sm text-gray-600">Daily Limit</div>
-                            <div class="text-2xl font-bold text-gray-900">€10,000</div>
-                        </div>
-                    </div>
-
-                    <!-- Enhanced KYC -->
-                    <div class="bg-white rounded-lg p-6 border border-gray-200">
-                        <div class="flex items-center justify-between mb-4">
-                            <h4 class="text-lg font-semibold text-gray-900">Enhanced Verification</h4>
-                            <span class="bg-green-100 text-green-700 text-sm px-3 py-1 rounded-full">Level 2</span>
-                        </div>
-                        <ul class="space-y-2 text-gray-600 mb-4">
-                            <li class="flex items-start">
-                                <svg class="w-5 h-5 text-green-500 mt-0.5 mr-2" fill="currentColor" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
-                                </svg>
-                                Passport verification
-                            </li>
-                            <li class="flex items-start">
-                                <svg class="w-5 h-5 text-green-500 mt-0.5 mr-2" fill="currentColor" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
-                                </svg>
-                                Proof of address
-                            </li>
-                            <li class="flex items-start">
-                                <svg class="w-5 h-5 text-green-500 mt-0.5 mr-2" fill="currentColor" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
-                                </svg>
-                                PEP & sanctions screening
-                            </li>
-                        </ul>
-                        <div class="pt-4 border-t border-gray-200">
-                            <div class="text-sm text-gray-600">Daily Limit</div>
-                            <div class="text-2xl font-bold text-gray-900">€50,000</div>
-                        </div>
-                    </div>
-
-                    <!-- Full KYC -->
-                    <div class="bg-white rounded-lg p-6 border border-gray-200">
-                        <div class="flex items-center justify-between mb-4">
-                            <h4 class="text-lg font-semibold text-gray-900">Full Verification</h4>
-                            <span class="bg-purple-100 text-purple-700 text-sm px-3 py-1 rounded-full">Level 3</span>
-                        </div>
-                        <ul class="space-y-2 text-gray-600 mb-4">
-                            <li class="flex items-start">
-                                <svg class="w-5 h-5 text-green-500 mt-0.5 mr-2" fill="currentColor" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
-                                </svg>
-                                All previous checks
-                            </li>
-                            <li class="flex items-start">
-                                <svg class="w-5 h-5 text-green-500 mt-0.5 mr-2" fill="currentColor" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
-                                </svg>
-                                Source of funds verification
-                            </li>
-                            <li class="flex items-start">
-                                <svg class="w-5 h-5 text-green-500 mt-0.5 mr-2" fill="currentColor" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
-                                </svg>
-                                Enhanced due diligence
-                            </li>
-                        </ul>
-                        <div class="pt-4 border-t border-gray-200">
-                            <div class="text-sm text-gray-600">Daily Limit</div>
-                            <div class="text-2xl font-bold text-gray-900">Unlimited</div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- AML Framework -->
-            <div class="bg-white border border-gray-200 rounded-lg p-8 mb-16">
-                <h3 class="text-2xl font-bold text-gray-900 mb-6">Anti-Money Laundering (AML) Framework</h3>
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
-                    
-                    <!-- Transaction Monitoring -->
-                    <div>
-                        <h4 class="text-lg font-semibold text-gray-900 mb-4">Real-Time Transaction Monitoring</h4>
-                        <ul class="space-y-3 text-gray-600">
-                            <li class="flex items-start">
-                                <svg class="w-5 h-5 text-blue-500 mt-0.5 mr-3" fill="currentColor" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
-                                </svg>
-                                <div>
-                                    <div class="font-medium">Pattern Detection</div>
-                                    <div class="text-sm">Structuring, velocity, and unusual patterns</div>
-                                </div>
-                            </li>
-                            <li class="flex items-start">
-                                <svg class="w-5 h-5 text-blue-500 mt-0.5 mr-3" fill="currentColor" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
-                                </svg>
-                                <div>
-                                    <div class="font-medium">Threshold Monitoring</div>
-                                    <div class="text-sm">€10,000 CTR threshold tracking</div>
-                                </div>
-                            </li>
-                            <li class="flex items-start">
-                                <svg class="w-5 h-5 text-blue-500 mt-0.5 mr-3" fill="currentColor" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
-                                </svg>
-                                <div>
-                                    <div class="font-medium">Risk Scoring</div>
-                                    <div class="text-sm">ML-based transaction risk assessment</div>
-                                </div>
-                            </li>
-                        </ul>
-                    </div>
-
-                    <!-- Regulatory Reporting -->
-                    <div>
-                        <h4 class="text-lg font-semibold text-gray-900 mb-4">Automated Regulatory Reporting</h4>
-                        <ul class="space-y-3 text-gray-600">
-                            <li class="flex items-start">
-                                <svg class="w-5 h-5 text-green-500 mt-0.5 mr-3" fill="currentColor" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
-                                </svg>
-                                <div>
-                                    <div class="font-medium">Currency Transaction Reports (CTR)</div>
-                                    <div class="text-sm">Daily automated generation</div>
-                                </div>
-                            </li>
-                            <li class="flex items-start">
-                                <svg class="w-5 h-5 text-green-500 mt-0.5 mr-3" fill="currentColor" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
-                                </svg>
-                                <div>
-                                    <div class="font-medium">Suspicious Activity Reports (SAR)</div>
-                                    <div class="text-sm">Monthly candidate identification</div>
-                                </div>
-                            </li>
-                            <li class="flex items-start">
-                                <svg class="w-5 h-5 text-green-500 mt-0.5 mr-3" fill="currentColor" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
-                                </svg>
-                                <div>
-                                    <div class="font-medium">Compliance Dashboards</div>
-                                    <div class="text-sm">Real-time metrics and alerts</div>
-                                </div>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-
-            <!-- GDPR Compliance -->
-            <div class="bg-blue-50 rounded-lg p-8 mb-16">
-                <h3 class="text-2xl font-bold text-gray-900 mb-6">GDPR & Data Protection</h3>
-                <div class="grid grid-cols-1 md:grid-cols-4 gap-6">
-                    <div class="text-center">
-                        <div class="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-3">
-                            <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
-                            </svg>
-                        </div>
-                        <h4 class="font-semibold text-gray-900">Data Export</h4>
-                        <p class="text-sm text-gray-600 mt-1">Full data portability support</p>
-                    </div>
-                    <div class="text-center">
-                        <div class="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-3">
-                            <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
-                            </svg>
-                        </div>
-                        <h4 class="font-semibold text-gray-900">Right to Deletion</h4>
-                        <p class="text-sm text-gray-600 mt-1">Secure data anonymization</p>
-                    </div>
-                    <div class="text-center">
-                        <div class="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-3">
-                            <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                            </svg>
-                        </div>
-                        <h4 class="font-semibold text-gray-900">Retention Policies</h4>
-                        <p class="text-sm text-gray-600 mt-1">Automated data lifecycle</p>
-                    </div>
-                    <div class="text-center">
-                        <div class="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-3">
-                            <svg class="w-6 h-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path>
-                            </svg>
-                        </div>
-                        <h4 class="font-semibold text-gray-900">Consent Management</h4>
-                        <p class="text-sm text-gray-600 mt-1">Granular privacy controls</p>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Banking Partners -->
-            <div class="bg-gray-50 rounded-lg p-8 mb-16">
-                <h3 class="text-2xl font-bold text-gray-900 mb-6">Example Banking Integrations</h3>
-                <div class="bg-amber-50 border border-amber-200 rounded-lg p-4 mb-6">
-                    <p class="text-sm text-amber-800">
-                        <strong>Disclaimer:</strong> The following are example integrations demonstrating our platform's technical capabilities. 
-                        These are not active partnerships or endorsements. If your institution is listed and you would like it removed, 
-                        please contact us at info@finaegis.org.
-                    </p>
-                </div>
-                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-                    
-                    <!-- Paysera -->
-                    <div class="bg-white rounded-lg p-6 border border-gray-200">
-                        <div class="bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded mb-2 inline-block">Example</div>
-                        <h4 class="font-semibold text-gray-900 mb-2">Paysera Connector</h4>
-                        <p class="text-sm text-gray-600 mb-3">EMI Integration Example</p>
-                        <ul class="text-xs text-gray-500 space-y-1">
-                            <li>• API integration ready</li>
-                            <li>• Multi-currency support</li>
-                            <li>• SEPA payments</li>
-                            <li>• PSD2 compatible APIs</li>
-                        </ul>
-                    </div>
-
-                    <!-- Deutsche Bank -->
-                    <div class="bg-white rounded-lg p-6 border border-gray-200">
-                        <div class="bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded mb-2 inline-block">Example</div>
-                        <h4 class="font-semibold text-gray-900 mb-2">Deutsche Bank API</h4>
-                        <p class="text-sm text-gray-600 mb-3">Banking Integration Demo</p>
-                        <ul class="text-xs text-gray-500 space-y-1">
-                            <li>• Corporate API access</li>
-                            <li>• Multi-currency accounts</li>
-                            <li>• SWIFT connectivity</li>
-                            <li>• SEPA Instant support</li>
-                        </ul>
-                    </div>
-
-                    <!-- Santander -->
-                    <div class="bg-white rounded-lg p-6 border border-gray-200">
-                        <div class="bg-blue-100 text-blue-700 text-xs px-2 py-1 rounded mb-2 inline-block">Example</div>
-                        <h4 class="font-semibold text-gray-900 mb-2">Santander Module</h4>
-                        <p class="text-sm text-gray-600 mb-3">Open Banking Sample</p>
-                        <ul class="text-xs text-gray-500 space-y-1">
-                            <li>• Open Banking APIs</li>
-                            <li>• Account aggregation</li>
-                            <li>• Payment initiation</li>
-                            <li>• Real-time balances</li>
-                        </ul>
-                    </div>
-
-                    <!-- Wise -->
-                    <div class="bg-white rounded-lg p-6 border border-gray-200">
-                        <div class="bg-green-100 text-green-700 text-xs px-2 py-1 rounded mb-2 inline-block">Available</div>
-                        <h4 class="font-semibold text-gray-900 mb-2">Custom Integrations</h4>
-                        <p class="text-sm text-gray-600 mb-3">Your Bank Here</p>
-                        <ul class="text-xs text-gray-500 space-y-1">
-                            <li>• Modular architecture</li>
-                            <li>• Standard interfaces</li>
-                            <li>• Webhook support</li>
-                            <li>• Easy integration</li>
-                        </ul>
-                    </div>
-                </div>
-                <div class="mt-6 text-center">
-                    <p class="text-sm text-gray-600">
-                        These reference implementations demonstrate our platform's integration patterns and capabilities.
-                        <br>No partnerships or endorsements are implied.
-                    </p>
-                </div>
-            </div>
-
-            <!-- Security Standards -->
-            <div class="bg-white border border-gray-200 rounded-lg p-8 mb-16">
-                <h3 class="text-2xl font-bold text-gray-900 mb-6">Security Architecture & Best Practices</h3>
-                <div class="grid grid-cols-2 md:grid-cols-4 gap-6">
-                    <div class="text-center">
-                        <div class="text-lg font-semibold text-gray-900">OWASP</div>
-                        <div class="text-sm text-gray-600">Security Guidelines</div>
-                    </div>
-                    <div class="text-center">
-                        <div class="text-lg font-semibold text-gray-900">AES-256</div>
-                        <div class="text-sm text-gray-600">Data Encryption</div>
-                    </div>
-                    <div class="text-center">
-                        <div class="text-lg font-semibold text-gray-900">OAuth 2.0</div>
-                        <div class="text-sm text-gray-600">API Security</div>
-                    </div>
-                    <div class="text-center">
-                        <div class="text-lg font-semibold text-gray-900">bcrypt</div>
-                        <div class="text-sm text-gray-600">Password Hashing</div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Compliance Metrics -->
-            <div class="bg-gradient-to-r from-blue-600 to-purple-600 rounded-lg p-8 text-white mb-16">
-                <h3 class="text-2xl font-bold mb-6">Platform Compliance Features</h3>
-                <div class="grid grid-cols-2 md:grid-cols-4 gap-6">
-                    <div class="text-center">
-                        <div class="text-3xl font-bold mb-2">Real-time</div>
-                        <div class="text-blue-100">Transaction Logging</div>
-                    </div>
-                    <div class="text-center">
-                        <div class="text-3xl font-bold mb-2">Automated</div>
-                        <div class="text-blue-100">Risk Scoring</div>
-                    </div>
-                    <div class="text-center">
-                        <div class="text-3xl font-bold mb-2">Built-in</div>
-                        <div class="text-blue-100">Audit Trail</div>
-                    </div>
-                    <div class="text-center">
-                        <div class="text-3xl font-bold mb-2">Flexible</div>
-                        <div class="text-blue-100">KYC Workflows</div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- API Endpoints Info -->
-            <div class="bg-white border border-gray-200 rounded-lg p-8 mb-16">
-                <h3 class="text-2xl font-bold text-gray-900 mb-6">API Endpoints for Compliance Features</h3>
-                <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6">
-                    <p class="text-sm text-blue-800">
-                        <strong>Note:</strong> For api.finaegis.org subdomain, these endpoints are available without the /api prefix. 
-                        For example: https://api.finaegis.org/compliance/kyc/status instead of https://api.finaegis.org/api/compliance/kyc/status
-                    </p>
-                </div>
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
-                    <div>
-                        <h4 class="text-lg font-semibold text-gray-900 mb-4">KYC Endpoints</h4>
-                        <ul class="space-y-2 text-sm text-gray-600 font-mono">
-                            <li>GET /api/compliance/kyc/status</li>
-                            <li>GET /api/compliance/kyc/requirements</li>
-                            <li>POST /api/compliance/kyc/submit</li>
-                            <li>POST /api/compliance/kyc/documents</li>
-                        </ul>
-                    </div>
-                    <div>
-                        <h4 class="text-lg font-semibold text-gray-900 mb-4">GDPR Endpoints</h4>
-                        <ul class="space-y-2 text-sm text-gray-600 font-mono">
-                            <li>GET /api/compliance/gdpr/consent</li>
-                            <li>POST /api/compliance/gdpr/consent</li>
-                            <li>POST /api/compliance/gdpr/export</li>
-                            <li>POST /api/compliance/gdpr/delete</li>
-                        </ul>
-                    </div>
-                    <div>
-                        <h4 class="text-lg font-semibold text-gray-900 mb-4">Regulatory Reporting</h4>
-                        <ul class="space-y-2 text-sm text-gray-600 font-mono">
-                            <li>POST /api/regulatory/reports/ctr</li>
-                            <li>POST /api/regulatory/reports/sar-candidates</li>
-                            <li>GET /api/regulatory/reports</li>
-                            <li>GET /api/regulatory/metrics</li>
-                        </ul>
-                    </div>
-                    <div>
-                        <h4 class="text-lg font-semibold text-gray-900 mb-4">Bank Health & Alerting</h4>
-                        <ul class="space-y-2 text-sm text-gray-600 font-mono">
-                            <li>POST /api/bank-health/check</li>
-                            <li>GET /api/bank-health/status</li>
-                            <li>GET /api/bank-health/alerts/stats</li>
-                            <li>PUT /api/bank-health/alerts/config</li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Contact Compliance -->
-            <div class="bg-blue-50 border border-blue-200 rounded-lg p-8 text-center">
-                <h3 class="text-2xl font-bold text-gray-900 mb-4">Learn More About Our Compliance Architecture</h3>
-                <p class="text-gray-600 mb-6">
-                    Interested in how our platform can support your compliance requirements? Contact us to learn more about integration possibilities.
-                </p>
-                <div class="flex flex-col sm:flex-row gap-4 justify-center">
-                    <a href="mailto:info@finaegis.org" class="bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700 transition duration-200">
-                        Contact Us
-                    </a>
-                    <a href="{{ route('developers.show', 'api-docs') }}" class="border border-blue-600 text-blue-600 px-6 py-3 rounded-lg hover:bg-blue-50 transition duration-200">
-                        View API Documentation
-                    </a>
-                </div>
+    <!-- CTA -->
+    <section class="py-20 bg-white">
+        <div class="max-w-4xl mx-auto text-center px-4 sm:px-6 lg:px-8 animate-on-scroll">
+            <h2 class="font-display text-3xl md:text-4xl font-bold text-slate-900 mb-4">Learn More About Our Compliance Architecture</h2>
+            <p class="text-lg text-slate-500 mb-10 max-w-2xl mx-auto">
+                Interested in how our platform can support your compliance requirements? Contact us to learn more.
+            </p>
+            <div class="flex flex-col sm:flex-row gap-4 justify-center">
+                <a href="{{ route('support.contact') }}" class="btn-primary px-8 py-4 text-lg">
+                    Contact Us
+                </a>
+                <a href="{{ route('developers.show', 'api-docs') }}" class="btn-outline-dark px-8 py-4 text-lg">
+                    View API Documentation
+                </a>
             </div>
         </div>
-    </div>
+    </section>
 @endsection

--- a/resources/views/features/index.blade.php
+++ b/resources/views/features/index.blade.php
@@ -48,33 +48,22 @@
 
 
     <!-- Development Notice -->
-    <section class="py-8 bg-amber-50">
+    <section class="py-6 bg-white border-b border-slate-100">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="bg-white rounded-lg shadow p-6 border-l-4 border-amber-400">
-                <div class="flex items-start">
-                    <div class="flex-shrink-0">
-                        <svg class="w-6 h-6 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
-                        </svg>
-                    </div>
-                    <div class="ml-3">
-                        <h3 class="text-lg font-semibold text-slate-900">Feature Status Guide</h3>
-                        <p class="mt-2 text-slate-500">
-                            FinAegis is under active development with new modules shipping regularly.
-                            Features are marked with status badges below. The demo environment lets you
-                            explore every feature without external dependencies.
-                        </p>
-                        <div class="mt-3 flex gap-4">
-                            <span class="inline-flex items-center px-2 py-1 bg-green-100 text-green-700 text-xs rounded-full">
-                                ✅ Available - Fully implemented
-                            </span>
-                            <span class="inline-flex items-center px-2 py-1 bg-blue-100 text-blue-700 text-xs rounded-full">
-                                🎭 Demo Mode - Available for testing
-                            </span>
-                            <span class="inline-flex items-center px-2 py-1 bg-yellow-100 text-yellow-700 text-xs rounded-full">
-                                🚧 In Progress - Under development
-                            </span>
-                        </div>
+            <div class="card-stat flex items-start gap-3 border-l-4 border-amber-400 bg-amber-50/50">
+                <svg class="w-5 h-5 text-amber-600 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                </svg>
+                <div>
+                    <h3 class="font-display text-sm font-semibold text-slate-900">Feature Status Guide</h3>
+                    <p class="text-sm text-slate-600 mt-1">
+                        FinAegis is under active development with new modules shipping regularly.
+                        The demo environment lets you explore every feature without external dependencies.
+                    </p>
+                    <div class="mt-3 flex flex-wrap gap-2">
+                        <span class="badge badge-success">Available</span>
+                        <span class="badge badge-info">Demo Mode</span>
+                        <span class="badge badge-warning">In Progress</span>
                     </div>
                 </div>
             </div>

--- a/resources/views/partners.blade.php
+++ b/resources/views/partners.blade.php
@@ -1,283 +1,190 @@
-<x-guest-layout>
-    <div class="bg-white">
-        <!-- Header -->
-        <div class="bg-gradient-to-r from-blue-900 to-blue-800">
-            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
-                <div class="text-center">
-                    <h1 class="text-4xl font-bold text-white sm:text-5xl lg:text-6xl">
-                        Our Banking Partners
-                    </h1>
-                    <p class="mt-6 text-xl text-blue-100 max-w-3xl mx-auto">
-                        FinAegis partners with leading financial institutions across Europe to provide you with maximum security and deposit protection.
+@extends('layouts.public')
+
+@section('title', 'Banking Partners - Multi-Bank Architecture | FinAegis')
+
+@section('seo')
+    @include('partials.seo', [
+        'title' => 'Banking Partners - Multi-Bank Architecture | FinAegis',
+        'description' => 'FinAegis multi-bank architecture with pluggable connectors for institutional partners. Distributed fund security across licensed European banks.',
+        'keywords' => 'FinAegis partners, banking partners, multi-bank, deposit protection, EU banking, fund distribution',
+    ])
+
+    <x-schema type="breadcrumb" :data="[
+        ['name' => 'Home', 'url' => url('/')],
+        ['name' => 'Partners', 'url' => url('/partners')]
+    ]" />
+@endsection
+
+@section('content')
+    <!-- Hero Section -->
+    <section class="bg-fa-navy relative overflow-hidden">
+        <div class="absolute inset-0 bg-grid-pattern"></div>
+        <div class="absolute top-1/3 right-1/4 w-80 h-80 bg-blue-500/8 rounded-full blur-[100px]"></div>
+        <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20 lg:py-24">
+            <div class="text-center">
+                <div class="inline-flex items-center justify-center w-16 h-16 bg-white/[0.04] border border-white/[0.08] rounded-2xl mb-6">
+                    <svg class="w-8 h-8 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/></svg>
+                </div>
+                <h1 class="font-display text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">Multi-Bank <span class="text-gradient">Architecture</span></h1>
+                <p class="text-lg text-slate-400 max-w-2xl mx-auto">
+                    Distributed fund security across licensed European banks with pluggable connectors and full deposit insurance coverage.
+                </p>
+            </div>
+        </div>
+        <div class="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-blue-500/20 to-transparent"></div>
+    </section>
+
+    <!-- Architecture Notice -->
+    <section class="py-6 bg-white border-b border-slate-100">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="card-stat flex items-start gap-3 border-l-4 border-amber-400 bg-amber-50/50">
+                <svg class="w-5 h-5 text-amber-600 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+                </svg>
+                <div>
+                    <h3 class="font-display text-sm font-semibold text-slate-900">Multi-Bank Architecture</h3>
+                    <p class="text-sm text-slate-600 mt-0.5">
+                        FinAegis supports <strong>multi-bank architecture</strong> with pluggable connectors for institutional partners.
+                        The bank integrations shown are reference implementations demonstrating production integration patterns.
+                        Live bank partnerships require separate commercial agreements.
                     </p>
                 </div>
             </div>
         </div>
+    </section>
 
-        <!-- Architecture Notice -->
-        <div class="py-8 bg-amber-50">
-            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-                <div class="bg-white rounded-lg shadow p-6 border-l-4 border-amber-400">
-                    <div class="flex items-start">
-                        <div class="flex-shrink-0">
-                            <svg class="w-6 h-6 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
-                            </svg>
-                        </div>
-                        <div class="ml-3">
-                            <h3 class="text-lg font-semibold text-gray-900">Multi-Bank Architecture</h3>
-                            <p class="mt-2 text-gray-600">
-                                FinAegis supports <strong>multi-bank architecture</strong> with pluggable connectors for institutional partners.
-                                The bank integrations shown here are reference implementations demonstrating production integration patterns.
-                                Live bank partnerships require separate commercial agreements. Deposit protection figures illustrate
-                                the benefit of multi-bank fund distribution.
-                            </p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Partner Banks Section -->
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
-            <div class="text-center mb-16">
-                <h2 class="text-3xl font-bold text-gray-900">Trusted Banking Partners</h2>
-                <p class="mt-4 text-xl text-gray-600">Your funds are distributed across licensed banks with full deposit insurance</p>
+    <!-- Partner Banks -->
+    <section class="py-24 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="text-center mb-14 animate-on-scroll">
+                <h2 class="font-display text-3xl md:text-4xl font-bold text-slate-900 mb-4">Reference Banking Partners</h2>
+                <p class="text-lg text-slate-500">Fund distribution across licensed banks with full deposit insurance</p>
             </div>
 
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-                <!-- Paysera -->
-                <div class="bg-white rounded-xl shadow-lg border border-gray-200 p-8 text-center">
-                    <div class="w-20 h-20 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-6">
-                        <svg class="w-10 h-10 text-green-600" fill="currentColor" viewBox="0 0 24 24">
-                            <path d="M12 2L2 7v10c0 5.55 3.84 9.74 9 11 5.16-1.26 9-5.45 9-11V7l-10-5z"/>
-                        </svg>
-                    </div>
-                    <h3 class="text-xl font-bold text-gray-900 mb-2">Paysera Bank</h3>
-                    <p class="text-gray-600 mb-4">Lithuanian EMI License</p>
-                    <div class="space-y-2 text-sm text-gray-600">
-                        <p><strong>License:</strong> EMI License (EU)</p>
-                        <p><strong>Deposit Protection:</strong> €100,000</p>
-                        <p><strong>Country:</strong> Lithuania</p>
-                        <p><strong>Founded:</strong> 2004</p>
-                    </div>
-                    <div class="mt-6 pt-6 border-t border-gray-200">
-                        <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                            Primary Partner
-                        </span>
-                    </div>
-                </div>
+            @php
+                $banks = [
+                    ['name' => 'Paysera Bank', 'license' => 'EMI License (EU)', 'country' => 'Lithuania', 'founded' => '2004', 'protection' => '€100,000', 'color' => 'teal', 'badge' => 'Primary Partner', 'badgeColor' => 'success'],
+                    ['name' => 'Deutsche Bank', 'license' => 'Full Banking License', 'country' => 'Germany', 'founded' => '1870', 'protection' => '€100,000', 'color' => 'blue', 'badge' => 'Corporate Banking', 'badgeColor' => 'info'],
+                    ['name' => 'Santander Bank', 'license' => 'Full Banking License', 'country' => 'Spain', 'founded' => '1857', 'protection' => '€100,000', 'color' => 'red', 'badge' => 'Retail Banking', 'badgeColor' => 'accent'],
+                    ['name' => 'Revolut Bank', 'license' => 'Full Banking License', 'country' => 'Lithuania', 'founded' => '2015', 'protection' => '€100,000', 'color' => 'violet', 'badge' => 'Digital Banking', 'badgeColor' => 'info'],
+                    ['name' => 'N26 Bank', 'license' => 'Full Banking License', 'country' => 'Germany', 'founded' => '2013', 'protection' => '€100,000', 'color' => 'slate', 'badge' => 'Mobile Banking', 'badgeColor' => 'info'],
+                ];
+            @endphp
 
-                <!-- Deutsche Bank -->
-                <div class="bg-white rounded-xl shadow-lg border border-gray-200 p-8 text-center">
-                    <div class="w-20 h-20 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-6">
-                        <svg class="w-10 h-10 text-blue-600" fill="currentColor" viewBox="0 0 24 24">
-                            <path d="M12 2L2 7v10c0 5.55 3.84 9.74 9 11 5.16-1.26 9-5.45 9-11V7l-10-5z"/>
-                        </svg>
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                @foreach($banks as $i => $bank)
+                <div class="card-feature text-center !p-8 animate-on-scroll stagger-{{ ($i % 6) + 1 }}">
+                    <div class="w-16 h-16 bg-{{ $bank['color'] }}-50 rounded-full flex items-center justify-center mx-auto mb-5">
+                        <svg class="w-8 h-8 text-{{ $bank['color'] }}-600" fill="currentColor" viewBox="0 0 24 24"><path d="M12 1L3 5v6c0 5.55 3.84 9.74 9 11 5.16-1.26 9-5.45 9-11V5l-9-4z"/></svg>
                     </div>
-                    <h3 class="text-xl font-bold text-gray-900 mb-2">Deutsche Bank</h3>
-                    <p class="text-gray-600 mb-4">German Banking License</p>
-                    <div class="space-y-2 text-sm text-gray-600">
-                        <p><strong>License:</strong> Full Banking License</p>
-                        <p><strong>Deposit Protection:</strong> €100,000</p>
-                        <p><strong>Country:</strong> Germany</p>
-                        <p><strong>Founded:</strong> 1870</p>
+                    <h3 class="font-display text-xl font-bold text-slate-900 mb-1">{{ $bank['name'] }}</h3>
+                    <p class="text-sm text-slate-500 mb-4">{{ $bank['license'] }}</p>
+                    <div class="space-y-1.5 text-sm text-slate-600 mb-5">
+                        <p><strong class="text-slate-900">Protection:</strong> {{ $bank['protection'] }}</p>
+                        <p><strong class="text-slate-900">Country:</strong> {{ $bank['country'] }}</p>
+                        <p><strong class="text-slate-900">Founded:</strong> {{ $bank['founded'] }}</p>
                     </div>
-                    <div class="mt-6 pt-6 border-t border-gray-200">
-                        <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-                            Corporate Banking
-                        </span>
-                    </div>
+                    <span class="badge badge-{{ $bank['badgeColor'] }}">{{ $bank['badge'] }}</span>
                 </div>
-
-                <!-- Santander -->
-                <div class="bg-white rounded-xl shadow-lg border border-gray-200 p-8 text-center">
-                    <div class="w-20 h-20 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-6">
-                        <svg class="w-10 h-10 text-red-600" fill="currentColor" viewBox="0 0 24 24">
-                            <path d="M12 2L2 7v10c0 5.55 3.84 9.74 9 11 5.16-1.26 9-5.45 9-11V7l-10-5z"/>
-                        </svg>
-                    </div>
-                    <h3 class="text-xl font-bold text-gray-900 mb-2">Santander Bank</h3>
-                    <p class="text-gray-600 mb-4">Spanish Banking License</p>
-                    <div class="space-y-2 text-sm text-gray-600">
-                        <p><strong>License:</strong> Full Banking License</p>
-                        <p><strong>Deposit Protection:</strong> €100,000</p>
-                        <p><strong>Country:</strong> Spain</p>
-                        <p><strong>Founded:</strong> 1857</p>
-                    </div>
-                    <div class="mt-6 pt-6 border-t border-gray-200">
-                        <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-red-100 text-red-800">
-                            Retail Banking
-                        </span>
-                    </div>
-                </div>
-
-                <!-- Revolut -->
-                <div class="bg-white rounded-xl shadow-lg border border-gray-200 p-8 text-center">
-                    <div class="w-20 h-20 bg-purple-100 rounded-full flex items-center justify-center mx-auto mb-6">
-                        <svg class="w-10 h-10 text-purple-600" fill="currentColor" viewBox="0 0 24 24">
-                            <path d="M12 2L2 7v10c0 5.55 3.84 9.74 9 11 5.16-1.26 9-5.45 9-11V7l-10-5z"/>
-                        </svg>
-                    </div>
-                    <h3 class="text-xl font-bold text-gray-900 mb-2">Revolut Bank</h3>
-                    <p class="text-gray-600 mb-4">Lithuanian Banking License</p>
-                    <div class="space-y-2 text-sm text-gray-600">
-                        <p><strong>License:</strong> Full Banking License</p>
-                        <p><strong>Deposit Protection:</strong> €100,000</p>
-                        <p><strong>Country:</strong> Lithuania</p>
-                        <p><strong>Founded:</strong> 2015</p>
-                    </div>
-                    <div class="mt-6 pt-6 border-t border-gray-200">
-                        <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
-                            Digital Banking
-                        </span>
-                    </div>
-                </div>
-
-                <!-- N26 -->
-                <div class="bg-white rounded-xl shadow-lg border border-gray-200 p-8 text-center">
-                    <div class="w-20 h-20 bg-indigo-100 rounded-full flex items-center justify-center mx-auto mb-6">
-                        <svg class="w-10 h-10 text-indigo-600" fill="currentColor" viewBox="0 0 24 24">
-                            <path d="M12 2L2 7v10c0 5.55 3.84 9.74 9 11 5.16-1.26 9-5.45 9-11V7l-10-5z"/>
-                        </svg>
-                    </div>
-                    <h3 class="text-xl font-bold text-gray-900 mb-2">N26 Bank</h3>
-                    <p class="text-gray-600 mb-4">German Banking License</p>
-                    <div class="space-y-2 text-sm text-gray-600">
-                        <p><strong>License:</strong> Full Banking License</p>
-                        <p><strong>Deposit Protection:</strong> €100,000</p>
-                        <p><strong>Country:</strong> Germany</p>
-                        <p><strong>Founded:</strong> 2013</p>
-                    </div>
-                    <div class="mt-6 pt-6 border-t border-gray-200">
-                        <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-indigo-100 text-indigo-800">
-                            Mobile Banking
-                        </span>
-                    </div>
-                </div>
+                @endforeach
 
                 <!-- Future Partner Slot -->
-                <div class="bg-gray-50 rounded-xl border-2 border-dashed border-gray-300 p-8 text-center">
-                    <div class="w-20 h-20 bg-gray-200 rounded-full flex items-center justify-center mx-auto mb-6">
-                        <svg class="w-10 h-10 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <div class="card-feature text-center !p-8 !border-2 !border-dashed !border-slate-200 !bg-slate-50/50 animate-on-scroll stagger-6">
+                    <div class="w-16 h-16 bg-slate-100 rounded-full flex items-center justify-center mx-auto mb-5">
+                        <svg class="w-8 h-8 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"/>
                         </svg>
                     </div>
-                    <h3 class="text-xl font-bold text-gray-500 mb-2">Your Bank Next?</h3>
-                    <p class="text-gray-400 mb-4">Partnership Opportunities</p>
-                    <p class="text-sm text-gray-500">
-                        We're always looking to expand our network of banking partners to provide better coverage and security.
+                    <h3 class="font-display text-xl font-bold text-slate-400 mb-1">Your Bank Next?</h3>
+                    <p class="text-sm text-slate-400 mb-4">Partnership Opportunities</p>
+                    <p class="text-sm text-slate-500 mb-5">
+                        We're expanding our network of banking partners for better coverage and security.
                     </p>
-                    <div class="mt-6">
-                        <a href="{{ route('support.contact') }}" class="text-blue-600 hover:text-blue-800 font-medium">
-                            Partner With Us →
-                        </a>
-                    </div>
+                    <a href="{{ route('support.contact') }}" class="text-blue-600 font-semibold text-sm hover:text-blue-700 transition">
+                        Partner With Us &rarr;
+                    </a>
                 </div>
             </div>
         </div>
+    </section>
 
-        <!-- Benefits Section -->
-        <div class="bg-gray-50 py-24">
-            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-                <div class="text-center mb-16">
-                    <h2 class="text-3xl font-bold text-gray-900">Why Multi-Bank Distribution?</h2>
-                    <p class="mt-4 text-xl text-gray-600">Maximum security through diversification</p>
+    <!-- Why Multi-Bank -->
+    <section class="py-24 bg-slate-50/50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="text-center mb-14 animate-on-scroll">
+                <h2 class="font-display text-3xl md:text-4xl font-bold text-slate-900 mb-4">Why Multi-Bank Distribution?</h2>
+                <p class="text-lg text-slate-500">Maximum security through diversification</p>
+            </div>
+
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6 animate-on-scroll stagger-1">
+                @php
+                    $benefits = [
+                        ['title' => 'Enhanced Security', 'desc' => 'Funds never concentrated in a single institution, reducing risk and increasing protection.', 'color' => 'teal', 'icon' => 'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z'],
+                        ['title' => 'Higher Insurance Coverage', 'desc' => 'Up to €500,000 total deposit protection across multiple banks, far exceeding single-bank limits.', 'color' => 'blue', 'icon' => 'M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1'],
+                        ['title' => 'Improved Uptime', 'desc' => 'If one bank experiences issues, other accounts remain fully operational, ensuring continuous access.', 'color' => 'amber', 'icon' => 'M13 10V3L4 14h7v7l9-11h-7z'],
+                    ];
+                @endphp
+
+                @foreach($benefits as $b)
+                <div class="card-feature text-center !p-8">
+                    <div class="icon-box-lg bg-{{ $b['color'] }}-50 mx-auto mb-5">
+                        <svg class="w-6 h-6 text-{{ $b['color'] }}-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="{{ $b['icon'] }}"/></svg>
+                    </div>
+                    <h3 class="font-display text-xl font-bold text-slate-900 mb-3">{{ $b['title'] }}</h3>
+                    <p class="text-slate-500 leading-relaxed">{{ $b['desc'] }}</p>
                 </div>
-
-                <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
-                    <div class="text-center">
-                        <div class="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-6">
-                            <svg class="w-8 h-8 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/>
-                            </svg>
-                        </div>
-                        <h3 class="text-xl font-bold text-gray-900 mb-4">Enhanced Security</h3>
-                        <p class="text-gray-600">Your funds are never concentrated in a single institution, reducing risk and increasing protection.</p>
-                    </div>
-
-                    <div class="text-center">
-                        <div class="w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-6">
-                            <svg class="w-8 h-8 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1"/>
-                            </svg>
-                        </div>
-                        <h3 class="text-xl font-bold text-gray-900 mb-4">Higher Insurance Coverage</h3>
-                        <p class="text-gray-600">Up to €500,000 total deposit protection across multiple banks, far exceeding single-bank limits.</p>
-                    </div>
-
-                    <div class="text-center">
-                        <div class="w-16 h-16 bg-purple-100 rounded-full flex items-center justify-center mx-auto mb-6">
-                            <svg class="w-8 h-8 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
-                            </svg>
-                        </div>
-                        <h3 class="text-xl font-bold text-gray-900 mb-4">Improved Uptime</h3>
-                        <p class="text-gray-600">If one bank experiences issues, your other accounts remain fully operational, ensuring continuous access.</p>
-                    </div>
-                </div>
+                @endforeach
             </div>
         </div>
+    </section>
 
-        <!-- Regulatory Compliance -->
-        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
-            <div class="text-center mb-16">
-                <h2 class="text-3xl font-bold text-gray-900">Regulatory Compliance</h2>
-                <p class="mt-4 text-xl text-gray-600">All our partners maintain the highest regulatory standards</p>
+    <!-- Regulatory Compliance -->
+    <section class="py-24 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="text-center mb-14 animate-on-scroll">
+                <h2 class="font-display text-3xl md:text-4xl font-bold text-slate-900 mb-4">Regulatory Compliance</h2>
+                <p class="text-lg text-slate-500">All partners maintain the highest regulatory standards</p>
             </div>
 
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
-                <div class="text-center">
-                    <div class="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center mx-auto mb-4">
-                        <svg class="w-6 h-6 text-blue-600" fill="currentColor" viewBox="0 0 24 24">
-                            <path d="M12 2L2 7v10c0 5.55 3.84 9.74 9 11 5.16-1.26 9-5.45 9-11V7l-10-5z"/>
-                        </svg>
-                    </div>
-                    <h3 class="text-lg font-semibold text-gray-900">EU Licensed</h3>
-                    <p class="text-gray-600 text-sm">All partners hold valid EU banking or EMI licenses</p>
-                </div>
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-6 animate-on-scroll stagger-1">
+                @php
+                    $compliance = [
+                        ['title' => 'EU Licensed', 'desc' => 'Valid EU banking or EMI licenses', 'color' => 'blue', 'icon' => 'M12 1L3 5v6c0 5.55 3.84 9.74 9 11 5.16-1.26 9-5.45 9-11V5l-9-4z'],
+                        ['title' => 'GDPR Compliant', 'desc' => 'European data protection compliance', 'color' => 'teal', 'icon' => 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z'],
+                        ['title' => 'AML/KYC', 'desc' => 'Anti-money laundering procedures', 'color' => 'amber', 'icon' => 'M12 1L3 5v6c0 5.55 3.84 9.74 9 11 5.16-1.26 9-5.45 9-11V5l-9-4z'],
+                        ['title' => 'PCI DSS', 'desc' => 'Payment card data security', 'color' => 'slate', 'icon' => 'M12 1L3 5v6c0 5.55 3.84 9.74 9 11 5.16-1.26 9-5.45 9-11V5l-9-4z'],
+                    ];
+                @endphp
 
-                <div class="text-center">
-                    <div class="w-12 h-12 bg-green-100 rounded-lg flex items-center justify-center mx-auto mb-4">
-                        <svg class="w-6 h-6 text-green-600" fill="currentColor" viewBox="0 0 24 24">
-                            <path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
-                        </svg>
+                @foreach($compliance as $c)
+                <div class="card-feature text-center !p-6">
+                    <div class="icon-box bg-{{ $c['color'] }}-50 mx-auto mb-3">
+                        <svg class="w-5 h-5 text-{{ $c['color'] }}-600" fill="currentColor" viewBox="0 0 24 24"><path d="{{ $c['icon'] }}"/></svg>
                     </div>
-                    <h3 class="text-lg font-semibold text-gray-900">GDPR Compliant</h3>
-                    <p class="text-gray-600 text-sm">Full compliance with European data protection regulations</p>
+                    <h3 class="font-display text-sm font-bold text-slate-900 mb-1">{{ $c['title'] }}</h3>
+                    <p class="text-xs text-slate-500">{{ $c['desc'] }}</p>
                 </div>
-
-                <div class="text-center">
-                    <div class="w-12 h-12 bg-yellow-100 rounded-lg flex items-center justify-center mx-auto mb-4">
-                        <svg class="w-6 h-6 text-yellow-600" fill="currentColor" viewBox="0 0 24 24">
-                            <path d="M12 1L3 5v6c0 5.55 3.84 9.74 9 11 5.16-1.26 9-5.45 9-11V5l-9-4z"/>
-                        </svg>
-                    </div>
-                    <h3 class="text-lg font-semibold text-gray-900">AML/KYC</h3>
-                    <p class="text-gray-600 text-sm">Strict anti-money laundering and know-your-customer procedures</p>
-                </div>
-
-                <div class="text-center">
-                    <div class="w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center mx-auto mb-4">
-                        <svg class="w-6 h-6 text-purple-600" fill="currentColor" viewBox="0 0 24 24">
-                            <path d="M12 1L3 5v6c0 5.55 3.84 9.74 9 11 5.16-1.26 9-5.45 9-11V5l-9-4z"/>
-                        </svg>
-                    </div>
-                    <h3 class="text-lg font-semibold text-gray-900">PCI DSS</h3>
-                    <p class="text-gray-600 text-sm">Payment card industry data security standards compliance</p>
-                </div>
+                @endforeach
             </div>
         </div>
+    </section>
 
-        <!-- CTA Section -->
-        <div class="bg-blue-900 py-16">
-            <div class="max-w-4xl mx-auto text-center px-4 sm:px-6 lg:px-8">
-                <h2 class="text-3xl font-bold text-white mb-4">Ready to experience multi-bank security?</h2>
-                <p class="text-xl text-blue-100 mb-8">Join FinAegis and benefit from our trusted network of banking partners.</p>
-                <a href="{{ route('register') }}" class="bg-white text-blue-900 px-8 py-3 rounded-lg font-semibold hover:bg-gray-100 transition duration-200">
-                    Get Started Today
+    <!-- CTA -->
+    <section class="bg-fa-navy relative overflow-hidden">
+        <div class="absolute inset-0 bg-dot-pattern"></div>
+        <div class="relative max-w-4xl mx-auto text-center px-4 sm:px-6 lg:px-8 py-20">
+            <h2 class="font-display text-3xl md:text-4xl font-bold text-white mb-4">Experience Multi-Bank Security</h2>
+            <p class="text-lg text-slate-400 mb-10 max-w-2xl mx-auto">
+                Join FinAegis and benefit from distributed fund protection across our trusted network of banking partners.
+            </p>
+            <div class="flex flex-col sm:flex-row gap-4 justify-center">
+                <a href="{{ route('register') }}" class="btn-primary px-8 py-4 text-lg">
+                    Get Started
+                </a>
+                <a href="{{ route('compliance') }}" class="btn-outline px-8 py-4 text-lg">
+                    View Compliance
                 </a>
             </div>
         </div>
-    </div>
-</x-guest-layout>
+    </section>
+@endsection

--- a/resources/views/policy.blade.php
+++ b/resources/views/policy.blade.php
@@ -1,13 +1,41 @@
-<x-guest-layout>
-    <div class="pt-4 bg-gray-100 dark:bg-gray-900">
-        <div class="min-h-screen flex flex-col items-center pt-6 sm:pt-0">
-            <div>
-                <x-authentication-card-logo />
-            </div>
+@extends('layouts.public')
 
-            <div class="w-full sm:max-w-2xl mt-6 p-6 bg-white dark:bg-gray-800 shadow-md overflow-hidden sm:rounded-lg prose dark:prose-invert">
+@section('title', 'Privacy Policy - FinAegis')
+
+@section('seo')
+    @include('partials.seo', [
+        'title' => 'Privacy Policy - FinAegis',
+        'description' => 'FinAegis privacy policy. Learn how we collect, use, and protect your personal data.',
+        'keywords' => 'FinAegis privacy policy, data protection, GDPR, personal data',
+    ])
+
+    <x-schema type="breadcrumb" :data="[
+        ['name' => 'Home', 'url' => url('/')],
+        ['name' => 'Privacy Policy', 'url' => url('/privacy-policy')]
+    ]" />
+@endsection
+
+@section('content')
+    <!-- Hero Section -->
+    <section class="bg-fa-navy relative overflow-hidden">
+        <div class="absolute inset-0 bg-grid-pattern"></div>
+        <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 lg:py-20">
+            <div class="text-center">
+                <h1 class="font-display text-4xl lg:text-5xl font-extrabold text-white tracking-tight mb-4">Privacy <span class="text-gradient">Policy</span></h1>
+                <p class="text-slate-400 max-w-xl mx-auto">
+                    How we collect, use, and protect your personal data.
+                </p>
+            </div>
+        </div>
+        <div class="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-blue-500/20 to-transparent"></div>
+    </section>
+
+    <!-- Content -->
+    <section class="py-16 bg-white">
+        <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="prose prose-slate prose-headings:font-display prose-headings:font-bold prose-a:text-blue-600 prose-a:no-underline hover:prose-a:underline max-w-none">
                 {!! $policy !!}
             </div>
         </div>
-    </div>
-</x-guest-layout>
+    </section>
+@endsection

--- a/resources/views/status.blade.php
+++ b/resources/views/status.blade.php
@@ -8,83 +8,90 @@
         'description' => 'Real-time status of FinAegis platform services and infrastructure.',
         'keywords' => 'FinAegis status, system status, platform uptime, service availability',
     ])
+
+    <x-schema type="breadcrumb" :data="[
+        ['name' => 'Home', 'url' => url('/')],
+        ['name' => 'System Status', 'url' => url('/status')]
+    ]" />
 @endsection
 
 @section('content')
-    <div class="bg-gray-50 min-h-screen">
-        <!-- Status Header -->
-        <div class="bg-white border-b border-gray-200">
-            <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-                <div class="flex items-center justify-between">
-                    <div class="flex items-center gap-4">
-                        @if($status['overall'] === 'operational')
-                            <div class="w-10 h-10 bg-green-500 rounded-full flex items-center justify-center">
-                                <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
-                                </svg>
-                            </div>
-                        @elseif($status['overall'] === 'degraded')
-                            <div class="w-10 h-10 bg-yellow-500 rounded-full flex items-center justify-center">
-                                <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01"></path>
-                                </svg>
-                            </div>
-                        @else
-                            <div class="w-10 h-10 bg-red-500 rounded-full flex items-center justify-center">
-                                <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
-                                </svg>
-                            </div>
-                        @endif
-                        <div>
-                            <h1 class="text-2xl font-bold text-gray-900">
-                                @if($status['overall'] === 'operational')
-                                    All Systems Operational
-                                @elseif($status['overall'] === 'degraded')
-                                    Some Systems Degraded
-                                @else
-                                    Major Outage
-                                @endif
-                            </h1>
-                            <p class="text-sm text-gray-500">Updated {{ $status['last_checked']->diffForHumans() }}</p>
+    <!-- Hero / Status Header -->
+    <section class="bg-fa-navy relative overflow-hidden">
+        <div class="absolute inset-0 bg-grid-pattern"></div>
+        <div class="relative max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16 lg:py-20">
+            <div class="flex flex-col sm:flex-row items-center justify-between gap-6">
+                <div class="flex items-center gap-4">
+                    @if($status['overall'] === 'operational')
+                        <div class="w-12 h-12 bg-emerald-500/20 border border-emerald-500/30 rounded-xl flex items-center justify-center">
+                            <svg class="w-6 h-6 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+                            </svg>
                         </div>
+                    @elseif($status['overall'] === 'degraded')
+                        <div class="w-12 h-12 bg-amber-500/20 border border-amber-500/30 rounded-xl flex items-center justify-center">
+                            <svg class="w-6 h-6 text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01"/>
+                            </svg>
+                        </div>
+                    @else
+                        <div class="w-12 h-12 bg-red-500/20 border border-red-500/30 rounded-xl flex items-center justify-center">
+                            <svg class="w-6 h-6 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                            </svg>
+                        </div>
+                    @endif
+                    <div>
+                        <h1 class="font-display text-2xl lg:text-3xl font-extrabold text-white">
+                            @if($status['overall'] === 'operational')
+                                All Systems Operational
+                            @elseif($status['overall'] === 'degraded')
+                                Some Systems Degraded
+                            @else
+                                Major Outage
+                            @endif
+                        </h1>
+                        <p class="text-sm text-slate-400 mt-1">Updated {{ $status['last_checked']->diffForHumans() }}</p>
                     </div>
-                    <div class="hidden sm:flex items-center gap-6 text-sm text-gray-500">
-                        <div class="text-center">
-                            <div class="text-lg font-bold text-gray-900">{{ $uptime['percentage'] }}%</div>
-                            <div>Uptime</div>
-                        </div>
-                        <div class="text-center">
-                            <div class="text-lg font-bold text-gray-900">{{ $status['response_time'] }}ms</div>
-                            <div>Avg Response</div>
-                        </div>
+                </div>
+                <div class="flex items-center gap-8">
+                    <div class="text-center">
+                        <div class="font-display text-2xl font-bold text-white">{{ $uptime['percentage'] }}%</div>
+                        <div class="text-xs text-slate-400 uppercase tracking-wider">Uptime</div>
+                    </div>
+                    <div class="text-center">
+                        <div class="font-display text-2xl font-bold text-white">{{ $status['response_time'] }}ms</div>
+                        <div class="text-xs text-slate-400 uppercase tracking-wider">Avg Response</div>
                     </div>
                 </div>
             </div>
         </div>
+        <div class="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-blue-500/20 to-transparent"></div>
+    </section>
 
-        <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-            <!-- Services grouped by category -->
+    <!-- Services -->
+    <section class="py-12 bg-white">
+        <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
             @php
                 $grouped = collect($services)->groupBy('category');
             @endphp
 
             @foreach($grouped as $category => $categoryServices)
-            <div class="mb-6">
-                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3 px-1">{{ $category }}</h2>
-                <div class="bg-white rounded-lg border border-gray-200 divide-y divide-gray-100">
+            <div class="mb-8 animate-on-scroll">
+                <h2 class="font-display text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3 px-1">{{ $category }}</h2>
+                <div class="card-feature !p-0 overflow-hidden divide-y divide-slate-100">
                     @foreach($categoryServices as $service)
                     <div class="px-5 py-4 flex items-center justify-between">
                         <div class="flex items-center gap-3">
-                            <div class="w-2.5 h-2.5 rounded-full {{ $service['status'] === 'operational' ? 'bg-green-500' : ($service['status'] === 'degraded' ? 'bg-yellow-500' : 'bg-red-500') }}"></div>
+                            <div class="w-2.5 h-2.5 rounded-full {{ $service['status'] === 'operational' ? 'bg-emerald-500' : ($service['status'] === 'degraded' ? 'bg-amber-500' : 'bg-red-500') }}"></div>
                             <div>
-                                <span class="text-sm font-medium text-gray-900">{{ $service['name'] }}</span>
-                                <span class="text-sm text-gray-400 ml-2 hidden sm:inline">{{ $service['description'] }}</span>
+                                <span class="text-sm font-medium text-slate-900">{{ $service['name'] }}</span>
+                                <span class="text-sm text-slate-400 ml-2 hidden sm:inline">{{ $service['description'] }}</span>
                             </div>
                         </div>
                         <div class="flex items-center gap-4">
-                            <span class="text-xs text-gray-400 hidden sm:inline">{{ $service['uptime'] }} uptime</span>
-                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{ $service['status'] === 'operational' ? 'bg-green-50 text-green-700' : ($service['status'] === 'degraded' ? 'bg-yellow-50 text-yellow-700' : 'bg-red-50 text-red-700') }}">
+                            <span class="text-xs text-slate-400 hidden sm:inline font-mono">{{ $service['uptime'] }}</span>
+                            <span class="badge {{ $service['status'] === 'operational' ? 'badge-success' : ($service['status'] === 'degraded' ? 'badge-warning' : 'badge-accent') }}">
                                 {{ ucfirst($service['status']) }}
                             </span>
                         </div>
@@ -95,18 +102,18 @@
             @endforeach
 
             <!-- System Health Checks -->
-            <div class="mb-6">
-                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3 px-1">System Health</h2>
-                <div class="bg-white rounded-lg border border-gray-200">
-                    <div class="grid grid-cols-1 sm:grid-cols-2 divide-y sm:divide-y-0 sm:divide-x divide-gray-100">
+            <div class="mb-8 animate-on-scroll">
+                <h2 class="font-display text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3 px-1">System Health</h2>
+                <div class="card-feature !p-0 overflow-hidden">
+                    <div class="grid grid-cols-1 sm:grid-cols-2 divide-y sm:divide-y-0 sm:divide-x divide-slate-100">
                         @foreach($status['checks'] as $check => $result)
                         <div class="px-5 py-4 flex items-start gap-3">
                             @if($result['status'] === 'operational')
-                                <svg class="w-5 h-5 text-green-500 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                                <svg class="w-5 h-5 text-emerald-500 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
                                     <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
                                 </svg>
                             @elseif($result['status'] === 'degraded')
-                                <svg class="w-5 h-5 text-yellow-500 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                                <svg class="w-5 h-5 text-amber-500 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
                                     <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
                                 </svg>
                             @else
@@ -115,10 +122,10 @@
                                 </svg>
                             @endif
                             <div>
-                                <div class="text-sm font-medium text-gray-900 capitalize">{{ str_replace('_', ' ', $check) }}</div>
-                                <div class="text-xs text-gray-500">{{ $result['message'] }}</div>
+                                <div class="font-display text-sm font-medium text-slate-900 capitalize">{{ str_replace('_', ' ', $check) }}</div>
+                                <div class="text-xs text-slate-500">{{ $result['message'] }}</div>
                                 @if(isset($result['response_time']))
-                                    <div class="text-xs text-gray-400 mt-0.5">{{ $result['response_time'] }}ms</div>
+                                    <div class="text-xs text-slate-400 mt-0.5 font-mono">{{ $result['response_time'] }}ms</div>
                                 @endif
                             </div>
                         </div>
@@ -129,15 +136,15 @@
 
             <!-- Recent Incidents -->
             @if(count($incidents) > 0)
-            <div class="mb-6">
-                <h2 class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3 px-1">Recent Incidents</h2>
-                <div class="bg-white rounded-lg border border-gray-200 divide-y divide-gray-100">
+            <div class="mb-8 animate-on-scroll">
+                <h2 class="font-display text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3 px-1">Recent Incidents</h2>
+                <div class="card-feature !p-0 overflow-hidden divide-y divide-slate-100">
                     @foreach($incidents as $incident)
                     <div class="px-5 py-4">
                         <div class="flex items-start justify-between mb-2">
                             <div>
-                                <h3 class="text-sm font-medium text-gray-900">{{ $incident['title'] }}</h3>
-                                <p class="text-xs text-gray-500 mt-0.5">
+                                <h3 class="font-display text-sm font-medium text-slate-900">{{ $incident['title'] }}</h3>
+                                <p class="text-xs text-slate-500 mt-0.5">
                                     {{ $incident['started_at']->format('M d, Y H:i') }}
                                     @if($incident['resolved_at'])
                                         &mdash; {{ $incident['resolved_at']->format('M d, Y H:i') }}
@@ -146,18 +153,17 @@
                                     @endif
                                 </p>
                             </div>
-                            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium
-                                {{ $incident['status'] === 'resolved' ? 'bg-green-50 text-green-700' : ($incident['status'] === 'in_progress' ? 'bg-yellow-50 text-yellow-700' : 'bg-red-50 text-red-700') }}">
+                            <span class="badge {{ $incident['status'] === 'resolved' ? 'badge-success' : ($incident['status'] === 'in_progress' ? 'badge-warning' : 'badge-accent') }}">
                                 {{ ucfirst(str_replace('_', ' ', $incident['status'])) }}
                             </span>
                         </div>
 
                         @if(count($incident['updates']) > 0)
-                        <div class="ml-4 border-l-2 border-gray-200 pl-4 mt-3 space-y-2">
+                        <div class="ml-4 border-l-2 border-slate-200 pl-4 mt-3 space-y-2">
                             @foreach($incident['updates'] as $update)
                             <div>
-                                <p class="text-xs text-gray-600">{{ $update['message'] }}</p>
-                                <p class="text-xs text-gray-400">{{ $update['created_at']->format('M d, H:i') }}</p>
+                                <p class="text-xs text-slate-600">{{ $update['message'] }}</p>
+                                <p class="text-xs text-slate-400">{{ $update['created_at']->format('M d, H:i') }}</p>
                             </div>
                             @endforeach
                         </div>
@@ -169,12 +175,12 @@
             @endif
 
             <!-- Footer -->
-            <div class="text-center py-8">
-                <p class="text-sm text-gray-500">
+            <div class="text-center py-6">
+                <p class="text-sm text-slate-500">
                     Programmatic access:
-                    <a href="{{ route('status.api') }}" class="text-indigo-600 hover:text-indigo-700 font-medium">Status API</a>
+                    <a href="{{ route('status.api') }}" class="text-blue-600 hover:text-blue-700 font-semibold">Status API</a>
                 </p>
             </div>
         </div>
-    </div>
+    </section>
 @endsection

--- a/resources/views/terms.blade.php
+++ b/resources/views/terms.blade.php
@@ -1,13 +1,41 @@
-<x-guest-layout>
-    <div class="pt-4 bg-gray-100 dark:bg-gray-900">
-        <div class="min-h-screen flex flex-col items-center pt-6 sm:pt-0">
-            <div>
-                <x-authentication-card-logo />
-            </div>
+@extends('layouts.public')
 
-            <div class="w-full sm:max-w-2xl mt-6 p-6 bg-white dark:bg-gray-800 shadow-md overflow-hidden sm:rounded-lg prose dark:prose-invert">
+@section('title', 'Terms of Service - FinAegis')
+
+@section('seo')
+    @include('partials.seo', [
+        'title' => 'Terms of Service - FinAegis',
+        'description' => 'FinAegis terms of service. Review the terms governing your use of our platform.',
+        'keywords' => 'FinAegis terms of service, terms and conditions, user agreement',
+    ])
+
+    <x-schema type="breadcrumb" :data="[
+        ['name' => 'Home', 'url' => url('/')],
+        ['name' => 'Terms of Service', 'url' => url('/terms-of-service')]
+    ]" />
+@endsection
+
+@section('content')
+    <!-- Hero Section -->
+    <section class="bg-fa-navy relative overflow-hidden">
+        <div class="absolute inset-0 bg-grid-pattern"></div>
+        <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 lg:py-20">
+            <div class="text-center">
+                <h1 class="font-display text-4xl lg:text-5xl font-extrabold text-white tracking-tight mb-4">Terms of <span class="text-gradient">Service</span></h1>
+                <p class="text-slate-400 max-w-xl mx-auto">
+                    The terms governing your use of the FinAegis platform.
+                </p>
+            </div>
+        </div>
+        <div class="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-blue-500/20 to-transparent"></div>
+    </section>
+
+    <!-- Content -->
+    <section class="py-16 bg-white">
+        <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="prose prose-slate prose-headings:font-display prose-headings:font-bold prose-a:text-blue-600 prose-a:no-underline hover:prose-a:underline max-w-none">
                 {!! $terms !!}
             </div>
         </div>
-    </div>
-</x-guest-layout>
+    </section>
+@endsection


### PR DESCRIPTION
## Summary
- **compliance.blade.php**: Full redesign from old purple gradient to FinAegis DS v2 — navy hero, card-feature/card-stat/badge components, animate-on-scroll, font-display typography
- **partners.blade.php**: Switch from `<x-guest-layout>` to `@extends('layouts.public')` for proper nav/footer, complete visual overhaul with DS v2 components
- **policy.blade.php** & **terms.blade.php**: Switch from bare `<x-guest-layout>` to branded public layout with navy hero and Tailwind prose styling
- **status.blade.php**: Add navy hero with status indicator, uptime/response stats, migrate service lists to DS v2 card-feature and badge components
- **features/index.blade.php**: Align notice section with DS v2 card-stat pattern and badge components

### Before
- compliance & partners used old layouts/styles (generic purple gradients, `<x-guest-layout>`, no animations)
- policy & terms had no branding (bare card with logo)
- status page had no hero or FinAegis branding

### After
- All inner pages use consistent FinAegis Design System v2 (navy heroes, font-display, card-feature, animate-on-scroll, badges)
- Proper public layout with nav and footer on all pages
- Cohesive visual language across the entire site

## Test plan
- [x] `php artisan view:cache` compiles all templates successfully
- [x] All routes verified: `/compliance`, `/partners`, `/privacy-policy`, `/terms-of-service`, `/status`, `/features`
- [x] Existing HTTP tests pass (3 pre-existing failures in EmailVerificationControllerTest unrelated to this PR)
- [ ] Visual QA: verify each page renders correctly in browser

Generated with [Claude Code](https://claude.com/claude-code)