### PR TITLE
feat: user invitation system — email invites with admin dashboard

### DIFF
--- a/app/Console/Commands/UserInviteCommand.php
+++ b/app/Console/Commands/UserInviteCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\User\Services\UserInvitationService;
+use App\Models\User;
+use Illuminate\Console\Command;
+use RuntimeException;
+
+class UserInviteCommand extends Command
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'user:invite
+                            {email : Email to invite}
+                            {--role=private : Role to assign (private, admin, super_admin)}
+                            {--inviter= : Email of the inviting admin (defaults to first admin)}';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Send an email invitation to join the platform';
+
+    public function handle(UserInvitationService $service): int
+    {
+        $email = (string) $this->argument('email');
+        $role = (string) $this->option('role');
+
+        $allowedRoles = ['private', 'admin', 'super_admin'];
+        if (! in_array($role, $allowedRoles, true)) {
+            $this->error("Invalid role: {$role}. Allowed: " . implode(', ', $allowedRoles));
+
+            return 1;
+        }
+
+        $inviterEmail = $this->option('inviter');
+        if (is_string($inviterEmail) && $inviterEmail !== '') {
+            $inviter = User::where('email', $inviterEmail)->first();
+        } else {
+            $inviter = User::role('admin')->first() ?? User::first();
+        }
+
+        if ($inviter === null) {
+            $this->error('No inviter found. Create an admin first: php artisan user:create --admin');
+
+            return 1;
+        }
+
+        try {
+            $invitation = $service->invite($email, $role, $inviter);
+
+            $this->info("Invitation sent to {$email}");
+            $this->line("  Role:    {$role}");
+            $this->line("  Expires: {$invitation->expires_at->format('Y-m-d H:i')}");
+            $this->line("  Token:   {$invitation->token}");
+            $this->line('');
+            $this->line('  Accept URL: ' . config('app.url') . '/invitation/accept?token=' . $invitation->token);
+
+            return 0;
+        } catch (RuntimeException $e) {
+            $this->error($e->getMessage());
+
+            return 1;
+        }
+    }
+}

--- a/app/Domain/User/Mail/UserInvitationMail.php
+++ b/app/Domain/User/Mail/UserInvitationMail.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\User\Mail;
+
+use App\Domain\User\Models\UserInvitation;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class UserInvitationMail extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    public string $acceptUrl;
+
+    public string $brandName;
+
+    public string $inviterName;
+
+    public function __construct(
+        public readonly UserInvitation $invitation,
+        string $inviterName,
+    ) {
+        $this->brandName = (string) config('brand.name', 'Zelta');
+        $this->inviterName = $inviterName;
+        $this->acceptUrl = config('app.url') . '/invitation/accept?token=' . $invitation->token;
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: "You're invited to join {$this->brandName}",
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'emails.user-invitation',
+        );
+    }
+}

--- a/app/Domain/User/Models/UserInvitation.php
+++ b/app/Domain/User/Models/UserInvitation.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\User\Models;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property string $id
+ * @property string $email
+ * @property string $token
+ * @property string $role
+ * @property int $invited_by
+ * @property \Carbon\Carbon $expires_at
+ * @property \Carbon\Carbon|null $accepted_at
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ */
+class UserInvitation extends Model
+{
+    use HasUuids;
+
+    protected $table = 'user_invitations';
+
+    protected $fillable = [
+        'email',
+        'token',
+        'role',
+        'invited_by',
+        'expires_at',
+        'accepted_at',
+    ];
+
+    protected $casts = [
+        'expires_at'  => 'datetime',
+        'accepted_at' => 'datetime',
+    ];
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function inviter(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'invited_by');
+    }
+
+    public function isExpired(): bool
+    {
+        return $this->expires_at->isPast();
+    }
+
+    public function isAccepted(): bool
+    {
+        return $this->accepted_at !== null;
+    }
+
+    public function isPending(): bool
+    {
+        return ! $this->isAccepted() && ! $this->isExpired();
+    }
+}

