### PR TITLE
feat: Visa CLI artisan commands — status, enroll, pay

### DIFF
--- a/app/Console/Commands/VisaCliEnrollCommand.php
+++ b/app/Console/Commands/VisaCliEnrollCommand.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\VisaCli\Services\VisaCliCardEnrollmentService;
+use App\Models\User;
+use Illuminate\Console\Command;
+use Throwable;
+
+class VisaCliEnrollCommand extends Command
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'visa:enroll
+                            {--user= : User ID or email to enroll a card for}';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Enroll a card for Visa CLI payments (non-production only)';
+
+    public function handle(VisaCliCardEnrollmentService $enrollmentService): int
+    {
+        if (app()->environment('production')) {
+            $this->error('This command is not available in production. Use the API instead.');
+
+            return 1;
+        }
+
+        if (! config('visacli.enabled', false)) {
+            $this->warn('Visa CLI integration is disabled. Set VISACLI_ENABLED=true to enable.');
+
+            return 1;
+        }
+
+        $userInput = $this->option('user');
+        if (empty($userInput)) {
+            $userInput = $this->ask('Enter user ID or email');
+        }
+
+        $user = is_numeric($userInput)
+            ? User::find($userInput)
+            : User::where('email', $userInput)->first();
+
+        if ($user === null) {
+            $this->error("User not found: {$userInput}");
+
+            return 1;
+        }
+
+        $this->info("Enrolling card for user: {$user->email} (ID: {$user->id})");
+
+        try {
+            $card = $enrollmentService->enrollCard((string) $user->id);
+
+            $this->info('Card enrolled successfully!');
+            $this->table(
+                ['Property', 'Value'],
+                [
+                    ['Card ID', $card->id],
+                    ['Card Identifier', $card->card_identifier],
+                    ['Last 4', $card->last4],
+                    ['Network', $card->network],
+                    ['Status', is_string($card->status) ? $card->status : $card->status->value],
+                    ['GitHub User', $card->github_username ?? 'N/A'],
+                ]
+            );
+
+            return 0;
+        } catch (Throwable $e) {
+            $this->error("Enrollment failed: {$e->getMessage()}");
+
+            return 1;
+        }
+    }
+}

--- a/app/Console/Commands/VisaCliPayCommand.php
+++ b/app/Console/Commands/VisaCliPayCommand.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\VisaCli\DataObjects\VisaCliPaymentRequest;
+use App\Domain\VisaCli\Services\VisaCliPaymentService;
+use Illuminate\Console\Command;
+use Throwable;
+
+class VisaCliPayCommand extends Command
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'visa:pay
+                            {url : The payment target URL}
+                            {--amount= : Payment amount in USD cents}
+                            {--card= : Card identifier to use}
+                            {--agent=cli-user : Agent identifier}';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Execute a Visa CLI payment to a URL';
+
+    public function handle(VisaCliPaymentService $paymentService): int
+    {
+        if (! config('visacli.enabled', false)) {
+            $this->warn('Visa CLI integration is disabled. Set VISACLI_ENABLED=true to enable.');
+
+            return 1;
+        }
+
+        $url = (string) $this->argument('url');
+        $amountCents = (int) $this->option('amount');
+        $cardId = $this->option('card');
+        $agentId = (string) $this->option('agent');
+
+        if ($amountCents <= 0) {
+            $amountInput = $this->ask('Enter payment amount in USD cents');
+            $amountCents = (int) $amountInput;
+        }
+
+        if ($amountCents <= 0) {
+            $this->error('Amount must be a positive integer (cents).');
+
+            return 1;
+        }
+
+        $this->info('Processing payment...');
+        $this->line("  URL:    {$url}");
+        $this->line('  Amount: $' . number_format($amountCents / 100, 2));
+        $this->line("  Agent:  {$agentId}");
+
+        if (! $this->confirm('Proceed with payment?', true)) {
+            $this->info('Payment cancelled.');
+
+            return 0;
+        }
+
+        try {
+            $request = new VisaCliPaymentRequest(
+                agentId: $agentId,
+                url: $url,
+                amountCents: $amountCents,
+                cardId: is_string($cardId) ? $cardId : null,
+                purpose: 'cli_payment',
+            );
+
+            $result = $this->paymentService($paymentService, $request);
+
+            $this->newLine();
+            $this->info('Payment completed!');
+            $this->table(
+                ['Property', 'Value'],
+                [
+                    ['Reference', $result->paymentReference],
+                    ['Status', $result->status->value],
+                    ['Amount', '$' . number_format($result->amountCents / 100, 2)],
+                    ['Currency', $result->currency],
+                    ['Card Last 4', $result->cardLast4 ?? 'N/A'],
+                ]
+            );
+
+            return 0;
+        } catch (Throwable $e) {
+            $this->error("Payment failed: {$e->getMessage()}");
+
+            return 1;
+        }
+    }
+
+    private function paymentService(
+        VisaCliPaymentService $paymentService,
+        VisaCliPaymentRequest $request,
+    ): \App\Domain\VisaCli\DataObjects\VisaCliPaymentResult {
+        return $paymentService->executePayment($request);
+    }
+}

