### PR TITLE
feat: VisaCli domain foundation — contracts, services, models, migrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -429,6 +429,17 @@ X402_REQUIRE_APPROVAL_ABOVE=1000000
 X402_PER_TRANSACTION_LIMIT=100000
 
 # =============================================================================
+# VISA CLI INTEGRATION
+# =============================================================================
+VISACLI_ENABLED=false
+VISACLI_DRIVER=demo
+VISACLI_BINARY_PATH=visa-cli
+VISACLI_GITHUB_TOKEN=
+VISACLI_DAILY_LIMIT=10000
+VISACLI_PER_TX_LIMIT=1000
+VISACLI_WEBHOOK_SECRET=
+
+# =============================================================================
 # CIRCLE CCTP (Native USDC Bridge)
 # =============================================================================
 CIRCLE_CCTP_ENABLED=false

--- a/app/Domain/VisaCli/Contracts/VisaCliClientInterface.php
+++ b/app/Domain/VisaCli/Contracts/VisaCliClientInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\VisaCli\Contracts;
+
+use App\Domain\VisaCli\DataObjects\VisaCliCard;
+use App\Domain\VisaCli\DataObjects\VisaCliPaymentResult;
+use App\Domain\VisaCli\DataObjects\VisaCliStatus;
+
+interface VisaCliClientInterface
+{
+    /**
+     * Get the current status of the Visa CLI installation.
+     */
+    public function getStatus(): VisaCliStatus;
+
+    /**
+     * Enroll a card for use with Visa CLI payments.
+     *
+     * @param array<string, mixed> $metadata
+     */
+    public function enrollCard(string $userId, array $metadata = []): VisaCliCard;
+
+    /**
+     * List all enrolled cards.
+     *
+     * @return array<VisaCliCard>
+     */
+    public function listCards(?string $userId = null): array;
+
+    /**
+     * Execute a payment to a URL.
+     */
+    public function pay(string $url, int $amountCents, ?string $cardId = null): VisaCliPaymentResult;
+
+    /**
+     * Check if Visa CLI is initialized and ready.
+     */
+    public function isInitialized(): bool;
+
+    /**
+     * Initialize the Visa CLI client.
+     */
+    public function initialize(): bool;
+}

--- a/app/Domain/VisaCli/Contracts/VisaCliPaymentGatewayInterface.php
+++ b/app/Domain/VisaCli/Contracts/VisaCliPaymentGatewayInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\VisaCli\Contracts;
+
+use App\Domain\FinancialInstitution\Models\PartnerInvoice;
+use App\Domain\VisaCli\DataObjects\VisaCliPaymentResult;
+
+interface VisaCliPaymentGatewayInterface
+{
+    /**
+     * Collect payment for a partner invoice.
+     */
+    public function collectPayment(PartnerInvoice $invoice, ?string $cardId = null): VisaCliPaymentResult;
+
+    /**
+     * Get payment status by reference.
+     */
+    public function getPaymentStatus(string $paymentReference): VisaCliPaymentResult;
+
+    /**
+     * Refund a payment by reference.
+     */
+    public function refundPayment(string $paymentReference, ?int $amountCents = null): VisaCliPaymentResult;
+}

--- a/app/Domain/VisaCli/DataObjects/VisaCliCard.php
+++ b/app/Domain/VisaCli/DataObjects/VisaCliCard.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\VisaCli\DataObjects;
+
+use App\Domain\VisaCli\Enums\VisaCliCardStatus;
+
+final class VisaCliCard
+{
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function __construct(
+        public readonly string $cardIdentifier,
+        public readonly string $last4,
+        public readonly string $network,
+        public readonly VisaCliCardStatus $status,
+        public readonly ?string $githubUsername = null,
+        public readonly array $metadata = [],
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'card_identifier' => $this->cardIdentifier,
+            'last4'           => $this->last4,
+            'network'         => $this->network,
+            'status'          => $this->status->value,
+            'github_username' => $this->githubUsername,
+            'metadata'        => $this->metadata,
+        ];
+    }
+}

--- a/app/Domain/VisaCli/DataObjects/VisaCliPaymentRequest.php
+++ b/app/Domain/VisaCli/DataObjects/VisaCliPaymentRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\VisaCli\DataObjects;
+
+use Illuminate\Support\Str;
+
+final class VisaCliPaymentRequest
+{
+    public readonly string $requestId;
+
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function __construct(
+        public readonly string $agentId,
+        public readonly string $url,
+        public readonly int $amountCents,
+        public readonly string $currency = 'USD',
+        public readonly ?string $cardId = null,
+        public readonly ?string $purpose = null,
+        public readonly array $metadata = [],
+    ) {
+        $this->requestId = Str::uuid()->toString();
+    }
+}

--- a/app/Domain/VisaCli/DataObjects/VisaCliPaymentResult.php
+++ b/app/Domain/VisaCli/DataObjects/VisaCliPaymentResult.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\VisaCli\DataObjects;
+
+use App\Domain\VisaCli\Enums\VisaCliPaymentStatus;
+
+final class VisaCliPaymentResult
+{
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function __construct(
+        public readonly string $paymentReference,
+        public readonly VisaCliPaymentStatus $status,
+        public readonly int $amountCents,
+        public readonly string $currency,
+        public readonly string $url,
+        public readonly ?string $cardLast4 = null,
+        public readonly ?string $errorMessage = null,
+        public readonly array $metadata = [],
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'payment_reference' => $this->paymentReference,
+            'status'            => $this->status->value,
+            'amount_cents'      => $this->amountCents,
+            'currency'          => $this->currency,
+            'url'               => $this->url,
+            'card_last4'        => $this->cardLast4,
+            'error_message'     => $this->errorMessage,
+            'metadata'          => $this->metadata,
+        ];
+    }
+}

--- a/app/Domain/VisaCli/DataObjects/VisaCliStatus.php
+++ b/app/Domain/VisaCli/DataObjects/VisaCliStatus.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\VisaCli\DataObjects;
+
+final class VisaCliStatus
+{
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function __construct(
+        public readonly bool $initialized,
+        public readonly ?string $version = null,
+        public readonly ?string $githubUsername = null,
+        public readonly int $enrolledCards = 0,
+        public readonly array $metadata = [],
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'initialized'     => $this->initialized,
+            'version'         => $this->version,
+            'github_username' => $this->githubUsername,
+            'enrolled_cards'  => $this->enrolledCards,
+            'metadata'        => $this->metadata,
+        ];
+    }
+}

--- a/app/Domain/VisaCli/Enums/VisaCliCardStatus.php
+++ b/app/Domain/VisaCli/Enums/VisaCliCardStatus.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\VisaCli\Enums;
+
+enum VisaCliCardStatus: string
+{
+    case ENROLLED = 'enrolled';
+    case ACTIVE = 'active';
+    case SUSPENDED = 'suspended';
+    case REMOVED = 'removed';
+}

--- a/app/Domain/VisaCli/Enums/VisaCliPaymentStatus.php
+++ b/app/Domain/VisaCli/Enums/VisaCliPaymentStatus.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\VisaCli\Enums;
+
+enum VisaCliPaymentStatus: string
+{
+    case PENDING = 'pending';
+    case PROCESSING = 'processing';
+    case COMPLETED = 'completed';
+    case FAILED = 'failed';
+    case REFUNDED = 'refunded';
+}

