### PR TITLE
fix: website content accuracy — domains, GraphQL, SDKs, broken links

### DIFF
--- a/resources/views/about.blade.php
+++ b/resources/views/about.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'About ' . config('brand.name', 'Zelta') . ' - Open Source Core Banking Infrastructure',
-        'description' => config('brand.name', 'Zelta') . ' is an open-source core banking platform with 45 DDD domains, event sourcing, CQRS, and the Global Currency Unit. Built with Laravel for fintech developers.',
+        'description' => config('brand.name', 'Zelta') . ' is an open-source core banking platform with 46 DDD domains, event sourcing, CQRS, and the Global Currency Unit. Built with Laravel for fintech developers.',
         'keywords' => config('brand.name', 'Zelta') . ' about, open source banking, core banking platform, GCU, event sourcing, CQRS, Laravel banking, DDD, fintech infrastructure',
     ])
 
@@ -33,7 +33,7 @@
                 @include('partials.breadcrumb', ['items' => [['name' => 'About', 'url' => url('/about')]]])
                 <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">About <span class="text-gradient">{{ config('brand.name', 'Zelta') }}</span></h1>
                 <p class="text-lg text-slate-400 max-w-2xl mx-auto">
-                    Open-source core banking infrastructure built with Laravel — 45 domain modules covering everything from democratic currency governance to AI agent commerce.
+                    Open-source core banking infrastructure built with Laravel — 46 domain modules covering everything from democratic currency governance to AI agent commerce.
                 </p>
             </div>
         </div>
@@ -47,7 +47,7 @@
                 <div class="animate-on-scroll">
                     <h2 class="font-display text-3xl lg:text-4xl font-bold text-slate-900 mb-6">What Is {{ config('brand.name', 'Zelta') }}?</h2>
                     <p class="text-lg text-slate-600 mb-4 leading-relaxed">
-                        {{ config('brand.name', 'Zelta') }} is a core banking platform built with Laravel, implementing event sourcing, CQRS, domain-driven design, and AI agent integration across 43 bounded contexts.
+                        {{ config('brand.name', 'Zelta') }} is a core banking platform built with Laravel, implementing event sourcing, CQRS, domain-driven design, and AI agent integration across 46 bounded contexts.
                     </p>
                     <p class="text-lg text-slate-600 mb-6 leading-relaxed">
                         At its heart is the <strong>Global Currency Unit (GCU)</strong>&mdash;a democratically governed basket currency where users vote on composition from six global reserve assets.
@@ -147,7 +147,7 @@
                     ['title' => 'Banking API Patterns', 'desc' => 'Open Banking-compliant API adapters including Ondato KYC, Chainalysis sanctions screening, and Marqeta card issuing for real-world integration patterns.'],
                     ['title' => 'Cross-Chain & DeFi', 'desc' => 'Bridge protocols (Wormhole, LayerZero, Axelar), DEX aggregation via Uniswap/Aave/Curve/Lido, cross-chain swaps, and multi-chain portfolio management.'],
                     ['title' => 'Privacy & Identity', 'desc' => 'ZK-KYC proofs, Merkle tree commitments, soulbound tokens, W3C verifiable credentials, Shamir secret sharing, and delegated proof verification.'],
-                    ['title' => 'GraphQL API', 'desc' => 'Lighthouse-powered GraphQL covering 36 domains with real-time subscriptions, N+1 safe DataLoaders, and cursor-based pagination alongside REST/OpenAPI.'],
+                    ['title' => 'GraphQL API', 'desc' => 'Lighthouse-powered GraphQL covering 39 domains with real-time subscriptions, N+1 safe DataLoaders, and cursor-based pagination alongside REST/OpenAPI.'],
                     ['title' => 'Plugin Marketplace', 'desc' => 'Extensible plugin system with sandboxed execution, static security scanning, hook-based integration points, and a manager UI for discovering and installing plugins.'],
                     ['title' => 'Event Streaming', 'desc' => 'Redis Streams-powered event streaming with a live dashboard, consumer groups, backpressure handling, and dead-letter queues for reliable event processing.'],
                     ['title' => 'Compliance Certification', 'desc' => 'SOC 2 Type II and PCI DSS readiness tooling, GDPR enhanced privacy (ROPA, DPIA, breach notification, consent v2), and multi-region deployment support.'],
@@ -205,7 +205,7 @@
                 <div class="card-feature">
                     <h4 class="font-display text-base font-bold text-slate-900 mb-2">For Founders</h4>
                     <p class="text-sm text-slate-500 mb-3">
-                        Build your fintech product on battle-tested infrastructure. 45 domain modules, MIT licensed, ready to customize.
+                        Build your fintech product on battle-tested infrastructure. 46 domain modules, MIT licensed, ready to customize.
                     </p>
                     <a href="{{ route('developers') }}" class="text-sm text-blue-600 font-semibold hover:text-blue-700 transition">
                         View Documentation &rarr;

--- a/resources/views/ai-framework/demo.blade.php
+++ b/resources/views/ai-framework/demo.blade.php
@@ -136,7 +136,7 @@
                     </div>
                     <h3 class="text-xl font-semibold mb-3">Full API Access</h3>
                     <p class="text-slate-500 mb-4">