--- a/app/Domain/User/Services/UserInvitationService.php
+++ b/app/Domain/User/Services/UserInvitationService.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\User\Services;
+
+use App\Domain\User\Mail\UserInvitationMail;
+use App\Domain\User\Models\UserInvitation;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+use RuntimeException;
+use Spatie\Permission\Models\Role;
+
+class UserInvitationService
+{
+    /**
+     * Send an invitation to a new user.
+     */
+    public function invite(string $email, string $role, User $inviter, int $expiryHours = 72): UserInvitation
+    {
+        // Prevent inviting existing users
+        if (User::where('email', $email)->exists()) {
+            throw new RuntimeException("User {$email} already exists.");
+        }
+
+        // Prevent duplicate pending invitations
+        $existing = UserInvitation::where('email', $email)
+            ->whereNull('accepted_at')
+            ->where('expires_at', '>', now())
+            ->first();
+
+        if ($existing !== null) {
+            throw new RuntimeException("A pending invitation for {$email} already exists (expires {$existing->expires_at->format('Y-m-d H:i')}).");
+        }
+
+        $invitation = UserInvitation::create([
+            'email'      => $email,
+            'token'      => Str::random(64),
+            'role'       => $role,
+            'invited_by' => $inviter->id,
+            'expires_at' => now()->addHours($expiryHours),
+        ]);
+
+        Mail::to($email)->queue(new UserInvitationMail($invitation, $inviter->name));
+
+        Log::info('User invitation sent', [
+            'email'      => $email,
+            'role'       => $role,
+            'invited_by' => $inviter->id,
+            'expires_at' => $invitation->expires_at->toIso8601String(),
+        ]);
+
+        return $invitation;
+    }
+
+    /**
+     * Accept an invitation and create the user account.
+     */
+    public function accept(string $token, string $name, string $password): User
+    {
+        $invitation = UserInvitation::where('token', $token)->first();
+
+        if ($invitation === null) {
+            throw new RuntimeException('Invalid invitation token.');
+        }
+
+        if ($invitation->isAccepted()) {
+            throw new RuntimeException('This invitation has already been used.');
+        }
+
+        if ($invitation->isExpired()) {
+            throw new RuntimeException('This invitation has expired.');
+        }
+
+        $user = User::create([
+            'name'     => $name,
+            'email'    => $invitation->email,
+            'password' => Hash::make($password),
+        ]);
+
+        // Assign the invited role
+        Role::firstOrCreate(['name' => $invitation->role, 'guard_name' => 'web']);
+        $user->assignRole($invitation->role);
+
+        $invitation->update(['accepted_at' => now()]);
+
+        Log::info('User invitation accepted', [
+            'user_id'       => $user->id,
+            'email'         => $user->email,
+            'role'          => $invitation->role,
+            'invitation_id' => $invitation->id,
+        ]);
+
+        return $user;
+    }
+
+    /**
+     * Resend an existing invitation.
+     */
+    public function resend(string $invitationId, User $inviter): UserInvitation
+    {
+        /** @var UserInvitation|null $invitation */
+        $invitation = UserInvitation::find($invitationId);
+
+        if ($invitation === null) {
+            throw new RuntimeException('Invitation not found.');
+        }
+
+        if ($invitation->isAccepted()) {
+            throw new RuntimeException('Cannot resend — invitation already accepted.');
+        }
+
+        // Refresh expiry
+        $invitation->update([
+            'expires_at' => now()->addHours(72),
+            'token'      => Str::random(64),
+        ]);
+
+        Mail::to($invitation->email)->queue(new UserInvitationMail($invitation, $inviter->name));
+
+        Log::info('User invitation resent', [
+            'email'         => $invitation->email,
+            'invitation_id' => $invitation->id,
+        ]);
+
+        return $invitation;
+    }
+
+    /**
+     * Revoke a pending invitation.
+     */
+    public function revoke(string $invitationId): bool
+    {
+        /** @var UserInvitation|null $invitation */
+        $invitation = UserInvitation::find($invitationId);
+
+        if ($invitation === null) {
+            return false;
+        }
+
+        $invitation->update(['expires_at' => now()]);
+
+        Log::info('User invitation revoked', [
+            'email'         => $invitation->email,
+            'invitation_id' => $invitation->id,
+        ]);
+
+        return true;
+    }
+}

