### PR TITLE
fix: eliminate all hardcoded finaegis.org domains + rebrand Postman files

### DIFF
--- a/public/docs/postman/Zelta-API.postman_collection.json
+++ b/public/docs/postman/Zelta-API.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
-    "name": "FinAegis API v2",
-    "description": "Complete API collection for FinAegis GCU Platform",
+    "name": "Zelta API v2",
+    "description": "Complete API collection for Zelta GCU Platform",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "auth": {

--- a/public/docs/postman/Zelta-Environment.postman_environment.json
+++ b/public/docs/postman/Zelta-Environment.postman_environment.json
@@ -1,6 +1,6 @@
 {
     "id": "finaegis-env",
-    "name": "FinAegis Environment",
+    "name": "Zelta Environment",
     "values": [
         {
             "key": "base_url",

--- a/resources/views/ai-framework/index.blade.php
+++ b/resources/views/ai-framework/index.blade.php
@@ -901,7 +901,7 @@
                 <a href="{{ route('register') }}" class="bg-white text-purple-600 px-8 py-4 rounded-lg text-lg font-semibold hover:bg-gray-100 transition shadow-lg hover:shadow-xl">
                     Start Free Trial
                 </a>
-                <a href="mailto:info@finaegis.org" class="border-2 border-white text-white px-8 py-4 rounded-lg text-lg font-semibold hover:bg-white hover:text-purple-600 transition">
+                <a href="mailto:{{ config('brand.support_email', 'info@zelta.app') }}" class="border-2 border-white text-white px-8 py-4 rounded-lg text-lg font-semibold hover:bg-white hover:text-purple-600 transition">
                     Schedule Demo
                 </a>
             </div>

--- a/resources/views/cgo/notify-success.blade.php
+++ b/resources/views/cgo/notify-success.blade.php
@@ -153,7 +153,7 @@
                     <div class="mt-10 pt-10 border-t border-gray-200 text-center">
                         <p class="text-sm text-gray-600">
                             Questions? Contact us at
-                            <a href="mailto:info@finaegis.org" class="text-indigo-600 hover:text-indigo-700 font-medium">info@finaegis.org</a>
+                            <a href="mailto:{{ config('brand.support_email', 'info@zelta.app') }}" class="text-indigo-600 hover:text-indigo-700 font-medium">{{ config('brand.support_email', 'info@zelta.app') }}</a>
                         </p>
                     </div>
                 </div>

--- a/resources/views/compliance.blade.php
+++ b/resources/views/compliance.blade.php
@@ -282,7 +282,7 @@
             <div class="card-feature !p-0 overflow-hidden animate-on-scroll stagger-1">
                 <div class="px-6 py-4 bg-slate-50 border-b border-slate-200">
                     <p class="text-sm text-slate-600">
-                        <strong class="text-slate-900">Note:</strong> For api.finaegis.org, endpoints are available without the /api prefix.
+                        <strong class="text-slate-900">Note:</strong> For {{ request()->getHost() }}, endpoints are available without the /api prefix.
                     </p>
                 </div>
                 <div class="grid grid-cols-1 md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-slate-100">

--- a/resources/views/developers/api-docs.blade.php
+++ b/resources/views/developers/api-docs.blade.php
@@ -65,7 +65,7 @@
                             
                             <h3>Base URL</h3>
                             <x-code-block language="plaintext">
-https://api.finaegis.org/v2
+{{ config('app.url') }}/api/v2
                             </x-code-block>
                             
                             <h3>Response Format</h3>
@@ -102,7 +102,7 @@ https://api.finaegis.org/v2
                             <x-code-block language="bash">
 curl -H "Authorization: Bearer fak_your_api_key_here" \
      -H "Content-Type: application/json" \
-     https://api.finaegis.org/v2/accounts
+     {{ config('app.url') }}/api/v2/accounts
                             </x-code-block>
                             
                             <h3>API Key Security</h3>
@@ -117,8 +117,8 @@ curl -H "Authorization: Bearer fak_your_api_key_here" \
                             <h3>Sandbox vs Production</h3>
                             <p>Use these base URLs for testing and production:</p>
                             <ul>
-                                <li><strong>Sandbox:</strong> https://api-sandbox.finaegis.org/v2</li>
-                                <li><strong>Production:</strong> https://api.finaegis.org/v2</li>
+                                <li><strong>Sandbox:</strong> {{ config('app.url') }}/api/v2</li>
+                                <li><strong>Production:</strong> {{ config('app.url') }}/api/v2</li>
                             </ul>
                         </div>
                     </section>
@@ -140,7 +140,7 @@ curl -H "Authorization: Bearer fak_your_api_key_here" \
                                 
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     https://api.finaegis.org/v2/accounts
+     {{ config('app.url') }}/api/v2/accounts
                                 </x-code-block>
                             </div>
 
@@ -157,7 +157,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     https://api.finaegis.org/v2/accounts/acct_1234567890
+     {{ config('app.url') }}/api/v2/accounts/acct_1234567890
                                 </x-code-block>
                             </div>
 
@@ -226,7 +226,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     "https://api.finaegis.org/v2/transactions?page=1&per_page=20"
+     "{{ config('app.url') }}/api/v2/transactions?page=1&per_page=20"
                                 </x-code-block>
                             </div>
                             
@@ -250,7 +250,7 @@ curl -X POST \
     "asset_code": "USD",
     "reference": "Initial deposit"
   }' \
-  https://api.finaegis.org/v2/accounts/acct_1234567890/deposit
+  {{ config('app.url') }}/api/v2/accounts/acct_1234567890/deposit
                                 </x-code-block>
                             </div>
                             
@@ -274,7 +274,7 @@ curl -X POST \
     "asset_code": "USD",
     "reference": "ATM withdrawal"
   }' \
-  https://api.finaegis.org/v2/accounts/acct_1234567890/withdraw
+  {{ config('app.url') }}/api/v2/accounts/acct_1234567890/withdraw
                                 </x-code-block>
                             </div>
                         </div>
@@ -307,7 +307,7 @@ curl -X POST \
     "reference": "Payment for services",
     "workflow_enabled": true
   }' \
-  https://api.finaegis.org/v2/transfers
+  {{ config('app.url') }}/api/v2/transfers
                                 </x-code-block>
                             </div>
                             
@@ -324,7 +324,7 @@ curl -X POST \
                                 
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     https://api.finaegis.org/v2/accounts/acct_1234567890/transfers
+     {{ config('app.url') }}/api/v2/accounts/acct_1234567890/transfers
                                 </x-code-block>
                             </div>
                         </div>
@@ -351,7 +351,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     https://api.finaegis.org/v2/gcu
+     {{ config('app.url') }}/api/v2/gcu
                                 </x-code-block>
                             </div>
 
@@ -368,7 +368,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     https://api.finaegis.org/v2/gcu/composition
+     {{ config('app.url') }}/api/v2/gcu/composition
                                 </x-code-block>
                                 
                                 <h4 class="font-semibold mb-2">Response Example:</h4>
@@ -440,7 +440,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     "https://api.finaegis.org/v2/gcu/value-history?period=7d&interval=hourly"
+     "{{ config('app.url') }}/api/v2/gcu/value-history?period=7d&interval=hourly"
                                 </x-code-block>
                             </div>
 
@@ -468,7 +468,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     "https://api.finaegis.org/v2/gcu/voting/proposals?status=active"
+     "{{ config('app.url') }}/api/v2/gcu/voting/proposals?status=active"
                                 </x-code-block>
                             </div>
 
@@ -485,7 +485,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     https://api.finaegis.org/v2/gcu/voting/proposals/123
+     {{ config('app.url') }}/api/v2/gcu/voting/proposals/123
                                 </x-code-block>
                             </div>
 
@@ -515,7 +515,7 @@ curl -X POST \
      -H "Authorization: Bearer your_api_key" \
      -H "Content-Type: application/json" \
      -d '{"vote": "for"}' \
-     https://api.finaegis.org/v2/gcu/voting/proposals/123/vote
+     {{ config('app.url') }}/api/v2/gcu/voting/proposals/123/vote
                                 </x-code-block>
                             </div>
 
@@ -535,7 +535,7 @@ curl -X POST \
                                 
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     https://api.finaegis.org/v2/gcu/voting/my-votes
+     {{ config('app.url') }}/api/v2/gcu/voting/my-votes
                                 </x-code-block>
                             </div>
                         </div>
@@ -562,7 +562,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     https://api.finaegis.org/v2/baskets
+     {{ config('app.url') }}/api/v2/baskets
                                 </x-code-block>
                             </div>
                             
@@ -579,7 +579,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     https://api.finaegis.org/v2/baskets/GCU
+     {{ config('app.url') }}/api/v2/baskets/GCU
                                 </x-code-block>
                             </div>
                             
@@ -602,7 +602,7 @@ curl -X POST \
     "basket_code": "GCU",
     "amount": "100.00"
   }' \
-  https://api.finaegis.org/v2/accounts/acct_123/baskets/compose
+  {{ config('app.url') }}/api/v2/accounts/acct_123/baskets/compose
                                 </x-code-block>
                             </div>
                             
