### PR TITLE
fix: security hardening for MachinePay + AP2 mandates

### DIFF
--- a/app/Domain/AgentProtocol/Services/MandateService.php
+++ b/app/Domain/AgentProtocol/Services/MandateService.php
@@ -147,20 +147,22 @@ class MandateService
      */
     public function completeMandate(string $mandateId): MandateResult
     {
-        $mandate = AgentMandate::where('uuid', $mandateId)->firstOrFail();
+        return DB::transaction(function () use ($mandateId): MandateResult {
+            $mandate = AgentMandate::where('uuid', $mandateId)->lockForUpdate()->firstOrFail();
 
-        if ($mandate->status !== MandateStatus::EXECUTED->value) {
-            throw new RuntimeException("Mandate '{$mandateId}' must be EXECUTED before completion.");
-        }
+            if ($mandate->status !== MandateStatus::EXECUTED->value) {
+                throw new RuntimeException("Mandate '{$mandateId}' must be EXECUTED before completion.");
+            }
 
-        $mandate->update([
-            'status'       => MandateStatus::COMPLETED->value,
-            'completed_at' => now()->toDateTimeString(),
-        ]);
+            $mandate->update([
+                'status'       => MandateStatus::COMPLETED->value,
+                'completed_at' => now()->toDateTimeString(),
+            ]);
 
-        MandateCompleted::dispatch($mandateId);
+            MandateCompleted::dispatch($mandateId);
 
-        return new MandateResult($mandateId, MandateStatus::COMPLETED, (array) ($mandate->payment_references ?? []));
+            return new MandateResult($mandateId, MandateStatus::COMPLETED, (array) ($mandate->payment_references ?? []));
+        });
     }
 
     /**
@@ -168,23 +170,25 @@ class MandateService
      */
     public function revokeMandate(string $mandateId, string $revokedByDid, string $reason): MandateResult
     {
-        $mandate = AgentMandate::where('uuid', $mandateId)->firstOrFail();
+        return DB::transaction(function () use ($mandateId, $revokedByDid, $reason): MandateResult {
+            $mandate = AgentMandate::where('uuid', $mandateId)->lockForUpdate()->firstOrFail();
 
-        if ($mandate->getStatusEnum()->isTerminal()) {
-            throw new RuntimeException("Mandate '{$mandateId}' is already in a terminal state.");
-        }
+            if ($mandate->getStatusEnum()->isTerminal()) {
+                throw new RuntimeException("Mandate '{$mandateId}' is already in a terminal state.");
+            }
 
-        $mandate->update(['status' => MandateStatus::REVOKED->value]);
+            $mandate->update(['status' => MandateStatus::REVOKED->value]);
 
-        MandateRevoked::dispatch($mandateId, $revokedByDid, $reason);
+            MandateRevoked::dispatch($mandateId, $revokedByDid, $reason);
 
-        Log::info('AP2: Mandate revoked', [
-            'mandate_id' => $mandateId,
-            'revoked_by' => $revokedByDid,
-            'reason'     => $reason,
-        ]);
+            Log::info('AP2: Mandate revoked', [
+                'mandate_id' => $mandateId,
+                'revoked_by' => $revokedByDid,
+                'reason'     => $reason,
+            ]);
 
-        return new MandateResult($mandateId, MandateStatus::REVOKED);
+            return new MandateResult($mandateId, MandateStatus::REVOKED);
+        });
     }
 
     /**
@@ -192,23 +196,25 @@ class MandateService
      */
     public function disputeMandate(string $mandateId, string $disputedByDid, string $reason): MandateResult
     {
-        $mandate = AgentMandate::where('uuid', $mandateId)->firstOrFail();
+        return DB::transaction(function () use ($mandateId, $disputedByDid, $reason): MandateResult {
+            $mandate = AgentMandate::where('uuid', $mandateId)->lockForUpdate()->firstOrFail();
 
-        if (! in_array($mandate->status, [MandateStatus::EXECUTED->value, MandateStatus::ACCEPTED->value], true)) {
-            throw new RuntimeException("Mandate '{$mandateId}' cannot be disputed in current state.");
-        }
+            if (! in_array($mandate->status, [MandateStatus::EXECUTED->value, MandateStatus::ACCEPTED->value], true)) {
+                throw new RuntimeException("Mandate '{$mandateId}' cannot be disputed in current state.");
+            }
 
-        $mandate->update(['status' => MandateStatus::DISPUTED->value]);
+            $mandate->update(['status' => MandateStatus::DISPUTED->value]);
 
-        MandateDisputed::dispatch($mandateId, $disputedByDid, $reason);
+            MandateDisputed::dispatch($mandateId, $disputedByDid, $reason);
 
-        Log::info('AP2: Mandate disputed', [
-            'mandate_id'  => $mandateId,
-            'disputed_by' => $disputedByDid,
-            'reason'      => $reason,
-        ]);
+            Log::info('AP2: Mandate disputed', [
+                'mandate_id'  => $mandateId,
+                'disputed_by' => $disputedByDid,
+                'reason'      => $reason,
+            ]);
 
-        return new MandateResult($mandateId, MandateStatus::DISPUTED, disputeInfo: $reason);
+            return new MandateResult($mandateId, MandateStatus::DISPUTED, disputeInfo: $reason);
+        });
     }
 
     /**

--- a/app/Domain/AgentProtocol/Services/VdcService.php
+++ b/app/Domain/AgentProtocol/Services/VdcService.php
@@ -40,7 +40,7 @@ class VdcService
             'claims'  => $claims,
         ], JSON_THROW_ON_ERROR);
 
-        $signature = hash_hmac('sha256', $signaturePayload, (string) config('app.key'));
+        $signature = hash_hmac('sha256', $signaturePayload, self::deriveVdcKey());
 
         $vdc = new VerifiableDigitalCredential(
             type: $type->value,
@@ -79,7 +79,7 @@ class VdcService
             'claims'  => $vdc->claims,
         ], JSON_THROW_ON_ERROR);
 
-        $expectedSignature = hash_hmac('sha256', $signaturePayload, (string) config('app.key'));
+        $expectedSignature = hash_hmac('sha256', $signaturePayload, self::deriveVdcKey());
 
         if (! hash_equals($expectedSignature, $vdc->signature)) {
             Log::warning('AP2: VDC signature verification failed', [
@@ -120,5 +120,14 @@ class VdcService
         }
 
         return true;
+    }
+
+    /**
+     * Derive a domain-specific key for VDC signing.
+     * Never reuses the app key directly (key separation principle).
+     */
+    private static function deriveVdcKey(): string
+    {
+        return hash_hmac('sha256', 'ap2-vdc-signing', (string) config('app.key'));
     }
 }