--- a/app/Filament/Admin/Resources/UserInvitationResource.php
+++ b/app/Filament/Admin/Resources/UserInvitationResource.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources;
+
+use App\Domain\User\Models\UserInvitation;
+use App\Domain\User\Services\UserInvitationService;
+use App\Filament\Admin\Resources\UserInvitationResource\Pages;
+use App\Filament\Admin\Traits\RespectsModuleVisibility;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Notifications\Notification;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class UserInvitationResource extends Resource
+{
+    use RespectsModuleVisibility;
+
+    protected static ?string $model = UserInvitation::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-envelope';
+
+    protected static ?string $navigationGroup = 'System';
+
+    protected static ?int $navigationSort = 2;
+
+    protected static ?string $navigationLabel = 'Invitations';
+
+    protected static ?string $modelLabel = 'Invitation';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\Section::make('Invite a New User')
+                    ->schema([
+                        Forms\Components\TextInput::make('email')
+                            ->email()
+                            ->required()
+                            ->unique('user_invitations', 'email', ignoreRecord: true)
+                            ->unique('users', 'email')
+                            ->maxLength(255),
+                        Forms\Components\Select::make('role')
+                            ->options([
+                                'private'     => 'User (Private)',
+                                'admin'       => 'Admin',
+                                'super_admin' => 'Super Admin',
+                            ])
+                            ->default('private')
+                            ->required(),
+                    ])->columns(2),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('email')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('role')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'admin', 'super_admin' => 'warning',
+                        default => 'gray',
+                    }),
+                Tables\Columns\TextColumn::make('inviter.name')
+                    ->label('Invited By'),
+                Tables\Columns\TextColumn::make('status')
+                    ->getStateUsing(function (UserInvitation $record): string {
+                        if ($record->isAccepted()) {
+                            return 'Accepted';
+                        }
+                        if ($record->isExpired()) {
+                            return 'Expired';
+                        }
+
+                        return 'Pending';
+                    })
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'Accepted' => 'success',
+                        'Expired'  => 'danger',
+                        default    => 'info',
+                    }),
+                Tables\Columns\TextColumn::make('expires_at')
+                    ->dateTime()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(),
+            ])
+            ->defaultSort('created_at', 'desc')
+            ->filters([
+                Tables\Filters\SelectFilter::make('role')
+                    ->options([
+                        'private'     => 'User',
+                        'admin'       => 'Admin',
+                        'super_admin' => 'Super Admin',
+                    ]),
+            ])
+            ->actions([
+                Tables\Actions\Action::make('resend')
+                    ->label('Resend')
+                    ->icon('heroicon-o-arrow-path')
+                    ->color('info')
+                    ->requiresConfirmation()
+                    ->visible(fn (UserInvitation $record): bool => $record->isPending() || $record->isExpired())
+                    ->action(function (UserInvitation $record): void {
+                        $inviter = auth()->user();
+                        app(UserInvitationService::class)->resend($record->id, $inviter);
+                        Notification::make()->title('Invitation resent')->success()->send();
+                    }),
+                Tables\Actions\Action::make('revoke')
+                    ->label('Revoke')
+                    ->icon('heroicon-o-x-circle')
+                    ->color('danger')
+                    ->requiresConfirmation()
+                    ->visible(fn (UserInvitation $record): bool => $record->isPending())
+                    ->action(function (UserInvitation $record): void {
+                        app(UserInvitationService::class)->revoke($record->id);
+                        Notification::make()->title('Invitation revoked')->success()->send();
+                    }),
+                Tables\Actions\Action::make('copyLink')
+                    ->label('Copy Link')
+                    ->icon('heroicon-o-clipboard')
+                    ->visible(fn (UserInvitation $record): bool => $record->isPending())
+                    ->action(function (UserInvitation $record): void {
+                        $url = config('app.url') . '/invitation/accept?token=' . $record->token;
+                        Notification::make()
+                            ->title('Invitation link')
+                            ->body($url)
+                            ->success()
+                            ->send();
+                    }),
+            ])
+            ->bulkActions([]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index'  => Pages\ListUserInvitations::route('/'),
+            'create' => Pages\CreateUserInvitation::route('/create'),
+        ];
+    }
+
+    public static function canEdit(\Illuminate\Database\Eloquent\Model $record): bool
+    {
+        return false;
+    }
+}

