### PR TITLE
feat: config-driven admin panel module visibility (ADMIN_MODULES)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -130,6 +130,11 @@ GOOGLE_ANALYTICS_ID=G-X65KH9NFMY
 GOOGLE_SITE_VERIFICATION=
 BRAND_TWITTER_HANDLE=
 
+# Admin panel — visible module groups (comma-separated, empty = show all)
+# Zelta: ADMIN_MODULES=System,Mobile,Relayer,TrustCert,Banking,AI Agents,Commerce,Mobile Payments,Privacy,Fraud Detection,Key Management
+# FinAegis: leave empty (shows all 25 groups)
+ADMIN_MODULES=
+
 # =============================================================================
 # SUB-PRODUCTS
 # =============================================================================

--- a/app/Filament/Admin/Resources/AccountResource.php
+++ b/app/Filament/Admin/Resources/AccountResource.php
@@ -20,6 +20,7 @@ use Illuminate\Support\Facades\DB;
 
 class AccountResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = Account::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-banknotes';

--- a/app/Filament/Admin/Resources/AnomalyDetectionResource.php
+++ b/app/Filament/Admin/Resources/AnomalyDetectionResource.php
@@ -14,6 +14,7 @@ use Filament\Tables\Table;
 
 class AnomalyDetectionResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = AnomalyDetection::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-shield-exclamation';

--- a/app/Filament/Admin/Resources/ApiKeyResource.php
+++ b/app/Filament/Admin/Resources/ApiKeyResource.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Builder;
 
 class ApiKeyResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = ApiKey::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-key';

--- a/app/Filament/Admin/Resources/AssetResource.php
+++ b/app/Filament/Admin/Resources/AssetResource.php
@@ -17,6 +17,7 @@ use Filament\Tables\Table;
 
 class AssetResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = Asset::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-currency-dollar';

--- a/app/Filament/Admin/Resources/BasketAssetResource.php
+++ b/app/Filament/Admin/Resources/BasketAssetResource.php
@@ -20,6 +20,7 @@ use Illuminate\Database\Eloquent\Builder;
 
 class BasketAssetResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = BasketAsset::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-squares-2x2';

--- a/app/Filament/Admin/Resources/BridgeTransactionResource.php
+++ b/app/Filament/Admin/Resources/BridgeTransactionResource.php
@@ -14,6 +14,7 @@ use Filament\Tables\Table;
 
 class BridgeTransactionResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = BridgeTransaction::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-arrows-right-left';

--- a/app/Filament/Admin/Resources/CertificateResource.php
+++ b/app/Filament/Admin/Resources/CertificateResource.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Carbon;
 
 class CertificateResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = Certificate::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-shield-check';

--- a/app/Filament/Admin/Resources/CgoNotificationResource.php
+++ b/app/Filament/Admin/Resources/CgoNotificationResource.php
@@ -12,6 +12,7 @@ use Filament\Tables\Table;
 
 class CgoNotificationResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = CgoNotification::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-sparkles';

--- a/app/Filament/Admin/Resources/DeFiPositionResource.php
+++ b/app/Filament/Admin/Resources/DeFiPositionResource.php
@@ -14,6 +14,7 @@ use Filament\Tables\Table;
 
 class DeFiPositionResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = DeFiPosition::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-chart-bar';

--- a/app/Filament/Admin/Resources/DelegatedProofJobResource.php
+++ b/app/Filament/Admin/Resources/DelegatedProofJobResource.php
@@ -14,6 +14,7 @@ use Filament\Tables\Table;
 
 class DelegatedProofJobResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = DelegatedProofJob::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-finger-print';

--- a/app/Filament/Admin/Resources/ExchangeRateResource.php
+++ b/app/Filament/Admin/Resources/ExchangeRateResource.php
@@ -18,6 +18,7 @@ use Illuminate\Database\Eloquent\Builder;
 
 class ExchangeRateResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = ExchangeRate::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-arrow-path';

--- a/app/Filament/Admin/Resources/FilingScheduleResource.php
+++ b/app/Filament/Admin/Resources/FilingScheduleResource.php
@@ -14,6 +14,7 @@ use Filament\Tables\Table;
 
 class FilingScheduleResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = FilingSchedule::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-clipboard-document-check';

--- a/app/Filament/Admin/Resources/FinancialInstitutionApplicationResource.php
+++ b/app/Filament/Admin/Resources/FinancialInstitutionApplicationResource.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Builder;
 
 class FinancialInstitutionApplicationResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = FinancialInstitutionApplication::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-building-office-2';

