### PR TITLE
feat: Visa CLI payment gateway for partner invoice collection

### DIFF
--- a/app/Domain/FinancialInstitution/Routes/api.php
+++ b/app/Domain/FinancialInstitution/Routes/api.php
@@ -34,6 +34,7 @@ Route::prefix('partner/v1')->name('api.partner.')->middleware('partner.auth')->g
     // Billing
     Route::get('/billing/invoices', [PartnerBillingController::class, 'invoices'])->name('billing.invoices');
     Route::get('/billing/invoices/{id}', [PartnerBillingController::class, 'invoice'])->name('billing.invoice');
+    Route::post('/billing/invoices/{id}/pay', [PartnerBillingController::class, 'payInvoice'])->name('billing.invoice.pay');
     Route::get('/billing/outstanding', [PartnerBillingController::class, 'outstanding'])->name('billing.outstanding');
     Route::get('/billing/breakdown', [PartnerBillingController::class, 'breakdown'])->name('billing.breakdown');
 

--- a/app/Http/Controllers/Api/Partner/PartnerBillingController.php
+++ b/app/Http/Controllers/Api/Partner/PartnerBillingController.php
@@ -7,6 +7,8 @@ namespace App\Http\Controllers\Api\Partner;
 use App\Domain\FinancialInstitution\Models\FinancialInstitutionPartner;
 use App\Domain\FinancialInstitution\Models\PartnerInvoice;
 use App\Domain\FinancialInstitution\Services\PartnerBillingService;
+use App\Domain\VisaCli\Contracts\VisaCliPaymentGatewayInterface;
+use App\Domain\VisaCli\Exceptions\VisaCliPaymentException;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -16,6 +18,7 @@ class PartnerBillingController extends Controller
 {
     public function __construct(
         private readonly PartnerBillingService $billingService,
+        private readonly VisaCliPaymentGatewayInterface $paymentGateway,
     ) {
     }
 
@@ -242,6 +245,96 @@ class PartnerBillingController extends Controller
             'success' => true,
             'data'    => $breakdown,
         ]);
+    }
+
+    /**
+     * Pay an invoice via Visa CLI.
+     *
+     * POST /api/partner/v1/billing/invoices/{id}/pay
+     */
+    #[OA\Post(
+        path: '/api/partner/v1/billing/invoices/{id}/pay',
+        operationId: 'partnerPayInvoice',
+        summary: 'Pay an invoice via Visa CLI',
+        description: 'Collects payment for a pending or overdue invoice using the Visa CLI payment gateway.',
+        tags: ['Partner BaaS'],
+        security: [['sanctum' => []]],
+        parameters: [
+        new OA\Parameter(name: 'id', in: 'path', required: true, description: 'Invoice ID', schema: new OA\Schema(type: 'integer', example: 1)),
+        ],
+        requestBody: new OA\RequestBody(
+            content: new OA\JsonContent(properties: [
+            new OA\Property(property: 'card_id', type: 'string', description: 'Optional enrolled card ID', example: null),
+            ])
+        )
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Payment successful',
+        content: new OA\JsonContent(properties: [
+        new OA\Property(property: 'success', type: 'boolean', example: true),
+        new OA\Property(property: 'data', type: 'object', properties: [
+        new OA\Property(property: 'payment_reference', type: 'string'),
+        new OA\Property(property: 'status', type: 'string', example: 'completed'),
+        new OA\Property(property: 'amount_cents', type: 'integer', example: 29900),
+        ]),
+        ])
+    )]
+    #[OA\Response(
+        response: 404,
+        description: 'Invoice not found',
+        content: new OA\JsonContent(properties: [
+        new OA\Property(property: 'success', type: 'boolean', example: false),
+        new OA\Property(property: 'message', type: 'string', example: 'Invoice not found'),
+        ])
+    )]
+    #[OA\Response(
+        response: 422,
+        description: 'Invoice cannot be paid or payment failed',
+        content: new OA\JsonContent(properties: [
+        new OA\Property(property: 'success', type: 'boolean', example: false),
+        new OA\Property(property: 'message', type: 'string', example: 'Invoice cannot be paid'),
+        ])
+    )]
+    public function payInvoice(Request $request, int $id): JsonResponse
+    {
+        $partner = $this->getPartner($request);
+
+        $invoice = PartnerInvoice::where('partner_id', $partner->id)
+            ->where('id', $id)
+            ->first();
+
+        if (! $invoice) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Invoice not found',
+            ], 404);
+        }
+
+        if (! $invoice->canBePaid()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Invoice cannot be paid (status: ' . $invoice->status . ')',
+            ], 422);
+        }
+
+        try {
+            $cardId = $request->input('card_id');
+            $result = $this->paymentGateway->collectPayment(
+                $invoice,
+                is_string($cardId) ? $cardId : null,
+            );
+
+            return response()->json([
+                'success' => true,
+                'data'    => $result->toArray(),
+            ]);
+        } catch (VisaCliPaymentException $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], 422);
+        }
     }
 
     private function getPartner(Request $request): FinancialInstitutionPartner