-                        Agents have access to the complete {{ config('brand.name', 'Zelta') }} API surface: 1,250+ REST endpoints and 35 GraphQL domain schemas with real-time subscriptions.
+                        Agents have access to the complete {{ config('brand.name', 'Zelta') }} API surface: 1,350+ REST endpoints and 39 GraphQL domain schemas with real-time subscriptions.
                     </p>
                     <code class="text-sm text-cyan-600 bg-cyan-50 px-3 py-1 rounded">REST + GraphQL</code>
                 </div>

--- a/resources/views/ai-framework/docs.blade.php
+++ b/resources/views/ai-framework/docs.blade.php
@@ -80,7 +80,7 @@
                                 </li>
                                 <li class="flex items-start">
                                     <svg class="w-5 h-5 text-blue-500 mr-2 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
-                                    <span><strong>Full API Surface:</strong> 1,250+ REST endpoints and 35 GraphQL domains</span>
+                                    <span><strong>Full API Surface:</strong> 1,350+ REST endpoints and 39 GraphQL domains</span>
                                 </li>
                             </ul>
                         </div>

--- a/resources/views/developers/api-docs.blade.php
+++ b/resources/views/developers/api-docs.blade.php
@@ -61,7 +61,7 @@
                         <h2 class="text-3xl font-bold text-gray-900 mb-8">Getting Started</h2>
                         
                         <div class="prose prose-lg max-w-none">
-                            <p>The {{ config('brand.name', 'Zelta') }} API provides programmatic access to our multi-asset banking platform spanning 45 DDD domains with over 1,250 routes. Our API is organized around REST principles with predictable, resource-oriented URLs. Domains include core banking, CrossChain bridging, DeFi protocols, RegTech compliance, Mobile Payment, Partner BaaS, and AI-powered queries.</p>
+                            <p>The {{ config('brand.name', 'Zelta') }} API provides programmatic access to our multi-asset banking platform spanning 46 DDD domains with over 1,350 routes. Our API is organized around REST principles with predictable, resource-oriented URLs. Domains include core banking, CrossChain bridging, DeFi protocols, RegTech compliance, Mobile Payment, Partner BaaS, and AI-powered queries.</p>
                             
                             <h3>Base URL</h3>
                             <x-code-block language="plaintext">
@@ -1250,8 +1250,8 @@ curl -H "Authorization: Bearer your_api_key" \
                         <h2 class="text-3xl font-bold text-gray-900 mb-8">GraphQL API</h2>
 
                         <div class="prose prose-lg max-w-none mb-8">
-                            <p>Schema-first GraphQL API powered by Lighthouse PHP. Provides queries, mutations, and subscriptions across 36 domain schemas with DataLoader-optimized resolvers and WebSocket-based real-time subscriptions.</p>
-                            <p class="text-sm text-gray-500">36 domain schemas &middot; Queries, Mutations, Subscriptions</p>
+                            <p>Schema-first GraphQL API powered by Lighthouse PHP. Provides queries, mutations, and subscriptions across 39 domain schemas with DataLoader-optimized resolvers and WebSocket-based real-time subscriptions.</p>
+                            <p class="text-sm text-gray-500">39 domain schemas &middot; Queries, Mutations, Subscriptions</p>
                         </div>
 
                         <div class="space-y-8">
@@ -1263,7 +1263,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                         <span class="ml-2 font-mono text-sm">/graphql</span>
                                     </div>
                                 </div>
-                                <p class="text-gray-600 mb-4">Execute a GraphQL query or mutation against the unified schema. Supports all 36 domain schemas including Account, AgentProtocol, Basket, Batch, CardIssuance, Cgo, Compliance, CrossChain, DeFi, Exchange, FinancialInstitution, Product, Regulatory, User, Wallet, and more.</p>
+                                <p class="text-gray-600 mb-4">Execute a GraphQL query or mutation against the unified schema. Supports all 39 domain schemas including Account, AgentProtocol, Basket, Batch, CardIssuance, Cgo, Compliance, CrossChain, DeFi, Exchange, FinancialInstitution, Product, Regulatory, User, Wallet, and more.</p>
                                 <x-code-block language="bash">
 curl -X POST \
   -H "Authorization: Bearer your_api_key" \
@@ -1572,7 +1572,7 @@ if (response.status === 402) {
                                 <li><a href="#mobile-payment" class="text-violet-600 hover:text-violet-800 flex justify-between"><span>Mobile Payment</span><span class="text-gray-400">25+ routes</span></a></li>
                                 <li><a href="#partner-baas" class="text-rose-600 hover:text-rose-800 flex justify-between"><span>Partner BaaS</span><span class="text-gray-400">24 routes</span></a></li>
                                 <li><a href="#ai" class="text-gray-600 hover:text-gray-800 flex justify-between"><span>AI Query</span><span class="text-gray-400">2 routes</span></a></li>
-                                <li><a href="#graphql" class="text-sky-600 hover:text-sky-800 flex justify-between"><span>GraphQL</span><span class="text-gray-400">36 domains</span></a></li>
+                                <li><a href="#graphql" class="text-sky-600 hover:text-sky-800 flex justify-between"><span>GraphQL</span><span class="text-gray-400">39 domains</span></a></li>
                                 <li><a href="#event-streaming" class="text-lime-600 hover:text-lime-800 flex justify-between"><span>Event Streaming</span><span class="text-gray-400">5 endpoints</span></a></li>
                                 <li><a href="#x402" class="text-emerald-600 hover:text-emerald-800 flex justify-between"><span>x402 Protocol</span><span class="text-gray-400">15+ endpoints</span></a></li>
                             </ul>

--- a/resources/views/developers/graphql.blade.php
+++ b/resources/views/developers/graphql.blade.php
@@ -7,7 +7,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'GraphQL API - ' . $brand . ' Developer Documentation',
-        'description' => $brand . ' GraphQL API — 36 domain schemas, real-time subscriptions, Lighthouse PHP powered.',
+        'description' => $brand . ' GraphQL API — 39 domain schemas, real-time subscriptions, Lighthouse PHP powered.',
         'keywords' => $brand . ', GraphQL, API, Lighthouse, subscriptions, queries, mutations',
     ])
 @endsection