@@ -625,7 +625,7 @@ curl -X POST \
     "basket_code": "GCU",
     "amount": "50.00"
   }' \
-  https://api.finaegis.org/v2/accounts/acct_123/baskets/decompose
+  {{ config('app.url') }}/api/v2/accounts/acct_123/baskets/decompose
                                 </x-code-block>
                             </div>
                         </div>
@@ -652,7 +652,7 @@ curl -X POST \
                                 
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     https://api.finaegis.org/v2/webhooks/events
+     {{ config('app.url') }}/api/v2/webhooks/events
                                 </x-code-block>
                             </div>
                             
@@ -676,7 +676,7 @@ curl -X POST \
     "events": ["transaction.created", "transfer.completed"],
     "description": "Main webhook endpoint"
   }' \
-  https://api.finaegis.org/v2/webhooks
+  {{ config('app.url') }}/api/v2/webhooks
                                 </x-code-block>
                             </div>
                             
@@ -693,7 +693,7 @@ curl -X POST \
                                 
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     https://api.finaegis.org/v2/webhooks
+     {{ config('app.url') }}/api/v2/webhooks
                                 </x-code-block>
                             </div>
                             
@@ -710,7 +710,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     https://api.finaegis.org/v2/webhooks/webhook_123/deliveries
+     {{ config('app.url') }}/api/v2/webhooks/webhook_123/deliveries
                                 </x-code-block>
                             </div>
                         </div>
@@ -746,7 +746,7 @@ curl -X POST \
     "amount": "1000.00",
     "protocol": "wormhole"
   }' \
-  https://api.finaegis.org/v2/crosschain/bridge
+  {{ config('app.url') }}/api/v2/crosschain/bridge
                                 </x-code-block>
                             </div>
 
@@ -761,7 +761,7 @@ curl -X POST \
                                 <p class="text-gray-600 mb-4">Compare fees and estimated times across all supported bridge protocols for a given route.</p>
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     "https://api.finaegis.org/v2/crosschain/bridge/fees?from=ethereum&to=arbitrum&token=USDC&amount=5000"
+     "{{ config('app.url') }}/api/v2/crosschain/bridge/fees?from=ethereum&to=arbitrum&token=USDC&amount=5000"
                                 </x-code-block>
                             </div>
 
@@ -786,7 +786,7 @@ curl -X POST \
     "amount": "1.5",
     "slippage_bps": 50
   }' \
-  https://api.finaegis.org/v2/crosschain/swap
+  {{ config('app.url') }}/api/v2/crosschain/swap
                                 </x-code-block>
                             </div>
 
