### PR TITLE
feat: .well-known passkey/deep link files for iOS and Android

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -351,6 +351,10 @@ MOBILE_STALE_DEVICE_DAYS=90
 MOBILE_MAX_BIOMETRIC_FAILURES=5
 MOBILE_BIOMETRIC_BLOCK_MINUTES=30
 
+# Mobile App Store — Passkey & Deep Links (.well-known files)
+MOBILE_APPLE_TEAM_ID=
+MOBILE_ANDROID_SHA256_FINGERPRINT=
+
 # =============================================================================
 # BIOMETRIC JWT (v2.6.0+)
 # =============================================================================

--- a/config/mobile.php
+++ b/config/mobile.php
@@ -288,4 +288,18 @@ return [
             'importance'  => 'high',
         ],
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | App Store & Play Store — Passkey / Deep Link Verification
+    |--------------------------------------------------------------------------
+    |
+    | Used by /.well-known/apple-app-site-association and assetlinks.json
+    | to enable native passkey registration and Universal/App Links.
+    |
+    */
+
+    'apple_team_id' => env('MOBILE_APPLE_TEAM_ID', ''),
+
+    'android_sha256_fingerprint' => env('MOBILE_ANDROID_SHA256_FINGERPRINT', ''),
 ];

--- a/routes/web.php
+++ b/routes/web.php
@@ -241,6 +241,43 @@ Route::get('/legal/cookies', function () {
     return view('legal.cookies');
 })->name('legal.cookies');
 
+// Apple App Site Association — enables passkey AutoFill + Universal Links on iOS 16+
+Route::get('/.well-known/apple-app-site-association', function () {
+    return response()->json([
+        'webcredentials' => [
+            'apps' => [config('mobile.apple_team_id', 'REPLACE_TEAM_ID') . '.com.zelta.wallet'],
+        ],
+        'applinks' => [
+            'apps'    => [],
+            'details' => [
+                [
+                    'appID'   => config('mobile.apple_team_id', 'REPLACE_TEAM_ID') . '.com.zelta.wallet',
+                    'paths'   => ['/pay/*', '/verify/*'],
+                ],
+            ],
+        ],
+    ], 200, ['Content-Type' => 'application/json']);
+})->name('well-known.apple-app-site-association');
+
+// Android Digital Asset Links — enables passkey + App Links on Android 9+
+Route::get('/.well-known/assetlinks.json', function () {
+    return response()->json([
+        [
+            'relation' => [
+                'delegate_permission/common.handle_all_urls',
+                'delegate_permission/common.get_login_creds',
+            ],
+            'target' => [
+                'namespace'              => 'android_app',
+                'package_name'           => 'com.zelta.wallet',
+                'sha256_cert_fingerprints' => array_filter([
+                    config('mobile.android_sha256_fingerprint', ''),
+                ]),
+            ],
+        ],
+    ], 200, ['Content-Type' => 'application/json']);
+})->name('well-known.assetlinks');
+
 Route::get('/status', [StatusController::class, 'index'])->name('status');
 
 Route::get('/cgo', function () {


### PR DESCRIPTION
## Summary
- `GET /.well-known/apple-app-site-association` — enables iOS 16+ passkey AutoFill + Universal Links
- `GET /.well-known/assetlinks.json` — enables Android 9+ passkey + App Links verification
- Config driven via `MOBILE_APPLE_TEAM_ID` and `MOBILE_ANDROID_SHA256_FINGERPRINT`
- Both endpoints serve `Content-Type: application/json` with no redirects

## Setup
```env
MOBILE_APPLE_TEAM_ID=YOUR_TEAM_ID
MOBILE_ANDROID_SHA256_FINGERPRINT=AA:BB:CC:...
```

## Test plan
- [ ] `curl -I https://zelta.app/.well-known/apple-app-site-association` returns 200 + application/json
- [ ] `curl -I https://zelta.app/.well-known/assetlinks.json` returns 200 + application/json
- [ ] iOS passkey registration works with associated domain
- [ ] Android App Links auto-verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)