@@ -33,10 +33,10 @@
     </div>
     <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
         <div class="text-center">
-            <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-white/10 text-white/80 border border-white/20 mb-4">35 Domain Schemas</span>
+            <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-white/10 text-white/80 border border-white/20 mb-4">39 Domain Schemas</span>
             <h1 class="text-4xl md:text-5xl font-extrabold tracking-tight mb-4">GraphQL API</h1>
             <p class="text-xl text-white/80 max-w-2xl mx-auto">
-                Query 36 domains with a single endpoint. Real-time subscriptions, Sanctum auth, and Lighthouse-powered schema composition.
+                Query 39 domains with a single endpoint. Real-time subscriptions, Sanctum auth, and Lighthouse-powered schema composition.
             </p>
         </div>
     </div>
@@ -132,7 +132,7 @@
 <section class="bg-slate-50 py-16">
     <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
         <h2 class="text-3xl font-bold mb-4">Domain Schemas</h2>
-        <p class="text-slate-600 mb-8">36 domain-specific schemas composed into one unified GraphQL endpoint. Each domain provides queries, mutations, and types scoped to its bounded context.</p>
+        <p class="text-slate-600 mb-8">39 domain-specific schemas composed into one unified GraphQL endpoint. Each domain provides queries, mutations, and types scoped to its bounded context.</p>
 
         @php
         $schemaGroups = [

--- a/resources/views/developers/index.blade.php
+++ b/resources/views/developers/index.blade.php
@@ -137,7 +137,7 @@
                 <div class="text-center">
                     <div class="inline-flex items-center px-4 py-2 bg-white/10 backdrop-blur-sm rounded-full text-sm mb-6">
                         <span class="w-2 h-2 bg-green-400 rounded-full mr-2 animate-pulse"></span>
-                        <span>v5.12 Documentation — 45 Domains, 1,250+ Routes, GraphQL + REST + x402</span>
+                        <span>v5.12 Documentation — 46 Domains, 1,350+ Routes, GraphQL + REST + x402</span>
                     </div>
                     <h1 class="text-5xl md:text-7xl font-bold mb-6 bg-clip-text text-transparent bg-gradient-to-r from-white to-blue-200">
                         Built for Developers
@@ -178,7 +178,7 @@
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                     </svg>
                     <span class="font-medium">v5.12 Released:</span>
-                    <span class="ml-2">Design System v2, Onramper Fiat Ramp, Foodo Insights, Referral System, Gas Sponsorship, Banners API, V1 Notifications — plus 45 DDD domains, 1,250+ API routes, GraphQL (36 domains), x402 Protocol, and more.</span>
+                    <span class="ml-2">Design System v2, Onramper Fiat Ramp, Foodo Insights, Referral System, Gas Sponsorship, Banners API, V1 Notifications — plus 46 DDD domains, 1,350+ API routes, GraphQL (39 domains), x402 Protocol, and more.</span>
                 </div>
             </div>
         </section>
@@ -434,7 +434,7 @@
                 <!-- Platform API Area Cards -->
                 <div class="mt-16">
                     <h3 class="text-2xl font-bold text-slate-900 mb-2 text-center">Platform API Areas</h3>
-                    <p class="text-slate-500 text-center mb-8">Explore the full breadth of the {{ config('brand.name', 'Zelta') }} platform across 45 DDD domains</p>
+                    <p class="text-slate-500 text-center mb-8">Explore the full breadth of the {{ config('brand.name', 'Zelta') }} platform across 46 DDD domains</p>
                     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
 
                         <!-- CrossChain -->
@@ -563,10 +563,10 @@
                                     </div>
                                     <div>
                                         <h4 class="text-lg font-semibold text-slate-900">GraphQL API</h4>
-                                        <span class="text-xs text-slate-400">36 domains</span>
+                                        <span class="text-xs text-slate-400">39 domains</span>
                                     </div>
                                 </div>
-                                <p class="text-slate-500 text-sm mb-3">Schema-first GraphQL via Lighthouse PHP with queries, mutations, subscriptions, and DataLoaders across 36 domain schemas.</p>
+                                <p class="text-slate-500 text-sm mb-3">Schema-first GraphQL via Lighthouse PHP with queries, mutations, subscriptions, and DataLoaders across 39 domain schemas.</p>
                                 <span class="text-sky-600 text-sm font-medium group-hover:text-sky-700">View endpoints &rarr;</span>
                             </div>
                         </a>
@@ -687,7 +687,7 @@
             <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                 <div class="grid grid-cols-2 md:grid-cols-5 gap-8 text-center">
                     <div>
-                        <div class="text-4xl md:text-5xl font-bold mb-2">1,250+</div>
+                        <div class="text-4xl md:text-5xl font-bold mb-2">1,350+</div>
                         <p class="text-indigo-200 flex items-center justify-center">
                             <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>

--- a/resources/views/developers/sdks.blade.php
+++ b/resources/views/developers/sdks.blade.php
@@ -292,7 +292,7 @@
 
                     <!-- Native SDKs -->
                     <div class="integration-card rounded-2xl p-8">
-                        <div class="status-indicator status-coming-soon">In Development</div>
+                        <div class="status-indicator status-available">Available</div>
                         <div class="flex items-center mb-6">
                             <div class="w-16 h-16 bg-yellow-100 rounded-xl flex items-center justify-center mr-4">
                                 <svg class="w-10 h-10 text-yellow-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -305,26 +305,26 @@
                             </div>
                         </div>
                         
-                        <p class="text-slate-600 mb-6">Official SDKs for popular programming languages with idiomatic APIs and comprehensive type safety.</p>
-                        
+                        <p class="text-slate-600 mb-6">Available for JavaScript/TypeScript, Python, and PHP. Official SDKs with idiomatic APIs and comprehensive type safety.</p>
+
                         <div class="grid grid-cols-2 gap-3 mb-6">
                             <div class="flex items-center">
-                                <svg class="w-5 h-5 text-gray-400 mr-2" fill="currentColor" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm-1-9a1 1 0 012 0v4a1 1 0 11-2 0V9zm0-4a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1z" clip-rule="evenodd"/>
+                                <svg class="w-5 h-5 text-green-500 mr-2" fill="currentColor" viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
                                 </svg>
-                                <span class="text-slate-500">JavaScript/TypeScript</span>
+                                <span class="text-slate-700">JavaScript/TypeScript</span>
                             </div>
                             <div class="flex items-center">
-                                <svg class="w-5 h-5 text-gray-400 mr-2" fill="currentColor" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm-1-9a1 1 0 012 0v4a1 1 0 11-2 0V9zm0-4a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1z" clip-rule="evenodd"/>
+                                <svg class="w-5 h-5 text-green-500 mr-2" fill="currentColor" viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
                                 </svg>
-                                <span class="text-slate-500">Python</span>
+                                <span class="text-slate-700">Python</span>
                             </div>
                             <div class="flex items-center">
-                                <svg class="w-5 h-5 text-gray-400 mr-2" fill="currentColor" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm-1-9a1 1 0 012 0v4a1 1 0 11-2 0V9zm0-4a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1z" clip-rule="evenodd"/>
+                                <svg class="w-5 h-5 text-green-500 mr-2" fill="currentColor" viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
                                 </svg>
-                                <span class="text-slate-500">PHP</span>
+                                <span class="text-slate-700">PHP</span>
                             </div>
                             <div class="flex items-center">
                                 <svg class="w-5 h-5 text-gray-400 mr-2" fill="currentColor" viewBox="0 0 20 20">
@@ -345,11 +345,17 @@
                                 <span class="text-slate-500">Java</span>
                             </div>
                         </div>
-                        
-                        <div class="bg-gray-50 border border-gray-200 rounded-lg p-4">
-                            <p class="text-sm text-slate-500">
-                                Native SDKs are planned for future development. Currently, use our REST API directly.
-                            </p>
+
+                        <div class="space-y-2">
+                            <div class="bg-gray-900 rounded-lg px-4 py-2 font-mono text-green-400 text-sm">
+                                <code>npm install @finaegis/sdk@1.0.0</code>
+                            </div>
+                            <div class="bg-gray-900 rounded-lg px-4 py-2 font-mono text-green-400 text-sm">
+                                <code>pip install finaegis-sdk==1.0.0</code>
+                            </div>
+                            <div class="bg-gray-900 rounded-lg px-4 py-2 font-mono text-green-400 text-sm">
+                                <code>composer require finaegis/sdk:^1.0</code>
+                            </div>
                         </div>
                     </div>
 
@@ -588,7 +594,7 @@ console.<span style="color: #89ddff;">log</span>(<span style="color: #82aaff;">r
 
                     <div class="bg-gray-900 rounded-lg p-6 font-mono text-green-400 text-sm overflow-x-auto mb-8">
 <pre><span class="text-gray-500"># Request SDK generation for your partner account</span>
-curl -X POST {{ config('app.url') }}/api/api/v1/partner/sdk/generate \
+curl -X POST {{ config('app.url') }}/api/v1/partner/sdk/generate \
   -H "Authorization: Bearer YOUR_PARTNER_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -610,38 +616,24 @@ curl -X POST {{ config('app.url') }}/api/api/v1/partner/sdk/generate \
     "packages": [
       {
         "language": "typescript",
-        "version": "5.0.0",
+        "version": "1.0.0",
         "package_name": "@finaegis/sdk",
-        "download_url": "{{ config('app.url') }}/developers/sdks/packages/typescript/finaegis-sdk-5.0.0.tgz",
-        "install_command": "npm install @finaegis/sdk@5.0.0"
+        "download_url": "{{ config('app.url') }}/developers/sdks/packages/typescript/finaegis-sdk-1.0.0.tgz",
+        "install_command": "npm install @finaegis/sdk@1.0.0"
       },
       {
         "language": "python",
-        "version": "5.0.0",
+        "version": "1.0.0",
         "package_name": "finaegis-sdk",
-        "download_url": "{{ config('app.url') }}/developers/sdks/packages/python/finaegis-sdk-5.0.0.tar.gz",
-        "install_command": "pip install finaegis-sdk==5.0.0"
-      },
-      {
-        "language": "java",
-        "version": "5.0.0",
-        "package_name": "com.finaegis:sdk",
-        "download_url": "{{ config('app.url') }}/developers/sdks/packages/java/finaegis-sdk-5.0.0.jar",
-        "install_command": "mvn install com.finaegis:sdk:5.0.0"
-      },
-      {
-        "language": "go",
-        "version": "5.0.0",
-        "package_name": "github.com/finaegis/sdk-go",
-        "download_url": "{{ config('app.url') }}/developers/sdks/packages/go/finaegis-sdk-go-5.12.0.tar.gz",
-        "install_command": "go get github.com/finaegis/sdk-go@v5.12.0"
+        "download_url": "{{ config('app.url') }}/developers/sdks/packages/python/finaegis-sdk-1.0.0.tar.gz",
+        "install_command": "pip install finaegis-sdk==1.0.0"
       },
       {
         "language": "php",
-        "version": "5.0.0",
+        "version": "1.0.0",
         "package_name": "finaegis/sdk",
-        "download_url": "{{ config('app.url') }}/developers/sdks/packages/php/finaegis-sdk-5.0.0.zip",
-        "install_command": "composer require finaegis/sdk:^5.0"
+        "download_url": "{{ config('app.url') }}/developers/sdks/packages/php/finaegis-sdk-1.0.0.zip",
+        "install_command": "composer require finaegis/sdk:^1.0"
       }
     ]
   }