--- a/app/Domain/VisaCli/Events/VisaCliCardEnrolled.php
+++ b/app/Domain/VisaCli/Events/VisaCliCardEnrolled.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\VisaCli\Events;
+
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
+
+class VisaCliCardEnrolled extends ShouldBeStored
+{
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function __construct(
+        public readonly string $userId,
+        public readonly string $cardIdentifier,
+        public readonly string $last4,
+        public readonly string $network,
+        public readonly array $metadata = [],
+    ) {
+    }
+}

--- a/app/Domain/VisaCli/Events/VisaCliCardRemoved.php
+++ b/app/Domain/VisaCli/Events/VisaCliCardRemoved.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\VisaCli\Events;
+
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
+
+class VisaCliCardRemoved extends ShouldBeStored
+{
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function __construct(
+        public readonly string $userId,
+        public readonly string $cardIdentifier,
+        public readonly array $metadata = [],
+    ) {
+    }
+}

--- a/app/Domain/VisaCli/Events/VisaCliPaymentCompleted.php
+++ b/app/Domain/VisaCli/Events/VisaCliPaymentCompleted.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\VisaCli\Events;
+
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
+
+class VisaCliPaymentCompleted extends ShouldBeStored
+{
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function __construct(
+        public readonly string $paymentId,
+        public readonly string $paymentReference,
+        public readonly int $amountCents,
+        public readonly string $currency,
+        public readonly array $metadata = [],
+    ) {
+    }
+}

--- a/app/Domain/VisaCli/Events/VisaCliPaymentFailed.php
+++ b/app/Domain/VisaCli/Events/VisaCliPaymentFailed.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\VisaCli\Events;
+
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
+
+class VisaCliPaymentFailed extends ShouldBeStored
+{
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function __construct(
+        public readonly string $paymentId,
+        public readonly string $reason,
+        public readonly int $amountCents,
+        public readonly string $currency,
+        public readonly array $metadata = [],
+    ) {
+    }
+}

--- a/app/Domain/VisaCli/Events/VisaCliPaymentInitiated.php
+++ b/app/Domain/VisaCli/Events/VisaCliPaymentInitiated.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\VisaCli\Events;
+
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
+
+class VisaCliPaymentInitiated extends ShouldBeStored
+{
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function __construct(
+        public readonly string $paymentId,
+        public readonly string $agentId,
+        public readonly string $url,
+        public readonly int $amountCents,
+        public readonly string $currency,
+        public readonly array $metadata = [],
+    ) {
+    }
+}

--- a/app/Domain/VisaCli/Exceptions/VisaCliEnrollmentException.php
+++ b/app/Domain/VisaCli/Exceptions/VisaCliEnrollmentException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\VisaCli\Exceptions;
+
+class VisaCliEnrollmentException extends VisaCliException
+{
+}

--- a/app/Domain/VisaCli/Exceptions/VisaCliException.php
+++ b/app/Domain/VisaCli/Exceptions/VisaCliException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\VisaCli\Exceptions;
+
+use RuntimeException;
+
+class VisaCliException extends RuntimeException
+{
+}

--- a/app/Domain/VisaCli/Exceptions/VisaCliPaymentException.php
+++ b/app/Domain/VisaCli/Exceptions/VisaCliPaymentException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\VisaCli\Exceptions;
+
+class VisaCliPaymentException extends VisaCliException
+{
+}

