### PR TITLE
feat: admin CLI commands + disable registration in production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,14 @@ LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug
 
 # =============================================================================
+# REGISTRATION & ACCESS CONTROL
+# =============================================================================
+# In production, registration is disabled by default. Users are created via CLI:
+#   php artisan user:create --admin
+# Set to true to enable public registration (demo/sandbox only).
+REGISTRATION_ENABLED=false
+
+# =============================================================================
 # DEMO MODE (APP_ENV=demo activates full demo mode; local uses demo services)
 # =============================================================================
 DEMO_INSTANT_DEPOSITS=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,12 @@ XDEBUG_MODE=off vendor/bin/phpstan analyse --memory-limit=2G
 php artisan serve                    # Start server
 npm run dev                          # Vite dev server
 php artisan l5-swagger:generate      # API docs
+
+# User & Admin management
+php artisan user:create --admin      # Create user (--admin for admin role)
+php artisan user:promote user@email  # Promote existing user to admin
+php artisan user:demote user@email   # Remove admin role
+php artisan user:admins              # List all admin users
 ```
 
 ## Architecture

--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -22,6 +22,12 @@ class CreateNewUser implements CreatesNewUsers
      */
     public function create(array $input): User
     {
+        // Defense-in-depth: block registration even if Fortify feature flag is bypassed
+        $registrationEnabled = (bool) env('REGISTRATION_ENABLED', in_array(app()->environment(), ['local', 'testing', 'demo']));
+        if (! $registrationEnabled) {
+            abort(403, 'Registration is disabled. Contact an administrator.');
+        }
+
         Validator::make(
             $input,
             [

--- a/app/Console/Commands/UserCreateCommand.php
+++ b/app/Console/Commands/UserCreateCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Validator;
+use Spatie\Permission\Models\Role;
+
+class UserCreateCommand extends Command
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'user:create
+                            {--name= : Full name}
+                            {--email= : Email address}
+                            {--password= : Password (prompted if omitted)}
+                            {--admin : Assign admin role}';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Create a new user account (production-safe alternative to web registration)';
+
+    public function handle(): int
+    {
+        $name = $this->option('name') ?: $this->ask('Full name');
+        $email = $this->option('email') ?: $this->ask('Email address');
+        $password = $this->option('password') ?: $this->secret('Password (min 8 characters)');
+        $makeAdmin = (bool) $this->option('admin');
+
+        $validator = Validator::make([
+            'name'     => $name,
+            'email'    => $email,
+            'password' => $password,
+        ], [
+            'name'     => 'required|string|max:255',
+            'email'    => 'required|email|unique:users,email',
+            'password' => 'required|string|min:8',
+        ]);
+
+        if ($validator->fails()) {
+            foreach ($validator->errors()->all() as $error) {
+                $this->error($error);
+            }
+
+            return 1;
+        }
+
+        $user = User::create([
+            'name'     => $name,
+            'email'    => $email,
+            'password' => Hash::make((string) $password),
+        ]);
+
+        if ($makeAdmin) {
+            Role::firstOrCreate(['name' => 'admin', 'guard_name' => 'web']);
+            $user->assignRole('admin');
+        }
+
+        $this->info("User created: {$user->email} (ID: {$user->id})");
+        if ($makeAdmin) {
+            $this->info('Admin role assigned — can access /admin dashboard.');
+        }
+
+        return 0;
+    }
+}

--- a/app/Console/Commands/UserDemoteCommand.php
+++ b/app/Console/Commands/UserDemoteCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+
+class UserDemoteCommand extends Command
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'user:demote
+                            {email : Email of the user to demote}
+                            {--role=admin : Role to remove (admin, super_admin)}';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Remove admin or super_admin role from a user';
+
+    public function handle(): int
+    {
+        $email = (string) $this->argument('email');
+        $roleName = (string) $this->option('role');
+
+        $user = User::where('email', $email)->first();
+        if ($user === null) {
+            $this->error("User not found: {$email}");
+
+            return 1;
+        }
+
+        if (! $user->hasRole($roleName)) {
+            $this->info("{$email} does not have the '{$roleName}' role.");
+
+            return 0;
+        }
+
+        $user->removeRole($roleName);
+
+        $this->info("Removed '{$roleName}' role from {$email}.");
+
+        return 0;
+    }
+}

--- a/app/Console/Commands/UserListAdminsCommand.php
+++ b/app/Console/Commands/UserListAdminsCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+
+class UserListAdminsCommand extends Command
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'user:admins';
+
+    /**
+     * @var string
+     */
+    protected $description = 'List all users with admin or super_admin roles';
+
+    public function handle(): int
+    {
+        $admins = User::role(['admin', 'super_admin'])->get();
+
+        if ($admins->isEmpty()) {
+            $this->warn('No admin users found. Create one with: php artisan user:create --admin');
+
+            return 0;
+        }
+
+        $this->table(
+            ['ID', 'Name', 'Email', 'Roles', 'Created'],
+            $admins->map(fn (User $user) => [
+                $user->id,
+                $user->name,
+                $user->email,
+                $user->getRoleNames()->implode(', '),
+                $user->created_at?->format('Y-m-d H:i'),
+            ])->toArray()
+        );
+
+        return 0;
+    }
+}

--- a/app/Console/Commands/UserPromoteCommand.php
+++ b/app/Console/Commands/UserPromoteCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+use Spatie\Permission\Models\Role;
+
+class UserPromoteCommand extends Command
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'user:promote
+                            {email : Email of the user to promote}
+                            {--role=admin : Role to assign (admin, super_admin)}';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Promote an existing user to admin or super_admin';
+
+    public function handle(): int
+    {
+        $email = (string) $this->argument('email');
+        $roleName = (string) $this->option('role');
+
+        $allowedRoles = ['admin', 'super_admin'];
+        if (! in_array($roleName, $allowedRoles, true)) {
+            $this->error("Invalid role: {$roleName}. Allowed: " . implode(', ', $allowedRoles));
+
+            return 1;
+        }
+
+        $user = User::where('email', $email)->first();
+        if ($user === null) {
+            $this->error("User not found: {$email}");
+
+            return 1;
+        }
+
+        if ($user->hasRole($roleName)) {
+            $this->info("{$email} already has the '{$roleName}' role.");
+
+            return 0;
+        }
+
+        Role::firstOrCreate(['name' => $roleName, 'guard_name' => 'web']);
+        $user->assignRole($roleName);
+
+        $this->info("Promoted {$email} to '{$roleName}'.");
+
+        return 0;
+    }
+}

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -143,8 +143,11 @@ return [
     |
     */
 
-    'features' => [
-        Features::registration(),
+    'features' => array_filter([
+        // Registration disabled in production — users are created by admins via CLI.
+        // Set REGISTRATION_ENABLED=true in .env for demo/sandbox environments.
+        // Defaults to enabled for local/testing/demo, disabled for production.
+        (bool) env('REGISTRATION_ENABLED', in_array(env('APP_ENV', 'production'), ['local', 'testing', 'demo'])) ? Features::registration() : null,
         Features::resetPasswords(),
         Features::emailVerification(),
         Features::updateProfileInformation(),
@@ -154,6 +157,6 @@ return [
             'confirmPassword' => true,
             // 'window' => 0,
         ]),
-    ],
+    ]),
 
 ];

--- a/docs/10-OPERATIONS/OPERATIONAL_RUNBOOK.md
+++ b/docs/10-OPERATIONS/OPERATIONAL_RUNBOOK.md
@@ -37,6 +37,30 @@ php artisan horizon:terminate                        # Stop all workers
 php artisan queue:retry all                          # Retry failed jobs
 ```
 