@@ -654,19 +646,19 @@ curl -X POST {{ config('app.url') }}/api/api/v1/partner/sdk/generate \
                         <div>
                             <p class="text-sm font-medium text-slate-600 mb-2">TypeScript / JavaScript</p>
                             <div class="bg-gray-900 rounded-lg p-4 font-mono text-green-400 text-sm">
-                                <code>npm install @finaegis/sdk@5.0.0</code>
+                                <code>npm install @finaegis/sdk@1.0.0</code>
                             </div>
                         </div>
                         <div>
                             <p class="text-sm font-medium text-slate-600 mb-2">Python</p>
                             <div class="bg-gray-900 rounded-lg p-4 font-mono text-green-400 text-sm">
-                                <code>pip install finaegis-sdk==5.0.0</code>
+                                <code>pip install finaegis-sdk==1.0.0</code>
                             </div>
                         </div>
                         <div>
                             <p class="text-sm font-medium text-slate-600 mb-2">PHP (Composer)</p>
                             <div class="bg-gray-900 rounded-lg p-4 font-mono text-green-400 text-sm">
-                                <code>composer require finaegis/sdk:^5.0</code>
+                                <code>composer require finaegis/sdk:^1.0</code>
                             </div>
                         </div>
                     </div>

--- a/resources/views/features/api.blade.php
+++ b/resources/views/features/api.blade.php
@@ -215,7 +215,7 @@
                     <h3 class="text-xl font-bold mb-4">Authentication</h3>
                     <div class="code-block">
                         <pre><code>// Login and get access token
