### PR TITLE
fix: encrypt webhook secrets at rest + brand User-Agent

### DIFF
--- a/app/Domain/Webhook/Jobs/ProcessWebhookDelivery.php
+++ b/app/Domain/Webhook/Jobs/ProcessWebhookDelivery.php
@@ -51,7 +51,7 @@ class ProcessWebhookDelivery implements ShouldQueue
             // Prepare headers
             $headers = $webhook->headers ?? [];
             $headers['Content-Type'] = 'application/json';
-            $headers['User-Agent'] = 'FinAegis-Webhook/1.0';
+            $headers['User-Agent'] = config('brand.name', 'Zelta') . '-Webhook/1.0';
             $headers['X-Webhook-ID'] = $webhook->uuid;
             $headers['X-Webhook-Event'] = $this->delivery->event_type;
             $headers['X-Webhook-Delivery'] = $this->delivery->uuid;

--- a/app/Domain/Webhook/Models/Webhook.php
+++ b/app/Domain/Webhook/Models/Webhook.php
@@ -77,6 +77,7 @@ class Webhook extends Model
     protected $casts = [
         'events'               => 'array',
         'headers'              => 'array',
+        'secret'               => 'encrypted',
         'is_active'            => 'boolean',
         'retry_attempts'       => 'integer',
         'timeout_seconds'      => 'integer',


### PR DESCRIPTION
## Summary
v6.0.0 Phase 3 — Webhook domain security hardening.

The webhook domain already had HMAC signature signing (sha256=...) via `X-Webhook-Signature` header — the domain audit overcounted this as a gap. The actual issues were:

## Changes
- **Webhook.secret**: Add `encrypted` cast for at-rest encryption (was stored plaintext)
- **User-Agent header**: `config('brand.name')` instead of hardcoded `FinAegis-Webhook/1.0`

## Test plan
- [ ] PHPStan passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)