--- a/app/Filament/Admin/Resources/GcuVotingProposalResource.php
+++ b/app/Filament/Admin/Resources/GcuVotingProposalResource.php
@@ -12,6 +12,7 @@ use Filament\Tables\Table;
 
 class GcuVotingProposalResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = GcuVotingProposal::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-archive-box';

--- a/app/Filament/Admin/Resources/KeyShardRecordResource.php
+++ b/app/Filament/Admin/Resources/KeyShardRecordResource.php
@@ -16,6 +16,7 @@ use Filament\Tables\Table;
 
 class KeyShardRecordResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = KeyShardRecord::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-key';

--- a/app/Filament/Admin/Resources/LoanResource.php
+++ b/app/Filament/Admin/Resources/LoanResource.php
@@ -14,6 +14,7 @@ use Filament\Tables\Table;
 
 class LoanResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = Loan::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-banknotes';

--- a/app/Filament/Admin/Resources/MerchantResource.php
+++ b/app/Filament/Admin/Resources/MerchantResource.php
@@ -15,6 +15,7 @@ use Filament\Tables\Table;
 
 class MerchantResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = Merchant::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-building-storefront';

--- a/app/Filament/Admin/Resources/MobileDeviceResource.php
+++ b/app/Filament/Admin/Resources/MobileDeviceResource.php
@@ -14,6 +14,7 @@ use Filament\Tables\Table;
 
 class MobileDeviceResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = MobileDevice::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-device-phone-mobile';

--- a/app/Filament/Admin/Resources/MultiSigWalletResource.php
+++ b/app/Filament/Admin/Resources/MultiSigWalletResource.php
@@ -14,6 +14,7 @@ use Filament\Tables\Table;
 
 class MultiSigWalletResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = MultiSigWallet::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-wallet';

--- a/app/Filament/Admin/Resources/OrderResource.php
+++ b/app/Filament/Admin/Resources/OrderResource.php
@@ -12,6 +12,7 @@ use Filament\Tables\Table;
 
 class OrderResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = Order::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-arrow-trending-up';

--- a/app/Filament/Admin/Resources/PartnerResource.php
+++ b/app/Filament/Admin/Resources/PartnerResource.php
@@ -14,6 +14,7 @@ use Filament\Tables\Table;
 
 class PartnerResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = FinancialInstitutionPartner::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-building-office-2';

--- a/app/Filament/Admin/Resources/PaymentIntentResource.php
+++ b/app/Filament/Admin/Resources/PaymentIntentResource.php
@@ -15,6 +15,7 @@ use Filament\Tables\Table;
 
 class PaymentIntentResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = PaymentIntent::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-device-phone-mobile';

--- a/app/Filament/Admin/Resources/PollResource.php
+++ b/app/Filament/Admin/Resources/PollResource.php
@@ -22,6 +22,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class PollResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = Poll::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-chart-bar';

--- a/app/Filament/Admin/Resources/PortfolioSnapshotResource.php
+++ b/app/Filament/Admin/Resources/PortfolioSnapshotResource.php
@@ -14,6 +14,7 @@ use Filament\Tables\Table;
 
 class PortfolioSnapshotResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = PortfolioSnapshot::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-chart-pie';

--- a/app/Filament/Admin/Resources/ReconciliationReportResource.php
+++ b/app/Filament/Admin/Resources/ReconciliationReportResource.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class ReconciliationReportResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = null; // We'll use a virtual model
 
     protected static ?string $navigationIcon = 'heroicon-o-document-chart-bar';

--- a/app/Filament/Admin/Resources/RewardProfileResource.php
+++ b/app/Filament/Admin/Resources/RewardProfileResource.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Builder;
 
 class RewardProfileResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = RewardProfile::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-star';

--- a/app/Filament/Admin/Resources/RewardQuestResource.php
+++ b/app/Filament/Admin/Resources/RewardQuestResource.php
@@ -14,6 +14,7 @@ use Filament\Tables\Table;
 
 class RewardQuestResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = RewardQuest::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-fire';

--- a/app/Filament/Admin/Resources/RewardShopItemResource.php
+++ b/app/Filament/Admin/Resources/RewardShopItemResource.php
@@ -14,6 +14,7 @@ use Filament\Tables\Table;
 
 class RewardShopItemResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = RewardShopItem::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-shopping-bag';

--- a/app/Filament/Admin/Resources/SmartAccountResource.php
+++ b/app/Filament/Admin/Resources/SmartAccountResource.php
@@ -14,6 +14,7 @@ use Filament\Tables\Table;
 
 class SmartAccountResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = SmartAccount::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-cpu-chip';