@@ -801,7 +801,7 @@ curl -X POST \
                                 <p class="text-gray-600 mb-4">Retrieve an aggregated portfolio view across all supported chains.</p>
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     https://api.finaegis.org/v2/crosschain/portfolio
+     {{ config('app.url') }}/api/v2/crosschain/portfolio
                                 </x-code-block>
                             </div>
                         </div>
@@ -828,7 +828,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <p class="text-gray-600 mb-4">Get the best swap quote aggregated across Uniswap, Curve, and other supported DEXes.</p>
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     "https://api.finaegis.org/v2/defi/swap/quote?from=ETH&to=USDC&amount=2.0&chain=ethereum"
+     "{{ config('app.url') }}/api/v2/defi/swap/quote?from=ETH&to=USDC&amount=2.0&chain=ethereum"
                                 </x-code-block>
                             </div>
 
@@ -852,7 +852,7 @@ curl -X POST \
     "slippage_bps": 50,
     "chain": "ethereum"
   }' \
-  https://api.finaegis.org/v2/defi/swap/execute
+  {{ config('app.url') }}/api/v2/defi/swap/execute
                                 </x-code-block>
                             </div>
 
@@ -867,7 +867,7 @@ curl -X POST \
                                 <p class="text-gray-600 mb-4">Retrieve all DeFi positions including lending deposits, staking, liquidity pools, and yield farming.</p>
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     https://api.finaegis.org/v2/defi/portfolio
+     {{ config('app.url') }}/api/v2/defi/portfolio
                                 </x-code-block>
                             </div>
 
@@ -892,7 +892,7 @@ curl -X POST \
       {"type": "swap", "from": "ETH", "to": "USDC", "dex": "curve"}
     ]
   }' \
-  https://api.finaegis.org/v2/defi/flash-loan
+  {{ config('app.url') }}/api/v2/defi/flash-loan
                                 </x-code-block>
                             </div>
                         </div>
@@ -926,7 +926,7 @@ curl -X POST \
     "report_type": "transaction",
     "jurisdiction": "EU"
   }' \
-  https://api.finaegis.org/v2/regtech/mifid/reports
+  {{ config('app.url') }}/api/v2/regtech/mifid/reports
                                 </x-code-block>
                             </div>
 
@@ -948,7 +948,7 @@ curl -X POST \
     "issuer_id": "issuer_xyz",
     "whitepaper_hash": "sha256:abc..."
   }' \
-  https://api.finaegis.org/v2/regtech/mica/check
+  {{ config('app.url') }}/api/v2/regtech/mica/check
                                 </x-code-block>
                             </div>
 
@@ -972,7 +972,7 @@ curl -X POST \
     "amount": "15000.00",
     "currency": "USDC"
   }' \
-  https://api.finaegis.org/v2/regtech/travel-rule/transfers
+  {{ config('app.url') }}/api/v2/regtech/travel-rule/transfers
                                 </x-code-block>
                             </div>
 
@@ -987,7 +987,7 @@ curl -X POST \
                                 <p class="text-gray-600 mb-4">Get overall compliance status across all active regulatory frameworks.</p>
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     https://api.finaegis.org/v2/regtech/status
+     {{ config('app.url') }}/api/v2/regtech/status
                                 </x-code-block>
                             </div>
                         </div>
@@ -1022,7 +1022,7 @@ curl -X POST \
     "recipient": "user_456",
     "description": "Coffee payment"
   }' \
-  https://api.finaegis.org/v2/mobile/payments/intents
+  {{ config('app.url') }}/api/v2/mobile/payments/intents
                                 </x-code-block>
                             </div>
 
@@ -1037,7 +1037,7 @@ curl -X POST \
                                 <p class="text-gray-600 mb-4">Retrieve the mobile wallet activity feed with payments, transfers, and notifications.</p>
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     "https://api.finaegis.org/v2/mobile/activity?page=1&per_page=20"
+     "{{ config('app.url') }}/api/v2/mobile/activity?page=1&per_page=20"
                                 </x-code-block>
                             </div>
 
@@ -1060,7 +1060,7 @@ curl -X POST \
     "currency": "USD",
     "note": "Dinner split"
   }' \
-  https://api.finaegis.org/v2/mobile/transfers/p2p
+  {{ config('app.url') }}/api/v2/mobile/transfers/p2p
                                 </x-code-block>
                             </div>
 
@@ -1082,7 +1082,7 @@ curl -X POST \
     "client_data_json": "base64...",
     "signature": "base64..."
   }' \
-  https://api.finaegis.org/v2/mobile/auth/passkey/verify
+  {{ config('app.url') }}/api/v2/mobile/auth/passkey/verify
                                 </x-code-block>
                             </div>
                         </div>
@@ -1120,7 +1120,7 @@ curl -X POST \
     "plan": "enterprise",
     "domain": "acme.finaegis.io"
   }' \
-  https://api.finaegis.org/v2/partner/tenants
+  {{ config('app.url') }}/api/v2/partner/tenants
                                 </x-code-block>
                             </div>
 
@@ -1146,7 +1146,7 @@ curl -X POST \
     "branding": {"name": "AcmeSDK", "color": "#3B82F6"},
     "modules": ["accounts", "transfers", "payments"]
   }' \
-  https://api.finaegis.org/v2/partner/sdk/generate
+  {{ config('app.url') }}/api/v2/partner/sdk/generate
                                 </x-code-block>
                             </div>
 
@@ -1172,7 +1172,7 @@ curl -X PUT \
     "primary_color": "#3B82F6",
     "features": {"defi": true, "crosschain": true, "lending": false}
   }' \
-  https://api.finaegis.org/v2/partner/config/whitelabel
+  {{ config('app.url') }}/api/v2/partner/config/whitelabel
                                 </x-code-block>
                             </div>
 
@@ -1191,7 +1191,7 @@ curl -X PUT \
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
      -H "X-Partner-Key: fpk_your_partner_key" \
