### PR TITLE
feat: referral code in registration + avatar upload/delete

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -33,6 +33,7 @@ class CreateNewUser implements CreatesNewUsers
                 'name'                 => ['required', 'string', 'max:255'],
                 'email'                => ['required', 'string', 'email', 'max:255', 'unique:users'],
                 'is_business_customer' => ['boolean'],
+                'referral_code'        => ['nullable', 'string', 'max:20'],
                 'password'             => $this->passwordRules(),
                 'terms'                => Jetstream::hasTermsAndPrivacyPolicyFeature() ? ['accepted', 'required'] : '',
             ]
@@ -45,6 +46,14 @@ class CreateNewUser implements CreatesNewUsers
                 'password' => Hash::make($input['password']),
             ]
         );
+
+        // Track referral if code provided
+        if (! empty($input['referral_code'])) {
+            $referrer = User::where('referral_code', $input['referral_code'])->first();
+            if ($referrer) {
+                $user->update(['referred_by' => $referrer->id]);
+            }
+        }
 
         $team = $this->createTeam($user);
 

--- a/app/Http/Controllers/Api/UserProfileController.php
+++ b/app/Http/Controllers/Api/UserProfileController.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use OpenApi\Attributes as OA;
+
+class UserProfileController extends Controller
+{
+    /**
+     * Upload or replace user avatar.
+     */
+    #[OA\Post(
+        path: '/api/v1/users/avatar',
+        operationId: 'uploadAvatar',
+        summary: 'Upload user avatar',
+        tags: ['User'],
+        security: [['sanctum' => []]],
+        requestBody: new OA\RequestBody(required: true, content: new OA\MediaType(
+            mediaType: 'multipart/form-data',
+            schema: new OA\Schema(required: ['avatar'], properties: [
+            new OA\Property(property: 'avatar', type: 'string', format: 'binary', description: 'Image file (jpg, png, webp, max 2MB)'),
+            ])
+        ))
+    )]
+    #[OA\Response(response: 200, description: 'Avatar uploaded')]
+    #[OA\Response(response: 401, description: 'Unauthorized')]
+    #[OA\Response(response: 422, description: 'Validation error')]
+    public function uploadAvatar(Request $request): JsonResponse
+    {
+        $request->validate([
+            'avatar' => ['required', 'image', 'mimes:jpg,jpeg,png,webp', 'max:2048'],
+        ]);
+
+        /** @var User $user */
+        $user = $request->user();
+
+        // Delete old avatar if exists
+        if ($user->avatar && Storage::disk('public')->exists($user->avatar)) {
+            Storage::disk('public')->delete($user->avatar);
+        }
+
+        /** @var \Illuminate\Http\UploadedFile $file */
+        $file = $request->file('avatar');
+        $path = $file->store('avatars', 'public');
+
+        if ($path === false) {
+            return response()->json([
+                'success' => false,
+                'error'   => ['code' => 'UPLOAD_FAILED', 'message' => 'Failed to store avatar.'],
+            ], 500);
+        }
+
+        $user->update(['avatar' => $path]);
+
+        return response()->json([
+            'success' => true,
+            'data'    => [
+                'avatar_url' => Storage::disk('public')->url($path),
+            ],
+        ]);
+    }
+
+    /**
+     * Remove user avatar.
+     */
+    #[OA\Delete(
+        path: '/api/v1/users/avatar',
+        operationId: 'deleteAvatar',
+        summary: 'Remove user avatar',
+        tags: ['User'],
+        security: [['sanctum' => []]]
+    )]
+    #[OA\Response(response: 200, description: 'Avatar removed')]
+    #[OA\Response(response: 401, description: 'Unauthorized')]
+    public function deleteAvatar(Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        if ($user->avatar && Storage::disk('public')->exists($user->avatar)) {
+            Storage::disk('public')->delete($user->avatar);
+        }
+
+        $user->update(['avatar' => null]);
+
+        return response()->json([
+            'success' => true,
+            'data'    => ['message' => 'Avatar removed.'],
+        ]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -132,6 +132,12 @@ Route::prefix('auth')->middleware('api.rate_limit:auth')->group(function () {
     });
 });
 
+// User profile (avatar upload/delete)
+Route::prefix('v1/users')->middleware(['auth:sanctum', 'api.rate_limit:query'])->group(function () {
+    Route::post('/avatar', [App\Http\Controllers\Api\UserProfileController::class, 'uploadAvatar'])->name('api.users.avatar.upload');
+    Route::delete('/avatar', [App\Http\Controllers\Api\UserProfileController::class, 'deleteAvatar'])->name('api.users.avatar.delete');
+});
+
 // Legacy profile route for backward compatibility
 Route::get('/profile', function (Request $request) {
     $user = $request->user();


### PR DESCRIPTION
## Mobile Developer Requests #1 and #4

### Referral Code in Registration
- `POST /auth/register` now accepts optional `referral_code` field
- Looks up referrer by code, sets `referred_by` on new user
- Silent skip if code is invalid (no error — matches mobile UX)

### Avatar Upload
| Method | Endpoint | Description |
|--------|----------|-------------|
| POST | `/api/v1/users/avatar` | Upload image (jpg/png/webp, 2MB max) |
| DELETE | `/api/v1/users/avatar` | Remove avatar |

- Stored to `storage/app/public/avatars/`
- Old avatar auto-deleted on re-upload
- `avatar_url` in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)