--- a/app/Console/Commands/VisaCliStatusCommand.php
+++ b/app/Console/Commands/VisaCliStatusCommand.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\VisaCli\Contracts\VisaCliClientInterface;
+use App\Domain\VisaCli\Models\VisaCliPayment;
+use Illuminate\Console\Command;
+
+class VisaCliStatusCommand extends Command
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'visa:status';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Show Visa CLI status: initialization state, enrolled cards, and recent payments';
+
+    public function handle(VisaCliClientInterface $client): int
+    {
+        if (! config('visacli.enabled', false)) {
+            $this->warn('Visa CLI integration is disabled. Set VISACLI_ENABLED=true to enable.');
+
+            return 0;
+        }
+
+        $this->info('Visa CLI Status');
+        $this->line('');
+
+        // Status
+        $status = $client->getStatus();
+        $this->table(
+            ['Property', 'Value'],
+            [
+                ['Initialized', $status->initialized ? 'Yes' : 'No'],
+                ['Version', $status->version ?? 'N/A'],
+                ['GitHub User', $status->githubUsername ?? 'N/A'],
+                ['Driver', (string) config('visacli.driver', 'demo')],
+                ['Enrolled Cards', (string) $status->enrolledCards],
+            ]
+        );
+
+        // Cards
+        $cards = $client->listCards();
+        if ($cards !== []) {
+            $this->line('');
+            $this->info('Enrolled Cards');
+            $this->table(
+                ['Identifier', 'Last 4', 'Network', 'Status'],
+                array_map(fn ($card) => [
+                    $card->cardIdentifier,
+                    $card->last4,
+                    $card->network,
+                    $card->status->value,
+                ], $cards)
+            );
+        }
+
+        // Recent payments
+        $payments = VisaCliPayment::orderBy('created_at', 'desc')->limit(10)->get();
+        if ($payments->isNotEmpty()) {
+            $this->line('');
+            $this->info('Recent Payments (last 10)');
+            $this->table(
+                ['ID', 'Agent', 'URL', 'Amount', 'Status', 'Created'],
+                $payments->map(fn (VisaCliPayment $p) => [
+                    substr($p->id, 0, 8) . '...',
+                    $p->agent_id,
+                    strlen($p->url) > 40 ? substr($p->url, 0, 40) . '...' : $p->url,
+                    '$' . number_format($p->amount_cents / 100, 2),
+                    is_string($p->status) ? $p->status : $p->status->value,
+                    $p->created_at->format('Y-m-d H:i'),
+                ])->toArray()
+            );
+        } else {
+            $this->line('');
+            $this->info('No payments recorded yet.');
+        }
+
+        return 0;
+    }
+}


### PR DESCRIPTION
## Summary
- `visa:status` — shows init state, enrolled cards, recent payments in table format
- `visa:enroll {--user=}` — interactive card enrollment, non-production only
- `visa:pay {url} {--amount=} {--card=} {--agent=}` — execute payment with confirmation

## Phase 5 of 6 — depends on Phase 4 (#788)

## Test plan
- [ ] PHPStan passes on all 3 command files
- [ ] `visa:status` outputs table with demo driver info
- [ ] `visa:enroll` blocked in production environment
- [ ] `visa:pay` confirms before executing payment

🤖 Generated with [Claude Code](https://claude.com/claude-code)