-     https://api.finaegis.org/v2/partner/tenants
+     {{ config('app.url') }}/api/v2/partner/tenants
                                 </x-code-block>
                             </div>
                         </div>
@@ -1224,7 +1224,7 @@ curl -X POST \
     "query": "What were my largest transactions last month?",
     "context": {"account_id": "acc_123"}
   }' \
-  https://api.finaegis.org/v2/ai/query
+  {{ config('app.url') }}/api/v2/ai/query
                                 </x-code-block>
                             </div>
 
@@ -1239,7 +1239,7 @@ curl -X POST \
                                 <p class="text-gray-600 mb-4">Retrieve your past AI query history with cached results.</p>
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     https://api.finaegis.org/v2/ai/queries
+     {{ config('app.url') }}/api/v2/ai/queries
                                 </x-code-block>
                             </div>
                         </div>
@@ -1271,7 +1271,7 @@ curl -X POST \
   -d '{
     "query": "{ accounts(first: 10) { data { id name currency balance { available total } } } }"
   }' \
-  https://api.finaegis.org/graphql
+  {{ config('app.url') }}/api/graphql
                                 </x-code-block>
 
                                 <h4 class="font-semibold mb-2 mt-6">Example Query:</h4>
@@ -1308,7 +1308,7 @@ query {
                                 <p class="text-gray-600 mb-4">Interactive GraphQL explorer with schema introspection, auto-complete, and query history. Use this to explore available types, queries, mutations, and subscriptions.</p>
                                 <x-code-block language="bash">
 # Open in your browser
-https://api.finaegis.org/graphql-playground
+{{ config('app.url') }}/api/graphql-playground
                                 </x-code-block>
                             </div>
 
@@ -1346,7 +1346,7 @@ https://api.finaegis.org/graphql-playground
                                 <p class="text-gray-600 mb-4">Retrieve aggregated system metrics including event counts, processing rates, error rates, and uptime statistics.</p>
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     https://api.finaegis.org/v1/live-dashboard/metrics
+     {{ config('app.url') }}/api/v1/live-dashboard/metrics
                                 </x-code-block>
                             </div>
 
@@ -1361,7 +1361,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <p class="text-gray-600 mb-4">Get health status for each event-sourced domain including event store connectivity, projector status, and recent error counts.</p>
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     https://api.finaegis.org/v1/live-dashboard/domain-health
+     {{ config('app.url') }}/api/v1/live-dashboard/domain-health
                                 </x-code-block>
                             </div>
 
@@ -1376,7 +1376,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <p class="text-gray-600 mb-4">Monitor real-time event throughput rates per domain and aggregate, including events per second and processing latency.</p>
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     https://api.finaegis.org/v1/live-dashboard/event-throughput
+     {{ config('app.url') }}/api/v1/live-dashboard/event-throughput
                                 </x-code-block>
                             </div>
 
@@ -1391,7 +1391,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <p class="text-gray-600 mb-4">Check Redis Streams connectivity, consumer group status, pending message counts, and stream memory usage.</p>
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     https://api.finaegis.org/v1/live-dashboard/stream-status
+     {{ config('app.url') }}/api/v1/live-dashboard/stream-status
                                 </x-code-block>
                             </div>
 
@@ -1406,7 +1406,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <p class="text-gray-600 mb-4">Monitor projector lag across all event-sourced domains showing how far behind each read model projector is from the latest events.</p>
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     https://api.finaegis.org/v1/live-dashboard/projector-lag
+     {{ config('app.url') }}/api/v1/live-dashboard/projector-lag
                                 </x-code-block>
                             </div>
                         </div>
@@ -1433,7 +1433,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <p class="text-gray-600 mb-4">Get the current x402 protocol status including supported networks, assets, and facilitator connectivity.</p>
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     https://api.finaegis.org/v2/x402/status
+     {{ config('app.url') }}/api/v2/x402/status
                                 </x-code-block>
                             </div>
 
@@ -1448,7 +1448,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <p class="text-gray-600 mb-4">List all supported blockchain networks and payment assets for x402 settlement.</p>
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     https://api.finaegis.org/v2/x402/supported
+     {{ config('app.url') }}/api/v2/x402/supported
                                 </x-code-block>
                             </div>
 
@@ -1472,7 +1472,7 @@ curl -X POST \
     "asset": "USDC",
     "description": "Premium market data"
   }' \
-  https://api.finaegis.org/v2/x402/endpoints
+  {{ config('app.url') }}/api/v2/x402/endpoints
                                 </x-code-block>
                             </div>
 
@@ -1487,7 +1487,7 @@ curl -X POST \
                                 <p class="text-gray-600 mb-4">Retrieve payment history and settlement status for x402 transactions.</p>
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     "https://api.finaegis.org/v2/x402/payments?page=1&per_page=20"
+     "{{ config('app.url') }}/api/v2/x402/payments?page=1&per_page=20"
                                 </x-code-block>
                             </div>
 
@@ -1502,7 +1502,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <p class="text-gray-600 mb-4">View and manage spending limits for automated x402 payments including AI agent budgets.</p>
                                 <x-code-block language="bash">
 curl -H "Authorization: Bearer your_api_key" \
-     https://api.finaegis.org/v2/x402/spending-limits
+     {{ config('app.url') }}/api/v2/x402/spending-limits
                                 </x-code-block>
                             </div>
 
@@ -1521,7 +1521,7 @@ X-Payment-Facilitator: https://x402.org/facilitator
 
                                 <h4 class="font-semibold mb-2 mt-6">JavaScript Client Example:</h4>
                                 <x-code-block language="javascript">