--- a/app/Filament/Admin/Resources/UserInvitationResource/Pages/CreateUserInvitation.php
+++ b/app/Filament/Admin/Resources/UserInvitationResource/Pages/CreateUserInvitation.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\UserInvitationResource\Pages;
+
+use App\Domain\User\Services\UserInvitationService;
+use App\Filament\Admin\Resources\UserInvitationResource;
+use Filament\Notifications\Notification;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateUserInvitation extends CreateRecord
+{
+    protected static string $resource = UserInvitationResource::class;
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        /** @var \App\Models\User $user */
+        $user = auth()->user();
+
+        $service = app(UserInvitationService::class);
+        $invitation = $service->invite(
+            (string) $data['email'],
+            (string) $data['role'],
+            $user,
+        );
+
+        Notification::make()
+            ->title('Invitation sent to ' . $data['email'])
+            ->success()
+            ->send();
+
+        // Redirect back to list — the record is already created by the service
+        $this->redirect(UserInvitationResource::getUrl('index'));
+
+        // Return the data from the created invitation so Filament doesn't try to create again
+        return [
+            'email'      => $invitation->email,
+            'token'      => $invitation->token,
+            'role'       => $invitation->role,
+            'invited_by' => $invitation->invited_by,
+            'expires_at' => $invitation->expires_at,
+        ];
+    }
+
+    protected function getRedirectUrl(): string
+    {
+        return UserInvitationResource::getUrl('index');
+    }
+}

--- a/app/Filament/Admin/Resources/UserInvitationResource/Pages/ListUserInvitations.php
+++ b/app/Filament/Admin/Resources/UserInvitationResource/Pages/ListUserInvitations.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\UserInvitationResource\Pages;
+
+use App\Filament\Admin\Resources\UserInvitationResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListUserInvitations extends ListRecords
+{
+    protected static string $resource = UserInvitationResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make()->label('Invite User'),
+        ];
+    }
+}

--- a/app/Http/Controllers/InvitationController.php
+++ b/app/Http/Controllers/InvitationController.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Domain\User\Models\UserInvitation;
+use App\Domain\User\Services\UserInvitationService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+use RuntimeException;
+
+class InvitationController extends Controller
+{
+    public function __construct(
+        private readonly UserInvitationService $invitationService,
+    ) {
+    }
+
+    /**
+     * Show the invitation acceptance form.
+     */
+    public function show(Request $request): View|RedirectResponse
+    {
+        $token = $request->query('token');
+
+        if (! is_string($token) || $token === '') {
+            return redirect('/')->with('error', 'Invalid invitation link.');
+        }
+
+        $invitation = UserInvitation::where('token', $token)->first();
+
+        if ($invitation === null) {
+            return redirect('/login')->with('error', 'Invalid invitation link.');
+        }
+
+        if ($invitation->isAccepted()) {
+            return redirect('/login')->with('info', 'This invitation has already been used. Please log in.');
+        }
+
+        if ($invitation->isExpired()) {
+            return redirect('/login')->with('error', 'This invitation has expired. Please contact the administrator.');
+        }
+
+        return view('auth.accept-invitation', [
+            'invitation' => $invitation,
+            'token'      => $token,
+        ]);
+    }
+
+    /**
+     * Accept the invitation and create the account.
+     */
+    public function accept(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'token'    => 'required|string',
+            'name'     => 'required|string|max:255',
+            'password' => 'required|string|min:8|confirmed',
+        ]);
+
+        try {
+            $this->invitationService->accept(
+                $validated['token'],
+                $validated['name'],
+                $validated['password'],
+            );
+
+            return redirect('/login')->with('success', 'Account created! Please log in.');
+        } catch (RuntimeException $e) {
+            return back()->withErrors(['token' => $e->getMessage()])->withInput();
+        }
+    }
+}

--- a/database/migrations/2026_03_23_000001_create_user_invitations_table.php
+++ b/database/migrations/2026_03_23_000001_create_user_invitations_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('user_invitations', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('email')->index();
+            $table->string('token', 64)->unique();
+            $table->string('role')->default('private');
+            $table->foreignId('invited_by')->constrained('users')->cascadeOnDelete();
+            $table->timestamp('expires_at');
+            $table->timestamp('accepted_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('user_invitations');
+    }
+};