+### User & Admin Management
+
+```bash
+# Create a new user (interactive — prompts for name, email, password)
+php artisan user:create
+
+# Create an admin user (one-liner for automation)
+php artisan user:create --name="Jane Admin" --email=jane@company.com --password=SecureP@ss123 --admin
+
+# Promote an existing user to admin
+php artisan user:promote jane@company.com
+
+# Promote to super_admin (Filament full access)
+php artisan user:promote jane@company.com --role=super_admin
+
+# Remove admin role
+php artisan user:demote jane@company.com
+
+# List all admin users
+php artisan user:admins
+```
+
+**Registration control:** Public registration is disabled in production (`REGISTRATION_ENABLED=false`). All users must be created by an admin via CLI. In demo/local/testing environments, registration is enabled by default.
+
 ### Key Metrics Thresholds
 
 | Metric | Warning | Critical |


### PR DESCRIPTION
## Summary

### Admin CLI Commands
| Command | Purpose |
|---------|---------|
| `user:create --admin` | Create user (interactive or scripted, optional admin role) |
| `user:promote user@email` | Assign admin or super_admin role |
| `user:demote user@email` | Remove admin role |
| `user:admins` | List all admin users |

### Registration Control
- `REGISTRATION_ENABLED=false` in production (default)
- Auto-enabled for local/testing/demo environments
- Defense-in-depth: both Fortify config AND CreateNewUser action check the flag
- Cannot bypass by hitting /register directly — returns 403

### Documentation
- CLAUDE.md: CLI commands added
- OPERATIONAL_RUNBOOK.md: User & Admin Management section

## Production setup
```bash
# After deploy:
php artisan user:promote yozaz.mandac@gmail.com --role=admin
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)