-const response = await fetch('https://api.finaegis.com/api/auth/login', {
+const response = await fetch('{{ config('app.url') }}/api/auth/login', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
@@ -241,7 +241,7 @@ const headers = {
                     <h3 class="text-xl font-bold mb-4">Create Transfer</h3>
                     <div class="code-block">
                         <pre><code>// Transfer between accounts
-const transfer = await fetch('https://api.finaegis.com/api/transfers', {
+const transfer = await fetch('{{ config('app.url') }}/api/transfers', {
   method: 'POST',
   headers: {
     'Authorization': `Bearer ${access_token}`,

--- a/resources/views/features/crosschain-defi.blade.php
+++ b/resources/views/features/crosschain-defi.blade.php
@@ -308,7 +308,7 @@
                 <h3 class="text-xl font-bold mb-4">Example: Get Bridge Quote</h3>
                 <div class="bg-gray-900 rounded-lg p-6 text-green-400 font-mono text-sm overflow-x-auto">
                     <pre><code>// Request a bridge quote across providers
-const response = await fetch('https://api.finaegis.com/api/v1/crosschain/bridge/quote', {
+const response = await fetch('{{ config('app.url') }}/api/v1/crosschain/bridge/quote', {
   method: 'POST',
   headers: {
     'Authorization': 'Bearer YOUR_API_TOKEN',

--- a/resources/views/features/index.blade.php
+++ b/resources/views/features/index.blade.php
@@ -38,7 +38,7 @@
         <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20 lg:py-24">
             <div class="text-center">
                 @include('partials.breadcrumb', ['items' => [['name' => 'Features', 'url' => url('/features')]]])
-                <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">45 Domain Modules. <span class="text-gradient">One Platform.</span></h1>
+                <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">46 Domain Modules. <span class="text-gradient">One Platform.</span></h1>
                 <p class="text-lg text-slate-400 max-w-2xl mx-auto">
                     Every building block a modern fintech needs — from democratic currency governance to AI agent commerce, cross-chain DeFi, and privacy-preserving identity.
                 </p>
@@ -251,7 +251,7 @@
                     </div>
                     <h3 class="text-xl font-semibold mb-3">Developer APIs</h3>
                     <p class="text-slate-500 mb-4">
-                        Full REST coverage with OpenAPI specs, GraphQL across 36 domains with real-time subscriptions, and configurable webhooks.
+                        Full REST coverage with OpenAPI specs, GraphQL across 39 domains with real-time subscriptions, and configurable webhooks.
                     </p>
                     <a href="{{ route('features.show', 'api') }}" class="text-blue-600 font-medium hover:text-blue-700">
                         View docs →
@@ -395,7 +395,7 @@
                     </div>
                     <h3 class="text-xl font-semibold mb-3">GraphQL API</h3>
                     <p class="text-slate-500 mb-4">
-                        Lighthouse-powered GraphQL covering 36 domains with real-time subscriptions, N+1 safe DataLoaders, and cursor-based pagination.
+                        Lighthouse-powered GraphQL covering 39 domains with real-time subscriptions, N+1 safe DataLoaders, and cursor-based pagination.
                     </p>
                     <a href="{{ route('features.show', 'api') }}" class="text-pink-600 font-medium hover:text-pink-700">
                         View API &rarr;

--- a/resources/views/partials/public-nav.blade.php
+++ b/resources/views/partials/public-nav.blade.php
@@ -38,7 +38,7 @@
                                     </div>
                                     <div>
                                         <div class="text-sm font-medium text-slate-200">All Features</div>
-                                        <div class="text-xs text-slate-500">45 domain modules</div>
+                                        <div class="text-xs text-slate-500">46 domain modules</div>
                                     </div>
                                 </a>
                                 <a href="{{ route('gcu') }}" class="dropdown-link {{ request()->routeIs('gcu*') ? 'dropdown-link-active' : '' }}">

--- a/resources/views/platform/index.blade.php
+++ b/resources/views/platform/index.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => config('brand.name', 'Zelta') . ' Platform - Open Banking for Developers',
-        'description' => config('brand.name', 'Zelta') . ' Platform - Open-source core banking infrastructure with 45 DDD domains, event sourcing, REST + GraphQL APIs, and cross-chain DeFi. MIT licensed.',
+        'description' => config('brand.name', 'Zelta') . ' Platform - Open-source core banking infrastructure with 46 DDD domains, event sourcing, REST + GraphQL APIs, and cross-chain DeFi. MIT licensed.',
         'keywords' => config('brand.name', 'Zelta') . ' platform, banking infrastructure, open source banking, developer API, MIT license, core banking API, fintech development, DDD, event sourcing',
     ])
 
@@ -475,7 +475,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-bold mb-2">GraphQL API</h3>
-                        <p class="text-pink-100 text-sm mb-4">36 domains, subscriptions, DataLoaders, and real-time queries</p>
+                        <p class="text-pink-100 text-sm mb-4">39 domains, subscriptions, DataLoaders, and real-time queries</p>
                         <a href="{{ route('features') }}" class="text-white font-semibold hover:underline">Learn more &rarr;</a>
                     </div>
 

--- a/resources/views/pricing.blade.php
+++ b/resources/views/pricing.blade.php
@@ -58,7 +58,7 @@
                         <ul class="space-y-3 mb-8 text-sm text-slate-600">
                             <li class="list-check">Full source code access</li>
                             <li class="list-check">MIT License</li>
-                            <li class="list-check">All 45 domain modules</li>
+                            <li class="list-check">All 46 domain modules</li>
                             <li class="list-check">Community support</li>
                             <li class="list-check">Self-hosted deployment</li>
                         </ul>
@@ -167,7 +167,7 @@
                     Start free with the Community Edition, or talk to us about managed and enterprise options.
                 </p>
                 <div class="flex flex-col sm:flex-row gap-4 justify-center">
-                    <a href="https://{{ config('brand.github_url') }}" target="_blank" class="btn-primary px-8 py-4 text-lg">
+                    <a href="{{ config('brand.github_url') }}" target="_blank" class="btn-primary px-8 py-4 text-lg">
                         Start with Community Edition
                     </a>
                     <a href="{{ route('support.contact') }}" class="btn-outline px-8 py-4 text-lg">

--- a/resources/views/support/contact.blade.php
+++ b/resources/views/support/contact.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'Contact Us - ' . config('brand.name', 'Zelta') . ' Support',
-        'description' => 'Contact the ' . config('brand.name', 'Zelta') . ' team for technical support, partnership inquiries, or to report issues. Community support for our open-source core banking platform with 45 domain modules.',
+        'description' => 'Contact the ' . config('brand.name', 'Zelta') . ' team for technical support, partnership inquiries, or to report issues. Community support for our open-source core banking platform with 46 domain modules.',
     ])
 @endsection
 

--- a/resources/views/support/faq.blade.php
+++ b/resources/views/support/faq.blade.php
@@ -13,7 +13,7 @@
     $faqData = [
         [
             'question' => 'What is the current status of ' . config('brand.name', 'Zelta') . '?',
-            'answer' => config('brand.name', 'Zelta') . ' v5.12.0 is a fully-featured open-source core banking platform with 45 domain modules. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
+            'answer' => config('brand.name', 'Zelta') . ' v5.12.0 is a fully-featured open-source core banking platform with 46 domain modules. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
         ],
         [
             'question' => 'Can I use real money on the platform?',
@@ -21,7 +21,7 @@
         ],
         [
             'question' => 'How do I get started?',
-            'answer' => 'Register for a free account to explore the sandbox, or clone the repository from GitHub to self-host. You can explore all 45 domain modules, test the APIs, and provide feedback through our support channels.'
+            'answer' => 'Register for a free account to explore the sandbox, or clone the repository from GitHub to self-host. You can explore all 46 domain modules, test the APIs, and provide feedback through our support channels.'
         ],
         [
             'question' => 'What is the Global Currency Unit (GCU)?',
@@ -130,8 +130,8 @@
                             {{ config('brand.name', 'Zelta') }} is a fully-featured open-source core banking platform at v5.12.0. The sandbox environment lets you:
                         </p>
                         <ul class="list-disc list-inside mt-2 text-slate-500 space-y-1">
-                            <li>Explore 45 domain modules including DeFi, cross-chain, privacy, and rewards</li>
-                            <li>Test 143+ REST API endpoints and a 35-domain GraphQL API</li>
+                            <li>Explore 46 domain modules including DeFi, cross-chain, privacy, and rewards</li>
+                            <li>Test 143+ REST API endpoints and a 39-domain GraphQL API</li>
                             <li>Try KYC/AML compliance flows, card issuing, and mobile payments</li>
                             <li>All transactions use test data &mdash; no real funds are involved</li>
                             <li>Community feedback drives the roadmap forward</li>
@@ -343,7 +343,7 @@
                             We have an exciting roadmap ahead:
                         </p>
                         <ul class="list-disc list-inside mt-2 text-slate-500 space-y-1">
-                            <li><strong>Delivered:</strong> 45 domain modules, 143+ API endpoints, GraphQL, event sourcing</li>
+                            <li><strong>Delivered:</strong> 46 domain modules, 143+ API endpoints, GraphQL, event sourcing</li>
                             <li><strong>Delivered:</strong> Mobile app backend, passkey auth, card issuing, KYC/AML</li>
                             <li><strong>Delivered:</strong> Cross-chain bridges, DeFi connectors, X402 micropayments</li>
                             <li><strong>Upcoming:</strong> GCU voting system, production bank integrations</li>

--- a/resources/views/support/guides.blade.php
+++ b/resources/views/support/guides.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'Support Guides - ' . config('brand.name', 'Zelta') . '',
-        'description' => config('brand.name', 'Zelta') . ' platform guides and documentation. Learn how to use, deploy, and contribute to our open-source core banking platform with 45 domain modules.',
+        'description' => config('brand.name', 'Zelta') . ' platform guides and documentation. Learn how to use, deploy, and contribute to our open-source core banking platform with 46 domain modules.',
         'keywords' => config('brand.name', 'Zelta') . ' guides, documentation, tutorials, open source banking, core banking platform',
     ])
 @endsection

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => config('brand.name', 'Zelta') . ' - Open Source Core Banking Infrastructure',
-        'description' => 'Open-source core banking infrastructure with 45 DDD domains, event sourcing, cross-chain DeFi, privacy-preserving identity, RegTech compliance, AI analytics, and HTTP-native micropayments. Built with Laravel.',
+        'description' => 'Open-source core banking infrastructure with 46 DDD domains, event sourcing, cross-chain DeFi, privacy-preserving identity, RegTech compliance, AI analytics, and HTTP-native micropayments. Built with Laravel.',
         'keywords' => config('brand.name', 'Zelta') . ', open source banking, core banking infrastructure, GCU, event sourcing, DeFi, cross-chain, RegTech, banking API, Laravel fintech',
     ])
 
@@ -32,7 +32,7 @@
                     <svg class="w-4 h-4 text-fa-teal" fill="currentColor" viewBox="0 0 20 20">
                         <path fill-rule="evenodd" d="M12.316 3.051a1 1 0 01.633 1.265l-4 12a1 1 0 11-1.898-.632l4-12a1 1 0 011.265-.633zM5.707 6.293a1 1 0 010 1.414L3.414 10l2.293 2.293a1 1 0 11-1.414 1.414l-3-3a1 1 0 010-1.414l3-3a1 1 0 011.414 0zm8.586 0a1 1 0 011.414 0l3 3a1 1 0 010 1.414l-3 3a1 1 0 11-1.414-1.414L16.586 10l-2.293-2.293a1 1 0 010-1.414z" clip-rule="evenodd"/>
                     </svg>
-                    Open Source &middot; MIT Licensed &middot; 45 Domains
+                    Open Source &middot; MIT Licensed &middot; 46 Domains
                 </div>
 
                 <!-- Heading -->
@@ -87,7 +87,7 @@
                         What Is {{ config('brand.name', 'Zelta') }}?
                     </h2>
                     <p class="text-lg text-slate-600 leading-relaxed mb-6">
-                        A production-grade core banking platform built with Laravel and domain-driven design. 43 bounded contexts, event sourcing, CQRS, and every integration pattern a modern fintech needs.
+                        A production-grade core banking platform built with Laravel and domain-driven design. 46 bounded contexts, event sourcing, CQRS, and every integration pattern a modern fintech needs.
                     </p>
                     <div class="space-y-3 mb-8">
                         @foreach([
@@ -150,7 +150,7 @@
             <div class="text-center mb-16 animate-on-scroll">
                 <h2 class="font-display text-4xl lg:text-5xl font-bold text-slate-900 tracking-tight mb-4">Built-In Capabilities</h2>
                 <p class="text-lg text-slate-500 max-w-2xl mx-auto">
-                    45 domain modules spanning payments, lending, compliance, DeFi, privacy, mobile wallets, AI analytics, and more.
+                    46 domain modules spanning payments, lending, compliance, DeFi, privacy, mobile wallets, AI analytics, and more.
                 </p>
             </div>
 
@@ -162,7 +162,7 @@
                         ['route' => 'features.show', 'slug' => 'settlements', 'title' => 'Event-Sourced Ledger', 'desc' => 'Every transaction is an immutable event. Full audit trails, point-in-time reconstruction, and replay capability.', 'icon' => 'M13 10V3L4 14h7v7l9-11h-7z', 'color' => 'emerald'],
                         ['route' => 'features.show', 'slug' => 'governance', 'title' => 'Democratic Governance', 'desc' => 'Stake-weighted voting on monetary policy. Users shape their currency through on-chain governance proposals.', 'icon' => 'M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z', 'color' => 'amber'],
                         ['route' => 'features.show', 'slug' => 'bank-integration', 'title' => 'Banking API Patterns', 'desc' => 'Open Banking-compliant API patterns with Ondato KYC, Chainalysis sanctions, and Marqeta card issuing.', 'icon' => 'M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4', 'color' => 'red'],
-                        ['route' => 'features.show', 'slug' => 'api', 'title' => 'REST, GraphQL & OpenAPI', 'desc' => 'Full REST coverage with OpenAPI specs, GraphQL across 36 domains, real-time subscriptions, and webhooks.', 'icon' => 'M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4', 'color' => 'sky'],
+                        ['route' => 'features.show', 'slug' => 'api', 'title' => 'REST, GraphQL & OpenAPI', 'desc' => 'Full REST coverage with OpenAPI specs, GraphQL across 39 domains, real-time subscriptions, and webhooks.', 'icon' => 'M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4', 'color' => 'sky'],
                         ['route' => 'ai-framework', 'slug' => null, 'title' => 'AI Agent Protocol', 'desc' => 'Google A2A protocol for autonomous agent commerce. MCP tools, spending limits, and transaction analytics.', 'icon' => 'M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z', 'color' => 'violet'],
                         ['route' => 'features.show', 'slug' => 'crosschain-defi', 'title' => 'Cross-Chain & DeFi', 'desc' => 'Bridge across Wormhole, LayerZero, Axelar. Aggregate DEX liquidity, optimize yield, manage multi-chain portfolios.', 'icon' => 'M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1', 'color' => 'orange'],
                         ['route' => 'features.show', 'slug' => 'privacy-identity', 'title' => 'Privacy & Identity', 'desc' => 'ZK-KYC proofs, RAILGUN shielded transfers, W3C verifiable credentials, soulbound tokens, Shamir key mgmt.', 'icon' => 'M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z', 'color' => 'teal'],
@@ -194,7 +194,7 @@
 
             <div class="text-center mt-12 animate-on-scroll">
                 <a href="{{ route('features') }}" class="btn-primary !bg-slate-900 hover:!bg-slate-800 !rounded-lg group">
-                    See All 45 Domains
+                    See All 46 Domains
                     <svg class="w-4 h-4 ml-2 transition-transform group-hover:translate-x-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path></svg>
                 </a>
             </div>
@@ -212,7 +212,7 @@
             <div class="text-center mb-16 animate-on-scroll">
                 <h2 class="font-display text-4xl lg:text-5xl font-bold text-white tracking-tight mb-4">Platform Architecture</h2>
                 <p class="text-lg text-slate-400 max-w-2xl mx-auto">
-                    43 bounded contexts built with DDD, event sourcing, and CQRS. Each module implements specific financial system patterns you can use independently.
+                    46 bounded contexts built with DDD, event sourcing, and CQRS. Each module implements specific financial system patterns you can use independently.
                 </p>
             </div>
 


### PR DESCRIPTION
## Summary
Full content audit and fix across 17 public-facing pages.

### Numbers corrected (verified from codebase)
| Metric | Was | Now | Verification |
|--------|-----|-----|-------------|
| Domain modules | 45 (or 43) | **46** | `ls app/Domain/ \| wc -l` |
| GraphQL schemas | 35 or 36 | **39** | `ls graphql/*.graphql \| wc -l` |
| Route definitions | 1,250+ | **1,350+** | `grep -r Route:: routes/ app/Domain/*/Routes/ \| wc -l` |

### Broken links fixed
- `pricing.blade.php` — double `https://` on GitHub URL
- `features/api.blade.php` — dead `api.finaegis.com` domain in code examples
- `features/crosschain-defi.blade.php` — same dead domain

### SDK page overhauled
- Status: "In Development" → "Available" (JS/TS, Python, PHP exist in `sdks/`)
- Package versions: 5.0.0 → 1.0.0 (matches actual `package.json`/`setup.py`)
- Removed non-existent Java/Go SDKs from response example
- Fixed double `/api/api/` typo in curl example
- Added real install commands replacing "planned" notice

### Files changed (17)
welcome, about, pricing, features/index, features/api, features/crosschain-defi, developers/index, developers/sdks, developers/graphql, developers/api-docs, platform/index, ai-framework/demo, ai-framework/docs, support/faq, support/guides, support/contact, partials/public-nav

## Test plan
- [ ] Visit each page and verify numbers render correctly
- [ ] Click GitHub link on pricing page
- [ ] Check SDK page install commands and status badges
- [ ] Verify no remaining "45 domain" or "api.finaegis.com" references

🤖 Generated with [Claude Code](https://claude.com/claude-code)