--- a/resources/views/auth/accept-invitation.blade.php
+++ b/resources/views/auth/accept-invitation.blade.php
@@ -1,0 +1,45 @@
+<x-guest-layout>
+    <x-authentication-card>
+        <x-slot name="logo">
+            <x-authentication-card-logo />
+        </x-slot>
+
+        <h2 class="text-xl font-bold text-center mb-2">You're invited!</h2>
+        <p class="text-sm text-gray-500 text-center mb-6">
+            Create your account for <strong>{{ $invitation->email }}</strong>
+        </p>
+
+        <x-validation-errors class="mb-4" />
+
+        <form method="POST" action="{{ url('/invitation/accept') }}">
+            @csrf
+            <input type="hidden" name="token" value="{{ $token }}">
+
+            <div class="mb-4">
+                <x-label for="name" value="{{ __('Name') }}" />
+                <x-input id="name" class="block mt-1 w-full" type="text" name="name" :value="old('name')" required autofocus autocomplete="name" />
+            </div>
+
+            <div class="mb-4">
+                <x-label for="email" value="{{ __('Email') }}" />
+                <x-input id="email" class="block mt-1 w-full bg-gray-100" type="email" value="{{ $invitation->email }}" disabled />
+            </div>
+
+            <div class="mb-4">
+                <x-label for="password" value="{{ __('Password') }}" />
+                <x-input id="password" class="block mt-1 w-full" type="password" name="password" required autocomplete="new-password" />
+            </div>
+
+            <div class="mb-4">
+                <x-label for="password_confirmation" value="{{ __('Confirm Password') }}" />
+                <x-input id="password_confirmation" class="block mt-1 w-full" type="password" name="password_confirmation" required autocomplete="new-password" />
+            </div>
+
+            <div class="flex items-center justify-end mt-4">
+                <x-button class="w-full justify-center">
+                    {{ __('Create Account') }}
+                </x-button>
+            </div>
+        </form>
+    </x-authentication-card>
+</x-guest-layout>

--- a/resources/views/emails/user-invitation.blade.php
+++ b/resources/views/emails/user-invitation.blade.php
@@ -1,0 +1,18 @@
+<x-mail::message>
+# You're invited to {{ $brandName }}
+
+**{{ $inviterName }}** has invited you to join {{ $brandName }}.
+
+Your account will be created with the **{{ $invitation->role }}** role.
+
+This invitation expires on **{{ $invitation->expires_at->format('F j, Y \a\t g:i A') }}**.
+
+<x-mail::button :url="$acceptUrl">
+Accept Invitation
+</x-mail::button>
+
+If you did not expect this invitation, you can safely ignore this email.
+
+Thanks,<br>
+{{ $brandName }}
+</x-mail::message>

--- a/routes/web.php
+++ b/routes/web.php
@@ -229,6 +229,10 @@ if (config('brand.show_promo_pages')) {
     Route::get('/marketplace/{vendor}/{name}', $redirectHome)->where(['vendor' => '[a-zA-Z0-9_-]+', 'name' => '[a-zA-Z0-9_-]+'])->name('marketplace.show');
 }
 
+// User invitation acceptance (public — no auth required)
+Route::get('/invitation/accept', [App\Http\Controllers\InvitationController::class, 'show'])->name('invitation.show');
+Route::post('/invitation/accept', [App\Http\Controllers\InvitationController::class, 'accept'])->name('invitation.accept');
+
 Route::get('/legal/terms', function () {
     return view('legal.terms');
 })->name('legal.terms');


### PR DESCRIPTION
## Summary
Complete user invitation system with email, CLI, and Filament admin integration.

### Three ways to invite
| Method | Command |
|--------|---------|
| CLI | `php artisan user:invite user@email --role=admin` |
| Admin panel | `/admin/user-invitations` → "Invite User" button |
| API (future) | `POST /api/v1/admin/invitations` |

### Flow
1. Admin enters email + role → invitation email sent
2. User clicks "Accept Invitation" link in email
3. User sets name + password on `/invitation/accept` page
4. Account created with assigned role
5. Token marked as used (single-use, 72h expiry)

### Filament dashboard features
- Status badges (Pending/Accepted/Expired)
- Resend expired invitations (refreshes token + expiry)
- Revoke pending invitations
- Copy invitation link
- Filter by role

### Security
- 64-char random tokens, single-use
- 72-hour expiry
- Duplicate pending invite prevention
- Existing user check
- All actions audit-logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)