### PR TITLE
fix: SEO audit — broken logo path, non-existent search schema

### DIFF
--- a/app/Helpers/SchemaHelper.php
+++ b/app/Helpers/SchemaHelper.php
@@ -15,7 +15,7 @@ class SchemaHelper
             '@type'    => 'Organization',
             'name'     => $brand,
             'url'      => config('app.url'),
-            'logo'     => config('app.url') . '/images/logo.png',
+            'logo'     => config('app.url') . '/images/og-default.png',
             'sameAs'   => [
                 config('brand.github_url', 'https://github.com/FinAegis'),
             ],
@@ -46,18 +46,10 @@ class SchemaHelper
     public static function website(): string
     {
         $schema = [
-            '@context'        => 'https://schema.org',
-            '@type'           => 'WebSite',
-            'name'            => config('brand.name', 'Zelta'),
-            'url'             => config('app.url'),
-            'potentialAction' => [
-                '@type'  => 'SearchAction',
-                'target' => [
-                    '@type'       => 'EntryPoint',
-                    'urlTemplate' => config('app.url') . '/search?q={search_term_string}',
-                ],
-                'query-input' => 'required name=search_term_string',
-            ],
+            '@context' => 'https://schema.org',
+            '@type'    => 'WebSite',
+            'name'     => config('brand.name', 'Zelta'),
+            'url'      => config('app.url'),
         ];
 
         return self::generateScript($schema);
@@ -224,7 +216,7 @@ class SchemaHelper
                 'name'  => config('brand.name', 'Zelta'),
                 'logo'  => [
                     '@type' => 'ImageObject',
-                    'url'   => config('app.url') . '/images/logo.png',
+                    'url'   => config('app.url') . '/images/og-default.png',
                 ],
             ],
             'datePublished'    => $data['published_at'] ?? now()->toIso8601String(),


### PR DESCRIPTION
## Summary

SEO audit findings:
- **SchemaHelper**: Logo referenced `/images/logo.png` which doesn't exist → fixed to `/images/og-default.png`
- **SchemaHelper**: WebSite schema declared SearchAction for `/search?q=` but no search route exists → removed to prevent Search Console errors
- Static `robots.txt` and `sitemap.xml` in `/public/` had hardcoded `finaegis.local` URLs — these are local artifacts (not in git), dynamic Laravel routes handle them

## Test plan
- [x] PHPStan passes
- [x] php-cs-fixer clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)