### PR TITLE
fix: blade syntax error on /developers portal page

### DIFF
--- a/resources/views/developers/index.blade.php
+++ b/resources/views/developers/index.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'Developer Documentation - ' . config('brand.name', 'Zelta') . '',
-        'description' => '{{ config('brand.name', 'Zelta') }} Developer Documentation - Build on ' . config('brand.name', 'Zelta') . ' platform. Open source, API-first, and designed for developers.',
+        'description' => config('brand.name', 'Zelta') . ' Developer Documentation - Build on ' . config('brand.name', 'Zelta') . ' platform. Open source, API-first, and designed for developers.',
         'keywords' => config('brand.name', 'Zelta') . ', developer, API, documentation, SDK, integration',
     ])
 @endsection


### PR DESCRIPTION
## Summary

- `/developers` page threw `syntax error, unexpected identifier "brand", expecting "]"`
- Line 8 in `developers/index.blade.php` used `{{ config('brand.name') }}` (Blade echo) inside a PHP `@include` array — invalid PHP syntax
- Replaced with PHP concatenation: `config('brand.name', 'Zelta') . ' text'`

## Test plan

- [x] `php artisan tinker --execute="view('developers.index')->render();"` renders without error
- [x] No other blade files have this pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)