### PR TITLE
feat: add public Plugin Marketplace UI

### DIFF
--- a/app/Http/Controllers/PluginMarketplaceWebController.php
+++ b/app/Http/Controllers/PluginMarketplaceWebController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers;
 
 use App\Domain\Shared\Models\Plugin;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\View\View;
 
 /**
@@ -21,11 +22,17 @@ class PluginMarketplaceWebController extends Controller
      */
     public function index(Request $request): View
     {
+        $validated = $request->validate([
+            'search' => 'nullable|string|max:100',
+            'status' => 'nullable|string|in:active,inactive,failed',
+            'vendor' => 'nullable|string|max:100',
+        ]);
+
         $query = Plugin::query()->orderBy('vendor')->orderBy('name');
 
-        // Search by name, vendor, or description
-        if ($search = $request->input('search')) {
-            $search = (string) $search;
+        if (! empty($validated['search'])) {
+            // Escape LIKE wildcards to prevent pattern injection
+            $search = str_replace(['%', '_'], ['\\%', '\\_'], $validated['search']);
             $query->where(function ($q) use ($search): void {
                 $q->where('name', 'like', "%{$search}%")
                     ->orWhere('vendor', 'like', "%{$search}%")
@@ -34,30 +41,27 @@ class PluginMarketplaceWebController extends Controller
             });
         }
 
-        // Filter by status
-        if ($status = $request->input('status')) {
-            $query->where('status', (string) $status);
+        if (! empty($validated['status'])) {
+            $query->where('status', $validated['status']);
         }
 
-        // Filter by vendor
-        if ($vendor = $request->input('vendor')) {
-            $query->byVendor((string) $vendor);
+        if (! empty($validated['vendor'])) {
+            $query->byVendor($validated['vendor']);
         }
 
         $plugins = $query->paginate(12)->withQueryString();
 
-        // Get stats for the header
-        $stats = [
+        // Cache stats for 5 minutes to avoid 3 COUNT queries per request
+        $stats = Cache::remember('marketplace:stats', 300, fn (): array => [
             'total'   => Plugin::count(),
             'active'  => Plugin::active()->count(),
             'vendors' => Plugin::distinct()->count('vendor'),
-        ];
+        ]);
 
-        // Get unique vendors for filter dropdown
-        $vendors = Plugin::select('vendor')
+        $vendors = Cache::remember('marketplace:vendors', 300, fn () => Plugin::select('vendor')
             ->distinct()
             ->orderBy('vendor')
-            ->pluck('vendor');
+            ->pluck('vendor'));
 
         return view('marketplace.index', compact('plugins', 'stats', 'vendors'));
     }

--- a/resources/views/marketplace/index.blade.php
+++ b/resources/views/marketplace/index.blade.php
@@ -63,16 +63,18 @@
         <form method="GET" action="{{ route('marketplace.index') }}" class="flex flex-col sm:flex-row gap-3">
             <!-- Search -->
             <div class="flex-1 relative">
-                <input type="text" name="search" value="{{ request('search') }}"
+                <label for="search-plugins" class="sr-only">Search plugins</label>
+                <input type="text" id="search-plugins" name="search" value="{{ request('search') }}"
                        placeholder="Search plugins..."
                        class="w-full pl-10 pr-4 py-2.5 rounded-lg border border-slate-300 focus:border-purple-500 focus:ring-2 focus:ring-purple-200 text-sm">
-                <svg class="absolute left-3 top-3 w-4 h-4 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg class="absolute left-3 top-3 w-4 h-4 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
                 </svg>
             </div>
 
             <!-- Vendor filter -->
-            <select name="vendor" class="px-4 py-2.5 rounded-lg border border-slate-300 text-sm bg-white">
+            <label for="filter-vendor" class="sr-only">Filter by vendor</label>
+            <select id="filter-vendor" name="vendor" class="px-4 py-2.5 rounded-lg border border-slate-300 text-sm bg-white">
                 <option value="">All Vendors</option>
                 @foreach($vendors as $v)
                 <option value="{{ $v }}" {{ request('vendor') === $v ? 'selected' : '' }}>{{ $v }}</option>
@@ -80,7 +82,8 @@
             </select>
 
             <!-- Status filter -->
-            <select name="status" class="px-4 py-2.5 rounded-lg border border-slate-300 text-sm bg-white">
+            <label for="filter-status" class="sr-only">Filter by status</label>
+            <select id="filter-status" name="status" class="px-4 py-2.5 rounded-lg border border-slate-300 text-sm bg-white">
                 <option value="">All Status</option>
                 <option value="active" {{ request('status') === 'active' ? 'selected' : '' }}>Active</option>
                 <option value="inactive" {{ request('status') === 'inactive' ? 'selected' : '' }}>Inactive</option>

--- a/resources/views/marketplace/show.blade.php
+++ b/resources/views/marketplace/show.blade.php
@@ -27,9 +27,9 @@
 <!-- Breadcrumb -->
 <section class="bg-white border-b border-slate-200">
     <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
-        <nav class="flex items-center gap-2 text-sm text-slate-500">
+        <nav class="flex items-center gap-2 text-sm text-slate-500" aria-label="Breadcrumb">
             <a href="{{ route('marketplace.index') }}" class="hover:text-slate-700">Marketplace</a>
-            <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+            <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
             <span class="text-slate-700">{{ $plugin->display_name ?? $plugin->name }}</span>
         </nav>
     </div>
@@ -96,10 +96,10 @@
                         <dd class="font-medium">{{ $plugin->author }}</dd>
                     </div>
                     @endif
-                    @if($plugin->homepage)
+                    @if($plugin->homepage && str_starts_with($plugin->homepage, 'https://'))
                     <div>
                         <dt class="text-slate-500">Homepage</dt>
-                        <dd><a href="{{ $plugin->homepage }}" class="text-purple-600 hover:underline text-xs" target="_blank" rel="noopener">{{ $plugin->homepage }}</a></dd>
+                        <dd><a href="{{ $plugin->homepage }}" class="text-purple-600 hover:underline text-xs" target="_blank" rel="noopener noreferrer">{{ $plugin->homepage }}</a></dd>
                     </div>
                     @endif
                     <div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -128,7 +128,9 @@ if (config('brand.show_promo_pages')) {
 
     // Plugin Marketplace (public browsing)
     Route::get('/marketplace', [App\Http\Controllers\PluginMarketplaceWebController::class, 'index'])->name('marketplace.index');
-    Route::get('/marketplace/{vendor}/{name}', [App\Http\Controllers\PluginMarketplaceWebController::class, 'show'])->name('marketplace.show');
+    Route::get('/marketplace/{vendor}/{name}', [App\Http\Controllers\PluginMarketplaceWebController::class, 'show'])
+        ->where(['vendor' => '[a-zA-Z0-9_-]+', 'name' => '[a-zA-Z0-9_-]+'])
+        ->name('marketplace.show');
 
     Route::get('/developers', function () {
         return view('developers.index');
@@ -223,6 +225,8 @@ if (config('brand.show_promo_pages')) {
     Route::post('/blog/subscribe', $redirectHome)->name('blog.subscribe');
     Route::post('/support/contact', $redirectHome)->name('support.contact.submit');
     Route::post('/financial-institutions/submit', $redirectHome)->name('financial-institutions.submit');
+    Route::get('/marketplace', $redirectHome)->name('marketplace.index');
+    Route::get('/marketplace/{vendor}/{name}', $redirectHome)->where(['vendor' => '[a-zA-Z0-9_-]+', 'name' => '[a-zA-Z0-9_-]+'])->name('marketplace.show');
 }
 
 Route::get('/legal/terms', function () {


### PR DESCRIPTION
## Summary
v6.0.0 Phase 2 — Customer-facing plugin marketplace at `/marketplace`.

## Features
- **Browse page** (`/marketplace`): Paginated plugin grid with search, vendor filter, status filter
- **Detail page** (`/marketplace/{vendor}/{name}`): Full info, permissions, dependencies, install commands
- **Stats header**: Total plugins, active count, vendor count
- **CTA**: Links to Plugin Development Guide for builders

## Files
| File | Description |
|------|-------------|
| `app/Http/Controllers/PluginMarketplaceWebController.php` | New controller |
| `resources/views/marketplace/index.blade.php` | Browse/search page |
| `resources/views/marketplace/show.blade.php` | Plugin detail page |
| `routes/web.php` | Routes: `/marketplace`, `/marketplace/{vendor}/{name}` |

## Test plan
- [ ] `/marketplace` loads and shows plugin grid
- [ ] Search filters work (name, vendor, status)
- [ ] `/marketplace/{vendor}/{name}` shows plugin detail
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)