### PR TITLE
fix: replace hardcoded FinAegis in email subjects

### DIFF
--- a/app/Domain/Cgo/Mail/CgoBankTransferInstructions.php
+++ b/app/Domain/Cgo/Mail/CgoBankTransferInstructions.php
@@ -26,7 +26,7 @@ class CgoBankTransferInstructions extends Mailable
     public function envelope(): Envelope
     {
         return new Envelope(
-            subject: 'CGO Bank Transfer Instructions - FinAegis',
+            subject: 'CGO Bank Transfer Instructions - ' . config('brand.name'),
         );
     }
 

--- a/app/Domain/Cgo/Mail/CgoCryptoPaymentInstructions.php
+++ b/app/Domain/Cgo/Mail/CgoCryptoPaymentInstructions.php
@@ -26,7 +26,7 @@ class CgoCryptoPaymentInstructions extends Mailable
     public function envelope(): Envelope
     {
         return new Envelope(
-            subject: 'CGO Crypto Payment Instructions - FinAegis',
+            subject: 'CGO Crypto Payment Instructions - ' . config('brand.name'),
         );
     }
 

--- a/app/Domain/Cgo/Mail/CgoInvestmentReceived.php
+++ b/app/Domain/Cgo/Mail/CgoInvestmentReceived.php
@@ -30,7 +30,7 @@ class CgoInvestmentReceived extends Mailable
     public function envelope(): Envelope
     {
         return new Envelope(
-            subject: 'CGO Investment Confirmation - FinAegis',
+            subject: 'CGO Investment Confirmation - ' . config('brand.name'),
         );
     }
 

--- a/app/Domain/Cgo/Mail/CgoNotificationReceived.php
+++ b/app/Domain/Cgo/Mail/CgoNotificationReceived.php
@@ -29,7 +29,7 @@ class CgoNotificationReceived extends Mailable
     public function envelope(): Envelope
     {
         return new Envelope(
-            subject: 'FinAegis CGO - Early Access Confirmed',
+            subject: config('brand.name') . ' CGO - Early Access Confirmed',
         );
     }
 

--- a/app/Domain/Contact/Mail/ContactFormSubmission.php
+++ b/app/Domain/Contact/Mail/ContactFormSubmission.php
@@ -28,7 +28,7 @@ class ContactFormSubmission extends Mailable
     public function envelope(): Envelope
     {
         return new Envelope(
-            subject: '[FinAegis Contact] ' . ucfirst($this->submission->priority) . ' - ' . $this->submission->subject_label,
+            subject: '[' . config('brand.name') . ' Contact] ' . ucfirst($this->submission->priority) . ' - ' . $this->submission->subject_label,
             replyTo: $this->submission->email,
         );
     }

--- a/app/Domain/Newsletter/Mail/SubscriberWelcome.php
+++ b/app/Domain/Newsletter/Mail/SubscriberWelcome.php
@@ -30,13 +30,13 @@ class SubscriberWelcome extends Mailable implements ShouldQueue
     public function envelope(): Envelope
     {
         $sourceText = match ($this->subscriber->source) {
-            Subscriber::SOURCE_BLOG       => 'FinAegis Blog',
+            Subscriber::SOURCE_BLOG       => config('brand.name') . ' Blog',
             Subscriber::SOURCE_CGO        => 'CGO Early Access',
             Subscriber::SOURCE_INVESTMENT => 'Investment Platform',
             Subscriber::SOURCE_FOOTER     => 'Newsletter',
             Subscriber::SOURCE_CONTACT    => 'Contact Form',
             Subscriber::SOURCE_PARTNER    => 'Partner Program',
-            default                       => 'FinAegis Platform',
+            default                       => config('brand.name'),
         };
 
         return new Envelope(

--- a/app/Notifications/AgentReputationChanged.php
+++ b/app/Notifications/AgentReputationChanged.php
@@ -79,7 +79,7 @@ class AgentReputationChanged extends Notification implements ShouldQueue
             ->line('- Change: ' . ($reputation['change'] ?? 0) . ' points')
             ->line('')
             ->action('View Agent Dashboard', url('/admin/agent-protocol'))
-            ->line('Thank you for using FinAegis!');
+            ->line('Thank you for using ' . config('brand.name') . '!');
     }
 
     /**


### PR DESCRIPTION
## Summary
- Replace 7 hardcoded "FinAegis" references in email subject lines and notification text with `config('brand.name')` for proper multi-brand support

## Files changed
| File | Change |
|------|--------|
| `app/Domain/Newsletter/Mail/SubscriberWelcome.php` | "FinAegis Blog" / "FinAegis Platform" → `config('brand.name')` |
| `app/Domain/Contact/Mail/ContactFormSubmission.php` | "[FinAegis Contact]" → `[config('brand.name') Contact]` |
| `app/Domain/Cgo/Mail/CgoInvestmentReceived.php` | "- FinAegis" → `config('brand.name')` |
| `app/Domain/Cgo/Mail/CgoNotificationReceived.php` | "FinAegis CGO" → `config('brand.name') CGO` |
| `app/Domain/Cgo/Mail/CgoBankTransferInstructions.php` | "- FinAegis" → `config('brand.name')` |
| `app/Domain/Cgo/Mail/CgoCryptoPaymentInstructions.php` | "- FinAegis" → `config('brand.name')` |
| `app/Notifications/AgentReputationChanged.php` | "Thank you for using FinAegis!" → dynamic |

## Test plan
- [ ] PHPStan passes (verified locally)
- [ ] Code style passes (verified locally)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)