--- a/app/Domain/MachinePay/Services/MppChallengeService.php
+++ b/app/Domain/MachinePay/Services/MppChallengeService.php
@@ -96,7 +96,7 @@ class MppChallengeService implements ChallengeSignerInterface
     public function signChallenge(MppChallenge $challenge): string
     {
         $input = $challenge->buildHmacInput();
-        $key = $this->hmacKey !== '' ? $this->hmacKey : (string) config('app.key');
+        $key = $this->resolveHmacKey();
 
         return hash_hmac('sha256', $input, $key);
     }
@@ -109,5 +109,21 @@ class MppChallengeService implements ChallengeSignerInterface
         $expected = $this->signChallenge($challenge);
 
         return hash_equals($expected, $hmac);
+    }
+
+    /**
+     * Resolve the HMAC key with key separation.
+     *
+     * Uses a dedicated HMAC key if configured, otherwise derives a
+     * domain-specific key from the app key to maintain key separation.
+     */
+    private function resolveHmacKey(): string
+    {
+        if ($this->hmacKey !== '') {
+            return $this->hmacKey;
+        }
+
+        // Derive a dedicated key — never reuse app key directly
+        return hash_hmac('sha256', 'mpp-challenge-signing', (string) config('app.key'));
     }
 }

--- a/app/Domain/MachinePay/Services/MppClientService.php
+++ b/app/Domain/MachinePay/Services/MppClientService.php
@@ -144,11 +144,12 @@ class MppClientService
                 ]);
             }
 