-const response = await fetch('https://api.finaegis.org/v2/premium/data', {
+const response = await fetch('{{ config('app.url') }}/api/v2/premium/data', {
   headers: { 'Authorization': 'Bearer YOUR_API_KEY' }
 });
 
@@ -1535,7 +1535,7 @@ if (response.status === 402) {
 
   // Sign and submit payment, then retry with proof
   const proof = await signPayment(paymentInfo);
-  const paid = await fetch('https://api.finaegis.org/v2/premium/data', {
+  const paid = await fetch('{{ config('app.url') }}/api/v2/premium/data', {
     headers: {
       'Authorization': 'Bearer YOUR_API_KEY',
       'X-Payment-Signature': proof.signature,

--- a/resources/views/developers/examples.blade.php
+++ b/resources/views/developers/examples.blade.php
@@ -244,7 +244,7 @@ import { {{ config('brand.name', 'Zelta') }} } from '@finaegis/sdk';
 
 const client = new {{ config('brand.name', 'Zelta') }}({
   apiKey: process.env.FINAEGIS_API_KEY,
-  baseURL: 'https://api.finaegis.org/v2'
+  baseURL: '{{ config('app.url') }}/api/v2'
 });
 
 async function createAccountAndCheckBalance() {
@@ -288,7 +288,7 @@ import os
 
 client = {{ config('brand.name', 'Zelta') }}(
     api_key=os.environ['FINAEGIS_API_KEY'],
-    base_url='https://api.finaegis.org/v2'
+    base_url='{{ config('app.url') }}/api/v2'
 )
 
 def create_account_and_check_balance():
@@ -330,7 +330,7 @@ use {{ config('brand.name', 'Zelta') }}\Client;
 
 $client = new Client([
     'apiKey' => $_ENV['FINAEGIS_API_KEY'],
-    'baseURL' => 'https://api.finaegis.org/v2'
+    'baseURL' => '{{ config('app.url') }}/api/v2'
 ]);
 
 function createAccountAndCheckBalance($client) {
@@ -370,7 +370,7 @@ createAccountAndCheckBalance($client);
                             <div id="create-curl" class="tab-content animate-fade-in">
                                 <x-code-block language="bash">
 # Create a new account
-curl -X POST https://api.finaegis.org/v2/accounts \
+curl -X POST {{ config('app.url') }}/api/v2/accounts \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -394,7 +394,7 @@ curl -X POST https://api.finaegis.org/v2/accounts \
 }
 
 # Get account balances
-curl -X GET https://api.finaegis.org/v2/accounts/acct_1234567890abcdef/balances \
+curl -X GET {{ config('app.url') }}/api/v2/accounts/acct_1234567890abcdef/balances \
   -H "Authorization: Bearer YOUR_API_KEY"
                                 </x-code-block>
                             </div>
@@ -609,11 +609,11 @@ getAccountTransactions('acct_1234567890', {
                             <div id="list-curl" class="tab-content animate-fade-in">
                                 <x-code-block language="bash">
 # Get all transactions for an account
-curl -X GET "https://api.finaegis.org/v2/accounts/acct_1234567890/transactions" \
+curl -X GET "{{ config('app.url') }}/api/v2/accounts/acct_1234567890/transactions" \
   -H "Authorization: Bearer YOUR_API_KEY"
 
 # Get transactions with filters
-curl -X GET "https://api.finaegis.org/v2/accounts/acct_1234567890/transactions?\
+curl -X GET "{{ config('app.url') }}/api/v2/accounts/acct_1234567890/transactions?\
 limit=20&\
 page=1&\
 type=withdrawal&\
@@ -664,10 +664,10 @@ sort=-created_at" \
     "to": 20
   },
   "links": {
-    "first": "https://api.finaegis.org/v2/accounts/acct_1234567890/transactions?page=1",
-    "last": "https://api.finaegis.org/v2/accounts/acct_1234567890/transactions?page=5",
+    "first": "{{ config('app.url') }}/api/v2/accounts/acct_1234567890/transactions?page=1",
+    "last": "{{ config('app.url') }}/api/v2/accounts/acct_1234567890/transactions?page=5",
     "prev": null,
-    "next": "https://api.finaegis.org/v2/accounts/acct_1234567890/transactions?page=2"
+    "next": "{{ config('app.url') }}/api/v2/accounts/acct_1234567890/transactions?page=2"
   }
 }
                                 </x-code-block>
@@ -1836,7 +1836,7 @@ processLoanApplication('cust_456', {
                             <div id="bridge-curl" class="tab-content active animate-fade-in">
                                 <x-code-block language="bash">
 # Step 1: Get a bridge quote
-curl -X POST https://api.finaegis.org/api/v1/crosschain/bridge/quote \
+curl -X POST {{ config('app.url') }}/api/api/v1/crosschain/bridge/quote \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -1848,7 +1848,7 @@ curl -X POST https://api.finaegis.org/api/v1/crosschain/bridge/quote \
   }'
 
 # Step 2: Initiate the bridge transfer using the quote_id
-curl -X POST https://api.finaegis.org/api/v1/crosschain/bridge/initiate \
+curl -X POST {{ config('app.url') }}/api/api/v1/crosschain/bridge/initiate \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -1868,7 +1868,7 @@ import { {{ config('brand.name', 'Zelta') }} } from '@finaegis/sdk';
 
 const client = new {{ config('brand.name', 'Zelta') }}({
   apiKey: process.env.FINAEGIS_API_KEY,
-  baseURL: 'https://api.finaegis.org'
+  baseURL: '{{ config('app.url') }}/api'
 });
 
 async function bridgeTokens(sourceChain, destChain, token, amount) {
@@ -1920,7 +1920,7 @@ import os
 
 client = {{ config('brand.name', 'Zelta') }}(
     api_key=os.environ['FINAEGIS_API_KEY'],
-    base_url='https://api.finaegis.org'
+    base_url='{{ config('app.url') }}/api'
 )
 
 def bridge_tokens(source_chain, dest_chain, token, amount):
@@ -2049,7 +2049,7 @@ bridge_tokens('ethereum', 'polygon', 'USDC', '1000.00')
                             <div id="swap-curl" class="tab-content active animate-fade-in">
                                 <x-code-block language="bash">
 # Step 1: Get a swap quote with DEX aggregation
-curl -X POST https://api.finaegis.org/api/v1/defi/swap/quote \
+curl -X POST {{ config('app.url') }}/api/api/v1/defi/swap/quote \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -2062,7 +2062,7 @@ curl -X POST https://api.finaegis.org/api/v1/defi/swap/quote \
   }'
 
 # Step 2: Execute the swap with the best route
-curl -X POST https://api.finaegis.org/api/v1/defi/swap/execute \
+curl -X POST {{ config('app.url') }}/api/api/v1/defi/swap/execute \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -2255,7 +2255,7 @@ swap_tokens('ethereum', 'WETH', 'USDC', '2.5')
                             <div id="travel-curl" class="tab-content active animate-fade-in">
                                 <x-code-block language="bash">
 # Run a Travel Rule compliance check before a transfer
-curl -X POST https://api.finaegis.org/api/v1/regtech/travel-rule/check \
+curl -X POST {{ config('app.url') }}/api/api/v1/regtech/travel-rule/check \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -2480,7 +2480,7 @@ check_travel_rule_compliance({
                             <div id="partner-curl" class="tab-content active animate-fade-in">
                                 <x-code-block language="bash">
 # Onboard a new BaaS partner
-curl -X POST https://api.finaegis.org/api/v1/partner/onboard \
+curl -X POST {{ config('app.url') }}/api/api/v1/partner/onboard \
   -H "Authorization: Bearer YOUR_ADMIN_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -2626,23 +2626,23 @@ onboard_partner({
         "language": "typescript",
         "version": "3.0.0",
         "package_name": "@finaegis/sdk",
-        "download_url": "https://sdk.finaegis.org/packages/typescript/finaegis-sdk-3.0.0.tgz",
-        "docs_url": "https://docs.finaegis.org/sdk/typescript"
+        "download_url": "{{ config('app.url') }}/developers/sdks/packages/typescript/finaegis-sdk-3.0.0.tgz",
+        "docs_url": "{{ config('app.url') }}/developers/sdk/typescript"
       },
       {
         "language": "python",
         "version": "3.0.0",
         "package_name": "finaegis-sdk",
-        "download_url": "https://sdk.finaegis.org/packages/python/finaegis-sdk-3.0.0.tar.gz",
-        "docs_url": "https://docs.finaegis.org/sdk/python"
+        "download_url": "{{ config('app.url') }}/developers/sdks/packages/python/finaegis-sdk-3.0.0.tar.gz",
+        "docs_url": "{{ config('app.url') }}/developers/sdk/python"
       }
     ],
     "rate_limits": {
       "requests_per_minute": 5000,
       "burst_limit": 500
     },
-    "sandbox_url": "https://sandbox.finaegis.org",
-    "dashboard_url": "https://partners.finaegis.org/acme-fintech",
+    "sandbox_url": "{{ config('app.url') }}",
+    "dashboard_url": "{{ config('app.url') }}/acme-fintech",
     "created_at": "2026-01-15T12:00:00Z",
     "onboarding_checklist": {
       "api_key_generated": true,
@@ -2694,7 +2694,7 @@ onboard_partner({
                             <div id="aitx-curl" class="tab-content active animate-fade-in">
                                 <x-code-block language="bash">
 # Query transactions with natural language
-curl -X POST https://api.finaegis.org/api/v1/ai/transactions \
+curl -X POST {{ config('app.url') }}/api/api/v1/ai/transactions \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -2901,7 +2901,7 @@ class {{ config('brand.name', 'Zelta') }}Wrapper {
   constructor(apiKey, options = {}) {
     this.client = new {{ config('brand.name', 'Zelta') }}({
       apiKey,
-      baseURL: options.baseURL || 'https://api.finaegis.org/v2'
+      baseURL: options.baseURL || '{{ config('app.url') }}/api/v2'
     });
     
     this.retryOptions = {

--- a/resources/views/developers/index.blade.php
+++ b/resources/views/developers/index.blade.php
@@ -342,7 +342,7 @@
                                         <div><span class="text-gray-400">};</span></div>
                                         <div class="mt-4"></div>
                                         <div><span class="text-gray-400">// Example API call</span></div>
-                                        <div><span class="text-purple-400">fetch</span><span class="text-gray-400">(</span><span class="text-yellow-400">'https://api.finaegis.org/v2/accounts'</span><span class="text-gray-400">,</span> <span class="text-gray-400">{</span></div>
+                                        <div><span class="text-purple-400">fetch</span><span class="text-gray-400">(</span><span class="text-yellow-400">'{{ config('app.url') }}/api/v2/accounts'</span><span class="text-gray-400">,</span> <span class="text-gray-400">{</span></div>
                                         <div class="pl-4"><span class="text-green-400">method</span><span class="text-gray-400">:</span> <span class="text-yellow-400">'GET'</span><span class="text-gray-400">,</span></div>
                                         <div class="pl-4"><span class="text-green-400">headers</span><span class="text-gray-400">:</span> <span class="text-white">headers</span></div>
                                         <div><span class="text-gray-400">})</span></div>
@@ -812,7 +812,7 @@
                                 </div>
                                 <div class="p-4 font-mono text-sm">
                                     <div id="code-partner-auth">
-                                        <div><span class="text-gray-500">$</span> <span class="text-green-400">curl</span> <span class="text-blue-400">-X</span> <span class="text-purple-400">POST</span> <span class="text-yellow-400">"https://api.finaegis.org/v2/partner/tenants"</span> <span class="text-gray-400">\</span></div>
+                                        <div><span class="text-gray-500">$</span> <span class="text-green-400">curl</span> <span class="text-blue-400">-X</span> <span class="text-purple-400">POST</span> <span class="text-yellow-400">"{{ config('app.url') }}/api/v2/partner/tenants"</span> <span class="text-gray-400">\</span></div>
                                         <div>  <span class="text-blue-400">-H</span> <span class="text-yellow-400">"Authorization: Bearer YOUR_API_KEY"</span> <span class="text-gray-400">\</span></div>
                                         <div>  <span class="text-blue-400">-H</span> <span class="text-yellow-400">"X-Partner-Key: fpk_your_partner_key"</span> <span class="text-gray-400">\</span></div>
                                         <div>  <span class="text-blue-400">-H</span> <span class="text-yellow-400">"Content-Type: application/json"</span> <span class="text-gray-400">\</span></div>
@@ -877,7 +877,7 @@
                                 </button>
                             </div>
                             <pre class="p-4 code-block"><code id="code-create-account"><span class="text-purple-400">const</span> <span class="text-blue-400">createAccount</span> = <span class="text-purple-400">async</span> () <span class="text-blue-400">=></span> {
-    <span class="text-purple-400">const</span> <span class="text-white">response</span> = <span class="text-purple-400">await</span> <span class="text-green-400">fetch</span>(<span class="text-amber-400">'https://api.finaegis.org/v2/accounts'</span>, {
+    <span class="text-purple-400">const</span> <span class="text-white">response</span> = <span class="text-purple-400">await</span> <span class="text-green-400">fetch</span>(<span class="text-amber-400">'{{ config('app.url') }}/api/v2/accounts'</span>, {
         <span class="text-cyan-400">method</span>: <span class="text-amber-400">'POST'</span>,
         <span class="text-cyan-400">headers</span>: {
             <span class="text-amber-400">'Authorization'</span>: <span class="text-amber-400">'Bearer YOUR_API_KEY'</span>,
@@ -921,7 +921,7 @@
                             <pre class="p-4 code-block"><code id="code-transfer"><span class="text-purple-400">import</span> <span class="text-amber-400">requests</span>
 
 <span class="text-purple-400">def</span> <span class="text-blue-400">transfer_funds</span>(<span class="text-white">from_account</span>, <span class="text-white">to_account</span>, <span class="text-white">amount</span>):
-    <span class="text-white">url</span> = <span class="text-amber-400">"https://api.finaegis.org/v2/transfers"</span>
+    <span class="text-white">url</span> = <span class="text-amber-400">"{{ config('app.url') }}/api/v2/transfers"</span>
     <span class="text-white">headers</span> = {
         <span class="text-amber-400">"Authorization"</span>: <span class="text-amber-400">"Bearer YOUR_API_KEY"</span>,
         <span class="text-amber-400">"Content-Type"</span>: <span class="text-amber-400">"application/json"</span>
@@ -967,7 +967,7 @@
                             </div>
                             <pre class="p-4 code-block"><code id="code-gcu-exchange"><span class="text-purple-400">&lt;?php</span>
 <span class="text-blue-400">$api_key</span> = <span class="text-amber-400">'YOUR_API_KEY'</span>;
-<span class="text-blue-400">$endpoint</span> = <span class="text-amber-400">'https://api.finaegis.org/v2/gcu/exchange'</span>;
+<span class="text-blue-400">$endpoint</span> = <span class="text-amber-400">'{{ config('app.url') }}/api/v2/gcu/exchange'</span>;
 
 <span class="text-blue-400">$data</span> = [
     <span class="text-amber-400">'from_currency'</span> => <span class="text-amber-400">'USD'</span>,

--- a/resources/views/developers/postman.blade.php
+++ b/resources/views/developers/postman.blade.php
@@ -144,7 +144,7 @@
                                         </svg>
                                         <code class="text-sm font-medium text-blue-600">base_url</code>
                                     </div>
-                                    <span class="text-sm text-gray-600">https://finaegis.org/api/v2</span>
+                                    <span class="text-sm text-gray-600">{{ config('app.url') }}/api/v2</span>
                                 </div>
                             </div>
                             <div class="bg-white rounded-lg p-3 border border-gray-200">
@@ -155,7 +155,7 @@
                                         </svg>
                                         <code class="text-sm font-medium text-blue-600">sandbox_url</code>
                                     </div>
-                                    <span class="text-sm text-gray-600">https://finaegis.org/api/v2</span>
+                                    <span class="text-sm text-gray-600">{{ config('app.url') }}/api/v2</span>
                                 </div>
                             </div>
                             <div class="bg-white rounded-lg p-3 border border-gray-200">

--- a/resources/views/developers/sdks.blade.php
+++ b/resources/views/developers/sdks.blade.php
@@ -591,7 +591,7 @@ console.<span style="color: #89ddff;">log</span>(<span style="color: #82aaff;">r
 
                     <div class="bg-gray-900 rounded-lg p-6 font-mono text-green-400 text-sm overflow-x-auto mb-8">
 <pre><span class="text-gray-500"># Request SDK generation for your partner account</span>
-curl -X POST https://api.finaegis.org/api/v1/partner/sdk/generate \
+curl -X POST {{ config('app.url') }}/api/api/v1/partner/sdk/generate \
   -H "Authorization: Bearer YOUR_PARTNER_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -615,35 +615,35 @@ curl -X POST https://api.finaegis.org/api/v1/partner/sdk/generate \
         "language": "typescript",
         "version": "5.0.0",
         "package_name": "@finaegis/sdk",
-        "download_url": "https://sdk.finaegis.org/packages/typescript/finaegis-sdk-5.0.0.tgz",
+        "download_url": "{{ config('app.url') }}/developers/sdks/packages/typescript/finaegis-sdk-5.0.0.tgz",
         "install_command": "npm install @finaegis/sdk@5.0.0"
       },
       {
         "language": "python",
         "version": "5.0.0",
         "package_name": "finaegis-sdk",
-        "download_url": "https://sdk.finaegis.org/packages/python/finaegis-sdk-5.0.0.tar.gz",
+        "download_url": "{{ config('app.url') }}/developers/sdks/packages/python/finaegis-sdk-5.0.0.tar.gz",
         "install_command": "pip install finaegis-sdk==5.0.0"
       },
       {
         "language": "java",
         "version": "5.0.0",
         "package_name": "com.finaegis:sdk",
-        "download_url": "https://sdk.finaegis.org/packages/java/finaegis-sdk-5.0.0.jar",
+        "download_url": "{{ config('app.url') }}/developers/sdks/packages/java/finaegis-sdk-5.0.0.jar",
         "install_command": "mvn install com.finaegis:sdk:5.0.0"
       },
       {
         "language": "go",
         "version": "5.0.0",
         "package_name": "github.com/finaegis/sdk-go",
-        "download_url": "https://sdk.finaegis.org/packages/go/finaegis-sdk-go-5.12.0.tar.gz",
+        "download_url": "{{ config('app.url') }}/developers/sdks/packages/go/finaegis-sdk-go-5.12.0.tar.gz",
         "install_command": "go get github.com/finaegis/sdk-go@v5.12.0"
       },
       {
         "language": "php",
         "version": "5.0.0",
         "package_name": "finaegis/sdk",
-        "download_url": "https://sdk.finaegis.org/packages/php/finaegis-sdk-5.0.0.zip",
+        "download_url": "{{ config('app.url') }}/developers/sdks/packages/php/finaegis-sdk-5.0.0.zip",
         "install_command": "composer require finaegis/sdk:^5.0"
       }
     ]

--- a/resources/views/developers/webhooks.blade.php
+++ b/resources/views/developers/webhooks.blade.php
@@ -119,7 +119,7 @@
                 <div class="bg-gradient-to-r from-yellow-50 to-orange-50 rounded-3xl p-8 text-center">
                     <h3 class="text-2xl font-bold text-slate-900 mb-4">Quick Setup</h3>
                     <x-code-block language="bash">
-curl -X POST https://api.finaegis.org/v2/webhooks \
+curl -X POST {{ config('app.url') }}/api/v2/webhooks \
   -H "Authorization: Bearer YOUR_API_KEY" \
   -d '{"url": "https://yourapp.com/webhooks", "events": ["*"]}'
                 </x-code-block>

--- a/resources/views/gcu/index.blade.php
+++ b/resources/views/gcu/index.blade.php
@@ -769,7 +769,7 @@
                 </div>
 
                 <div class="mt-12 text-sm text-slate-500">
-                    <p>Questions? Contact our team at <a href="mailto:info@finaegis.org" class="underline">info@finaegis.org</a></p>
+                    <p>Questions? Contact our team at <a href="mailto:{{ config('brand.support_email', 'info@zelta.app') }}" class="underline">{{ config('brand.support_email', 'info@zelta.app') }}</a></p>
                 </div>
             </div>
         </section>

--- a/resources/views/support/contact.blade.php
+++ b/resources/views/support/contact.blade.php
@@ -38,7 +38,7 @@
                     </div>
                     <h3 class="text-xl font-semibold mb-2">Email Support</h3>
                     <p class="text-slate-500 mb-2">General inquiries & support</p>
-                    <a href="mailto:info@finaegis.org" class="text-indigo-600 hover:text-indigo-700 font-medium">info@finaegis.org</a>
+                    <a href="mailto:{{ config('brand.support_email', 'info@zelta.app') }}" class="text-indigo-600 hover:text-indigo-700 font-medium">{{ config('brand.support_email', 'info@zelta.app') }}</a>
                 </div>
                 
                 <!-- GitHub Issues -->

--- a/resources/views/support/faq.blade.php
+++ b/resources/views/support/faq.blade.php
@@ -185,7 +185,7 @@
                             <li>Register for a free account on the platform</li>
                             <li>Explore the sandbox features and test transactions</li>
                             <li>Report bugs and issues on our GitHub repository</li>
-                            <li>Provide feedback via email at info@finaegis.org</li>
+                            <li>Provide feedback via email at {{ config('brand.support_email', 'info@zelta.app') }}</li>
                             <li>Join discussions on our GitHub community forum</li>
                         </ol>
                         <p class="text-slate-500 mt-3">

--- a/resources/views/support/guides.blade.php
+++ b/resources/views/support/guides.blade.php
@@ -319,7 +319,7 @@
                             <p class="text-slate-500 mb-4">Join our community:</p>
                             <ul class="list-disc list-inside text-slate-500 space-y-2">
                                 <li>GitHub Discussions for general topics</li>
-                                <li>Email info@finaegis.org for direct feedback</li>
+                                <li>Email {{ config('brand.support_email', 'info@zelta.app') }} for direct feedback</li>
                                 <li>Star the repository to show support</li>
                                 <li>Share the project with other developers</li>
                             </ul>
@@ -327,7 +327,7 @@
                                 <a href="{{ config('brand.github_url') }}/discussions" class="text-indigo-600 font-medium hover:text-indigo-700">
                                     Join Discussions →
                                 </a>
-                                <a href="mailto:info@finaegis.org" class="text-indigo-600 font-medium hover:text-indigo-700">
+                                <a href="mailto:{{ config('brand.support_email', 'info@zelta.app') }}" class="text-indigo-600 font-medium hover:text-indigo-700">
                                     Email Feedback →
                                 </a>
                             </div>


### PR DESCRIPTION
## Summary
Comprehensive audit found 100+ hardcoded `finaegis.org` domain references across developer portal pages and support pages. All eliminated.

## Changes
- **Developer pages** (5 files): Replace `docs.finaegis.org`, `sdk.finaegis.org`, `sandbox.finaegis.org`, `partners.finaegis.org`, `api.finaegis.org` → `config('app.url')`
- **Postman files**: Rename `FinAegis-API.*` → `Zelta-API.*`, rebrand JSON contents
- **Support pages** (3 files): Replace `info@finaegis.org` → `config('brand.support_email')`
- **CGO/GCU/AI pages** (3 files): Replace remaining email references

Zero hardcoded `finaegis.org` references remaining in any blade template.

## Test plan
- [ ] CI passes
- [ ] Postman download links work at `/docs/postman/Zelta-API.postman_collection.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)