### PR TITLE
feat: wallet WebSocket events + Alchemy webhook for push-based updates

### DIFF
--- a/app/Domain/Privacy/Events/Broadcast/PrivacyBalanceUpdated.php
+++ b/app/Domain/Privacy/Events/Broadcast/PrivacyBalanceUpdated.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Privacy\Events\Broadcast;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Broadcast when a user's shielded (privacy pool) balance changes.
+ *
+ * Fires alongside PrivacyOperationCompleted after shield/unshield/transfer.
+ * Mobile clients invalidate their shielded balance cache.
+ *
+ * Channel: private-privacy.{userId}
+ * Event name: privacy.balance_updated
+ */
+class PrivacyBalanceUpdated implements ShouldBroadcast
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly int $userId,
+        public readonly ?string $chainId = null,
+    ) {
+    }
+
+    /**
+     * @return array<int, PrivateChannel>
+     */
+    public function broadcastOn(): array
+    {
+        return [new PrivateChannel("privacy.{$this->userId}")];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'privacy.balance_updated';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        $data = [];
+        if ($this->chainId !== null) {
+            $data['chain_id'] = $this->chainId;
+        }
+
+        return $data;
+    }
+
+    public function broadcastWhen(): bool
+    {
+        return config('websocket.enabled', true);
+    }
+
+    public function broadcastConnection(): string
+    {
+        return config('websocket.queue.connection', 'redis');
+    }
+
+    public function broadcastQueue(): string
+    {
+        return config('websocket.queue.name', 'broadcasts');
+    }
+}

--- a/app/Domain/Wallet/Events/Broadcast/WalletBalanceUpdated.php
+++ b/app/Domain/Wallet/Events/Broadcast/WalletBalanceUpdated.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Wallet\Events\Broadcast;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Broadcast when a user's on-chain token balance changes.
+ *
+ * Mobile clients invalidate their cached balances and re-fetch on demand.
+ * This replaces the 60-second polling pattern with event-driven updates.
+ *
+ * Channel: private-wallet.{userId}
+ * Event name: wallet.balance_updated
+ */
+class WalletBalanceUpdated implements ShouldBroadcast
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly int $userId,
+        public readonly ?string $chainId = null,
+    ) {
+    }
+
+    /**
+     * @return array<int, PrivateChannel>
+     */
+    public function broadcastOn(): array
+    {
+        return [new PrivateChannel("wallet.{$this->userId}")];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'wallet.balance_updated';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        $data = [];
+        if ($this->chainId !== null) {
+            $data['chain_id'] = $this->chainId;
+        }
+
+        return $data;
+    }
+
+    public function broadcastWhen(): bool
+    {
+        return config('websocket.enabled', true);
+    }
+
+    public function broadcastConnection(): string
+    {
+        return config('websocket.queue.connection', 'redis');
+    }
+
+    public function broadcastQueue(): string
+    {
+        return config('websocket.queue.name', 'broadcasts');
+    }
+}

--- a/app/Domain/Wallet/Events/Broadcast/WalletStateChanged.php
+++ b/app/Domain/Wallet/Events/Broadcast/WalletStateChanged.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Wallet\Events\Broadcast;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Broadcast when a user's wallet state changes.
+ *
+ * Triggers: wallet activation, smart account deployment, recovery shard backup.
+ * Mobile clients invalidate wallet state cache and re-fetch on demand.
+ *
+ * Channel: private-wallet.{userId}
+ * Event name: wallet.state_changed
+ */
+class WalletStateChanged implements ShouldBroadcast
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly int $userId,
+    ) {
+    }
+
+    /**
+     * @return array<int, PrivateChannel>
+     */
+    public function broadcastOn(): array
+    {
+        return [new PrivateChannel("wallet.{$this->userId}")];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'wallet.state_changed';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        return [];
+    }
+
+    public function broadcastWhen(): bool
+    {
+        return config('websocket.enabled', true);
+    }
+
+    public function broadcastConnection(): string
+    {
+        return config('websocket.queue.connection', 'redis');
+    }
+
+    public function broadcastQueue(): string
+    {
+        return config('websocket.queue.name', 'broadcasts');
+    }
+}

--- a/app/Http/Controllers/Api/Privacy/PrivacyController.php
+++ b/app/Http/Controllers/Api/Privacy/PrivacyController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api\Privacy;
 
 use App\Domain\Privacy\Contracts\MerkleTreeServiceInterface;
+use App\Domain\Privacy\Events\Broadcast\PrivacyBalanceUpdated;
 use App\Domain\Privacy\Events\Broadcast\PrivacyOperationCompleted;
 use App\Domain\Privacy\Exceptions\CommitmentNotFoundException;
 use App\Domain\Privacy\Models\DelegatedProofJob;
@@ -772,6 +773,7 @@ class PrivacyController extends Controller
                 network: $validated['network'],
                 status: 'completed',
             );
