### PR TITLE
feat: Visa CLI MCP tools for AI agent payments

### DIFF
--- a/app/Domain/AI/MCP/Tools/VisaCli/VisaCliCardsTool.php
+++ b/app/Domain/AI/MCP/Tools/VisaCli/VisaCliCardsTool.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AI\MCP\Tools\VisaCli;
+
+use App\Domain\AI\Contracts\MCPToolInterface;
+use App\Domain\AI\ValueObjects\ToolExecutionResult;
+use App\Domain\VisaCli\Contracts\VisaCliClientInterface;
+use Exception;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * MCP Tool for listing enrolled Visa CLI cards.
+ *
+ * Read-only tool that returns enrolled cards available for payments.
+ */
+class VisaCliCardsTool implements MCPToolInterface
+{
+    public function __construct(
+        private readonly VisaCliClientInterface $client,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'visacli.cards';
+    }
+
+    public function getCategory(): string
+    {
+        return 'visacli';
+    }
+
+    public function getDescription(): string
+    {
+        return 'List enrolled Visa CLI cards available for making payments. '
+            . 'Returns card identifiers, last 4 digits, network, and status.';
+    }
+
+    /** @return array<string, mixed> */
+    public function getInputSchema(): array
+    {
+        return [
+            'type'       => 'object',
+            'properties' => [
+                'user_id' => [
+                    'type'        => 'string',
+                    'description' => 'Optional user ID to filter cards by user.',
+                ],
+            ],
+            'required' => [],
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    public function getOutputSchema(): array
+    {
+        return [
+            'type'       => 'object',
+            'properties' => [
+                'cards' => [
+                    'type'  => 'array',
+                    'items' => [
+                        'type'       => 'object',
+                        'properties' => [
+                            'card_identifier' => ['type' => 'string'],
+                            'last4'           => ['type' => 'string'],
+                            'network'         => ['type' => 'string'],
+                            'status'          => ['type' => 'string'],
+                        ],
+                    ],
+                ],
+                'count' => ['type' => 'integer'],
+            ],
+        ];
+    }
+
+    /** @param array<string, mixed> $parameters */
+    public function execute(array $parameters, ?string $conversationId = null): ToolExecutionResult
+    {
+        try {
+            $startTime = microtime(true);
+
+            $userId = isset($parameters['user_id']) ? (string) $parameters['user_id'] : null;
+
+            Log::info('MCP Tool: Listing Visa CLI cards', [
+                'user_id'         => $userId,
+                'conversation_id' => $conversationId,
+            ]);
+
+            $cards = $this->client->listCards($userId);
+
+            $cardData = array_map(fn ($card) => $card->toArray(), $cards);
+
+            $durationMs = (int) ((microtime(true) - $startTime) * 1000);
+
+            return ToolExecutionResult::success([
+                'cards' => $cardData,
+                'count' => count($cardData),
+            ], $durationMs);
+        } catch (Exception $e) {
+            Log::error('MCP Tool error: visacli.cards', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return ToolExecutionResult::failure(
+                'Failed to list Visa CLI cards: ' . $e->getMessage()
+            );
+        }
+    }
+
+    /** @return array<int, string> */
+    public function getCapabilities(): array
+    {
+        return [
+            'read',
+            'visa-cli',
+            'card-management',
+        ];
+    }
+
+    public function isCacheable(): bool
+    {
+        return true;
+    }
+
+    public function getCacheTtl(): int
+    {
+        return 300; // 5 minutes
+    }
+
+    /** @param array<string, mixed> $parameters */
+    public function validateInput(array $parameters): bool
+    {
+        // No required parameters — all optional
+        return true;
+    }
+
+    public function authorize(?string $userId): bool
+    {
+        return true;
+    }
+}

--- a/app/Domain/AI/MCP/Tools/VisaCli/VisaCliPaymentTool.php
+++ b/app/Domain/AI/MCP/Tools/VisaCli/VisaCliPaymentTool.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AI\MCP\Tools\VisaCli;
+
+use App\Domain\AI\Contracts\MCPToolInterface;
+use App\Domain\AI\ValueObjects\ToolExecutionResult;
+use App\Domain\VisaCli\DataObjects\VisaCliPaymentRequest;
+use App\Domain\VisaCli\Exceptions\VisaCliPaymentException;
+use App\Domain\VisaCli\Services\VisaCliPaymentService;
+use Exception;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * MCP Tool for executing Visa CLI payments in AI agent workflows.
+ *
+ * Allows AI agents to:
+ * - Make programmatic Visa card payments to URLs
+ * - Enforce spending limits per agent
+ * - Track payment history
+ */
+class VisaCliPaymentTool implements MCPToolInterface
+{
+    public function __construct(
+        private readonly VisaCliPaymentService $paymentService,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'visacli.payment';
+    }
+
+    public function getCategory(): string
+    {
+        return 'visacli';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Execute a Visa card payment to a URL using Visa CLI. '
+            . 'Enforces per-agent spending limits and records all payment events for audit.';
+    }
+
+    /** @return array<string, mixed> */
+    public function getInputSchema(): array
+    {
+        return [
+            'type'       => 'object',
+            'properties' => [
+                'agent_id' => [
+                    'type'        => 'string',
+                    'description' => 'The agent identifier for spending limit enforcement.',
+                    'minLength'   => 1,
+                    'maxLength'   => 255,
+                ],
+                'url' => [
+                    'type'        => 'string',
+                    'description' => 'The payment target URL (API endpoint, service, etc.).',
+                    'minLength'   => 1,
+                ],
+                'max_amount_cents' => [
+                    'type'        => 'integer',
+                    'description' => 'Maximum payment amount in USD cents.',
+                    'minimum'     => 1,
+                ],
+                'card_id' => [
+                    'type'        => 'string',
+                    'description' => 'Optional enrolled card identifier to use for payment.',
+                ],
+                'purpose' => [
+                    'type'        => 'string',
+                    'description' => 'Purpose of the payment (e.g., "image_generation", "dataset_access").',
+                ],
+            ],
+            'required' => ['agent_id', 'url', 'max_amount_cents'],
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    public function getOutputSchema(): array
+    {
+        return [
+            'type'       => 'object',
+            'properties' => [
+                'payment_reference' => ['type' => 'string', 'description' => 'Unique payment reference ID'],
+                'status'            => ['type' => 'string', 'description' => 'Payment status'],
+                'amount_cents'      => ['type' => 'integer', 'description' => 'Actual amount charged in cents'],
+                'currency'          => ['type' => 'string', 'description' => 'Currency code'],
+                'url'               => ['type' => 'string', 'description' => 'Payment target URL'],
+            ],
+        ];
+    }
+
+    /** @param array<string, mixed> $parameters */
+    public function execute(array $parameters, ?string $conversationId = null): ToolExecutionResult
+    {
+        try {
+            $startTime = microtime(true);
+
+            $agentId = (string) $parameters['agent_id'];
+            $url = (string) $parameters['url'];
+            $amountCents = (int) $parameters['max_amount_cents'];
+
+            Log::info('MCP Tool: Visa CLI payment requested', [
+                'agent_id'        => $agentId,
+                'url'             => $url,
+                'amount_cents'    => $amountCents,
+                'conversation_id' => $conversationId,
+            ]);
+
+            $request = new VisaCliPaymentRequest(
+                agentId: $agentId,
+                url: $url,
+                amountCents: $amountCents,
+                cardId: isset($parameters['card_id']) ? (string) $parameters['card_id'] : null,
+                purpose: isset($parameters['purpose']) ? (string) $parameters['purpose'] : null,
+            );
+
+            $result = $this->paymentService->executePayment($request);
+
+            $durationMs = (int) ((microtime(true) - $startTime) * 1000);
+
+            Log::info('MCP Tool: Visa CLI payment completed', [
+                'agent_id'  => $agentId,
+                'reference' => $result->paymentReference,
+                'status'    => $result->status->value,
+            ]);
+
+            return ToolExecutionResult::success($result->toArray(), $durationMs);
+        } catch (VisaCliPaymentException $e) {
+            Log::warning('MCP Tool: Visa CLI payment rejected', [
+                'agent_id' => $parameters['agent_id'] ?? 'unknown',
+                'error'    => $e->getMessage(),
+            ]);
+
+            return ToolExecutionResult::failure(
+                $e->getMessage() . ' Check spending limits or Visa CLI configuration.'
+            );
+        } catch (Exception $e) {
+            Log::error('MCP Tool error: visacli.payment', [
+                'error'      => $e->getMessage(),
+                'parameters' => ['agent_id' => $parameters['agent_id'] ?? 'unknown'],
+            ]);
+
+            return ToolExecutionResult::failure(
+                'An unexpected error occurred processing the Visa CLI payment.'
+            );
+        }
+    }
+
+    /** @return array<int, string> */
+    public function getCapabilities(): array
+    {
+        return [
+            'write',
+            'payment',
+            'visa-cli',
+            'spending-limits',
+            'agent-autonomous',
+        ];
+    }
+
+    public function isCacheable(): bool
+    {
+        return false;
+    }
+
+    public function getCacheTtl(): int
+    {
+        return 0;
+    }
+
+    /** @param array<string, mixed> $parameters */
+    public function validateInput(array $parameters): bool
+    {
+        if (empty($parameters['agent_id']) || empty($parameters['url'])) {
+            return false;
+        }
+
+        if (! isset($parameters['max_amount_cents']) || (int) $parameters['max_amount_cents'] <= 0) {
+            return false;
+        }
+
+        return filter_var($parameters['url'], FILTER_VALIDATE_URL) !== false;
+    }
+
+    public function authorize(?string $userId): bool
+    {
+        // Visa CLI payments are initiated by AI agents in autonomous workflows.
+        // Authorization is enforced via spending limits in VisaCliPaymentService.
+        return true;
+    }
+}

--- a/app/Domain/AI/Services/AIAgentProtocolBridgeService.php
+++ b/app/Domain/AI/Services/AIAgentProtocolBridgeService.php
@@ -12,6 +12,8 @@ use App\Domain\AgentProtocol\Services\AgentRegistryService;
 use App\Domain\AgentProtocol\Services\DIDService;
 use App\Domain\AgentProtocol\Services\EscrowService;
 use App\Domain\AgentProtocol\Services\ReputationService;
+use App\Domain\VisaCli\DataObjects\VisaCliPaymentRequest;
+use App\Domain\VisaCli\Services\VisaCliPaymentService;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
@@ -58,6 +60,7 @@ class AIAgentProtocolBridgeService
         private readonly ReputationService $reputationService,
         /** @phpstan-ignore-next-line property.onlyWritten - Reserved for future escrow integration */
         private readonly EscrowService $escrowService,
+        private readonly ?VisaCliPaymentService $visaCliPaymentService = null,
     ) {
     }
 
@@ -195,6 +198,64 @@ class AIAgentProtocolBridgeService
             'fees'           => $fee,
             'from_did'       => $fromDid,
             'to_did'         => $toDid,
+        ];
+    }
+
+    /**
+     * Initiate a Visa CLI payment from an AI agent.
+     *
+     * @param  string  $aiAgentName  Source AI agent name
+     * @param  string  $url          Payment target URL
+     * @param  int     $amountCents  Amount in USD cents
+     * @param  string  $purpose      Payment purpose
+     * @param  array<string, mixed>  $metadata Additional metadata
+     * @return array{transaction_id: string, status: string, amount_cents: int, payment_reference: string|null, from_did: string}
+     */
+    public function initiateVisaCliPayment(
+        string $aiAgentName,
+        string $url,
+        int $amountCents,
+        string $purpose = 'ai_agent_visa_payment',
+        array $metadata = []
+    ): array {
+        if ($this->visaCliPaymentService === null) {
+            return [
+                'transaction_id'    => '',
+                'status'            => 'unavailable',
+                'amount_cents'      => $amountCents,
+                'payment_reference' => null,
+                'from_did'          => '',
+            ];
+        }
+
+        $fromDid = $this->getOrRegisterAIAgentDid($aiAgentName);
+
+        $request = new VisaCliPaymentRequest(
+            agentId: $fromDid,
+            url: $url,
+            amountCents: $amountCents,
+            purpose: $purpose,
+            metadata: array_merge($metadata, [
+                'ai_agent_name' => $aiAgentName,
+                'source'        => 'agent_protocol_bridge',
+            ]),
+        );
+
+        $result = $this->visaCliPaymentService->executePayment($request);
+
+        Log::info('AI Agent Visa CLI payment initiated', [
+            'agent'     => $aiAgentName,
+            'url'       => $url,
+            'amount'    => $amountCents,
+            'reference' => $result->paymentReference,
+        ]);
+
+        return [
+            'transaction_id'    => $request->requestId,
+            'status'            => $result->status->value,
+            'amount_cents'      => $result->amountCents,
+            'payment_reference' => $result->paymentReference,
+            'from_did'          => $fromDid,
         ];
     }
 

--- a/app/Providers/MCPToolServiceProvider.php
+++ b/app/Providers/MCPToolServiceProvider.php
@@ -19,6 +19,8 @@ use App\Domain\AI\MCP\Tools\Exchange\QuoteTool;
 use App\Domain\AI\MCP\Tools\Exchange\TradeTool;
 use App\Domain\AI\MCP\Tools\Payment\PaymentStatusTool;
 use App\Domain\AI\MCP\Tools\Payment\TransferTool;
+use App\Domain\AI\MCP\Tools\VisaCli\VisaCliCardsTool;
+use App\Domain\AI\MCP\Tools\VisaCli\VisaCliPaymentTool;
 use App\Domain\AI\MCP\Tools\X402\X402PaymentTool;
 use Exception;
 use Illuminate\Support\ServiceProvider;
@@ -64,6 +66,10 @@ class MCPToolServiceProvider extends ServiceProvider
 
         // x402 Payment Tools
         X402PaymentTool::class,
+
+        // Visa CLI Payment Tools
+        VisaCliPaymentTool::class,
+        VisaCliCardsTool::class,
     ];
 
     /**


### PR DESCRIPTION
## Summary
- `VisaCliPaymentTool` — executes Visa card payments with per-agent spending limit enforcement (non-cacheable)
- `VisaCliCardsTool` — read-only card listing with 300s cache TTL
- Both tools registered in `MCPToolServiceProvider`
- `AIAgentProtocolBridgeService::initiateVisaCliPayment()` added for agent-to-URL payment bridge

## Phase 2 of 6 — depends on Phase 1 (#785)

## Test plan
- [ ] PHPStan passes on new tool files
- [ ] MCP tool names `visacli.payment` and `visacli.cards` appear in tool registry
- [ ] Payment tool enforces spending limits before executing
- [ ] Cards tool returns enrolled cards from demo adapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)