### PR TITLE
fix: support credential_id lookup in passkey authenticate

### DIFF
--- a/app/Http/Controllers/Api/Auth/PasskeyController.php
+++ b/app/Http/Controllers/Api/Auth/PasskeyController.php
@@ -290,7 +290,15 @@ class PasskeyController extends Controller
     )]
     public function authenticate(PasskeyAuthenticateRequest $request): JsonResponse
     {
-        $device = $this->deviceService->findByDeviceId($request->device_id);
+        // Standard WebAuthn: look up device by credential_id (no device_id needed).
+        // Legacy flow: look up by device_id directly.
+        if ($request->device_id) {
+            $device = $this->deviceService->findByDeviceId($request->device_id);
+        } else {
+            $device = MobileDevice::where('passkey_credential_id', $request->credential_id)
+                ->where('passkey_enabled', true)
+                ->first();
+        }
 
         if (! $device) {
             return response()->json([

--- a/app/Http/Requests/Mobile/PasskeyAuthenticateRequest.php
+++ b/app/Http/Requests/Mobile/PasskeyAuthenticateRequest.php
@@ -7,7 +7,10 @@ namespace App\Http\Requests\Mobile;
 /**
  * Form request for verifying passkey/WebAuthn authentication.
  *
- * @property string $device_id
+ * device_id is optional: when absent, the device is looked up by credential_id
+ * (standard WebAuthn flow where the RP identifies the key by credential).
+ *
+ * @property string|null $device_id
  * @property string $challenge       The challenge string issued by the server
  * @property string $credential_id   Base64url-encoded credential ID
  * @property string $authenticator_data  Base64url-encoded authenticator data
@@ -27,7 +30,7 @@ class PasskeyAuthenticateRequest extends BaseMobileRequest
     public function rules(): array
     {
         return [
-            'device_id'          => ['required', 'string'],
+            'device_id'          => ['nullable', 'string'],
             'challenge'          => ['required', 'string'],
             'credential_id'      => ['required', 'string'],
             'authenticator_data' => ['required', 'string'],
@@ -42,7 +45,6 @@ class PasskeyAuthenticateRequest extends BaseMobileRequest
     public function messages(): array
     {
         return [
-            'device_id.required'          => 'Device ID is required.',
             'challenge.required'          => 'Challenge is required.',
             'credential_id.required'      => 'Credential ID is required.',
             'authenticator_data.required' => 'Authenticator data is required.',


### PR DESCRIPTION
## Summary
- Make `device_id` optional in `PasskeyAuthenticateRequest` (nullable instead of required)
- When `device_id` is absent, look up the device by `credential_id` — standard WebAuthn pattern where the RP identifies the key from the assertion's credential ID
- Backward compatible: existing flows that send `device_id` continue to work unchanged

## Context
The mobile app's passkey login flow sends `credential_id` from `navigator.credentials.get()` but has no way to obtain the server-side `device_id`. Standard WebAuthn relying parties identify devices by credential ID, not by a separate device identifier.

## Test plan
- [ ] Existing passkey auth with `device_id` still works
- [ ] New passkey auth with only `credential_id` (no `device_id`) finds the correct device
- [ ] Returns 404 when `credential_id` doesn't match any device

🤖 Generated with [Claude Code](https://claude.com/claude-code)