### PR TITLE
fix: invitation security hardening — rate limiting, auth, transactions

### DIFF
--- a/app/Console/Commands/UserInviteCommand.php
+++ b/app/Console/Commands/UserInviteCommand.php
@@ -55,9 +55,9 @@ class UserInviteCommand extends Command
             $this->info("Invitation sent to {$email}");
             $this->line("  Role:    {$role}");
             $this->line("  Expires: {$invitation->expires_at->format('Y-m-d H:i')}");
-            $this->line("  Token:   {$invitation->token}");
+            $this->line("  ID:      {$invitation->id}");
             $this->line('');
-            $this->line('  Accept URL: ' . config('app.url') . '/invitation/accept?token=' . $invitation->token);
+            $this->info('The invitation link has been sent via email.');
 
             return 0;
         } catch (RuntimeException $e) {

--- a/app/Domain/User/Services/UserInvitationService.php
+++ b/app/Domain/User/Services/UserInvitationService.php
@@ -7,6 +7,7 @@ namespace App\Domain\User\Services;
 use App\Domain\User\Mail\UserInvitationMail;
 use App\Domain\User\Models\UserInvitation;
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
@@ -16,25 +17,24 @@ use Spatie\Permission\Models\Role;
 
 class UserInvitationService
 {
+    private const ALLOWED_ROLES = ['private', 'admin', 'super_admin'];
+
     /**
      * Send an invitation to a new user.
      */
     public function invite(string $email, string $role, User $inviter, int $expiryHours = 72): UserInvitation
     {
-        // Prevent inviting existing users
+        $this->validateRole($role);
+
         if (User::where('email', $email)->exists()) {
             throw new RuntimeException("User {$email} already exists.");
         }
 
-        // Prevent duplicate pending invitations
-        $existing = UserInvitation::where('email', $email)
+        // Expire any previous pending invitations for this email
+        UserInvitation::where('email', $email)
             ->whereNull('accepted_at')
             ->where('expires_at', '>', now())
-            ->first();
-
-        if ($existing !== null) {
-            throw new RuntimeException("A pending invitation for {$email} already exists (expires {$existing->expires_at->format('Y-m-d H:i')}).");
-        }
+            ->update(['expires_at' => now()]);
 
         $invitation = UserInvitation::create([
             'email'      => $email,
@@ -58,47 +58,54 @@ class UserInvitationService
 
     /**
      * Accept an invitation and create the user account.
+     *
+     * Atomic: locks the invitation row, creates user + role, marks accepted.
      */
     public function accept(string $token, string $name, string $password): User
     {
-        $invitation = UserInvitation::where('token', $token)->first();
+        return DB::transaction(function () use ($token, $name, $password): User {
+            $invitation = UserInvitation::where('token', $token)
+                ->lockForUpdate()
+                ->first();
 
-        if ($invitation === null) {
-            throw new RuntimeException('Invalid invitation token.');
-        }
+            if ($invitation === null) {
+                throw new RuntimeException('Invalid invitation token.');
+            }
 
-        if ($invitation->isAccepted()) {
-            throw new RuntimeException('This invitation has already been used.');
-        }
+            if ($invitation->isAccepted()) {
+                throw new RuntimeException('This invitation has already been used.');
+            }
 
-        if ($invitation->isExpired()) {
-            throw new RuntimeException('This invitation has expired.');
-        }
+            if ($invitation->isExpired()) {
+                throw new RuntimeException('This invitation has expired.');
+            }
 
-        $user = User::create([
-            'name'     => $name,
-            'email'    => $invitation->email,
-            'password' => Hash::make($password),
-        ]);
+            $this->validateRole($invitation->role);
 
-        // Assign the invited role
-        Role::firstOrCreate(['name' => $invitation->role, 'guard_name' => 'web']);
-        $user->assignRole($invitation->role);
+            $user = User::create([
+                'name'     => $name,
+                'email'    => $invitation->email,
+                'password' => Hash::make($password),
+            ]);
 
-        $invitation->update(['accepted_at' => now()]);
+            Role::firstOrCreate(['name' => $invitation->role, 'guard_name' => 'web']);
+            $user->assignRole($invitation->role);
 
-        Log::info('User invitation accepted', [
-            'user_id'       => $user->id,
-            'email'         => $user->email,
-            'role'          => $invitation->role,
-            'invitation_id' => $invitation->id,
-        ]);
+            $invitation->update(['accepted_at' => now()]);
 
-        return $user;
+            Log::info('User invitation accepted', [
+                'user_id'       => $user->id,
+                'email'         => $user->email,
+                'role'          => $invitation->role,
+                'invitation_id' => $invitation->id,
+            ]);
+
+            return $user;
+        });
     }
 
     /**
-     * Resend an existing invitation.
+     * Resend an existing invitation (refreshes token + expiry).
      */
     public function resend(string $invitationId, User $inviter): UserInvitation
     {
@@ -113,7 +120,6 @@ class UserInvitationService
             throw new RuntimeException('Cannot resend — invitation already accepted.');
         }
 
-        // Refresh expiry
         $invitation->update([
             'expires_at' => now()->addHours(72),
             'token'      => Str::random(64),
@@ -149,5 +155,12 @@ class UserInvitationService
         ]);
 
         return true;
+    }
+
+    private function validateRole(string $role): void
+    {
+        if (! in_array($role, self::ALLOWED_ROLES, true)) {
+            throw new RuntimeException("Invalid role: {$role}. Allowed: " . implode(', ', self::ALLOWED_ROLES));
+        }
     }
 }

--- a/app/Filament/Admin/Resources/UserInvitationResource.php
+++ b/app/Filament/Admin/Resources/UserInvitationResource.php
@@ -14,6 +14,7 @@ use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
+use RuntimeException;
 
 class UserInvitationResource extends Resource
 {
@@ -112,9 +113,14 @@ class UserInvitationResource extends Resource
                     ->requiresConfirmation()
                     ->visible(fn (UserInvitation $record): bool => $record->isPending() || $record->isExpired())
                     ->action(function (UserInvitation $record): void {
-                        $inviter = auth()->user();
-                        app(UserInvitationService::class)->resend($record->id, $inviter);
-                        Notification::make()->title('Invitation resent')->success()->send();
+                        try {
+                            /** @var \App\Models\User $inviter */
+                            $inviter = auth()->user();
+                            app(UserInvitationService::class)->resend($record->id, $inviter);
+                            Notification::make()->title('Invitation resent')->success()->send();
+                        } catch (RuntimeException $e) {
+                            Notification::make()->title('Error')->body($e->getMessage())->danger()->send();
+                        }
                     }),
                 Tables\Actions\Action::make('revoke')
                     ->label('Revoke')
@@ -123,8 +129,12 @@ class UserInvitationResource extends Resource
                     ->requiresConfirmation()
                     ->visible(fn (UserInvitation $record): bool => $record->isPending())
                     ->action(function (UserInvitation $record): void {
-                        app(UserInvitationService::class)->revoke($record->id);
-                        Notification::make()->title('Invitation revoked')->success()->send();
+                        try {
+                            app(UserInvitationService::class)->revoke($record->id);
+                            Notification::make()->title('Invitation revoked')->success()->send();
+                        } catch (RuntimeException $e) {
+                            Notification::make()->title('Error')->body($e->getMessage())->danger()->send();
+                        }
                     }),
                 Tables\Actions\Action::make('copyLink')
                     ->label('Copy Link')
@@ -153,6 +163,16 @@ class UserInvitationResource extends Resource
             'index'  => Pages\ListUserInvitations::route('/'),
             'create' => Pages\CreateUserInvitation::route('/create'),
         ];
+    }
+
+    public static function canViewAny(): bool
+    {
+        return auth()->user()?->hasRole(['admin', 'super_admin']) ?? false;
+    }
+
+    public static function canCreate(): bool
+    {
+        return auth()->user()?->hasRole(['admin', 'super_admin']) ?? false;
     }
 
     public static function canEdit(\Illuminate\Database\Eloquent\Model $record): bool

--- a/routes/web.php
+++ b/routes/web.php
@@ -229,9 +229,11 @@ if (config('brand.show_promo_pages')) {
     Route::get('/marketplace/{vendor}/{name}', $redirectHome)->where(['vendor' => '[a-zA-Z0-9_-]+', 'name' => '[a-zA-Z0-9_-]+'])->name('marketplace.show');
 }
 
-// User invitation acceptance (public — no auth required)
-Route::get('/invitation/accept', [App\Http\Controllers\InvitationController::class, 'show'])->name('invitation.show');
-Route::post('/invitation/accept', [App\Http\Controllers\InvitationController::class, 'accept'])->name('invitation.accept');
+// User invitation acceptance (public — rate-limited to prevent token brute-force)
+Route::middleware('throttle:5,1')->group(function () {
+    Route::get('/invitation/accept', [App\Http\Controllers\InvitationController::class, 'show'])->name('invitation.show');
+    Route::post('/invitation/accept', [App\Http\Controllers\InvitationController::class, 'accept'])->name('invitation.accept');
+});
 
 Route::get('/legal/terms', function () {
     return view('legal.terms');


### PR DESCRIPTION
## Security Review Fixes

| # | Severity | Fix |
|---|----------|-----|
| 1 | CRITICAL | Rate limiting on `/invitation/accept` (throttle:5,1) |
| 3 | CRITICAL | Filament `canViewAny()` + `canCreate()` require admin role |
| 7 | HIGH | `accept()` wrapped in DB::transaction + lockForUpdate |
| 8 | HIGH | New invites expire old pending ones (no duplicate conflict) |
| 6 | HIGH | Token removed from CLI output |
| 13 | HIGH | Role whitelist validation (private/admin/super_admin) |
| 19 | MEDIUM | Error handling on Filament resend/revoke actions |

🤖 Generated with [Claude Code](https://claude.com/claude-code)