--- a/app/Filament/Admin/Resources/SubscriberResource.php
+++ b/app/Filament/Admin/Resources/SubscriberResource.php
@@ -18,6 +18,7 @@ use Illuminate\Database\Eloquent\Builder;
 
 class SubscriberResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = Subscriber::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-envelope';

--- a/app/Filament/Admin/Resources/UserResource.php
+++ b/app/Filament/Admin/Resources/UserResource.php
@@ -12,6 +12,7 @@ use Filament\Tables\Table;
 
 class UserResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = User::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-users';

--- a/app/Filament/Admin/Resources/VirtualsAgentResource.php
+++ b/app/Filament/Admin/Resources/VirtualsAgentResource.php
@@ -16,6 +16,7 @@ use Filament\Tables\Table;
 
 class VirtualsAgentResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = VirtualsAgentProfile::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-cpu-chip';

--- a/app/Filament/Admin/Resources/VoteResource.php
+++ b/app/Filament/Admin/Resources/VoteResource.php
@@ -18,6 +18,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class VoteResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = Vote::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-hand-raised';

--- a/app/Filament/Admin/Resources/WebhookResource.php
+++ b/app/Filament/Admin/Resources/WebhookResource.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Builder;
 
 class WebhookResource extends Resource
 {
+    use \App\Filament\Admin\Traits\RespectsModuleVisibility;
     protected static ?string $model = Webhook::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-arrow-top-right-on-square';

--- a/app/Filament/Admin/Traits/RespectsModuleVisibility.php
+++ b/app/Filament/Admin/Traits/RespectsModuleVisibility.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Traits;
+
+/**
+ * Hides Filament resources whose navigation group is not in brand.admin_modules.
+ *
+ * When ADMIN_MODULES is not set (null), all groups are visible (FinAegis full platform).
+ * When set to a comma-separated list, only listed groups appear (e.g. Zelta mobile wallet).
+ *
+ * Usage: add `use RespectsModuleVisibility;` to any Filament Resource class.
+ */
+trait RespectsModuleVisibility
+{
+    public static function shouldRegisterNavigation(): bool
+    {
+        /** @var array<string>|null $allowedModules */
+        $allowedModules = config('brand.admin_modules');
+
+        // null = show all (FinAegis full platform mode)
+        if ($allowedModules === null) {
+            return true;
+        }
+
+        $group = static::getNavigationGroup();
+
+        // Resources without a group are always visible (ungrouped)
+        if ($group === null || $group === '') {
+            return true;
+        }
+
+        return in_array($group, $allowedModules, true);
+    }
+}

--- a/config/brand.php
+++ b/config/brand.php
@@ -53,6 +53,25 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Admin Panel — Visible Module Groups
+    |--------------------------------------------------------------------------
+    |
+    | Controls which Filament navigation groups appear in /admin.
+    | Set ADMIN_MODULES in .env as comma-separated list, or leave empty for all.
+    |
+    | Zelta (mobile wallet):
+    |   ADMIN_MODULES=System,Mobile,Relayer,TrustCert,Banking,AI Agents,Commerce,Mobile Payments,Privacy,Fraud Detection
+    |
+    | FinAegis (full platform): leave empty or don't set — shows everything.
+    |
+    */
+
+    'admin_modules' => env('ADMIN_MODULES')
+        ? array_map('trim', explode(',', (string) env('ADMIN_MODULES')))
+        : null, // null = show all
+
+    /*
+    |--------------------------------------------------------------------------
     | Favicon & Theme
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
## Summary
New `ADMIN_MODULES` env var controls which Filament navigation groups appear in `/admin`.

### How it works
- `ADMIN_MODULES=` (empty/unset) → **all 25 groups visible** (FinAegis demo)
- `ADMIN_MODULES=System,Mobile,Banking,...` → **only listed groups visible** (Zelta production)

### Zelta recommended config
```env
ADMIN_MODULES=System,Mobile,Relayer,TrustCert,Banking,AI Agents,Commerce,Mobile Payments,Privacy,Fraud Detection,Key Management
```

This shows 11 groups (what Zelta needs) and hides 14 (GCU governance, Exchange, Lending, DeFi, Cross-Chain, Treasury, BaaS partners, RegTech, Marketing, etc.)

### Implementation
- `RespectsModuleVisibility` trait added to all 34 Filament resources
- Overrides `shouldRegisterNavigation()` — checks navigation group against config
- Ungrouped resources always visible
- Zero breaking changes — empty ADMIN_MODULES = same behavior as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)