+            PrivacyBalanceUpdated::dispatch($user->id, $validated['network']);
 
             return response()->json([
                 'success' => true,
@@ -862,6 +864,7 @@ class PrivacyController extends Controller
                 network: $validated['network'],
                 status: 'completed',
             );
+            PrivacyBalanceUpdated::dispatch($user->id, $validated['network']);
 
             return response()->json([
                 'success' => true,
@@ -956,6 +959,7 @@ class PrivacyController extends Controller
                 network: $validated['network'],
                 status: 'completed',
             );
+            PrivacyBalanceUpdated::dispatch($user->id, $validated['network']);
 
             return response()->json([
                 'success' => true,

--- a/app/Http/Controllers/Api/Relayer/SmartAccountController.php
+++ b/app/Http/Controllers/Api/Relayer/SmartAccountController.php
@@ -170,6 +170,9 @@ class SmartAccountController extends Controller
                 $validated['network']
             );
 
+            // Notify mobile that wallet state changed (new account created/deployed)
+            \App\Domain\Wallet\Events\Broadcast\WalletStateChanged::dispatch($user->id);
+
             return response()->json([
                 'success' => true,
                 'data'    => $account->toApiResponse(),

--- a/app/Http/Controllers/Api/Webhook/AlchemyWebhookController.php
+++ b/app/Http/Controllers/Api/Webhook/AlchemyWebhookController.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Webhook;
+
+use App\Domain\Account\Models\BlockchainAddress;
+use App\Domain\Wallet\Events\Broadcast\WalletBalanceUpdated;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Handle Alchemy Address Activity Webhooks.
+ *
+ * When a tracked wallet address receives or sends tokens, Alchemy pushes
+ * an event here. We identify the user by address and broadcast a
+ * WalletBalanceUpdated event so the mobile app invalidates its cache.
+ *
+ * This eliminates per-user polling and gives near-instant balance updates.
+ *
+ * @see https://docs.alchemy.com/reference/address-activity-webhook
+ */
+class AlchemyWebhookController extends Controller
+{
+    public function handle(Request $request): JsonResponse
+    {
+        // Verify webhook signature
+        if (! $this->verifySignature($request)) {
+            Log::warning('Alchemy webhook signature verification failed', [
+                'ip' => $request->ip(),
+            ]);
+
+            return response()->json(['error' => 'Invalid signature'], 401);
+        }
+
+        $payload = $request->all();
+        $webhookType = $payload['type'] ?? null;
+
+        if ($webhookType !== 'ADDRESS_ACTIVITY') {
+            return response()->json(['status' => 'ignored']);
+        }
+
+        $activities = $payload['event']['activity'] ?? [];
+        $network = $this->resolveNetwork($payload['event']['network'] ?? '');
+
+        $notifiedUsers = [];
+
+        foreach ($activities as $activity) {
+            $addresses = array_filter([
+                $activity['fromAddress'] ?? null,
+                $activity['toAddress'] ?? null,
+            ]);
+
+            foreach ($addresses as $address) {
+                $address = strtolower($address);
+
+                // Find the user who owns this address
+                $blockchainAddress = BlockchainAddress::where('address', $address)->first();
+                if ($blockchainAddress === null || $blockchainAddress->user === null) {
+                    continue;
+                }
+
+                $userId = $blockchainAddress->user->id;
+
+                // Deduplicate: only notify each user once per webhook batch
+                if (isset($notifiedUsers[$userId])) {
+                    continue;
+                }
+                $notifiedUsers[$userId] = true;
+
+                broadcast(new WalletBalanceUpdated($userId, $network));
+
+                Log::info('Alchemy webhook: balance update broadcast', [
+                    'user_id'  => $userId,
+                    'address'  => $address,
+                    'network'  => $network,
+                    'category' => $activity['category'] ?? 'unknown',
+                ]);
+            }
+        }
+
+        return response()->json([
+            'status'         => 'processed',
+            'users_notified' => count($notifiedUsers),
+        ]);
+    }
+
+    /**
+     * Verify the Alchemy webhook signature using HMAC-SHA256.
+     */
+    private function verifySignature(Request $request): bool
+    {
+        $signingKey = config('relayer.alchemy_webhook_signing_key');
+
+        // Skip verification if no signing key configured (dev/testing)
+        if (empty($signingKey)) {
+            return true;
+        }
+
+        $signature = $request->header('X-Alchemy-Signature');
+        if ($signature === null) {
+            return false;
+        }
+
+        $expectedSignature = hash_hmac('sha256', $request->getContent(), $signingKey);
+
+        return hash_equals($expectedSignature, $signature);
+    }
+
+    /**
+     * Map Alchemy network names to our chain_id format.
+     */
+    private function resolveNetwork(string $alchemyNetwork): ?string
+    {
+        return match (strtolower($alchemyNetwork)) {
+            'eth-mainnet', 'eth_mainnet' => 'ethereum',
+            'polygon-mainnet', 'matic_mainnet' => 'polygon',
+            'arb-mainnet', 'arb_mainnet' => 'arbitrum',
+            'base-mainnet', 'base_mainnet' => 'base',
+            'opt-mainnet', 'opt_mainnet' => 'optimism',
+            default => null,
+        };
+    }
+}

--- a/config/relayer.php
+++ b/config/relayer.php
@@ -224,6 +224,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Alchemy Webhook Configuration (v5.14.0)
+    |--------------------------------------------------------------------------
+    |
+    | Signing key for verifying Alchemy Address Activity Webhooks.
+    | Set via Alchemy Dashboard → Notify → Signing Key.
+    |
+    */
+
+    'alchemy_webhook_signing_key' => env('ALCHEMY_WEBHOOK_SIGNING_KEY'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Gas Sponsorship Configuration (v5.13.0)
     |--------------------------------------------------------------------------
     |

--- a/routes/api.php
+++ b/routes/api.php
@@ -253,6 +253,11 @@ Route::post('v1/ramp/webhook/{provider}', [App\Http\Controllers\Api\V1\RampWebho
     ->middleware('api.rate_limit:webhook')
     ->name('api.v1.ramp.webhook');
 
+// v5.14.0 — Alchemy Address Activity Webhook (no auth, HMAC verified)
+Route::post('webhooks/alchemy/address-activity', [App\Http\Controllers\Api\Webhook\AlchemyWebhookController::class, 'handle'])
+    ->middleware('api.rate_limit:webhook')
+    ->name('api.webhooks.alchemy.address-activity');
+
 // v5.13.0 — Referral System
 Route::prefix('v1/referrals')->name('api.v1.referrals.')
     ->middleware(['auth:sanctum'])

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -146,3 +146,19 @@ Broadcast::channel('commerce.{merchantId}', function ($user, string $merchantId)
 Broadcast::channel('trustcert.{userId}', function ($user, int $userId) {
     return $user->id === $userId;
 });
+
+/*
+|--------------------------------------------------------------------------
+| Wallet Balance & State Channels (v5.14.0)
+|--------------------------------------------------------------------------
+|
+| Real-time wallet balance and state updates. Replaces 60-second polling
+| with event-driven WebSocket pushes triggered by Alchemy Address Activity
+| Webhooks and internal wallet state changes.
+|
+*/
+
+// Wallet balance/state updates - user-specific
+Broadcast::channel('wallet.{userId}', function ($user, int $userId) {
+    return $user->id === $userId;
+});


### PR DESCRIPTION
## Summary
Replace 60-second mobile polling with event-driven WebSocket pushes. Mobile PR #260 is fully implemented — this is the backend counterpart.

**Problem**: Mobile polled `/api/v1/wallet/balances` + `/api/v1/wallet/state` every 60s per user → 15 Alchemy RPC calls/min → 98K calls/day with just 1 device.

**Solution**: Backend pushes events via WebSocket when data changes. Mobile only fetches on-demand (app foreground, pull-to-refresh, WS event).

## New Broadcast Events

| Channel | Event | When |
|---------|-------|------|
| `private-wallet.{userId}` | `wallet.balance_updated` | Token transfer detected via Alchemy webhook |
| `private-wallet.{userId}` | `wallet.state_changed` | Smart account created/deployed |
| `private-privacy.{userId}` | `privacy.balance_updated` | Shield/unshield/transfer completed |

## Alchemy Address Activity Webhook
- **Endpoint**: `POST /api/webhooks/alchemy/address-activity`
- **Auth**: HMAC-SHA256 signature verification (`ALCHEMY_WEBHOOK_SIGNING_KEY`)
- **Flow**: Alchemy detects token transfer → webhook fires → backend identifies user by address → broadcasts `wallet.balance_updated`

## Files
| File | Change |
|------|--------|
| `app/Domain/Wallet/Events/Broadcast/WalletBalanceUpdated.php` | NEW broadcast event |
| `app/Domain/Wallet/Events/Broadcast/WalletStateChanged.php` | NEW broadcast event |
| `app/Domain/Privacy/Events/Broadcast/PrivacyBalanceUpdated.php` | NEW broadcast event |
| `app/Http/Controllers/Api/Webhook/AlchemyWebhookController.php` | NEW webhook handler |
| `routes/api.php` | Webhook route registration |
| `routes/channels.php` | `wallet.{userId}` channel authorization |
| `config/relayer.php` | `ALCHEMY_WEBHOOK_SIGNING_KEY` config |
| `app/Http/Controllers/Api/Privacy/PrivacyController.php` | Dispatch PrivacyBalanceUpdated |
| `app/Http/Controllers/Api/Relayer/SmartAccountController.php` | Dispatch WalletStateChanged |

## Setup Required
1. In Alchemy Dashboard → Notify → Create Webhook → Address Activity
2. URL: `https://zelta.app/api/webhooks/alchemy/address-activity`
3. Copy signing key → set `ALCHEMY_WEBHOOK_SIGNING_KEY` in production `.env`
4. Register tracked addresses (done automatically when wallets are created)

## Test plan
- [ ] PHPStan passes
- [ ] CI pipeline passes
- [ ] Webhook endpoint returns 200 on valid payload
- [ ] Events broadcast on correct channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)