--- a/app/Domain/VisaCli/Models/VisaCliEnrolledCard.php
+++ b/app/Domain/VisaCli/Models/VisaCliEnrolledCard.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\VisaCli\Models;
+
+use App\Domain\VisaCli\Enums\VisaCliCardStatus;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * @property string $id
+ * @property int $user_id
+ * @property string $card_identifier
+ * @property string $last4
+ * @property string $network
+ * @property string $status
+ * @property string|null $github_username
+ * @property array<string, mixed>|null $metadata
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ * @property \Carbon\Carbon|null $deleted_at
+ */
+class VisaCliEnrolledCard extends Model
+{
+    use HasUuids;
+    use SoftDeletes;
+
+    protected $table = 'visa_cli_enrolled_cards';
+
+    protected $fillable = [
+        'user_id',
+        'card_identifier',
+        'last4',
+        'network',
+        'status',
+        'github_username',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'metadata' => 'array',
+        'status'   => VisaCliCardStatus::class,
+    ];
+
+    protected $attributes = [
+        'status'  => VisaCliCardStatus::ENROLLED,
+        'network' => 'visa',
+    ];
+
+    /**
+     * @return BelongsTo<\App\Models\User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(\App\Models\User::class);
+    }
+
+    public function isActive(): bool
+    {
+        return in_array($this->status, [VisaCliCardStatus::ENROLLED, VisaCliCardStatus::ACTIVE]);
+    }
+}

--- a/app/Domain/VisaCli/Models/VisaCliPayment.php
+++ b/app/Domain/VisaCli/Models/VisaCliPayment.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\VisaCli\Models;
+
+use App\Domain\VisaCli\Enums\VisaCliPaymentStatus;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * @property string $id
+ * @property string $agent_id
+ * @property int|null $invoice_id
+ * @property string $url
+ * @property int $amount_cents
+ * @property string $currency
+ * @property string $status
+ * @property string|null $card_identifier
+ * @property string|null $payment_reference
+ * @property array<string, mixed>|null $metadata
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ * @property \Carbon\Carbon|null $deleted_at
+ */
+class VisaCliPayment extends Model
+{
+    use HasUuids;
+    use SoftDeletes;
+
+    protected $table = 'visa_cli_payments';
+
+    protected $fillable = [
+        'agent_id',
+        'invoice_id',
+        'url',
+        'amount_cents',
+        'currency',
+        'status',
+        'card_identifier',
+        'payment_reference',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'metadata'     => 'array',
+        'amount_cents' => 'integer',
+        'status'       => VisaCliPaymentStatus::class,
+    ];
+
+    protected $attributes = [
+        'currency' => 'USD',
+        'status'   => VisaCliPaymentStatus::PENDING,
+    ];
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<\App\Domain\FinancialInstitution\Models\PartnerInvoice, $this>
+     */
+    public function invoice(): \Illuminate\Database\Eloquent\Relations\BelongsTo
+    {
+        return $this->belongsTo(\App\Domain\FinancialInstitution\Models\PartnerInvoice::class, 'invoice_id');
+    }
+
+    public function isCompleted(): bool
+    {
+        return $this->status === VisaCliPaymentStatus::COMPLETED;
+    }
+
+    public function isFailed(): bool
+    {
+        return $this->status === VisaCliPaymentStatus::FAILED;
+    }
+
+    public function isPending(): bool
+    {
+        return in_array($this->status, [VisaCliPaymentStatus::PENDING, VisaCliPaymentStatus::PROCESSING]);
+    }
+
+    public function markCompleted(string $paymentReference): void
+    {
+        $this->update([
+            'status'            => VisaCliPaymentStatus::COMPLETED,
+            'payment_reference' => $paymentReference,
+        ]);
+    }
+
+    public function markFailed(string $reason): void
+    {
+        $this->update([
+            'status'   => VisaCliPaymentStatus::FAILED,
+            'metadata' => array_merge($this->metadata ?? [], ['failure_reason' => $reason]),
+        ]);
+    }
+}

--- a/app/Domain/VisaCli/Models/VisaCliSpendingLimit.php
+++ b/app/Domain/VisaCli/Models/VisaCliSpendingLimit.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\VisaCli\Models;
+
+use App\Models\Team;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Agent spending limit — controls automated Visa CLI payment budgets.
+ *
+ * @property string $id
+ * @property string $agent_id
+ * @property string $agent_type
+ * @property int $daily_limit
+ * @property int $spent_today
+ * @property int|null $per_transaction_limit
+ * @property bool $auto_pay_enabled
+ * @property \Carbon\Carbon $limit_resets_at
+ * @property int|null $team_id
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ */
+class VisaCliSpendingLimit extends Model
+{
+    use HasUuids;
+
+    protected $table = 'visa_cli_spending_limits';
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected $attributes = [
+        'spent_today'      => 0,
+        'auto_pay_enabled' => false,
+    ];
+
+    protected $fillable = [
+        'agent_id',
+        'agent_type',
+        'daily_limit',
+        'spent_today',
+        'per_transaction_limit',
+        'auto_pay_enabled',
+        'limit_resets_at',
+        'team_id',
+    ];
+
+    protected $casts = [
+        'daily_limit'           => 'integer',
+        'spent_today'           => 'integer',
+        'per_transaction_limit' => 'integer',
+        'auto_pay_enabled'      => 'boolean',
+        'limit_resets_at'       => 'datetime',
+    ];
+
+    // ----------------------------------------------------------------
+    // Relationships
+    // ----------------------------------------------------------------
+
+    /**
+     * @return BelongsTo<Team, $this>
+     */
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+
+    // ----------------------------------------------------------------
+    // Helpers
+    // ----------------------------------------------------------------
+
+    /**
+     * Determine whether this agent can auto-pay the given amount.
+     */
+    public function canAutoPay(int $amount): bool
+    {
+        if (! $this->auto_pay_enabled) {
+            return false;
+        }
+
+        if ($this->per_transaction_limit !== null && $amount > $this->per_transaction_limit) {
+            return false;
+        }
+
+        return $this->canSpend($amount);
+    }
+
+    /**
+     * Determine whether the daily budget has room for the given amount.
+     */
+    public function canSpend(int $amount): bool
+    {
+        $this->resetIfNeeded();
+
+        return ($this->daily_limit - $this->spent_today) >= $amount;
+    }
+
+    /**
+     * Record a spending event against today's budget.
+     */
+    public function recordSpending(int $amount): void
+    {
+        $this->resetIfNeeded();
+
+        $this->spent_today += $amount;
+        $this->save();
+    }
+
+    /**
+     * Reset daily counters if the reset window has passed.
+     */
+    public function resetIfNeeded(): void
+    {
+        if ($this->limit_resets_at !== null && $this->limit_resets_at->isPast()) {
+            $this->spent_today = 0;
+            $this->limit_resets_at = now()->addDay();
+        }
+    }
+
+    /**
+     * Get the remaining daily budget in cents.
+     */
+    public function remainingDailyBudget(): int
+    {
+        $this->resetIfNeeded();
+
+        $remaining = $this->daily_limit - $this->spent_today;
+
+        return max(0, $remaining);
+    }
+
+    /**
+     * Get the percentage of daily budget that has been spent.
+     */
+    public function spentPercentage(): float
+    {
+        if ($this->daily_limit === 0) {
+            return 0.0;
+        }
+
+        return round(($this->spent_today / $this->daily_limit) * 100, 2);
+    }
+
+    // ----------------------------------------------------------------
+    // API Serialization
+    // ----------------------------------------------------------------
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toApiResponse(): array
+    {
+        return [
+            'id'                  => $this->id,
+            'agentId'             => $this->agent_id,
+            'agentType'           => $this->agent_type,
+            'dailyLimit'          => $this->daily_limit,
+            'spentToday'          => $this->spent_today,
+            'perTransactionLimit' => $this->per_transaction_limit,
+            'autoPayEnabled'      => $this->auto_pay_enabled,
+            'remainingBudget'     => $this->remainingDailyBudget(),
+            'spentPercentage'     => $this->spentPercentage(),
+            'limitResetsAt'       => $this->limit_resets_at->toIso8601String(),
+            'createdAt'           => $this->created_at->toIso8601String(),
+            'updatedAt'           => $this->updated_at->toIso8601String(),
+        ];
+    }
+}

--- a/app/Domain/VisaCli/Services/DemoVisaCliClient.php
+++ b/app/Domain/VisaCli/Services/DemoVisaCliClient.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\VisaCli\Services;
+
+use App\Domain\VisaCli\Contracts\VisaCliClientInterface;
+use App\Domain\VisaCli\DataObjects\VisaCliCard;
+use App\Domain\VisaCli\DataObjects\VisaCliPaymentResult;
+use App\Domain\VisaCli\DataObjects\VisaCliStatus;
+use App\Domain\VisaCli\Enums\VisaCliCardStatus;
+use App\Domain\VisaCli\Enums\VisaCliPaymentStatus;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Demo implementation of Visa CLI client for development and testing.
+ */
+class DemoVisaCliClient implements VisaCliClientInterface
+{
+    private const CACHE_PREFIX = 'visacli_demo:';
+
+    public function getStatus(): VisaCliStatus
+    {
+        return new VisaCliStatus(
+            initialized: true,
+            version: '0.1.0-beta',
+            githubUsername: 'demo-user',
+            enrolledCards: count($this->listCards()),
+            metadata: ['driver' => 'demo'],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function enrollCard(string $userId, array $metadata = []): VisaCliCard
+    {
+        $cardId = 'visa_demo_' . bin2hex(random_bytes(8));
+        $last4 = (string) random_int(1000, 9999);
+
+        $card = new VisaCliCard(
+            cardIdentifier: $cardId,
+            last4: $last4,
+            network: 'visa',
+            status: VisaCliCardStatus::ENROLLED,
+            githubUsername: 'demo-user',
+            metadata: array_merge($metadata, ['user_id' => $userId]),
+        );
+
+        // Store in cache for demo
+        /** @var array<string, array<string, mixed>> $cards */
+        $cards = Cache::get(self::CACHE_PREFIX . 'cards', []);
+        $cards[$cardId] = $card->toArray();
+        Cache::put(self::CACHE_PREFIX . 'cards', $cards, now()->addDays(30));
+
+        // Track user cards
+        /** @var array<string> $userCards */
+        $userCards = Cache::get(self::CACHE_PREFIX . "user_cards:{$userId}", []);
+        $userCards[] = $cardId;
+        Cache::put(self::CACHE_PREFIX . "user_cards:{$userId}", $userCards, now()->addDays(30));
+
+        return $card;
+    }
+
+    /**
+     * @return array<VisaCliCard>
+     */
+    public function listCards(?string $userId = null): array
+    {
+        if ($userId !== null) {
+            return $this->listUserCards($userId);
+        }
+
+        /** @var array<string, array<string, mixed>> $cards */
+        $cards = Cache::get(self::CACHE_PREFIX . 'cards', []);
+
+        return array_map(
+            fn (array $data) => new VisaCliCard(
+                cardIdentifier: (string) $data['card_identifier'],
+                last4: (string) $data['last4'],
+                network: (string) $data['network'],
+                status: VisaCliCardStatus::from((string) $data['status']),
+                githubUsername: $data['github_username'] ?? null,
+                metadata: (array) ($data['metadata'] ?? []),
+            ),
+            array_values($cards),
+        );
+    }
+
+    public function pay(string $url, int $amountCents, ?string $cardId = null): VisaCliPaymentResult
+    {
+        $reference = 'visa_pay_demo_' . bin2hex(random_bytes(12));
+
+        // Store demo payment
+        /** @var array<string, array<string, mixed>> $payments */
+        $payments = Cache::get(self::CACHE_PREFIX . 'payments', []);
+        $payments[$reference] = [
+            'reference'    => $reference,
+            'url'          => $url,
+            'amount_cents' => $amountCents,
+            'currency'     => 'USD',
+            'status'       => VisaCliPaymentStatus::COMPLETED->value,
+            'card_id'      => $cardId,
+            'created_at'   => now()->toIso8601String(),
+        ];
+        Cache::put(self::CACHE_PREFIX . 'payments', $payments, now()->addDays(30));
+
+        return new VisaCliPaymentResult(
+            paymentReference: $reference,
+            status: VisaCliPaymentStatus::COMPLETED,
+            amountCents: $amountCents,
+            currency: 'USD',
+            url: $url,
+            cardLast4: '4242',
+            metadata: ['driver' => 'demo'],
+        );
+    }
+
+    public function isInitialized(): bool
+    {
+        return true;
+    }
+
+    public function initialize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<VisaCliCard>
+     */
+    private function listUserCards(string $userId): array
+    {
+        /** @var array<string> $userCardIds */
+        $userCardIds = Cache::get(self::CACHE_PREFIX . "user_cards:{$userId}", []);
+
+        /** @var array<string, array<string, mixed>> $allCards */
+        $allCards = Cache::get(self::CACHE_PREFIX . 'cards', []);
+
+        $cards = [];
+        foreach ($userCardIds as $cardId) {
+            if (isset($allCards[$cardId])) {
+                $data = $allCards[$cardId];
+                $cards[] = new VisaCliCard(
+                    cardIdentifier: (string) $data['card_identifier'],
+                    last4: (string) $data['last4'],
+                    network: (string) $data['network'],
+                    status: VisaCliCardStatus::from((string) $data['status']),
+                    githubUsername: $data['github_username'] ?? null,
+                    metadata: (array) ($data['metadata'] ?? []),
+                );
+            }
+        }
+
+        return $cards;
+    }
+}

--- a/app/Domain/VisaCli/Services/VisaCliCardEnrollmentService.php
+++ b/app/Domain/VisaCli/Services/VisaCliCardEnrollmentService.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\VisaCli\Services;
+
+use App\Domain\VisaCli\Contracts\VisaCliClientInterface;
+use App\Domain\VisaCli\DataObjects\VisaCliCard;
+use App\Domain\VisaCli\Enums\VisaCliCardStatus;
+use App\Domain\VisaCli\Events\VisaCliCardEnrolled;
+use App\Domain\VisaCli\Events\VisaCliCardRemoved;
+use App\Domain\VisaCli\Exceptions\VisaCliEnrollmentException;
+use App\Domain\VisaCli\Models\VisaCliEnrolledCard;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Card enrollment bridge between Visa CLI and the FinAegis card system.
+ */
+class VisaCliCardEnrollmentService
+{
+    public function __construct(
+        private readonly VisaCliClientInterface $client,
+    ) {
+    }
+
+    /**
+     * Enroll a card for a user.
+     */
+    public function enrollCard(string $userId): VisaCliEnrolledCard
+    {
+        if (! config('visacli.enabled', false)) {
+            throw new VisaCliEnrollmentException('Visa CLI integration is not enabled.');
+        }
+
+        $card = $this->client->enrollCard($userId);
+
+        $enrolledCard = VisaCliEnrolledCard::create([
+            'user_id'         => $userId,
+            'card_identifier' => $card->cardIdentifier,
+            'last4'           => $card->last4,
+            'network'         => $card->network,
+            'status'          => VisaCliCardStatus::ENROLLED,
+            'github_username' => $card->githubUsername,
+            'metadata'        => $card->metadata,
+        ]);
+
+        event(new VisaCliCardEnrolled(
+            userId: $userId,
+            cardIdentifier: $card->cardIdentifier,
+            last4: $card->last4,
+            network: $card->network,
+            metadata: $card->metadata,
+        ));
+
+        Log::info('Visa CLI card enrolled', [
+            'user_id'         => $userId,
+            'card_identifier' => $card->cardIdentifier,
+            'last4'           => $card->last4,
+        ]);
+
+        return $enrolledCard;
+    }
+
+    /**
+     * Sync cards from Visa CLI for a user.
+     *
+     * @return array<VisaCliEnrolledCard>
+     */
+    public function syncCards(string $userId): array
+    {
+        $remoteCards = $this->client->listCards($userId);
+        $synced = [];
+
+        foreach ($remoteCards as $card) {
+            $existing = VisaCliEnrolledCard::where('card_identifier', $card->cardIdentifier)
+                ->where('user_id', $userId)
+                ->first();
+
+            if ($existing !== null) {
+                $existing->update([
+                    'status'          => $card->status,
+                    'github_username' => $card->githubUsername,
+                    'metadata'        => $card->metadata,
+                ]);
+                $synced[] = $existing;
+            } else {
+                $synced[] = VisaCliEnrolledCard::create([
+                    'user_id'         => $userId,
+                    'card_identifier' => $card->cardIdentifier,
+                    'last4'           => $card->last4,
+                    'network'         => $card->network,
+                    'status'          => $card->status,
+                    'github_username' => $card->githubUsername,
+                    'metadata'        => $card->metadata,
+                ]);
+            }
+        }
+
+        return $synced;
+    }
+
+    /**
+     * Get enrolled cards for a user.
+     *
+     * @return \Illuminate\Database\Eloquent\Collection<int, VisaCliEnrolledCard>
+     */
+    public function getEnrolledCards(string $userId): \Illuminate\Database\Eloquent\Collection
+    {
+        return VisaCliEnrolledCard::where('user_id', $userId)
+            ->whereIn('status', [VisaCliCardStatus::ENROLLED, VisaCliCardStatus::ACTIVE])
+            ->get();
+    }
+
+    /**
+     * Remove an enrolled card.
+     */
+    public function removeCard(string $userId, string $cardId): bool
+    {
+        $card = VisaCliEnrolledCard::where('user_id', $userId)
+            ->where('id', $cardId)
+            ->first();
+
+        if ($card === null) {
+            return false;
+        }
+
+        $card->update(['status' => VisaCliCardStatus::REMOVED]);
+        $card->delete();
+
+        event(new VisaCliCardRemoved(
+            userId: $userId,
+            cardIdentifier: $card->card_identifier,
+        ));
+
+        Log::info('Visa CLI card removed', [
+            'user_id'         => $userId,
+            'card_identifier' => $card->card_identifier,
+        ]);
+
+        return true;
+    }
+
+    /**
+     * Convert enrolled card model to DTO.
+     */
+    public function toCard(VisaCliEnrolledCard $model): VisaCliCard
+    {
+        return new VisaCliCard(
+            cardIdentifier: $model->card_identifier,
+            last4: $model->last4,
+            network: $model->network,
+            status: $model->status instanceof VisaCliCardStatus ? $model->status : VisaCliCardStatus::from($model->status),
+            githubUsername: $model->github_username,
+            metadata: $model->metadata ?? [],
+        );
+    }
+}

--- a/app/Domain/VisaCli/Services/VisaCliPaymentGatewayService.php
+++ b/app/Domain/VisaCli/Services/VisaCliPaymentGatewayService.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\VisaCli\Services;
+
+use App\Domain\FinancialInstitution\Models\PartnerInvoice;
+use App\Domain\VisaCli\Contracts\VisaCliClientInterface;
+use App\Domain\VisaCli\Contracts\VisaCliPaymentGatewayInterface;
+use App\Domain\VisaCli\DataObjects\VisaCliPaymentResult;
+use App\Domain\VisaCli\Enums\VisaCliPaymentStatus;
+use App\Domain\VisaCli\Exceptions\VisaCliPaymentException;
+use App\Domain\VisaCli\Models\VisaCliPayment;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Payment gateway service for collecting partner invoice payments via Visa CLI.
+ */
+class VisaCliPaymentGatewayService implements VisaCliPaymentGatewayInterface
+{
+    public function __construct(
+        private readonly VisaCliClientInterface $client,
+    ) {
+    }
+
+    public function collectPayment(PartnerInvoice $invoice, ?string $cardId = null): VisaCliPaymentResult
+    {
+        if (! $invoice->canBePaid()) {
+            throw new VisaCliPaymentException(
+                "Invoice {$invoice->invoice_number} cannot be paid (status: {$invoice->status})."
+            );
+        }
+
+        $amountCents = (int) round((float) $invoice->total_amount_usd * 100);
+        $paymentUrl = config('app.url') . '/api/partner/v1/billing/invoices/' . $invoice->id;
+
+        return DB::transaction(function () use ($invoice, $cardId, $amountCents, $paymentUrl): VisaCliPaymentResult {
+            // Create payment record
+            $payment = VisaCliPayment::create([
+                'agent_id'        => 'invoice-gateway',
+                'invoice_id'      => $invoice->id,
+                'url'             => $paymentUrl,
+                'amount_cents'    => $amountCents,
+                'currency'        => 'USD',
+                'status'          => VisaCliPaymentStatus::PROCESSING,
+                'card_identifier' => $cardId,
+                'metadata'        => [
+                    'invoice_number' => $invoice->invoice_number,
+                    'partner_id'     => $invoice->partner_id,
+                ],
+            ]);
+
+            try {
+                $result = $this->client->pay($paymentUrl, $amountCents, $cardId);
+
+                $payment->markCompleted($result->paymentReference);
+
+                // Mark the invoice as paid
+                $invoice->markAsPaid('visa_cli', $result->paymentReference);
+
+                Log::info('Visa CLI invoice payment collected', [
+                    'invoice_number'    => $invoice->invoice_number,
+                    'payment_reference' => $result->paymentReference,
+                    'amount_cents'      => $amountCents,
+                ]);
+
+                return $result;
+            } catch (Throwable $e) {
+                $payment->markFailed($e->getMessage());
+
+                Log::error('Visa CLI invoice payment failed', [
+                    'invoice_number' => $invoice->invoice_number,
+                    'error'          => $e->getMessage(),
+                ]);
+
+                throw new VisaCliPaymentException(
+                    "Failed to collect payment for invoice {$invoice->invoice_number}: {$e->getMessage()}",
+                    0,
+                    $e,
+                );
+            }
+        });
+    }
+
+    public function getPaymentStatus(string $paymentReference): VisaCliPaymentResult
+    {
+        $payment = VisaCliPayment::where('payment_reference', $paymentReference)->first();
+
+        if ($payment === null) {
+            throw new VisaCliPaymentException("Payment not found: {$paymentReference}");
+        }
+
+        $status = $payment->status instanceof VisaCliPaymentStatus
+            ? $payment->status
+            : VisaCliPaymentStatus::from($payment->status);
+
+        return new VisaCliPaymentResult(
+            paymentReference: (string) $payment->payment_reference,
+            status: $status,
+            amountCents: $payment->amount_cents,
+            currency: $payment->currency,
+            url: $payment->url,
+            metadata: $payment->metadata ?? [],
+        );
+    }
+
+    public function refundPayment(string $paymentReference, ?int $amountCents = null): VisaCliPaymentResult
+    {
+        $payment = VisaCliPayment::where('payment_reference', $paymentReference)->first();
+
+        if ($payment === null) {
+            throw new VisaCliPaymentException("Payment not found: {$paymentReference}");
+        }
+
+        $currentStatus = $payment->status instanceof VisaCliPaymentStatus
+            ? $payment->status
+            : VisaCliPaymentStatus::from($payment->status);
+
+        if ($currentStatus !== VisaCliPaymentStatus::COMPLETED) {
+            throw new VisaCliPaymentException("Cannot refund payment with status: {$currentStatus->value}");
+        }
+
+        $payment->update([
+            'status'   => VisaCliPaymentStatus::REFUNDED,
+            'metadata' => array_merge($payment->metadata ?? [], [
+                'refunded_at'   => now()->toIso8601String(),
+                'refund_amount' => $amountCents ?? $payment->amount_cents,
+            ]),
+        ]);
+
+        Log::info('Visa CLI payment refunded', [
+            'payment_reference' => $paymentReference,
+            'amount_cents'      => $amountCents ?? $payment->amount_cents,
+        ]);
+
+        return new VisaCliPaymentResult(
+            paymentReference: $paymentReference,
+            status: VisaCliPaymentStatus::REFUNDED,
+            amountCents: $amountCents ?? $payment->amount_cents,
+            currency: $payment->currency,
+            url: $payment->url,
+            metadata: $payment->metadata ?? [],
+        );
+    }
+}

--- a/app/Domain/VisaCli/Services/VisaCliPaymentService.php
+++ b/app/Domain/VisaCli/Services/VisaCliPaymentService.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\VisaCli\Services;
+
+use App\Domain\VisaCli\Contracts\VisaCliClientInterface;
+use App\Domain\VisaCli\DataObjects\VisaCliPaymentRequest;
+use App\Domain\VisaCli\DataObjects\VisaCliPaymentResult;
+use App\Domain\VisaCli\Enums\VisaCliPaymentStatus;
+use App\Domain\VisaCli\Events\VisaCliPaymentCompleted;
+use App\Domain\VisaCli\Events\VisaCliPaymentFailed;
+use App\Domain\VisaCli\Events\VisaCliPaymentInitiated;
+use App\Domain\VisaCli\Exceptions\VisaCliPaymentException;
+use App\Domain\VisaCli\Models\VisaCliPayment;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Orchestrates Visa CLI payments with spending limits and event sourcing.
+ */
+class VisaCliPaymentService
+{
+    public function __construct(
+        private readonly VisaCliClientInterface $client,
+        private readonly VisaCliSpendingLimitService $spendingLimitService,
+    ) {
+    }
+
+    /**
+     * Execute a payment with spending limit enforcement.
+     */
+    public function executePayment(VisaCliPaymentRequest $request): VisaCliPaymentResult
+    {
+        if (! config('visacli.enabled', false)) {
+            throw new VisaCliPaymentException('Visa CLI integration is not enabled.');
+        }
+
+        // Enforce spending limits
+        if (! $this->spendingLimitService->canSpend($request->agentId, $request->amountCents)) {
+            throw new VisaCliPaymentException(
+                "Spending limit exceeded for agent {$request->agentId}. "
+                . "Requested: {$request->amountCents} cents."
+            );
+        }
+
+        // Record the payment
+        $payment = VisaCliPayment::create([
+            'agent_id'        => $request->agentId,
+            'url'             => $request->url,
+            'amount_cents'    => $request->amountCents,
+            'currency'        => $request->currency,
+            'status'          => VisaCliPaymentStatus::PROCESSING,
+            'card_identifier' => $request->cardId,
+            'metadata'        => array_merge($request->metadata, [
+                'request_id' => $request->requestId,
+                'purpose'    => $request->purpose,
+            ]),
+        ]);
+
+        // Dispatch initiated event
+        event(new VisaCliPaymentInitiated(
+            paymentId: $payment->id,
+            agentId: $request->agentId,
+            url: $request->url,
+            amountCents: $request->amountCents,
+            currency: $request->currency,
+            metadata: ['request_id' => $request->requestId],
+        ));
+
+        Log::info('Visa CLI payment initiated', [
+            'payment_id' => $payment->id,
+            'agent_id'   => $request->agentId,
+            'url'        => $request->url,
+            'amount'     => $request->amountCents,
+        ]);
+
+        try {
+            $result = DB::transaction(function () use ($request, $payment): VisaCliPaymentResult {
+                // Execute the payment via client
+                $result = $this->client->pay(
+                    $request->url,
+                    $request->amountCents,
+                    $request->cardId,
+                );
+
+                // Record spending
+                $this->spendingLimitService->recordSpending($request->agentId, $request->amountCents);
+
+                // Update payment record
+                $payment->markCompleted($result->paymentReference);
+
+                // Dispatch completed event
+                event(new VisaCliPaymentCompleted(
+                    paymentId: $payment->id,
+                    paymentReference: $result->paymentReference,
+                    amountCents: $request->amountCents,
+                    currency: $request->currency,
+                ));
+
+                Log::info('Visa CLI payment completed', [
+                    'payment_id' => $payment->id,
+                    'reference'  => $result->paymentReference,
+                ]);
+
+                return $result;
+            });
+
+            return $result;
+        } catch (VisaCliPaymentException $e) {
+            $payment->markFailed($e->getMessage());
+
+            event(new VisaCliPaymentFailed(
+                paymentId: $payment->id,
+                reason: $e->getMessage(),
+                amountCents: $request->amountCents,
+                currency: $request->currency,
+            ));
+
+            Log::error('Visa CLI payment failed', [
+                'payment_id' => $payment->id,
+                'error'      => $e->getMessage(),
+            ]);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Get payment by reference.
+     */
+    public function getPaymentByReference(string $reference): ?VisaCliPayment
+    {
+        return VisaCliPayment::where('payment_reference', $reference)->first();
+    }
+
+    /**
+     * Get recent payments for an agent.
+     *
+     * @return \Illuminate\Database\Eloquent\Collection<int, VisaCliPayment>
+     */
+    public function getAgentPayments(string $agentId, int $limit = 20): \Illuminate\Database\Eloquent\Collection
+    {
+        return VisaCliPayment::where('agent_id', $agentId)
+            ->orderBy('created_at', 'desc')
+            ->limit($limit)
+            ->get();
+    }
+}

--- a/app/Domain/VisaCli/Services/VisaCliProcessClient.php
+++ b/app/Domain/VisaCli/Services/VisaCliProcessClient.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\VisaCli\Services;
+
+use App\Domain\VisaCli\Contracts\VisaCliClientInterface;
+use App\Domain\VisaCli\DataObjects\VisaCliCard;
+use App\Domain\VisaCli\DataObjects\VisaCliPaymentResult;
+use App\Domain\VisaCli\DataObjects\VisaCliStatus;
+use App\Domain\VisaCli\Enums\VisaCliCardStatus;
+use App\Domain\VisaCli\Enums\VisaCliPaymentStatus;
+use App\Domain\VisaCli\Exceptions\VisaCliException;
+use App\Domain\VisaCli\Exceptions\VisaCliPaymentException;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\Process\Process;
+
+/**
+ * Calls the visa-cli binary via Symfony Process.
+ */
+class VisaCliProcessClient implements VisaCliClientInterface
+{
+    private readonly string $binaryPath;
+
+    private readonly int $defaultTimeout;
+
+    public function __construct()
+    {
+        $this->binaryPath = (string) config('visacli.binary_path', 'visa-cli');
+        $this->defaultTimeout = (int) config('visacli.timeouts.status', 10);
+    }
+
+    public function getStatus(): VisaCliStatus
+    {
+        $output = $this->runCommand(['status', '--json']);
+
+        /** @var array<string, mixed> $data */
+        $data = json_decode($output, true) ?? [];
+
+        return new VisaCliStatus(
+            initialized: (bool) ($data['initialized'] ?? false),
+            version: $data['version'] ?? null,
+            githubUsername: $data['github_username'] ?? null,
+            enrolledCards: (int) ($data['enrolled_cards'] ?? 0),
+            metadata: $data,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function enrollCard(string $userId, array $metadata = []): VisaCliCard
+    {
+        $output = $this->runCommand(
+            ['enroll-card', '--json'],
+            (int) config('visacli.timeouts.enrollment', 60),
+        );
+
+        /** @var array<string, mixed> $data */
+        $data = json_decode($output, true) ?? [];
+
+        return new VisaCliCard(
+            cardIdentifier: (string) ($data['card_id'] ?? ''),
+            last4: (string) ($data['last4'] ?? ''),
+            network: (string) ($data['network'] ?? 'visa'),
+            status: VisaCliCardStatus::ENROLLED,
+            githubUsername: $data['github_username'] ?? null,
+            metadata: array_merge($metadata, ['user_id' => $userId]),
+        );
+    }
+
+    /**
+     * @return array<VisaCliCard>
+     */
+    public function listCards(?string $userId = null): array
+    {
+        $output = $this->runCommand(['cards', '--json']);
+
+        /** @var array<int, array<string, mixed>> $data */
+        $data = json_decode($output, true) ?? [];
+
+        return array_map(
+            fn (array $card) => new VisaCliCard(
+                cardIdentifier: (string) ($card['card_id'] ?? ''),
+                last4: (string) ($card['last4'] ?? ''),
+                network: (string) ($card['network'] ?? 'visa'),
+                status: VisaCliCardStatus::tryFrom((string) ($card['status'] ?? 'enrolled')) ?? VisaCliCardStatus::ENROLLED,
+                githubUsername: $card['github_username'] ?? null,
+                metadata: (array) ($card['metadata'] ?? []),
+            ),
+            $data,
+        );
+    }
+
+    public function pay(string $url, int $amountCents, ?string $cardId = null): VisaCliPaymentResult
+    {
+        $args = ['pay', $url, '--amount', (string) $amountCents, '--json'];
+        if ($cardId !== null) {
+            $args[] = '--card';
+            $args[] = $cardId;
+        }
+
+        try {
+            $output = $this->runCommand(
+                $args,
+                (int) config('visacli.timeouts.payment', 30),
+            );
+
+            /** @var array<string, mixed> $data */
+            $data = json_decode($output, true) ?? [];
+
+            return new VisaCliPaymentResult(
+                paymentReference: (string) ($data['payment_reference'] ?? ''),
+                status: VisaCliPaymentStatus::tryFrom((string) ($data['status'] ?? 'completed')) ?? VisaCliPaymentStatus::COMPLETED,
+                amountCents: (int) ($data['amount_cents'] ?? $amountCents),
+                currency: (string) ($data['currency'] ?? 'USD'),
+                url: $url,
+                cardLast4: $data['card_last4'] ?? null,
+                metadata: $data,
+            );
+        } catch (VisaCliException $e) {
+            throw new VisaCliPaymentException(
+                "Payment failed for URL {$url}: " . $e->getMessage(),
+                $e->getCode(),
+                $e,
+            );
+        }
+    }
+
+    public function isInitialized(): bool
+    {
+        try {
+            $status = $this->getStatus();
+
+            return $status->initialized;
+        } catch (VisaCliException) {
+            return false;
+        }
+    }
+
+    public function initialize(): bool
+    {
+        try {
+            $this->runCommand(['init']);
+
+            return true;
+        } catch (VisaCliException $e) {
+            Log::error('Visa CLI initialization failed', ['error' => $e->getMessage()]);
+
+            return false;
+        }
+    }
+
+    /**
+     * @param array<string> $args
+     */
+    private function runCommand(array $args, ?int $timeout = null): string
+    {
+        $command = array_merge([$this->binaryPath], $args);
+
+        $env = [];
+        $githubToken = config('visacli.auth.github_token');
+        if ($githubToken !== null) {
+            $env['GITHUB_TOKEN'] = (string) $githubToken;
+        }
+
+        $process = new Process($command, null, $env !== [] ? $env : null);
+        $process->setTimeout($timeout ?? $this->defaultTimeout);
+
+        Log::debug('Visa CLI: executing command', ['command' => implode(' ', $command)]);
+
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            $errorOutput = $process->getErrorOutput() ?: $process->getOutput();
+
+            Log::error('Visa CLI command failed', [
+                'command'   => implode(' ', $command),
+                'exit_code' => $process->getExitCode(),
+                'error'     => $errorOutput,
+            ]);
+
+            throw new VisaCliException(
+                "Visa CLI command failed: {$errorOutput}",
+                $process->getExitCode() ?? 1,
+            );
+        }
+
+        return $process->getOutput();
+    }
+}

--- a/app/Domain/VisaCli/Services/VisaCliSpendingLimitService.php
+++ b/app/Domain/VisaCli/Services/VisaCliSpendingLimitService.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\VisaCli\Services;
+
+use App\Domain\VisaCli\Models\VisaCliSpendingLimit;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Budget control for Visa CLI agent payments.
+ */
+class VisaCliSpendingLimitService
+{
+    /**
+     * Check if an agent can spend the given amount.
+     */
+    public function canSpend(string $agentId, int $amountCents): bool
+    {
+        $limit = $this->getOrCreateLimit($agentId);
+
+        return $limit->canSpend($amountCents);
+    }
+
+    /**
+     * Check if an agent can auto-pay the given amount.
+     */
+    public function canAutoPay(string $agentId, int $amountCents): bool
+    {
+        $limit = $this->getOrCreateLimit($agentId);
+
+        return $limit->canAutoPay($amountCents);
+    }
+
+    /**
+     * Record spending for an agent with row-level locking.
+     */
+    public function recordSpending(string $agentId, int $amountCents): void
+    {
+        DB::transaction(function () use ($agentId, $amountCents): void {
+            /** @var VisaCliSpendingLimit $limit */
+            $limit = VisaCliSpendingLimit::where('agent_id', $agentId)
+                ->lockForUpdate()
+                ->first();
+
+            if ($limit === null) {
+                $limit = $this->createDefaultLimit($agentId);
+            }
+
+            $limit->recordSpending($amountCents);
+        });
+    }
+
+    /**
+     * Get or create a spending limit for an agent.
+     */
+    public function getOrCreateLimit(string $agentId): VisaCliSpendingLimit
+    {
+        $limit = VisaCliSpendingLimit::where('agent_id', $agentId)->first();
+
+        if ($limit === null) {
+            $limit = $this->createDefaultLimit($agentId);
+        }
+
+        return $limit;
+    }
+
+    /**
+     * Update spending limits for an agent.
+     */
+    public function updateLimit(
+        string $agentId,
+        ?int $dailyLimit = null,
+        ?int $perTransactionLimit = null,
+        ?bool $autoPayEnabled = null,
+    ): VisaCliSpendingLimit {
+        $limit = $this->getOrCreateLimit($agentId);
+
+        $updates = [];
+        if ($dailyLimit !== null) {
+            $updates['daily_limit'] = $dailyLimit;
+        }
+        if ($perTransactionLimit !== null) {
+            $updates['per_transaction_limit'] = $perTransactionLimit;
+        }
+        if ($autoPayEnabled !== null) {
+            $updates['auto_pay_enabled'] = $autoPayEnabled;
+        }
+
+        if ($updates !== []) {
+            $limit->update($updates);
+            $limit->refresh();
+        }
+
+        return $limit;
+    }
+
+    private function createDefaultLimit(string $agentId): VisaCliSpendingLimit
+    {
+        return VisaCliSpendingLimit::create([
+            'agent_id'              => $agentId,
+            'agent_type'            => 'ai',
+            'daily_limit'           => (int) config('visacli.spending_limits.daily', 10000),
+            'per_transaction_limit' => (int) config('visacli.spending_limits.per_tx', 1000),
+            'auto_pay_enabled'      => (bool) config('visacli.spending_limits.auto_pay', false),
+            'limit_resets_at'       => now()->addDay(),
+        ]);
+    }
+}

--- a/app/Providers/VisaCliServiceProvider.php
+++ b/app/Providers/VisaCliServiceProvider.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use App\Domain\VisaCli\Contracts\VisaCliClientInterface;
+use App\Domain\VisaCli\Contracts\VisaCliPaymentGatewayInterface;
+use App\Domain\VisaCli\Services\DemoVisaCliClient;
+use App\Domain\VisaCli\Services\VisaCliPaymentGatewayService;
+use App\Domain\VisaCli\Services\VisaCliProcessClient;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Service provider for the VisaCli domain.
+ *
+ * Binds Visa CLI contracts to implementations based on configuration.
+ * Supports demo and process (real binary) drivers.
+ */
+class VisaCliServiceProvider extends ServiceProvider
+{
+    /**
+     * Register any application services.
+     */
+    public function register(): void
+    {
+        $this->app->bind(VisaCliClientInterface::class, function ($app) {
+            $driver = config('visacli.driver', 'demo');
+
+            return match ($driver) {
+                'process' => new VisaCliProcessClient(),
+                default   => new DemoVisaCliClient(),
+            };
+        });
+
+        $this->app->bind(VisaCliPaymentGatewayInterface::class, VisaCliPaymentGatewayService::class);
+    }
+
+    /**
+     * Bootstrap any application services.
+     */
+    public function boot(): void
+    {
+        //
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -37,6 +37,7 @@ return [
     App\Providers\TelescopeServiceProvider::class,
     App\Providers\TenancyServiceProvider::class,
     App\Providers\TestingServiceProvider::class,
+    App\Providers\VisaCliServiceProvider::class,
     App\Providers\WalletServiceProvider::class,
     App\Providers\X402ServiceProvider::class,
     App\Providers\WebhookServiceProvider::class,

--- a/config/visacli.php
+++ b/config/visacli.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Visa CLI Integration Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Configuration for the Visa CLI payment integration.
+    | Visa CLI enables AI agents and developers to make programmatic
+    | Visa card payments without managing API keys directly.
+    | See: https://visacli.sh/
+    |
+    */
+
+    'enabled' => (bool) env('VISACLI_ENABLED', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Driver
+    |--------------------------------------------------------------------------
+    |
+    | The driver to use for Visa CLI operations. Supported: "demo", "process".
+    | "demo" uses a cache-based mock for development and testing.
+    | "process" calls the actual visa-cli binary via Symfony Process.
+    |
+    */
+
+    'driver' => env('VISACLI_DRIVER', 'demo'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Binary Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Path to the visa-cli binary and API base URL for the process driver.
+    |
+    */
+
+    'binary_path' => env('VISACLI_BINARY_PATH', 'visa-cli'),
+
+    'api' => [
+        'base_url' => env('VISACLI_API_BASE_URL', 'https://api.visacli.sh'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication
+    |--------------------------------------------------------------------------
+    |
+    | GitHub token for Visa CLI authentication and session management.
+    |
+    */
+
+    'auth' => [
+        'github_token'  => env('VISACLI_GITHUB_TOKEN'),
+        'session_token' => env('VISACLI_SESSION_TOKEN'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Spending Limits
+    |--------------------------------------------------------------------------
+    |
+    | Default spending limits for Visa CLI payments.
+    | All amounts in USD cents.
+    |
+    */
+
+    'spending_limits' => [
+        // $100.00 daily limit
+        'daily' => (int) env('VISACLI_DAILY_LIMIT', 10000),
+
+        // $10.00 per-transaction limit
+        'per_tx' => (int) env('VISACLI_PER_TX_LIMIT', 1000),
+
+        // Enable auto-pay for agent-initiated payments
+        'auto_pay' => (bool) env('VISACLI_AUTO_PAY', false),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Webhook Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Secret for verifying inbound webhook signatures from Visa CLI.
+    |
+    */
+
+    'webhook' => [
+        'secret' => env('VISACLI_WEBHOOK_SECRET'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Timeouts
+    |--------------------------------------------------------------------------
+    |
+    | Timeout settings for Visa CLI operations in seconds.
+    |
+    */
+
+    'timeouts' => [
+        'payment'    => (int) env('VISACLI_PAYMENT_TIMEOUT', 30),
+        'enrollment' => (int) env('VISACLI_ENROLLMENT_TIMEOUT', 60),
+        'status'     => (int) env('VISACLI_STATUS_TIMEOUT', 10),
+    ],
+];

--- a/database/migrations/2026_03_20_000001_create_visa_cli_enrolled_cards_table.php
+++ b/database/migrations/2026_03_20_000001_create_visa_cli_enrolled_cards_table.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('visa_cli_enrolled_cards', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('card_identifier')->unique()->comment('Visa CLI card identifier');
+            $table->string('last4', 4)->comment('Last 4 digits of card');
+            $table->string('network')->default('visa')->comment('Card network');
+            $table->string('status')->default('enrolled')->comment('Card status');
+            $table->string('github_username')->nullable()->comment('GitHub username linked to card');
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['user_id', 'status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('visa_cli_enrolled_cards');
+    }
+};

--- a/database/migrations/2026_03_20_000002_create_visa_cli_payments_table.php
+++ b/database/migrations/2026_03_20_000002_create_visa_cli_payments_table.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('visa_cli_payments', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('agent_id')->comment('Agent or gateway identifier');
+            $table->unsignedBigInteger('invoice_id')->nullable()->comment('FK to partner_invoices');
+            $table->string('url')->comment('Payment target URL');
+            $table->integer('amount_cents')->comment('Payment amount in USD cents');
+            $table->string('currency', 3)->default('USD');
+            $table->string('status')->default('pending')->comment('Payment status');
+            $table->string('card_identifier')->nullable()->comment('Card used for payment');
+            $table->string('payment_reference')->nullable()->comment('External payment reference');
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index('agent_id');
+            $table->index('invoice_id');
+            $table->index('payment_reference');
+            $table->index('status');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('visa_cli_payments');
+    }
+};

--- a/database/migrations/2026_03_20_000003_create_visa_cli_spending_limits_table.php
+++ b/database/migrations/2026_03_20_000003_create_visa_cli_spending_limits_table.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('visa_cli_spending_limits', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('agent_id')->comment('Agent DID or identifier');
+            $table->string('agent_type')->default('ai')->comment('Agent type: ai, user, service');
+            $table->integer('daily_limit')->comment('Maximum daily spend in cents');
+            $table->integer('spent_today')->default(0)->comment('Amount spent today in cents');
+            $table->integer('per_transaction_limit')->nullable()->comment('Max per-transaction in cents');
+            $table->boolean('auto_pay_enabled')->default(false)->comment('Whether auto-pay is enabled');
+            $table->timestamp('limit_resets_at')->comment('When daily limit resets');
+            $table->foreignId('team_id')->nullable()->constrained()->nullOnDelete();
+            $table->timestamps();
+
+            $table->unique(['agent_id', 'team_id']);
+            $table->index('agent_type');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('visa_cli_spending_limits');
+    }
+};


### PR DESCRIPTION
## Summary
- New `VisaCli` domain (46th domain) for Visa CLI payment integration enabling AI agents and the developer portal to make programmatic Visa card payments
- Complete domain structure: 2 contracts, 6 services (incl. demo adapter), 4 data objects, 2 enums, 5 events, 3 models, 3 exceptions
- 3 new database migrations (`visa_cli_enrolled_cards`, `visa_cli_payments`, `visa_cli_spending_limits`)
- `VisaCliServiceProvider` with match-based driver binding (demo/process)
- PHPStan Level 8 clean, code style fixed

## Phase 1 of 6 — Visa CLI Integration
This PR establishes the domain foundation. Subsequent phases add:
- Phase 2: MCP tools for AI agent payments
- Phase 3: Developer portal payment collection
- Phase 4: Card enrollment bridge
- Phase 5: Artisan CLI commands
- Phase 6: Test suite

## Test plan
- [ ] PHPStan passes: `XDEBUG_MODE=off vendor/bin/phpstan analyse --memory-limit=2G`
- [ ] Code style: `./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --dry-run`
- [ ] Service provider resolves: `php artisan tinker --execute="app(App\Domain\VisaCli\Contracts\VisaCliClientInterface::class)"`
- [ ] Migrations run: `php artisan migrate --pretend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)