### PR TITLE
fix: DeFi portfolio test cache race condition

### DIFF
--- a/tests/Unit/Domain/DeFi/Services/DeFiPortfolioServiceTest.php
+++ b/tests/Unit/Domain/DeFi/Services/DeFiPortfolioServiceTest.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Cache;
 uses(Tests\TestCase::class);
 
 beforeEach(function () {
+    config(['cache.default' => 'array']);
     Cache::flush();
     $this->tracker = new DeFiPositionTrackerService();
     $this->portfolio = new DeFiPortfolioService($this->tracker);


### PR DESCRIPTION
## Summary

`DeFiPortfolioServiceTest` fails intermittently in parallel CI runs because `DeFiPositionTrackerService` uses Cache for position storage. Multiple parallel test processes share the same cache store, causing get→append→put race conditions that lose positions.

**Failure**: `expect(chain_breakdown.ethereum.positions)->toBe(2)` gets `1` — one of the two `openPosition` calls was overwritten by a concurrent test.

**Fix**: `config(['cache.default' => 'array'])` in `beforeEach` — same pattern used in `AccountVerificationServiceTest` and documented in project memory.

## Test plan
- [x] Local: 6/6 DeFi portfolio tests pass
- [ ] CI: Unit tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)