-            // Reset daily spending if new day
-            if ($limit->last_reset !== now()->toDateString()) {
+            // Reset daily spending if new day (UTC to avoid timezone drift)
+            $todayUtc = gmdate('Y-m-d');
+            if ($limit->last_reset !== $todayUtc) {
                 $limit->update([
                     'spent_today' => 0,
-                    'last_reset'  => now()->toDateString(),
+                    'last_reset'  => $todayUtc,
                 ]);
                 $limit->refresh();
             }
@@ -182,6 +183,12 @@ class MppClientService
      */
     private function generateProof(string $rail, MppChallenge $challenge): array
     {
+        if (app()->environment('production')) {
+            throw new MppException(
+                "Production MPP client proof generation requires real rail integration (rail: {$rail})."
+            );
+        }
+
         // Demo mode: return simulated proof structures
         return match ($rail) {
             'stripe'    => ['spt' => 'spt_demo_' . bin2hex(random_bytes(12)), 'type' => 'stripe_payment_token'],

--- a/app/Domain/MachinePay/Services/MppSettlementService.php
+++ b/app/Domain/MachinePay/Services/MppSettlementService.php
@@ -20,8 +20,8 @@ use Illuminate\Support\Str;
 /**
  * Orchestrates MPP payment settlement across payment rails.
  *
- * Handles idempotency via payload hash, dispatches domain events,
- * and records settlement results in the payments ledger.
+ * Handles idempotency via payload hash with row-level locking,
+ * dispatches domain events, and records settlement results.
  */
 class MppSettlementService
 {
@@ -34,66 +34,76 @@ class MppSettlementService
     /**
      * Settle a verified payment credential.
      *
+     * The entire settlement is wrapped in a transaction with row-level
+     * locking to prevent duplicate payments and race conditions.
+     *
      * @throws MppSettlementException
      */
     public function settle(MppCredential $credential, MppChallenge $challenge): MppReceipt
     {
-        // Idempotency: check if this credential has already been settled
         $payloadHash = hash('sha256', (string) json_encode($credential->toArray()));
-        $existing = MppPayment::where('payload_hash', $payloadHash)
-            ->where('status', MppSettlementStatus::SETTLED->value)
-            ->first();
 
-        if ($existing instanceof MppPayment) {
-            Log::info('MPP: Returning idempotent settlement', ['payment_id' => $existing->uuid]);
+        return DB::transaction(function () use ($credential, $challenge, $payloadHash): MppReceipt {
+            // Idempotency: check with lock to prevent concurrent duplicate settlements
+            $existing = MppPayment::where('payload_hash', $payloadHash)
+                ->lockForUpdate()
+                ->first();
 
-            return new MppReceipt(
-                receiptId: $existing->uuid,
-                challengeId: $challenge->id,
-                rail: $credential->rail,
-                settlementReference: (string) $existing->settlement_reference,
-                settledAt: $existing->updated_at?->format('c') ?? gmdate('c'),
-                amountCents: $challenge->amountCents,
-                currency: $challenge->currency,
-            );
-        }
+            if ($existing instanceof MppPayment && $existing->status === MppSettlementStatus::SETTLED->value) {
+                Log::info('MPP: Returning idempotent settlement', ['payment_id' => $existing->uuid]);
 
-        // Verify the credential
-        $verifyResult = $this->verification->verify($credential, $challenge);
+                return new MppReceipt(
+                    receiptId: $existing->uuid,
+                    challengeId: $challenge->id,
+                    rail: $credential->rail,
+                    settlementReference: (string) $existing->settlement_reference,
+                    settledAt: $existing->updated_at?->format('c') ?? gmdate('c'),
+                    amountCents: $challenge->amountCents,
+                    currency: $challenge->currency,
+                );
+            }
 
-        if (! $verifyResult['valid']) {
-            throw MppSettlementException::verificationFailed((string) $verifyResult['reason']);
-        }
+            // Verify the credential
+            $verifyResult = $this->verification->verify($credential, $challenge);
 
-        MppPaymentVerified::dispatch($challenge->id, $credential->rail);
+            if (! $verifyResult['valid']) {
+                throw MppSettlementException::verificationFailed((string) $verifyResult['reason']);
+            }
 
-        // Record the payment attempt
-        $payment = MppPayment::create([
-            'uuid'             => Str::uuid()->toString(),
-            'challenge_id'     => $challenge->id,
-            'rail'             => $credential->rail,
-            'amount_cents'     => $challenge->amountCents,
-            'currency'         => $challenge->currency,
-            'status'           => MppSettlementStatus::VERIFIED->value,
-            'payer_identifier' => $credential->payerIdentifier,
-            'endpoint_method'  => '',
-            'endpoint_path'    => $challenge->resourceId,
-            'payment_payload'  => $credential->toArray(),
-            'payload_hash'     => $payloadHash,
-        ]);
+            MppPaymentVerified::dispatch($challenge->id, $credential->rail);
 
-        // Delegate to the payment rail for settlement
-        $rail = $this->railResolver->resolve($credential->rail);
+            // Resolve rail inside the transaction
+            $rail = $this->railResolver->resolve($credential->rail);
 
-        if ($rail === null) {
-            $payment->update(['status' => MppSettlementStatus::FAILED->value]);
-            MppPaymentFailed::dispatch($challenge->id, $credential->rail, 'Rail unavailable');
+            if ($rail === null) {
+                MppPaymentFailed::dispatch($challenge->id, $credential->rail, 'Rail unavailable');
 
-            throw MppSettlementException::railUnavailable($credential->rail);
-        }
+                throw MppSettlementException::railUnavailable($credential->rail);
+            }
 
-        try {
-            $receipt = DB::transaction(function () use ($rail, $credential, $challenge, $payment): MppReceipt {
+            // Record the payment attempt
+            $payment = MppPayment::create([
+                'uuid'             => Str::uuid()->toString(),
+                'challenge_id'     => $challenge->id,
+                'rail'             => $credential->rail,
+                'amount_cents'     => $challenge->amountCents,
+                'currency'         => $challenge->currency,
+                'status'           => MppSettlementStatus::VERIFIED->value,
+                'payer_identifier' => $credential->payerIdentifier,
+                'endpoint_method'  => '',
+                'endpoint_path'    => $challenge->resourceId,
+                'payment_payload'  => $credential->toArray(),
+                'payload_hash'     => $payloadHash,
+            ]);
+
+            Log::info('MPP: Payment record created', [
+                'payment_id'   => $payment->uuid,
+                'challenge_id' => $challenge->id,
+                'amount_cents' => $challenge->amountCents,
+            ]);
+
+            // Process payment via rail
+            try {
                 $receipt = $rail->processPayment($credential, [
                     'amount_cents' => $challenge->amountCents,
                     'currency'     => $challenge->currency,
@@ -105,25 +115,23 @@ class MppSettlementService
                     'settlement_reference' => $receipt->settlementReference,
                 ]);
 
+                MppPaymentSettled::dispatch(
+                    $challenge->id,
+                    $credential->rail,
+                    $receipt->settlementReference,
+                    $challenge->amountCents,
+                );
+
                 return $receipt;
-            });
+            } catch (MppSettlementException $e) {
+                $payment->update([
+                    'status'        => MppSettlementStatus::FAILED->value,
+                    'error_message' => $e->getMessage(),
+                ]);
+                MppPaymentFailed::dispatch($challenge->id, $credential->rail, $e->getMessage());
 
-            MppPaymentSettled::dispatch(
-                $challenge->id,
-                $credential->rail,
-                $receipt->settlementReference,
-                $challenge->amountCents,
-            );
-
-            return $receipt;
-        } catch (MppSettlementException $e) {
-            $payment->update([
-                'status'        => MppSettlementStatus::FAILED->value,
-                'error_message' => $e->getMessage(),
-            ]);
-            MppPaymentFailed::dispatch($challenge->id, $credential->rail, $e->getMessage());
-
-            throw $e;
-        }
+                throw $e;
+            }
+        });
     }
 }

--- a/app/Http/Controllers/Api/MachinePay/MppResourceController.php
+++ b/app/Http/Controllers/Api/MachinePay/MppResourceController.php
@@ -11,6 +11,11 @@ use Illuminate\Http\Request;
 
 class MppResourceController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware('is_admin')->except(['index', 'show']);
+    }
+
     public function index(Request $request): JsonResponse
     {
         $resources = MppMonetizedResource::query()
@@ -28,14 +33,37 @@ class MppResourceController extends Controller
     {
         $validated = $request->validate([
             'method'            => ['required', 'string', 'in:GET,POST,PUT,PATCH,DELETE'],
-            'path'              => ['required', 'string', 'max:500'],
-            'amount_cents'      => ['required', 'integer', 'min:1'],
+            'path'              => ['required', 'string', 'max:500', 'regex:/^[a-zA-Z0-9\/_\-\.{}]+$/'],
+            'amount_cents'      => ['required', 'integer', 'min:1', 'max:100000000'],
             'currency'          => ['required', 'string', 'max:10'],
             'available_rails'   => ['required', 'array', 'min:1'],
             'available_rails.*' => ['string', 'in:stripe,tempo,lightning,card'],
             'description'       => ['nullable', 'string', 'max:500'],
             'mime_type'         => ['nullable', 'string', 'max:128'],
         ]);
+
+        // Prevent duplicate method+path
+        $exists = MppMonetizedResource::where('method', $validated['method'])
+            ->where('path', $validated['path'])
+            ->exists();
+
+        if ($exists) {
+            return response()->json([
+                'success' => false,
+                'error'   => 'A monetized resource with this method and path already exists.',
+            ], 409);
+        }
+
+        // Block monetization of sensitive paths
+        $blockedPrefixes = ['auth/', 'admin/', 'monitoring/', 'webhooks/'];
+        foreach ($blockedPrefixes as $prefix) {
+            if (str_starts_with($validated['path'], $prefix)) {
+                return response()->json([
+                    'success' => false,
+                    'error'   => "Cannot monetize paths starting with '{$prefix}'.",
+                ], 422);
+            }
+        }
 
         $resource = MppMonetizedResource::create($validated);
 
@@ -60,7 +88,7 @@ class MppResourceController extends Controller
         $resource = MppMonetizedResource::findOrFail($id);
 
         $validated = $request->validate([
-            'amount_cents'      => ['sometimes', 'integer', 'min:1'],
+            'amount_cents'      => ['sometimes', 'integer', 'min:1', 'max:100000000'],
             'currency'          => ['sometimes', 'string', 'max:10'],
             'available_rails'   => ['sometimes', 'array', 'min:1'],
             'available_rails.*' => ['string', 'in:stripe,tempo,lightning,card'],

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -801,7 +801,14 @@
             </div>
         </div>
 
-        <div class="relative z-10 mx-auto max-w-6xl mt-10 pt-6 flex flex-col sm:flex-row items-center justify-between gap-4"
+        {{-- Legal disclaimer --}}
+        <div class="relative z-10 mx-auto max-w-6xl mt-8 pt-6" style="border-top: 2px solid #e5e5e5;">
+            <p class="text-xs opacity-30 leading-relaxed max-w-4xl">
+                {{ $brand }} is a technology platform providing a user interface for services offered by independent third-party providers. {{ $brand }} does not offer, hold, or transmit funds or provide financial, custodial, or regulated services. All wallet functionality is non-custodial &mdash; private keys remain under exclusive user control. Financial services are provided by third-party licensed providers. All investments carry risks, including total loss. The user is responsible for their recovery phrase.
+            </p>
+        </div>
+
+        <div class="relative z-10 mx-auto max-w-6xl mt-6 pt-6 flex flex-col sm:flex-row items-center justify-between gap-4"
              style="border-top: 2px solid #e5e5e5;">
             <p class="text-sm opacity-40">&copy; {{ date('Y') }} {{ $brand }}. All rights reserved.</p>
             <div class="flex gap-6">


### PR DESCRIPTION
## Summary
Professional security review found 15 issues. This PR fixes all critical ones:

- **Race condition**: Settlement idempotency check now wrapped in `DB::transaction` with `lockForUpdate` (prevents duplicate payments)
- **Key separation**: HMAC signing and VDC signing derive domain-specific keys via `hash_hmac()` instead of reusing `config('app.key')` directly
- **State machine**: `completeMandate`, `revokeMandate`, `disputeMandate` now use `DB::transaction + lockForUpdate` (prevents concurrent state corruption)
- **Authorization**: `MppResourceController` now requires `is_admin` for write operations; blocks monetization of sensitive paths (`auth/`, `admin/`, `monitoring/`, `webhooks/`)
- **Input validation**: Duplicate method+path prevention, path regex, amount_cents max limit
- **Demo safety**: Production environment guard on demo proof generation
- **Timezone**: Daily spending limit reset uses UTC consistently
- **Landing page**: Legal disclaimer added to brutalist footer

## Test plan
- [ ] All 32 MPP/AP2 tests still pass
- [ ] PHPStan Level 8 clean
- [ ] `POST /api/v1/mpp/resources` blocked for non-admins

🤖 Generated with [Claude Code](https://claude.com/claude-code)