### PR TITLE
feat: Visa CLI card enrollment bridge to CardIssuance

### DIFF
--- a/app/Domain/VisaCli/Listeners/SyncVisaCliCardToCardIssuance.php
+++ b/app/Domain/VisaCli/Listeners/SyncVisaCliCardToCardIssuance.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\VisaCli\Listeners;
+
+use App\Domain\CardIssuance\Models\Card;
+use App\Domain\VisaCli\Events\VisaCliCardEnrolled;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Syncs a newly enrolled Visa CLI card to the CardIssuance domain.
+ *
+ * Creates a read-only Card record with metadata.source = 'visa_cli'
+ * to maintain a unified card view across the platform.
+ */
+class SyncVisaCliCardToCardIssuance
+{
+    public function handle(VisaCliCardEnrolled $event): void
+    {
+        // Check if already synced
+        $existing = Card::where('issuer_card_token', $event->cardIdentifier)
+            ->where('issuer', 'visa_cli')
+            ->first();
+
+        if ($existing !== null) {
+            Log::debug('Visa CLI card already synced to CardIssuance', [
+                'card_identifier' => $event->cardIdentifier,
+            ]);
+
+            return;
+        }
+
+        Card::create([
+            'user_id'           => $event->userId,
+            'cardholder_id'     => $event->userId,
+            'issuer_card_token' => $event->cardIdentifier,
+            'issuer'            => 'visa_cli',
+            'last4'             => $event->last4,
+            'network'           => $event->network,
+            'status'            => 'active',
+            'currency'          => 'USD',
+            'label'             => 'Visa CLI Card',
+            'metadata'          => array_merge($event->metadata, [
+                'source'    => 'visa_cli',
+                'synced_at' => now()->toIso8601String(),
+            ]),
+        ]);
+
+        Log::info('Visa CLI card synced to CardIssuance', [
+            'user_id'         => $event->userId,
+            'card_identifier' => $event->cardIdentifier,
+            'last4'           => $event->last4,
+        ]);
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -9,6 +9,8 @@ use App\Domain\Mobile\Listeners\LogMobileAuditEventListener;
 use App\Domain\Mobile\Listeners\SendSecurityAlertListener;
 use App\Domain\Mobile\Listeners\SendTransactionPushNotificationListener;
 use App\Domain\Referral\Listeners\CompleteReferralOnKycApproval;
+use App\Domain\VisaCli\Events\VisaCliCardEnrolled;
+use App\Domain\VisaCli\Listeners\SyncVisaCliCardToCardIssuance;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 
@@ -28,6 +30,9 @@ class EventServiceProvider extends ServiceProvider
         ],
         KycVerificationCompleted::class => [
             CompleteReferralOnKycApproval::class,
+        ],
+        VisaCliCardEnrolled::class => [
+            SyncVisaCliCardToCardIssuance::class,
         ],
     ];
 


### PR DESCRIPTION
## Summary
- `SyncVisaCliCardToCardIssuance` listener creates read-only Card records in CardIssuance domain
- Event-driven DDD boundary sync: `VisaCliCardEnrolled` -> Card with `metadata.source = 'visa_cli'`
- Deduplication prevents double-sync on re-enrollment
- Registered in `EventServiceProvider`

## Phase 4 of 6 — depends on Phase 3 (#787)

## Test plan
- [ ] PHPStan passes on listener and updated EventServiceProvider
- [ ] Card enrollment creates VisaCliEnrolledCard and dispatches event
- [ ] Listener creates matching Card record in CardIssuance domain
- [ ] Duplicate enrollment does not create duplicate Card records

🤖 Generated with [Claude Code](https://claude.com/claude-code)