--- a/app/Http/Controllers/Api/Webhook/VisaCliWebhookController.php
+++ b/app/Http/Controllers/Api/Webhook/VisaCliWebhookController.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Webhook;
+
+use App\Domain\VisaCli\Enums\VisaCliPaymentStatus;
+use App\Domain\VisaCli\Models\VisaCliPayment;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Handle inbound Visa CLI payment status webhooks.
+ *
+ * Verifies HMAC signature and updates payment records based on
+ * status callbacks from the Visa CLI service.
+ */
+class VisaCliWebhookController extends Controller
+{
+    public function handle(Request $request): JsonResponse
+    {
+        if (! $this->verifySignature($request)) {
+            Log::warning('Visa CLI webhook signature verification failed', [
+                'ip' => $request->ip(),
+            ]);
+
+            return response()->json(['error' => 'Invalid signature'], 401);
+        }
+
+        /** @var array<string, mixed> $payload */
+        $payload = $request->all();
+        $eventType = (string) ($payload['event'] ?? '');
+
+        Log::info('Visa CLI webhook received', [
+            'event'     => $eventType,
+            'reference' => $payload['payment_reference'] ?? null,
+        ]);
+
+        return match ($eventType) {
+            'payment.completed' => $this->handlePaymentCompleted($payload),
+            'payment.failed'    => $this->handlePaymentFailed($payload),
+            'payment.refunded'  => $this->handlePaymentRefunded($payload),
+            default             => response()->json(['status' => 'ignored', 'event' => $eventType]),
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function handlePaymentCompleted(array $payload): JsonResponse
+    {
+        $reference = (string) ($payload['payment_reference'] ?? '');
+        $payment = VisaCliPayment::where('payment_reference', $reference)->first();
+
+        if ($payment === null) {
+            return response()->json(['status' => 'not_found'], 404);
+        }
+
+        $payment->update(['status' => VisaCliPaymentStatus::COMPLETED]);
+
+        return response()->json(['status' => 'updated']);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function handlePaymentFailed(array $payload): JsonResponse
+    {
+        $reference = (string) ($payload['payment_reference'] ?? '');
+        $reason = (string) ($payload['reason'] ?? 'Unknown');
+
+        $payment = VisaCliPayment::where('payment_reference', $reference)->first();
+
+        if ($payment === null) {
+            return response()->json(['status' => 'not_found'], 404);
+        }
+
+        $payment->markFailed($reason);
+
+        return response()->json(['status' => 'updated']);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function handlePaymentRefunded(array $payload): JsonResponse
+    {
+        $reference = (string) ($payload['payment_reference'] ?? '');
+        $payment = VisaCliPayment::where('payment_reference', $reference)->first();
+
+        if ($payment === null) {
+            return response()->json(['status' => 'not_found'], 404);
+        }
+
+        $payment->update([
+            'status'   => VisaCliPaymentStatus::REFUNDED,
+            'metadata' => array_merge($payment->metadata ?? [], [
+                'refunded_at' => now()->toIso8601String(),
+            ]),
+        ]);
+
+        return response()->json(['status' => 'updated']);
+    }
+
+    private function verifySignature(Request $request): bool
+    {
+        $secret = config('visacli.webhook.secret');
+
+        // Skip verification if no secret configured (demo mode)
+        if (empty($secret)) {
+            return true;
+        }
+
+        $signature = $request->header('X-VisaCli-Signature', '');
+        $payload = $request->getContent();
+
+        $expected = hash_hmac('sha256', $payload, (string) $secret);
+
+        return hash_equals($expected, (string) $signature);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -258,6 +258,11 @@ Route::post('webhooks/alchemy/address-activity', [App\Http\Controllers\Api\Webho
     ->middleware('api.rate_limit:webhook')
     ->name('api.webhooks.alchemy.address-activity');
 
+// Visa CLI payment status webhook (no auth, HMAC verified)
+Route::post('webhooks/visa-cli/payment', [App\Http\Controllers\Api\Webhook\VisaCliWebhookController::class, 'handle'])
+    ->middleware('api.rate_limit:webhook')
+    ->name('api.webhooks.visacli.payment');
+
 // v5.13.0 — Referral System
 Route::prefix('v1/referrals')->name('api.v1.referrals.')
     ->middleware(['auth:sanctum'])


### PR DESCRIPTION
## Summary
- `POST /api/partner/v1/billing/invoices/{id}/pay` — collects payment via Visa CLI gateway
- `VisaCliWebhookController` handles inbound payment status callbacks with HMAC verification
- `POST /webhooks/visa-cli/payment` route for payment.completed/failed/refunded events
- OpenAPI/Swagger annotations on new endpoint

## Phase 3 of 6 — depends on Phase 2 (#786)

## Test plan
- [ ] PHPStan passes on modified controller and new webhook handler
- [ ] Invoice payment endpoint validates invoice ownership and payability
- [ ] Webhook HMAC verification skips in demo mode (no secret configured)
- [ ] Payment.completed webhook updates payment record status

🤖 Generated with [Claude Code](https://claude.com/claude-code)