### PR TITLE
feat: AI framework completion — pages, OpenAPI, tests

### DIFF
--- a/app/Http/Controllers/Api/Documentation/OpenApiDoc.php
+++ b/app/Http/Controllers/Api/Documentation/OpenApiDoc.php
@@ -5,9 +5,9 @@ namespace App\Http\Controllers\Api\Documentation;
 use OpenApi\Attributes as OA;
 
 #[OA\Info(
-    version: '5.1.5',
+    version: '6.5.0',
     title: 'Zelta API',
-    description: 'Agentic payments API — stablecoin-powered virtual cards, non-custodial wallet, and AI agent card issuance. Built with Laravel 12, featuring 43 DDD domains, event sourcing, CQRS, and privacy-preserving architecture.',
+    description: 'Agentic payments API — stablecoin-powered virtual cards, non-custodial wallet, and AI agent card issuance. Built with Laravel 12, featuring 49 DDD domains, event sourcing, CQRS, and privacy-preserving architecture.',
     contact: new OA\Contact(email: 'support@finaegis.org', name: 'Zelta Support'),
     license: new OA\License(name: 'Apache 2.0', url: 'https://www.apache.org/licenses/LICENSE-2.0.html'),
 )]
@@ -48,6 +48,9 @@ use OpenApi\Attributes as OA;
 #[OA\Tag(name: 'Mobile Wallet', description: 'Mobile wallet: token balances, transaction history, address management, and transfers')]
 #[OA\Tag(name: 'Treasury', description: 'Treasury management: liquidity forecasting, alerts, and workflow orchestration')]
 #[OA\Tag(name: 'Lending', description: 'P2P lending: loan applications, payments, early settlement, and loan management')]
+#[OA\Tag(name: 'SMS', description: 'SMS messaging: send messages, check rates, delivery status, and service info')]
+#[OA\Tag(name: 'Machine Payments', description: 'Machine Payments Protocol (MPP): multi-rail HTTP 402 payments with Stripe, USDC, Lightning, and x402')]
+#[OA\Tag(name: 'SMS Webhooks', description: 'SMS delivery report webhooks from VertexSMS')]
 class OpenApiDoc
 {
 }

--- a/app/Http/Controllers/Api/MachinePay/MppPaymentController.php
+++ b/app/Http/Controllers/Api/MachinePay/MppPaymentController.php
@@ -9,12 +9,33 @@ use App\Domain\MachinePay\Models\MppSpendingLimit;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use OpenApi\Attributes as OA;
 
+#[OA\Tag(name: 'Machine Payments')]
 class MppPaymentController extends Controller
 {
-    /**
-     * List payment history.
-     */
+    #[OA\Get(
+        path: '/api/v1/mpp/payments',
+        operationId: 'mppPayments',
+        summary: 'List MPP payment history',
+        description: 'Returns paginated payment history with optional rail and status filters.',
+        security: [['sanctum' => []]],
+        tags: ['Machine Payments'],
+        parameters: [
+            new OA\Parameter(name: 'rail', in: 'query', required: false, schema: new OA\Schema(type: 'string'), description: 'Filter by rail (stripe, tempo, lightning, card, x402)'),
+            new OA\Parameter(name: 'status', in: 'query', required: false, schema: new OA\Schema(type: 'string'), description: 'Filter by status (pending, settled, failed)'),
+        ],
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Payment history',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean'),
+                new OA\Property(property: 'data', type: 'object'),
+            ],
+        ),
+    )]
     public function index(Request $request): JsonResponse
     {
         $payments = MppPayment::query()
@@ -29,9 +50,30 @@ class MppPaymentController extends Controller
         ]);
     }
 
-    /**
-     * Payment statistics.
-     */
+    #[OA\Get(
+        path: '/api/v1/mpp/payments/stats',
+        operationId: 'mppPaymentStats',
+        summary: 'Payment statistics',
+        description: 'Returns aggregate statistics: total payments, settled/failed counts, total volume, and breakdown by rail.',
+        security: [['sanctum' => []]],
+        tags: ['Machine Payments'],
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Payment stats',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean'),
+                new OA\Property(property: 'data', type: 'object', properties: [
+                    new OA\Property(property: 'total_payments', type: 'integer'),
+                    new OA\Property(property: 'settled', type: 'integer'),
+                    new OA\Property(property: 'failed', type: 'integer'),
+                    new OA\Property(property: 'total_settled_cents', type: 'integer'),
+                    new OA\Property(property: 'by_rail', type: 'object'),
+                ]),
+            ],
+        ),
+    )]
     public function stats(): JsonResponse
     {
         $total = MppPayment::count();
@@ -58,9 +100,15 @@ class MppPaymentController extends Controller
         ]);
     }
 
-    /**
-     * List agent spending limits.
-     */
+    #[OA\Get(
+        path: '/api/v1/mpp/spending-limits',
+        operationId: 'mppSpendingLimits',
+        summary: 'List agent spending limits',
+        description: 'Returns all configured agent spending limits for MPP payments.',
+        security: [['sanctum' => []]],
+        tags: ['Machine Payments'],
+    )]
+    #[OA\Response(response: 200, description: 'Spending limits')]
     public function spendingLimits(): JsonResponse
     {
         $limits = MppSpendingLimit::orderBy('agent_id')->get();
@@ -71,9 +119,28 @@ class MppPaymentController extends Controller
         ]);
     }
 
-    /**
-     * Set or update a spending limit.
-     */
+    #[OA\Post(
+        path: '/api/v1/mpp/spending-limits',
+        operationId: 'mppSetSpendingLimit',
+        summary: 'Set or update a spending limit',
+        description: 'Creates or updates daily and per-transaction spending limits for an agent.',
+        security: [['sanctum' => []]],
+        tags: ['Machine Payments'],
+    )]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            required: ['agent_id', 'daily_limit', 'per_tx_limit'],
+            properties: [
+                new OA\Property(property: 'agent_id', type: 'string'),
+                new OA\Property(property: 'daily_limit', type: 'integer', example: 5000000),
+                new OA\Property(property: 'per_tx_limit', type: 'integer', example: 100000),
+                new OA\Property(property: 'auto_pay', type: 'boolean', example: true),
+            ],
+        ),
+    )]
+    #[OA\Response(response: 201, description: 'Spending limit set')]
+    #[OA\Response(response: 422, description: 'Validation error')]
     public function setSpendingLimit(Request $request): JsonResponse
     {
         $validated = $request->validate([
@@ -94,9 +161,17 @@ class MppPaymentController extends Controller
         ], 201);
     }
 
-    /**
-     * Delete a spending limit.
-     */
+    #[OA\Delete(
+        path: '/api/v1/mpp/spending-limits/{agentId}',
+        operationId: 'mppDeleteSpendingLimit',
+        summary: 'Delete a spending limit',
+        security: [['sanctum' => []]],
+        tags: ['Machine Payments'],
+        parameters: [
+            new OA\Parameter(name: 'agentId', in: 'path', required: true, schema: new OA\Schema(type: 'string')),
+        ],
+    )]
+    #[OA\Response(response: 200, description: 'Spending limit deleted')]
     public function deleteSpendingLimit(string $agentId): JsonResponse
     {
         MppSpendingLimit::where('agent_id', $agentId)->delete();

--- a/app/Http/Controllers/Api/MachinePay/MppResourceController.php
+++ b/app/Http/Controllers/Api/MachinePay/MppResourceController.php
@@ -8,7 +8,9 @@ use App\Domain\MachinePay\Models\MppMonetizedResource;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use OpenApi\Attributes as OA;
 
+#[OA\Tag(name: 'Machine Payments')]
 class MppResourceController extends Controller
 {
     public function __construct()
@@ -16,6 +18,18 @@ class MppResourceController extends Controller
         $this->middleware('is_admin')->except(['index', 'show']);
     }
 
+    #[OA\Get(
+        path: '/api/v1/mpp/resources',
+        operationId: 'mppResources',
+        summary: 'List monetized resources',
+        description: 'Returns paginated list of API endpoints that require MPP payment. Filter active-only by default.',
+        security: [['sanctum' => []]],
+        tags: ['Machine Payments'],
+        parameters: [
+            new OA\Parameter(name: 'active_only', in: 'query', required: false, schema: new OA\Schema(type: 'boolean'), description: 'Filter to active resources only (default: true)'),
+        ],
+    )]
+    #[OA\Response(response: 200, description: 'Monetized resources')]
     public function index(Request $request): JsonResponse
     {
         $resources = MppMonetizedResource::query()
@@ -29,6 +43,31 @@ class MppResourceController extends Controller
         ]);
     }
 
+    #[OA\Post(
+        path: '/api/v1/mpp/resources',
+        operationId: 'mppCreateResource',
+        summary: 'Create a monetized resource',
+        description: 'Register an API endpoint for MPP payment gating. Admin only. Blocked for auth/admin/monitoring/webhook paths.',
+        security: [['sanctum' => []]],
+        tags: ['Machine Payments'],
+    )]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            required: ['method', 'path', 'amount_cents', 'currency', 'available_rails'],
+            properties: [
+                new OA\Property(property: 'method', type: 'string', enum: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']),
+                new OA\Property(property: 'path', type: 'string', example: 'v1/sms/send'),
+                new OA\Property(property: 'amount_cents', type: 'integer', example: 5000),
+                new OA\Property(property: 'currency', type: 'string', example: 'USD'),
+                new OA\Property(property: 'available_rails', type: 'array', items: new OA\Items(type: 'string', enum: ['stripe', 'tempo', 'lightning', 'card', 'x402'])),
+                new OA\Property(property: 'description', type: 'string', nullable: true),
+            ],
+        ),
+    )]
+    #[OA\Response(response: 201, description: 'Resource created')]
+    #[OA\Response(response: 409, description: 'Duplicate method+path')]
+    #[OA\Response(response: 422, description: 'Validation error or blocked path')]
     public function store(Request $request): JsonResponse
     {
         $validated = $request->validate([
@@ -73,6 +112,18 @@ class MppResourceController extends Controller
         ], 201);
     }
 
+    #[OA\Get(
+        path: '/api/v1/mpp/resources/{id}',
+        operationId: 'mppShowResource',
+        summary: 'Get a monetized resource',
+        security: [['sanctum' => []]],
+        tags: ['Machine Payments'],
+        parameters: [
+            new OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),
+        ],
+    )]
+    #[OA\Response(response: 200, description: 'Resource details')]
+    #[OA\Response(response: 404, description: 'Not found')]
     public function show(int $id): JsonResponse
     {
         $resource = MppMonetizedResource::findOrFail($id);
@@ -83,6 +134,29 @@ class MppResourceController extends Controller
         ]);
     }
 
+    #[OA\Put(
+        path: '/api/v1/mpp/resources/{id}',
+        operationId: 'mppUpdateResource',
+        summary: 'Update a monetized resource',
+        description: 'Update pricing, rails, or active status. Admin only.',
+        security: [['sanctum' => []]],
+        tags: ['Machine Payments'],
+        parameters: [
+            new OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),
+        ],
+    )]
+    #[OA\RequestBody(
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'amount_cents', type: 'integer'),
+                new OA\Property(property: 'currency', type: 'string'),
+                new OA\Property(property: 'available_rails', type: 'array', items: new OA\Items(type: 'string')),
+                new OA\Property(property: 'is_active', type: 'boolean'),
+            ],
+        ),
+    )]
+    #[OA\Response(response: 200, description: 'Resource updated')]
+    #[OA\Response(response: 404, description: 'Not found')]
     public function update(Request $request, int $id): JsonResponse
     {
         $resource = MppMonetizedResource::findOrFail($id);
@@ -104,6 +178,19 @@ class MppResourceController extends Controller
         ]);
     }
 
+    #[OA\Delete(
+        path: '/api/v1/mpp/resources/{id}',
+        operationId: 'mppDeleteResource',
+        summary: 'Delete a monetized resource',
+        description: 'Remove an API endpoint from MPP payment gating. Admin only.',
+        security: [['sanctum' => []]],
+        tags: ['Machine Payments'],
+        parameters: [
+            new OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'integer')),
+        ],
+    )]
+    #[OA\Response(response: 200, description: 'Resource deleted')]
+    #[OA\Response(response: 404, description: 'Not found')]
     public function destroy(int $id): JsonResponse
     {
         $resource = MppMonetizedResource::findOrFail($id);

--- a/app/Http/Controllers/Api/MachinePay/MppStatusController.php
+++ b/app/Http/Controllers/Api/MachinePay/MppStatusController.php
@@ -8,7 +8,9 @@ use App\Domain\MachinePay\Services\MppDiscoveryService;
 use App\Domain\MachinePay\Services\MppRailResolverService;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
+use OpenApi\Attributes as OA;
 
+#[OA\Tag(name: 'Machine Payments')]
 class MppStatusController extends Controller
 {
     public function __construct(
@@ -17,9 +19,30 @@ class MppStatusController extends Controller
     ) {
     }
 
-    /**
-     * MPP protocol status.
-     */
+    #[OA\Get(
+        path: '/api/v1/mpp/status',
+        operationId: 'mppStatus',
+        summary: 'MPP protocol status',
+        description: 'Returns whether MPP is enabled, protocol version, available payment rails, and MCP binding status.',
+        tags: ['Machine Payments'],
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Protocol status',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean'),
+                new OA\Property(property: 'data', type: 'object', properties: [
+                    new OA\Property(property: 'enabled', type: 'boolean'),
+                    new OA\Property(property: 'version', type: 'integer'),
+                    new OA\Property(property: 'available_rails', type: 'array', items: new OA\Items(type: 'string')),
+                    new OA\Property(property: 'rail_count', type: 'integer'),
+                    new OA\Property(property: 'mcp_enabled', type: 'boolean'),
+                    new OA\Property(property: 'spec_url', type: 'string'),
+                ]),
+            ],
+        ),
+    )]
     public function status(): JsonResponse
     {
         $availableRails = $this->railResolver->getAvailableRailIds();
@@ -37,9 +60,34 @@ class MppStatusController extends Controller
         ]);
     }
 
-    /**
-     * List supported payment rails with details.
-     */
+    #[OA\Get(
+        path: '/api/v1/mpp/supported-rails',
+        operationId: 'mppSupportedRails',
+        summary: 'List supported payment rails',
+        description: 'Returns detailed info for each payment rail: Stripe SPT, Tempo, Lightning, Card, and x402 USDC.',
+        tags: ['Machine Payments'],
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Rail details',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'success', type: 'boolean'),
+                new OA\Property(property: 'data', type: 'array', items: new OA\Items(
+                    properties: [
+                        new OA\Property(property: 'id', type: 'string'),
+                        new OA\Property(property: 'label', type: 'string'),
+                        new OA\Property(property: 'description', type: 'string'),
+                        new OA\Property(property: 'supports_fiat', type: 'boolean'),
+                        new OA\Property(property: 'supports_crypto', type: 'boolean'),
+                        new OA\Property(property: 'currencies', type: 'array', items: new OA\Items(type: 'string')),
+                        new OA\Property(property: 'available', type: 'boolean'),
+                    ],
+                    type: 'object',
+                )),
+            ],
+        ),
+    )]
     public function supportedRails(): JsonResponse
     {
         $rails = $this->railResolver->getAvailableRails();
@@ -64,9 +112,14 @@ class MppStatusController extends Controller
         ]);
     }
 
-    /**
-     * .well-known/mpp-configuration discovery endpoint.
-     */
+    #[OA\Get(
+        path: '/.well-known/mpp-configuration',
+        operationId: 'mppWellKnown',
+        summary: 'MPP discovery endpoint',
+        description: 'Returns the .well-known/mpp-configuration JSON for protocol discovery.',
+        tags: ['Machine Payments'],
+    )]
+    #[OA\Response(response: 200, description: 'MPP configuration JSON')]
     public function wellKnown(): JsonResponse
     {
         return response()->json($this->discovery->getWellKnownConfiguration());

--- a/app/Http/Controllers/Api/SMS/SmsController.php
+++ b/app/Http/Controllers/Api/SMS/SmsController.php
@@ -9,7 +9,9 @@ use App\Domain\SMS\Services\SmsService;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use OpenApi\Attributes as OA;
 
+#[OA\Tag(name: 'SMS')]
 class SmsController extends Controller
 {
     public function __construct(
@@ -18,12 +20,41 @@ class SmsController extends Controller
     ) {
     }
 
-    /**
-     * Send an SMS message.
-     *
-     * This endpoint is protected by MppPaymentGateMiddleware.
-     * Payment metadata is attached to the request by the middleware.
-     */
+    #[OA\Post(
+        path: '/api/v1/sms/send',
+        operationId: 'smsSend',
+        summary: 'Send an SMS message',
+        description: 'Send an SMS message to a phone number. Protected by MPP payment gate — requires payment via x402, Stripe, or other configured rail.',
+        tags: ['SMS'],
+    )]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            required: ['to', 'message'],
+            properties: [
+                new OA\Property(property: 'to', type: 'string', example: '+37069912345', description: 'E.164 phone number'),
+                new OA\Property(property: 'from', type: 'string', example: 'Zelta', description: 'Sender ID (alphanumeric, max 20 chars)'),
+                new OA\Property(property: 'message', type: 'string', example: 'Hello from Zelta!', description: 'Message body (max 1600 chars)'),
+            ],
+        ),
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'SMS sent successfully',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'data', type: 'object', properties: [
+                    new OA\Property(property: 'message_id', type: 'string'),
+                    new OA\Property(property: 'status', type: 'string', enum: ['pending', 'sent']),
+                    new OA\Property(property: 'price_usdc', type: 'string'),
+                    new OA\Property(property: 'parts', type: 'integer'),
+                ]),
+            ],
+        ),
+    )]
+    #[OA\Response(response: 402, description: 'Payment required — MPP challenge issued')]
+    #[OA\Response(response: 422, description: 'Validation error')]
+    #[OA\Response(response: 503, description: 'SMS service disabled')]
     public function send(Request $request): JsonResponse
     {
         if (! config('sms.enabled', false)) {
@@ -54,9 +85,31 @@ class SmsController extends Controller
         ]);
     }
 
-    /**
-     * Get SMS rates for a country.
-     */
+    #[OA\Get(
+        path: '/api/v1/sms/rates',
+        operationId: 'smsRates',
+        summary: 'Get SMS rates for a country',
+        description: 'Returns per-message USDC pricing for a given ISO 3166-1 alpha-2 country code.',
+        tags: ['SMS'],
+        parameters: [
+            new OA\Parameter(name: 'country', in: 'query', required: true, schema: new OA\Schema(type: 'string', minLength: 2, maxLength: 2), example: 'LT'),
+        ],
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Rate found',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'data', type: 'object', properties: [
+                    new OA\Property(property: 'country_code', type: 'string'),
+                    new OA\Property(property: 'price_usdc', type: 'string'),
+                    new OA\Property(property: 'currency', type: 'string', example: 'USDC'),
+                ]),
+            ],
+        ),
+    )]
+    #[OA\Response(response: 404, description: 'No rate found for country')]
+    #[OA\Response(response: 422, description: 'Invalid country code')]
     public function rates(Request $request): JsonResponse
     {
         $request->validate([
@@ -78,9 +131,32 @@ class SmsController extends Controller
         ]);
     }
 
-    /**
-     * Get message delivery status.
-     */
+    #[OA\Get(
+        path: '/api/v1/sms/status/{messageId}',
+        operationId: 'smsStatus',
+        summary: 'Get message delivery status',
+        description: 'Returns the current delivery status of a previously sent SMS message. Requires authentication.',
+        tags: ['SMS'],
+        security: [['sanctum' => []]],
+        parameters: [
+            new OA\Parameter(name: 'messageId', in: 'path', required: true, schema: new OA\Schema(type: 'string')),
+        ],
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Message status',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'data', type: 'object', properties: [
+                    new OA\Property(property: 'message_id', type: 'string'),
+                    new OA\Property(property: 'status', type: 'string', enum: ['pending', 'sent', 'delivered', 'failed']),
+                    new OA\Property(property: 'delivered_at', type: 'string', nullable: true),
+                ]),
+            ],
+        ),
+    )]
+    #[OA\Response(response: 401, description: 'Unauthenticated')]
+    #[OA\Response(response: 404, description: 'Message not found')]
     public function status(string $messageId): JsonResponse
     {
         $result = $this->smsService->getStatus($messageId);
@@ -97,9 +173,27 @@ class SmsController extends Controller
         ]);
     }
 
-    /**
-     * Get SMS service info.
-     */
+    #[OA\Get(
+        path: '/api/v1/sms/info',
+        operationId: 'smsInfo',
+        summary: 'Get SMS service info',
+        description: 'Returns provider information, enabled status, test mode flag, and supported networks.',
+        tags: ['SMS'],
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Service info',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'data', type: 'object', properties: [
+                    new OA\Property(property: 'provider', type: 'string'),
+                    new OA\Property(property: 'enabled', type: 'boolean'),
+                    new OA\Property(property: 'test_mode', type: 'boolean'),
+                    new OA\Property(property: 'networks', type: 'array', items: new OA\Items(type: 'string')),
+                ]),
+            ],
+        ),
+    )]
     public function info(): JsonResponse
     {
         return response()->json([

--- a/app/Http/Controllers/Api/Webhook/VertexSmsDlrController.php
+++ b/app/Http/Controllers/Api/Webhook/VertexSmsDlrController.php
@@ -10,7 +10,9 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
+use OpenApi\Attributes as OA;
 
+#[OA\Tag(name: 'SMS Webhooks')]
 class VertexSmsDlrController extends Controller
 {
     public function __construct(
@@ -19,9 +21,27 @@ class VertexSmsDlrController extends Controller
     ) {
     }
 
-    /**
-     * Handle VertexSMS delivery report webhook.
-     */
+    #[OA\Post(
+        path: '/api/v1/webhooks/vertexsms/dlr',
+        operationId: 'vertexSmsDlr',
+        summary: 'VertexSMS delivery report webhook',
+        description: 'Receives SMS delivery status updates from VertexSMS. Verifies HMAC-SHA256 signature from X-VertexSMS-Signature header.',
+        tags: ['SMS Webhooks'],
+    )]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            required: ['message_id', 'status'],
+            properties: [
+                new OA\Property(property: 'message_id', type: 'string'),
+                new OA\Property(property: 'status', type: 'string', enum: ['sent', 'delivered', 'failed']),
+                new OA\Property(property: 'delivered_at', type: 'string', nullable: true),
+            ],
+        ),
+    )]
+    #[OA\Response(response: 200, description: 'Delivery report accepted')]
+    #[OA\Response(response: 401, description: 'Invalid webhook signature')]
+    #[OA\Response(response: 422, description: 'Missing message_id')]
     public function handle(Request $request): JsonResponse
     {
         // Verify signature

--- a/database/seeders/AiPromptTemplateSeeder.php
+++ b/database/seeders/AiPromptTemplateSeeder.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Domain\AI\Models\AiPromptTemplate;
+use Illuminate\Database\Seeder;
+
+class AiPromptTemplateSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $templates = [
+            [
+                'name'          => 'Transaction Query',
+                'category'      => AiPromptTemplate::CATEGORY_QUERY,
+                'system_prompt' => 'You are a financial assistant that translates natural language questions into structured database queries. Only return results the authenticated user is authorized to see. Never expose internal table names or query syntax to the user. Validate all date ranges and amounts before querying.',
+                'user_template' => 'The user asks: "{{question}}". Their account ID is {{account_id}}. Translate this into a safe, scoped query and return the results in a structured format with amounts, dates, and counterparties.',
+                'variables'     => ['question', 'account_id'],
+                'metadata'      => ['agent' => 'general', 'max_tokens' => 2000],
+                'version'       => '1.0',
+            ],
+            [
+                'name'          => 'Spending Analysis',
+                'category'      => AiPromptTemplate::CATEGORY_ANALYSIS,
+                'system_prompt' => 'You are a financial analyst that categorizes transactions and identifies spending patterns. Provide actionable insights. Never recommend specific financial products or make investment advice.',
+                'user_template' => 'Analyze spending for account {{account_id}} over the period {{period}}. Categorize transactions, identify top spending categories, detect unusual patterns, and summarize trends.',
+                'variables'     => ['account_id', 'period'],
+                'metadata'      => ['agent' => 'financial', 'max_tokens' => 3000],
+                'version'       => '1.0',
+            ],
+            [
+                'name'          => 'Credit Risk Assessment',
+                'category'      => AiPromptTemplate::CATEGORY_ANALYSIS,
+                'system_prompt' => 'You are a credit risk analyst. Evaluate financial health based on transaction history, debt ratios, and payment patterns. Provide a structured risk assessment with confidence scores. Never make lending decisions — only provide analysis.',
+                'user_template' => 'Assess credit risk for account {{account_id}}. Consider: income patterns over {{period}}, debt-to-income ratio, payment consistency, and transaction velocity. Return a structured assessment with risk tier (low/medium/high) and confidence score.',
+                'variables'     => ['account_id', 'period'],
+                'metadata'      => ['agent' => 'financial', 'max_tokens' => 2500],
+                'version'       => '1.0',
+            ],
+            [
+                'name'          => 'AML Screening Summary',
+                'category'      => AiPromptTemplate::CATEGORY_COMPLIANCE,
+                'system_prompt' => 'You are a compliance assistant. Summarize AML screening results in clear, actionable language for compliance officers. Flag items requiring manual review. Never approve or reject — only summarize and recommend.',
+                'user_template' => 'Summarize AML screening results for entity "{{entity_name}}" (type: {{entity_type}}). Screening data: {{screening_data}}. Highlight matches, near-matches, and recommended actions.',
+                'variables'     => ['entity_name', 'entity_type', 'screening_data'],
+                'metadata'      => ['agent' => 'compliance', 'max_tokens' => 2000],
+                'version'       => '1.0',
+            ],
+            [
+                'name'          => 'Anomaly Detection Report',
+                'category'      => AiPromptTemplate::CATEGORY_ANALYSIS,
+                'system_prompt' => 'You are a fraud detection analyst. Explain anomaly detection findings in human-readable terms. Provide context for why each anomaly was flagged and suggest investigation priorities. Never auto-block accounts — only flag for review.',
+                'user_template' => 'Explain the following anomaly detection results for account {{account_id}}: Statistical score: {{stat_score}}, Behavioral score: {{behavior_score}}, Velocity score: {{velocity_score}}, Geo score: {{geo_score}}. Ensemble confidence: {{confidence}}. Describe what triggered each model and recommend investigation priority.',
+                'variables'     => ['account_id', 'stat_score', 'behavior_score', 'velocity_score', 'geo_score', 'confidence'],
+                'metadata'      => ['agent' => 'compliance', 'max_tokens' => 2500],
+                'version'       => '1.0',
+            ],
+            [
+                'name'          => 'Trading Strategy Summary',
+                'category'      => AiPromptTemplate::CATEGORY_ANALYSIS,
+                'system_prompt' => 'You are a trading analyst. Summarize technical indicators and generated strategies. Present RSI, MACD, and momentum data clearly. Include risk warnings. Never recommend specific trades — only analyze conditions.',
+                'user_template' => 'Summarize trading analysis for {{asset_pair}}. RSI: {{rsi}}, MACD: {{macd_signal}}, Momentum: {{momentum}}. Timeframe: {{timeframe}}. Describe market conditions and what the indicators suggest.',
+                'variables'     => ['asset_pair', 'rsi', 'macd_signal', 'momentum', 'timeframe'],
+                'metadata'      => ['agent' => 'trading', 'max_tokens' => 2000],
+                'version'       => '1.0',
+            ],
+            [
+                'name'          => 'Transfer Intent Parser',
+                'category'      => AiPromptTemplate::CATEGORY_QUERY,
+                'system_prompt' => 'You are a payment assistant. Parse natural language transfer requests into structured payment intents. Extract: recipient, amount, currency, and any scheduling info. Always confirm details before executing. Never execute without explicit user confirmation.',
+                'user_template' => 'Parse this transfer request from user {{user_id}}: "{{request}}". Extract the payment intent: recipient identifier, amount, currency, timing, and any special instructions. Return structured JSON.',
+                'variables'     => ['user_id', 'request'],
+                'metadata'      => ['agent' => 'transfer', 'max_tokens' => 1500],
+                'version'       => '1.0',
+            ],
+            [
+                'name'          => 'Regulatory Report Narrative',
+                'category'      => AiPromptTemplate::CATEGORY_COMPLIANCE,
+                'system_prompt' => 'You are a regulatory reporting assistant. Generate narrative sections for compliance reports (SAR, CTR, STR). Use formal regulatory language. Reference specific transaction IDs and dates. Never fabricate details.',
+                'user_template' => 'Generate a {{report_type}} narrative for filing. Subject: {{subject_name}}. Activity period: {{period}}. Key transactions: {{transactions}}. Suspicious indicators: {{indicators}}. Write a formal narrative suitable for regulatory filing.',
+                'variables'     => ['report_type', 'subject_name', 'period', 'transactions', 'indicators'],
+                'metadata'      => ['agent' => 'compliance', 'max_tokens' => 3000],
+                'version'       => '1.0',
+            ],
+        ];
+
+        foreach ($templates as $template) {
+            AiPromptTemplate::updateOrCreate(
+                ['name' => $template['name']],
+                $template,
+            );
+        }
+    }
+}

--- a/resources/views/features/agent-protocol.blade.php
+++ b/resources/views/features/agent-protocol.blade.php
@@ -1,0 +1,523 @@
+@extends('layouts.public')
+
+@section('title', 'Agent Protocol (AP2) — Autonomous Agent Commerce | ' . config('brand.name', 'Zelta') . '')
+
+@section('seo')
+    @include('partials.seo', [
+        'title' => 'Agent Protocol (AP2) — Autonomous Agent Commerce',
+        'description' => 'Google A2A agent-to-agent protocol with DID authentication, escrow, reputation scoring, AP2 mandates, and Verifiable Digital Credentials for autonomous financial operations.',
+        'keywords' => 'agent protocol, AP2, A2A, DID authentication, escrow, reputation, mandates, VDC, agent commerce, autonomous payments, ' . config('brand.name', 'Zelta') . '',
+    ])
+
+    {{-- Schema.org Markup --}}
+    <x-schema type="software" />
+    <x-schema type="breadcrumb" :data="[
+        ['name' => 'Home', 'url' => url('/')],
+        ['name' => 'Features', 'url' => url('/features')],
+        ['name' => 'Agent Protocol', 'url' => url('/features/agent-protocol')]
+    ]" />
+@endsection
+
+@section('content')
+
+    <!-- Hero -->
+    <section class="bg-fa-navy relative overflow-hidden">
+        <div class="absolute inset-0 bg-grid-pattern"></div>
+        <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20 lg:py-24">
+            <div class="text-center">
+                <div class="flex justify-center mb-6">
+                    <div class="w-20 h-20 bg-white/10 rounded-2xl flex items-center justify-center">
+                        <svg class="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"></path>
+                        </svg>
+                    </div>
+                </div>
+                <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
+                    <span class="w-2 h-2 bg-cyan-400 rounded-full mr-2"></span>
+                    v6.5.0 &middot; 10 Aggregates &middot; 60+ Events &middot; 200+ Files
+                </div>
+                <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
+                    Agent Protocol
+                </h1>
+                <p class="text-lg md:text-xl text-slate-300 max-w-3xl mx-auto mb-8">
+                    The infrastructure layer for autonomous agent commerce. DID-based identity, agent-to-agent messaging, escrow with dispute resolution, reputation scoring, and AP2 payment mandates.
+                </p>
+                <div class="flex flex-wrap justify-center gap-4">
+                    <a href="{{ url('/api/v1/agent-protocol/protocol/versions') }}" class="btn-primary px-8 py-4 text-lg">Protocol Versions</a>
+                    <a href="{{ route('features.show', 'ai-framework') }}" class="btn-outline px-8 py-4 text-lg">AI Framework</a>
+                </div>
+            </div>
+        </div>
+        <div class="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-cyan-500/20 to-transparent"></div>
+    </section>
+
+    <!-- Core Pillars -->
+    <section class="py-20 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+                <div class="card-feature !p-6 text-center">
+                    <div class="w-14 h-14 bg-cyan-50 rounded-lg flex items-center justify-center mx-auto mb-4">
+                        <svg class="w-7 h-7 text-cyan-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V8a2 2 0 00-2-2h-5m-4 0V5a2 2 0 114 0v1m-4 0a2 2 0 104 0m-5 8a2 2 0 100-4 2 2 0 000 4zm0 0c1.306 0 2.417.835 2.83 2M9 14a3.001 3.001 0 00-2.83 2M15 11h3m-3 4h2"></path></svg>
+                    </div>
+                    <h3 class="text-lg font-bold mb-2">DID Identity</h3>
+                    <p class="text-sm text-slate-500">Decentralized identifiers for agents. Register, authenticate, and manage agent identity with cryptographic verification.</p>
+                </div>
+
+                <div class="card-feature !p-6 text-center">
+                    <div class="w-14 h-14 bg-purple-50 rounded-lg flex items-center justify-center mx-auto mb-4">
+                        <svg class="w-7 h-7 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"></path></svg>
+                    </div>
+                    <h3 class="text-lg font-bold mb-2">A2A Messaging</h3>
+                    <p class="text-sm text-slate-500">Structured agent-to-agent communication with priority queuing, delivery receipts, and protocol negotiation.</p>
+                </div>
+
+                <div class="card-feature !p-6 text-center">
+                    <div class="w-14 h-14 bg-green-50 rounded-lg flex items-center justify-center mx-auto mb-4">
+                        <svg class="w-7 h-7 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"></path></svg>
+                    </div>
+                    <h3 class="text-lg font-bold mb-2">Escrow</h3>
+                    <p class="text-sm text-slate-500">Multi-party escrow with milestone-based release, dispute resolution, voting, and automatic expiration.</p>
+                </div>
+
+                <div class="card-feature !p-6 text-center">
+                    <div class="w-14 h-14 bg-amber-50 rounded-lg flex items-center justify-center mx-auto mb-4">
+                        <svg class="w-7 h-7 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"></path></svg>
+                    </div>
+                    <h3 class="text-lg font-bold mb-2">Reputation</h3>
+                    <p class="text-sm text-slate-500">Trust scoring with decay, boosts, and penalties. Reputation leaderboards and threshold-based access control.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Agent Lifecycle -->
+    <section class="py-20 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <h2 class="font-display text-3xl md:text-4xl font-bold text-center text-slate-900 mb-4">Agent Lifecycle</h2>
+            <p class="text-lg text-slate-500 text-center max-w-3xl mx-auto mb-12">
+                From registration to autonomous commerce, each agent goes through a verified lifecycle with granular permission scoping.
+            </p>
+
+            <div class="grid grid-cols-1 md:grid-cols-5 gap-4">
+                <div class="text-center">
+                    <div class="w-12 h-12 bg-cyan-100 rounded-full flex items-center justify-center mx-auto mb-3">
+                        <span class="text-lg font-bold text-cyan-700">1</span>
+                    </div>
+                    <h4 class="font-semibold text-sm mb-1">Register</h4>
+                    <p class="text-xs text-slate-500">DID creation, capability declaration</p>
+                </div>
+                <div class="text-center">
+                    <div class="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-3">
+                        <span class="text-lg font-bold text-blue-700">2</span>
+                    </div>
+                    <h4 class="font-semibold text-sm mb-1">Verify</h4>
+                    <p class="text-xs text-slate-500">KYC documents, identity checks</p>
+                </div>
+                <div class="text-center">
+                    <div class="w-12 h-12 bg-indigo-100 rounded-full flex items-center justify-center mx-auto mb-3">
+                        <span class="text-lg font-bold text-indigo-700">3</span>
+                    </div>
+                    <h4 class="font-semibold text-sm mb-1">Fund</h4>
+                    <p class="text-xs text-slate-500">Wallet creation, initial deposit</p>
+                </div>
+                <div class="text-center">
+                    <div class="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center mx-auto mb-3">
+                        <span class="text-lg font-bold text-purple-700">4</span>
+                    </div>
+                    <h4 class="font-semibold text-sm mb-1">Connect</h4>
+                    <p class="text-xs text-slate-500">Protocol negotiation, capability matching</p>
+                </div>
+                <div class="text-center">
+                    <div class="w-12 h-12 bg-emerald-100 rounded-full flex items-center justify-center mx-auto mb-3">
+                        <span class="text-lg font-bold text-emerald-700">5</span>
+                    </div>
+                    <h4 class="font-semibold text-sm mb-1">Transact</h4>
+                    <p class="text-xs text-slate-500">Payments, escrow, messaging</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Authentication & Security -->
+    <section class="py-20 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-12 items-start">
+                <div>
+                    <h2 class="font-display text-3xl md:text-4xl font-bold text-slate-900 mb-6">Authentication & Security</h2>
+                    <p class="text-lg text-slate-500 mb-6">
+                        Multiple authentication methods with 23 granular scopes ensure agents operate within their authorized boundaries.
+                    </p>
+
+                    <div class="space-y-4">
+                        <div class="card-feature !p-5">
+                            <h4 class="font-bold text-slate-900 mb-2">DID Challenge-Response</h4>
+                            <p class="text-sm text-slate-500">Cryptographic authentication using Decentralized Identifiers. Agents prove identity without sharing secrets.</p>
+                        </div>
+                        <div class="card-feature !p-5">
+                            <h4 class="font-bold text-slate-900 mb-2">API Key Authentication</h4>
+                            <p class="text-sm text-slate-500">64-character API keys for programmatic access. Per-key scoping, rotation, and revocation.</p>
+                        </div>
+                        <div class="card-feature !p-5">
+                            <h4 class="font-bold text-slate-900 mb-2">Session Management</h4>
+                            <p class="text-sm text-slate-500">24-hour sessions with 5-minute nonce TTL. Session listing, individual and bulk revocation.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <div>
+                    <h3 class="text-2xl font-bold text-slate-900 mb-4">Permission Scopes</h3>
+                    <div class="card-feature !p-6">
+                        <div class="grid grid-cols-2 gap-3">
+                            @foreach (['payments.send', 'payments.receive', 'wallet.read', 'wallet.transfer', 'escrow.create', 'escrow.release', 'messaging.send', 'messaging.receive', 'reputation.read', 'reputation.update', 'compliance.read', 'admin.manage'] as $scope)
+                                <div class="flex items-center text-sm">
+                                    <code class="bg-slate-100 text-slate-700 px-2 py-0.5 rounded text-xs font-mono">{{ $scope }}</code>
+                                </div>
+                            @endforeach
+                        </div>
+                        <p class="text-xs text-slate-400 mt-4">23 scopes total &mdash; showing 12 most common. Full list at <code class="text-xs">/agent-protocol/auth/scopes</code></p>
+                    </div>
+
+                    <h3 class="text-2xl font-bold text-slate-900 mb-4 mt-8">Digital Signatures</h3>
+                    <div class="card-feature !p-6">
+                        <ul class="space-y-2 text-sm text-slate-600">
+                            <li class="flex items-center">
+                                <svg class="w-4 h-4 text-green-500 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                                Transaction signing and verification
+                            </li>
+                            <li class="flex items-center">
+                                <svg class="w-4 h-4 text-green-500 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                                End-to-end message encryption
+                            </li>
+                            <li class="flex items-center">
+                                <svg class="w-4 h-4 text-green-500 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                                Fraud detection with 16+ risk factors
+                            </li>
+                            <li class="flex items-center">
+                                <svg class="w-4 h-4 text-green-500 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                                AML screening with high-risk country list
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Escrow & Financial -->
+    <section class="py-20 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <h2 class="font-display text-3xl md:text-4xl font-bold text-center text-slate-900 mb-12">Financial Operations</h2>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+                <div class="card-feature !p-8">
+                    <h3 class="text-2xl font-bold mb-6 text-cyan-900">Escrow System</h3>
+                    <ul class="space-y-4">
+                        <li class="flex items-start">
+                            <svg class="w-6 h-6 text-cyan-600 mr-3 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4"></path></svg>
+                            <div>
+                                <h4 class="font-semibold mb-1">Multi-Party Escrow</h4>
+                                <p class="text-slate-600 text-sm">$10 to $1M range with configurable hold periods and automatic expiration (30-day default).</p>
+                            </div>
+                        </li>
+                        <li class="flex items-start">
+                            <svg class="w-6 h-6 text-cyan-600 mr-3 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4"></path></svg>
+                            <div>
+                                <h4 class="font-semibold mb-1">Dispute Resolution</h4>
+                                <p class="text-slate-600 text-sm">Voting-based resolution for escrows above $10k. Dispute filing, evidence submission, and arbitration.</p>
+                            </div>
+                        </li>
+                        <li class="flex items-start">
+                            <svg class="w-6 h-6 text-cyan-600 mr-3 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4"></path></svg>
+                            <div>
+                                <h4 class="font-semibold mb-1">Event-Sourced Lifecycle</h4>
+                                <p class="text-slate-600 text-sm">Full audit trail: created, funded, held, released, expired, cancelled, disputed, resolved.</p>
+                            </div>
+                        </li>
+                    </ul>
+                </div>
+
+                <div class="card-feature !p-8">
+                    <h3 class="text-2xl font-bold mb-6 text-purple-900">Agent Wallets</h3>
+                    <ul class="space-y-4">
+                        <li class="flex items-start">
+                            <svg class="w-6 h-6 text-purple-600 mr-3 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4"></path></svg>
+                            <div>
+                                <h4 class="font-semibold mb-1">Multi-Currency Support</h4>
+                                <p class="text-slate-600 text-sm">10+ supported currencies with per-asset fee rates (0.5%&ndash;2.5%). Fund from main accounts or external sources.</p>
+                            </div>
+                        </li>
+                        <li class="flex items-start">
+                            <svg class="w-6 h-6 text-purple-600 mr-3 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4"></path></svg>
+                            <div>
+                                <h4 class="font-semibold mb-1">Transaction Limits</h4>
+                                <p class="text-slate-600 text-sm">Configurable daily ($10k) and per-transaction ($5k) limits. Automatic escalation when exceeded.</p>
+                            </div>
+                        </li>
+                        <li class="flex items-start">
+                            <svg class="w-6 h-6 text-purple-600 mr-3 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4"></path></svg>
+                            <div>
+                                <h4 class="font-semibold mb-1">Fee Structure</h4>
+                                <p class="text-slate-600 text-sm">2.5% standard rate, $0.50 minimum, $100 maximum. Fee calculations recorded as events.</p>
+                            </div>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- AP2 Mandates -->
+    <section class="py-20 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <h2 class="font-display text-3xl md:text-4xl font-bold text-center text-slate-900 mb-4">AP2 Payment Mandates</h2>
+            <p class="text-lg text-slate-500 text-center max-w-3xl mx-auto mb-12">
+                Google's Agent Payments Protocol v2 adds structured authorization for autonomous agent spending. Three mandate types cover every agent commerce scenario.
+            </p>
+
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+                <div class="card-feature !p-8 border-t-4 border-cyan-500">
+                    <h3 class="text-xl font-bold mb-3 text-cyan-900">Cart Mandate</h3>
+                    <p class="text-slate-500 mb-4 text-sm">Human-present shopping. Agent builds a cart, user approves the total, payment executes.</p>
+                    <ul class="text-sm text-slate-600 space-y-2">
+                        <li class="flex items-center">
+                            <span class="w-1.5 h-1.5 bg-cyan-500 rounded-full mr-2"></span>
+                            W3C PaymentRequest format
+                        </li>
+                        <li class="flex items-center">
+                            <span class="w-1.5 h-1.5 bg-cyan-500 rounded-full mr-2"></span>
+                            Itemized cart with merchant DID
+                        </li>
+                        <li class="flex items-center">
+                            <span class="w-1.5 h-1.5 bg-cyan-500 rounded-full mr-2"></span>
+                            User approval required
+                        </li>
+                    </ul>
+                </div>
+
+                <div class="card-feature !p-8 border-t-4 border-purple-500">
+                    <h3 class="text-xl font-bold mb-3 text-purple-900">Intent Mandate</h3>
+                    <p class="text-slate-500 mb-4 text-sm">Autonomous spending. Agent receives a budget and natural-language intent, acts within constraints.</p>
+                    <ul class="text-sm text-slate-600 space-y-2">
+                        <li class="flex items-center">
+                            <span class="w-1.5 h-1.5 bg-purple-500 rounded-full mr-2"></span>
+                            Natural language intent description
+                        </li>
+                        <li class="flex items-center">
+                            <span class="w-1.5 h-1.5 bg-purple-500 rounded-full mr-2"></span>
+                            Budget cap with constraint rules
+                        </li>
+                        <li class="flex items-center">
+                            <span class="w-1.5 h-1.5 bg-purple-500 rounded-full mr-2"></span>
+                            Delegator + agent DID binding
+                        </li>
+                    </ul>
+                </div>
+
+                <div class="card-feature !p-8 border-t-4 border-emerald-500">
+                    <h3 class="text-xl font-bold mb-3 text-emerald-900">Payment Mandate</h3>
+                    <p class="text-slate-500 mb-4 text-sm">Direct agent-to-agent payment. Fixed amount, specific payee, with payment method preferences.</p>
+                    <ul class="text-sm text-slate-600 space-y-2">
+                        <li class="flex items-center">
+                            <span class="w-1.5 h-1.5 bg-emerald-500 rounded-full mr-2"></span>
+                            Payee DID with fixed amount
+                        </li>
+                        <li class="flex items-center">
+                            <span class="w-1.5 h-1.5 bg-emerald-500 rounded-full mr-2"></span>
+                            Bridges to x402 and MPP rails
+                        </li>
+                        <li class="flex items-center">
+                            <span class="w-1.5 h-1.5 bg-emerald-500 rounded-full mr-2"></span>
+                            VDC-backed authorization
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Reputation & KYC -->
+    <section class="py-20 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-12 items-start">
+                <div>
+                    <h2 class="font-display text-3xl font-bold text-slate-900 mb-6">Reputation System</h2>
+                    <p class="text-slate-500 mb-6">
+                        Trust scoring that evolves with every interaction. Agents build reputation through successful transactions, and face penalties for disputes or failures.
+                    </p>
+                    <div class="card-feature !p-6">
+                        <div class="space-y-4">
+                            <div class="flex justify-between items-center">
+                                <span class="text-sm font-medium text-slate-700">Initial Score</span>
+                                <span class="font-bold text-slate-900">50/100</span>
+                            </div>
+                            <div class="flex justify-between items-center">
+                                <span class="text-sm font-medium text-slate-700">Decay After Inactivity</span>
+                                <span class="font-bold text-slate-900">30 days</span>
+                            </div>
+                            <div class="flex justify-between items-center">
+                                <span class="text-sm font-medium text-slate-700">Score Components</span>
+                                <span class="font-bold text-slate-900">Weighted</span>
+                            </div>
+                            <div class="flex justify-between items-center">
+                                <span class="text-sm font-medium text-slate-700">Public Leaderboard</span>
+                                <span class="font-bold text-emerald-600">Active</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div>
+                    <h2 class="font-display text-3xl font-bold text-slate-900 mb-6">Agent KYC</h2>
+                    <p class="text-slate-500 mb-6">
+                        Three verification tiers unlock progressively higher transaction limits and capabilities.
+                    </p>
+                    <div class="space-y-3">
+                        <div class="card-feature !p-5 flex items-center justify-between">
+                            <div>
+                                <h4 class="font-bold text-slate-900">Basic</h4>
+                                <p class="text-xs text-slate-500">Identity document verification</p>
+                            </div>
+                            <span class="text-sm font-semibold text-blue-600 bg-blue-50 px-3 py-1 rounded-full">Limited</span>
+                        </div>
+                        <div class="card-feature !p-5 flex items-center justify-between">
+                            <div>
+                                <h4 class="font-bold text-slate-900">Enhanced</h4>
+                                <p class="text-xs text-slate-500">+ Business registration, proof of address</p>
+                            </div>
+                            <span class="text-sm font-semibold text-purple-600 bg-purple-50 px-3 py-1 rounded-full">Higher Limits</span>
+                        </div>
+                        <div class="card-feature !p-5 flex items-center justify-between">
+                            <div>
+                                <h4 class="font-bold text-slate-900">Full</h4>
+                                <p class="text-xs text-slate-500">+ Biometric verification, compliance officer review</p>
+                            </div>
+                            <span class="text-sm font-semibold text-emerald-600 bg-emerald-50 px-3 py-1 rounded-full">Unlimited</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Event Sourcing -->
+    <section class="py-20 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <h2 class="font-display text-3xl md:text-4xl font-bold text-center text-slate-900 mb-4">Event-Sourced Architecture</h2>
+            <p class="text-lg text-slate-500 text-center max-w-3xl mx-auto mb-12">
+                Every agent action is recorded as an immutable event. 10 aggregates and 60+ domain events provide a complete audit trail for regulatory compliance.
+            </p>
+
+            <div class="grid grid-cols-2 md:grid-cols-5 gap-4">
+                @foreach ([
+                    ['Agent Identity', '7 events'],
+                    ['Agent Wallet', '4 events'],
+                    ['Capabilities', '6 events'],
+                    ['Transactions', '10 events'],
+                    ['Escrow', '10 events'],
+                    ['Reputation', '5 events'],
+                    ['Payments', '6 events'],
+                    ['Messaging', '7 events'],
+                    ['Security', '4 events'],
+                    ['Mandates', '6 events'],
+                ] as $aggregate)
+                    <div class="text-center p-4 bg-gray-50 rounded-xl">
+                        <p class="font-semibold text-sm text-slate-900">{{ $aggregate[0] }}</p>
+                        <p class="text-xs text-slate-500 mt-1">{{ $aggregate[1] }}</p>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    </section>
+
+    <!-- API Endpoints -->
+    <section class="py-20 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <h2 class="font-display text-3xl md:text-4xl font-bold text-center text-slate-900 mb-12">API Surface</h2>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                <div class="card-feature !p-5">
+                    <h4 class="font-bold text-slate-900 mb-2">Discovery</h4>
+                    <p class="text-xs text-slate-400 mb-3">Public &mdash; no auth required</p>
+                    <ul class="text-sm text-slate-600 space-y-1">
+                        <li><code class="text-xs bg-slate-100 px-1 rounded">GET</code> <code class="text-xs">/.well-known/ap2-configuration</code></li>
+                        <li><code class="text-xs bg-slate-100 px-1 rounded">GET</code> <code class="text-xs">/agents/discover</code></li>
+                        <li><code class="text-xs bg-slate-100 px-1 rounded">GET</code> <code class="text-xs">/agents/{did}</code></li>
+                        <li><code class="text-xs bg-slate-100 px-1 rounded">GET</code> <code class="text-xs">/protocol/versions</code></li>
+                    </ul>
+                </div>
+
+                <div class="card-feature !p-5">
+                    <h4 class="font-bold text-slate-900 mb-2">Authentication</h4>
+                    <p class="text-xs text-slate-400 mb-3">Public &mdash; returns session tokens</p>
+                    <ul class="text-sm text-slate-600 space-y-1">
+                        <li><code class="text-xs bg-slate-100 px-1 rounded">POST</code> <code class="text-xs">/auth/challenge</code></li>
+                        <li><code class="text-xs bg-slate-100 px-1 rounded">POST</code> <code class="text-xs">/auth/did</code></li>
+                        <li><code class="text-xs bg-slate-100 px-1 rounded">POST</code> <code class="text-xs">/auth/api-key</code></li>
+                        <li><code class="text-xs bg-slate-100 px-1 rounded">POST</code> <code class="text-xs">/auth/validate</code></li>
+                    </ul>
+                </div>
+
+                <div class="card-feature !p-5">
+                    <h4 class="font-bold text-slate-900 mb-2">Agent Operations</h4>
+                    <p class="text-xs text-slate-400 mb-3">Agent-authenticated</p>
+                    <ul class="text-sm text-slate-600 space-y-1">
+                        <li><code class="text-xs bg-slate-100 px-1 rounded">POST</code> <code class="text-xs">/agents/{did}/payments</code></li>
+                        <li><code class="text-xs bg-slate-100 px-1 rounded">POST</code> <code class="text-xs">/escrow/create</code></li>
+                        <li><code class="text-xs bg-slate-100 px-1 rounded">POST</code> <code class="text-xs">/agents/{did}/messages</code></li>
+                        <li><code class="text-xs bg-slate-100 px-1 rounded">POST</code> <code class="text-xs">/agents/{did}/reputation</code></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Related -->
+    <section class="py-20 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <h2 class="font-display text-3xl md:text-4xl font-bold text-center text-slate-900 mb-12">Related Capabilities</h2>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+                <a href="{{ route('features.show', 'ai-framework') }}" class="card-feature !p-6 hover:border-purple-300 transition-colors group">
+                    <div class="w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center mb-4">
+                        <svg class="w-6 h-6 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path></svg>
+                    </div>
+                    <h3 class="font-bold text-slate-900 mb-2 group-hover:text-purple-700">AI Framework</h3>
+                    <p class="text-sm text-slate-500">6 specialized agents, 24 MCP tools, ML anomaly detection, and Temporal workflow orchestration.</p>
+                </a>
+                <a href="{{ route('features.show', 'machine-payments') }}" class="card-feature !p-6 hover:border-orange-300 transition-colors group">
+                    <div class="w-12 h-12 bg-orange-100 rounded-lg flex items-center justify-center mb-4">
+                        <svg class="w-6 h-6 text-orange-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z"></path></svg>
+                    </div>
+                    <h3 class="font-bold text-slate-900 mb-2 group-hover:text-orange-700">Machine Payments (MPP)</h3>
+                    <p class="text-sm text-slate-500">Multi-rail HTTP 402 payments. AP2 mandates bridge directly to MPP and x402 payment rails.</p>
+                </a>
+                <a href="{{ route('features.show', 'virtuals-protocol') }}" class="card-feature !p-6 hover:border-violet-300 transition-colors group">
+                    <div class="w-12 h-12 bg-violet-100 rounded-lg flex items-center justify-center mb-4">
+                        <svg class="w-6 h-6 text-violet-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path></svg>
+                    </div>
+                    <h3 class="font-bold text-slate-900 mb-2 group-hover:text-violet-700">AI Agent Commerce</h3>
+                    <p class="text-sm text-slate-500">Virtuals Protocol integration with TrustCert identity, spending limits, and Pimlico enforcement.</p>
+                </a>
+            </div>
+        </div>
+    </section>
+
+    <!-- CTA -->
+    <section class="bg-fa-navy relative overflow-hidden">
+        <div class="absolute inset-0 bg-dot-pattern"></div>
+        <div class="relative max-w-4xl mx-auto text-center px-4 sm:px-6 lg:px-8 py-20">
+            <h2 class="font-display text-3xl md:text-4xl font-bold text-white mb-4">Give Your Agents a Bank Account</h2>
+            <p class="text-lg text-slate-400 mb-10 max-w-2xl mx-auto">
+                Register an agent, fund its wallet, and let it transact autonomously &mdash; with escrow protection, reputation tracking, and compliance built in.
+            </p>
+            <div class="flex flex-col sm:flex-row gap-4 justify-center">
+                <a href="{{ route('register') }}" class="btn-primary px-8 py-4 text-lg">
+                    Register an Agent
+                </a>
+                <a href="{{ route('developers') }}" class="btn-outline px-8 py-4 text-lg">
+                    Protocol Documentation
+                </a>
+            </div>
+        </div>
+    </section>
+
+@endsection

--- a/resources/views/features/ai-framework.blade.php
+++ b/resources/views/features/ai-framework.blade.php
@@ -1,12 +1,12 @@
 @extends('layouts.public')
 
-@section('title', 'AI Framework - ' . config('brand.name', 'Zelta') . '')
+@section('title', 'AI Framework — Multi-Agent Intelligence | ' . config('brand.name', 'Zelta') . '')
 
 @section('seo')
     @include('partials.seo', [
-        'title' => 'AI Framework',
-        'description' => 'Intelligent banking powered by AI. Natural language transaction queries, spending analysis, ML anomaly detection, and Model Context Protocol tools for agent-driven operations.',
-        'keywords' => 'AI framework, machine learning, anomaly detection, natural language queries, spending analysis, MCP tools, AI agent, banking AI, ' . config('brand.name', 'Zelta') . '',
+        'title' => 'AI Framework — Multi-Agent Intelligence for Banking',
+        'description' => '6 specialized AI agents, 24 MCP tools, ML anomaly detection, natural language queries, and Temporal workflow orchestration. Intelligence woven into every layer of banking.',
+        'keywords' => 'AI framework, MCP tools, multi-agent, anomaly detection, NLP banking, agent orchestration, Temporal workflows, AI banking, ' . config('brand.name', 'Zelta') . '',
     ])
 
     {{-- Schema.org Markup --}}
@@ -18,96 +18,308 @@
     ]" />
 @endsection
 
-
 @section('content')
 
-    <!-- Hero Section -->
+    <!-- Hero -->
     <section class="bg-fa-navy relative overflow-hidden">
         <div class="absolute inset-0 bg-grid-pattern"></div>
         <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20 lg:py-24">
             <div class="text-center">
-                <h1 class="font-display text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">AI Framework</h1>
-                <p class="text-lg text-slate-400 max-w-3xl mx-auto">
-                    Intelligence woven into every layer of banking. Query transactions in plain English, detect anomalies with machine learning, and let AI agents handle complex financial operations autonomously.
+                <div class="flex justify-center mb-6">
+                    <div class="w-20 h-20 bg-white/10 rounded-2xl flex items-center justify-center">
+                        <svg class="w-10 h-10 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
+                        </svg>
+                    </div>
+                </div>
+                <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
+                    <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
+                    v6.5.0 &middot; 6 Agents &middot; 24 MCP Tools
+                </div>
+                <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
+                    AI Framework
+                </h1>
+                <p class="text-lg md:text-xl text-slate-300 max-w-3xl mx-auto mb-8">
+                    Intelligence woven into every layer of banking. Six specialized agents, 24 MCP tools, ML anomaly detection, and Temporal workflow orchestration &mdash; all coordinated through a multi-agent consensus engine.
                 </p>
+                <div class="flex flex-wrap justify-center gap-4">
+                    <a href="{{ route('features.show', 'agent-protocol') }}" class="btn-primary px-8 py-4 text-lg">Agent Protocol (AP2)</a>
+                    <a href="{{ route('developers') }}" class="btn-outline px-8 py-4 text-lg">API Reference</a>
+                </div>
             </div>
         </div>
         <div class="absolute bottom-0 left-0 right-0 h-px bg-gradient-to-r from-transparent via-blue-500/20 to-transparent"></div>
     </section>
 
-    <!-- Overview Cards -->
+    <!-- Three Pillars -->
     <section class="py-20 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
-                <div class="ai-card card-feature !p-8 text-center">
+                <div class="card-feature !p-8 text-center">
                     <div class="w-16 h-16 bg-indigo-50 rounded-lg flex items-center justify-center mx-auto mb-6">
                         <svg class="w-8 h-8 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"></path>
                         </svg>
                     </div>
                     <h3 class="text-xl font-bold mb-3">Natural Language Queries</h3>
-                    <p class="text-slate-500">Ask questions about your transactions in plain English. The AI translates your intent into precise database queries and returns structured results.</p>
+                    <p class="text-slate-500">Ask questions about your transactions in plain English. The AI translates your intent into precise database queries and returns structured results with charts and tables.</p>
                 </div>
 
-                <div class="ai-card card-feature !p-8 text-center">
+                <div class="card-feature !p-8 text-center">
                     <div class="w-16 h-16 bg-purple-50 rounded-lg flex items-center justify-center mx-auto mb-6">
                         <svg class="w-8 h-8 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path>
                         </svg>
                     </div>
-                    <h3 class="text-xl font-bold mb-3">Spending Analysis</h3>
-                    <p class="text-slate-500">AI-powered categorization and trend analysis of spending patterns. Get actionable insights about your financial behavior automatically.</p>
+                    <h3 class="text-xl font-bold mb-3">Multi-Agent Orchestration</h3>
+                    <p class="text-slate-500">Six specialized agents &mdash; General, Compliance, Financial, Trading, Transfer, and a consensus orchestrator &mdash; coordinate to handle complex financial operations autonomously.</p>
                 </div>
 
-                <div class="ai-card card-feature !p-8 text-center">
+                <div class="card-feature !p-8 text-center">
                     <div class="w-16 h-16 bg-green-50 rounded-lg flex items-center justify-center mx-auto mb-6">
                         <svg class="w-8 h-8 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z"></path>
                         </svg>
                     </div>
                     <h3 class="text-xl font-bold mb-3">ML Anomaly Detection</h3>
-                    <p class="text-slate-500">Multi-model detection using statistical, behavioral, velocity, and geo-based analysis to catch suspicious activity before it causes harm.</p>
+                    <p class="text-slate-500">Multi-model detection using statistical, behavioral, velocity, and geo-based analysis. Model ensemble with weighted confidence scoring and automated alert escalation.</p>
                 </div>
             </div>
         </div>
     </section>
 
-    <!-- AI Capabilities Detail -->
+    <!-- Agent Architecture -->
     <section class="py-20 bg-gray-50">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <h2 class="font-display text-3xl md:text-4xl font-bold text-center text-slate-900 mb-12">AI-Powered Banking Operations</h2>
+            <h2 class="font-display text-3xl md:text-4xl font-bold text-center text-slate-900 mb-4">Specialized Agent Architecture</h2>
+            <p class="text-lg text-slate-500 text-center max-w-3xl mx-auto mb-12">
+                Each agent is a domain expert. The orchestrator routes requests to the right agent, and a consensus engine reconciles results when multiple agents weigh in.
+            </p>
 
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                <div class="card-feature !p-6">
+                    <div class="flex items-center mb-4">
+                        <div class="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center mr-3">
+                            <svg class="w-5 h-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"></path></svg>
+                        </div>
+                        <h3 class="font-bold text-slate-900">General Agent</h3>
+                    </div>
+                    <p class="text-sm text-slate-500">Handles natural language queries, FAQ responses, account summaries, and general banking assistance.</p>
+                </div>
+
+                <div class="card-feature !p-6">
+                    <div class="flex items-center mb-4">
+                        <div class="w-10 h-10 bg-amber-100 rounded-lg flex items-center justify-center mr-3">
+                            <svg class="w-5 h-5 text-amber-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path></svg>
+                        </div>
+                        <h3 class="font-bold text-slate-900">Compliance Agent</h3>
+                    </div>
+                    <p class="text-sm text-slate-500">AML screening, KYC verification, sanctions checks, and regulatory reporting. Auto-escalates high-risk findings.</p>
+                </div>
+
+                <div class="card-feature !p-6">
+                    <div class="flex items-center mb-4">
+                        <div class="w-10 h-10 bg-green-100 rounded-lg flex items-center justify-center mr-3">
+                            <svg class="w-5 h-5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path></svg>
+                        </div>
+                        <h3 class="font-bold text-slate-900">Financial Agent</h3>
+                    </div>
+                    <p class="text-sm text-slate-500">Spending analysis, budget tracking, credit scoring, debt-ratio calculations, and loan affordability assessments.</p>
+                </div>
+
+                <div class="card-feature !p-6">
+                    <div class="flex items-center mb-4">
+                        <div class="w-10 h-10 bg-purple-100 rounded-lg flex items-center justify-center mr-3">
+                            <svg class="w-5 h-5 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"></path></svg>
+                        </div>
+                        <h3 class="font-bold text-slate-900">Trading Agent</h3>
+                    </div>
+                    <p class="text-sm text-slate-500">RSI, MACD indicators, momentum strategy generation, pattern identification, and market analysis with configurable risk limits.</p>
+                </div>
+
+                <div class="card-feature !p-6">
+                    <div class="flex items-center mb-4">
+                        <div class="w-10 h-10 bg-pink-100 rounded-lg flex items-center justify-center mr-3">
+                            <svg class="w-5 h-5 text-pink-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"></path></svg>
+                        </div>
+                        <h3 class="font-bold text-slate-900">Transfer Agent</h3>
+                    </div>
+                    <p class="text-sm text-slate-500">Payment execution, cross-border transfers, fee optimization, and multi-currency routing with spending limit enforcement.</p>
+                </div>
+
+                <div class="card-feature !p-6 border-2 border-indigo-200">
+                    <div class="flex items-center mb-4">
+                        <div class="w-10 h-10 bg-indigo-100 rounded-lg flex items-center justify-center mr-3">
+                            <svg class="w-5 h-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z"></path></svg>
+                        </div>
+                        <h3 class="font-bold text-indigo-900">Orchestrator</h3>
+                    </div>
+                    <p class="text-sm text-slate-500">Routes requests to the right agent, coordinates multi-agent workflows, and builds consensus when multiple agents contribute to a decision.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- MCP Tool Registry -->
+    <section class="py-20 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <h2 class="font-display text-3xl md:text-4xl font-bold text-center text-slate-900 mb-4">24 MCP Tools</h2>
+            <p class="text-lg text-slate-500 text-center max-w-3xl mx-auto mb-12">
+                The Model Context Protocol (MCP) tool registry lets external AI agents securely perform banking operations. Each tool is sandboxed, rate-limited, and audit-logged.
+            </p>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+                <!-- Account -->
+                <div class="card-feature !p-5">
+                    <h4 class="font-bold text-slate-900 mb-3 flex items-center">
+                        <span class="w-8 h-8 bg-blue-100 rounded flex items-center justify-center mr-2 text-xs font-bold text-blue-700">4</span>
+                        Account
+                    </h4>
+                    <ul class="text-sm text-slate-500 space-y-1.5">
+                        <li>Create Account</li>
+                        <li>Balance Inquiry</li>
+                        <li>Deposit</li>
+                        <li>Withdraw</li>
+                    </ul>
+                </div>
+
+                <!-- Payment -->
+                <div class="card-feature !p-5">
+                    <h4 class="font-bold text-slate-900 mb-3 flex items-center">
+                        <span class="w-8 h-8 bg-green-100 rounded flex items-center justify-center mr-2 text-xs font-bold text-green-700">2</span>
+                        Payment
+                    </h4>
+                    <ul class="text-sm text-slate-500 space-y-1.5">
+                        <li>Transfer</li>
+                        <li>Payment Status</li>
+                    </ul>
+                </div>
+
+                <!-- Exchange -->
+                <div class="card-feature !p-5">
+                    <h4 class="font-bold text-slate-900 mb-3 flex items-center">
+                        <span class="w-8 h-8 bg-purple-100 rounded flex items-center justify-center mr-2 text-xs font-bold text-purple-700">3</span>
+                        Exchange
+                    </h4>
+                    <ul class="text-sm text-slate-500 space-y-1.5">
+                        <li>Quote</li>
+                        <li>Trade</li>
+                        <li>Liquidity Pool</li>
+                    </ul>
+                </div>
+
+                <!-- Compliance -->
+                <div class="card-feature !p-5">
+                    <h4 class="font-bold text-slate-900 mb-3 flex items-center">
+                        <span class="w-8 h-8 bg-amber-100 rounded flex items-center justify-center mr-2 text-xs font-bold text-amber-700">2</span>
+                        Compliance
+                    </h4>
+                    <ul class="text-sm text-slate-500 space-y-1.5">
+                        <li>AML Screening</li>
+                        <li>KYC Verification</li>
+                    </ul>
+                </div>
+
+                <!-- Transaction -->
+                <div class="card-feature !p-5">
+                    <h4 class="font-bold text-slate-900 mb-3 flex items-center">
+                        <span class="w-8 h-8 bg-indigo-100 rounded flex items-center justify-center mr-2 text-xs font-bold text-indigo-700">2</span>
+                        Transaction
+                    </h4>
+                    <ul class="text-sm text-slate-500 space-y-1.5">
+                        <li>NL Query</li>
+                        <li>Spending Analysis</li>
+                    </ul>
+                </div>
+
+                <!-- Agent Protocol -->
+                <div class="card-feature !p-5">
+                    <h4 class="font-bold text-slate-900 mb-3 flex items-center">
+                        <span class="w-8 h-8 bg-cyan-100 rounded flex items-center justify-center mr-2 text-xs font-bold text-cyan-700">5</span>
+                        Agent Protocol
+                    </h4>
+                    <ul class="text-sm text-slate-500 space-y-1.5">
+                        <li>Agent Payment</li>
+                        <li>Escrow</li>
+                        <li>Reputation</li>
+                        <li>Mandate</li>
+                        <li>VDC Issuance</li>
+                    </ul>
+                </div>
+
+                <!-- Payment Protocols -->
+                <div class="card-feature !p-5">
+                    <h4 class="font-bold text-slate-900 mb-3 flex items-center">
+                        <span class="w-8 h-8 bg-emerald-100 rounded flex items-center justify-center mr-2 text-xs font-bold text-emerald-700">3</span>
+                        Payment Rails
+                    </h4>
+                    <ul class="text-sm text-slate-500 space-y-1.5">
+                        <li>x402 (USDC)</li>
+                        <li>MPP Discovery</li>
+                        <li>MPP Payment</li>
+                    </ul>
+                </div>
+
+                <!-- Services -->
+                <div class="card-feature !p-5">
+                    <h4 class="font-bold text-slate-900 mb-3 flex items-center">
+                        <span class="w-8 h-8 bg-pink-100 rounded flex items-center justify-center mr-2 text-xs font-bold text-pink-700">3</span>
+                        Services
+                    </h4>
+                    <ul class="text-sm text-slate-500 space-y-1.5">
+                        <li>SMS Send</li>
+                        <li>Visa CLI Cards</li>
+                        <li>Visa CLI Payment</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Workflow Engine -->
+    <section class="py-20 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="grid grid-cols-1 md:grid-cols-2 gap-12 items-center">
                 <div>
+                    <h2 class="font-display text-3xl md:text-4xl font-bold text-slate-900 mb-6">Temporal Workflow Engine</h2>
                     <p class="text-lg text-slate-500 mb-6">
-                        The {{ config('brand.name', 'Zelta') }} AI Framework integrates large language models and machine learning pipelines directly into the banking infrastructure. From conversational interfaces to autonomous agents, AI augments every aspect of financial operations.
+                        Complex financial operations are orchestrated as durable workflows with automatic retries, compensation logic, and human-in-the-loop approval gates.
                     </p>
                     <div class="space-y-4">
                         <div class="flex items-start">
                             <div class="flex-shrink-0 w-10 h-10 bg-indigo-50 rounded-full flex items-center justify-center mr-4">
-                                <span class="text-indigo-600 font-bold">1</span>
+                                <span class="text-indigo-600 font-bold text-sm">1</span>
                             </div>
                             <div>
-                                <h4 class="font-semibold mb-1">Transaction Query Tool</h4>
-                                <p class="text-slate-500">Users ask questions like "Show my largest purchases last month" and receive structured, accurate results instantly.</p>
+                                <h4 class="font-semibold mb-1">Risk Assessment Saga</h4>
+                                <p class="text-slate-500 text-sm">Credit scoring, VaR calculation, debt-ratio analysis, and device/location verification run as parallel activities.</p>
                             </div>
                         </div>
                         <div class="flex items-start">
                             <div class="flex-shrink-0 w-10 h-10 bg-purple-50 rounded-full flex items-center justify-center mr-4">
-                                <span class="text-purple-600 font-bold">2</span>
+                                <span class="text-purple-600 font-bold text-sm">2</span>
                             </div>
                             <div>
-                                <h4 class="font-semibold mb-1">Model Context Protocol</h4>
-                                <p class="text-slate-500">MCP tools enable external AI agents to securely perform banking operations such as transfers, balance checks, and reporting.</p>
+                                <h4 class="font-semibold mb-1">Trading Execution Saga</h4>
+                                <p class="text-slate-500 text-sm">Market analysis, RSI/MACD calculation, strategy generation, and pattern identification with configurable risk limits.</p>
                             </div>
                         </div>
                         <div class="flex items-start">
                             <div class="flex-shrink-0 w-10 h-10 bg-green-50 rounded-full flex items-center justify-center mr-4">
-                                <span class="text-green-600 font-bold">3</span>
+                                <span class="text-green-600 font-bold text-sm">3</span>
                             </div>
                             <div>
-                                <h4 class="font-semibold mb-1">Conversation Management</h4>
-                                <p class="text-slate-500">Context-aware sessions that remember previous queries, enabling natural follow-up questions and progressive analysis.</p>
+                                <h4 class="font-semibold mb-1">Human Approval Gate</h4>
+                                <p class="text-slate-500 text-sm">Transactions above configurable thresholds ($10k default) pause for human review. Auto-approve below 0.9 confidence threshold.</p>
+                            </div>
+                        </div>
+                        <div class="flex items-start">
+                            <div class="flex-shrink-0 w-10 h-10 bg-amber-50 rounded-full flex items-center justify-center mr-4">
+                                <span class="text-amber-600 font-bold text-sm">4</span>
+                            </div>
+                            <div>
+                                <h4 class="font-semibold mb-1">Compliance Workflow</h4>
+                                <p class="text-slate-500 text-sm">AML screening, KYC document verification, proof-of-address checks, and regulatory reporting as a single orchestrated workflow.</p>
                             </div>
                         </div>
                     </div>
@@ -121,28 +333,35 @@
                                 <span class="font-semibold text-gray-800">Statistical Analysis</span>
                                 <p class="text-sm text-gray-500">Deviation from baseline patterns</p>
                             </div>
-                            <span class="text-lg font-bold text-indigo-600">Active</span>
+                            <span class="text-sm font-bold text-indigo-600 bg-indigo-50 px-3 py-1 rounded-full">Active</span>
                         </div>
                         <div class="flex justify-between items-center p-4 bg-gray-50 rounded-lg">
                             <div>
                                 <span class="font-semibold text-gray-800">Behavioral Profiling</span>
                                 <p class="text-sm text-gray-500">User habit and routine modeling</p>
                             </div>
-                            <span class="text-lg font-bold text-purple-600">Active</span>
+                            <span class="text-sm font-bold text-purple-600 bg-purple-50 px-3 py-1 rounded-full">Active</span>
                         </div>
                         <div class="flex justify-between items-center p-4 bg-gray-50 rounded-lg">
                             <div>
                                 <span class="font-semibold text-gray-800">Velocity Checks</span>
                                 <p class="text-sm text-gray-500">Transaction frequency monitoring</p>
                             </div>
-                            <span class="text-lg font-bold text-green-600">Active</span>
+                            <span class="text-sm font-bold text-green-600 bg-green-50 px-3 py-1 rounded-full">Active</span>
                         </div>
                         <div class="flex justify-between items-center p-4 bg-gray-50 rounded-lg">
                             <div>
                                 <span class="font-semibold text-gray-800">Geo-Based Detection</span>
-                                <p class="text-sm text-gray-500">Location anomaly identification</p>
+                                <p class="text-sm text-gray-500">Impossible travel identification</p>
                             </div>
-                            <span class="text-lg font-bold text-pink-600">Active</span>
+                            <span class="text-sm font-bold text-pink-600 bg-pink-50 px-3 py-1 rounded-full">Active</span>
+                        </div>
+                        <div class="flex justify-between items-center p-4 bg-gray-50 rounded-lg">
+                            <div>
+                                <span class="font-semibold text-gray-800">Ensemble Scoring</span>
+                                <p class="text-sm text-gray-500">Weighted confidence aggregation</p>
+                            </div>
+                            <span class="text-sm font-bold text-cyan-600 bg-cyan-50 px-3 py-1 rounded-full">Active</span>
                         </div>
                     </div>
                 </div>
@@ -150,74 +369,68 @@
         </div>
     </section>
 
-    <!-- Agent Operations -->
+    <!-- Technical Capabilities -->
     <section class="py-20 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <h2 class="font-display text-3xl md:text-4xl font-bold text-center text-slate-900 mb-12">AI Agent Banking Operations</h2>
+            <h2 class="font-display text-3xl md:text-4xl font-bold text-center text-slate-900 mb-12">Technical Capabilities</h2>
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
                 <div class="card-feature !p-8">
-                    <h3 class="text-2xl font-bold mb-6 text-indigo-900">MCP Tool Capabilities</h3>
-                    <ul class="space-y-4">
+                    <h3 class="text-2xl font-bold mb-6">LLM Integration</h3>
+                    <ul class="space-y-3">
                         <li class="flex items-start">
-                            <svg class="w-6 h-6 text-indigo-600 mr-3 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4"></path>
-                            </svg>
-                            <div>
-                                <h4 class="font-semibold mb-1">Balance Inquiries</h4>
-                                <p class="text-slate-600">AI agents query real-time balances across accounts, wallets, and tokens</p>
-                            </div>
+                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                            <span>Dual LLM providers: OpenAI (GPT-4) and Anthropic (Claude)</span>
                         </li>
                         <li class="flex items-start">
-                            <svg class="w-6 h-6 text-indigo-600 mr-3 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4"></path>
-                            </svg>
-                            <div>
-                                <h4 class="font-semibold mb-1">Transaction Execution</h4>
-                                <p class="text-slate-600">Authorized agents can initiate transfers with configurable spending limits</p>
-                            </div>
+                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                            <span>Automatic failover between providers</span>
                         </li>
                         <li class="flex items-start">
-                            <svg class="w-6 h-6 text-indigo-600 mr-3 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4"></path>
-                            </svg>
-                            <div>
-                                <h4 class="font-semibold mb-1">Report Generation</h4>
-                                <p class="text-slate-600">Automated financial reports, tax summaries, and compliance documentation</p>
-                            </div>
+                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                            <span>Natural language to SQL query translation</span>
+                        </li>
+                        <li class="flex items-start">
+                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                            <span>Intent classification with confidence scoring</span>
+                        </li>
+                        <li class="flex items-start">
+                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                            <span>Token usage tracking and cost management ($10/user/day limit)</span>
+                        </li>
+                        <li class="flex items-start">
+                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                            <span>Query safety validation and injection prevention</span>
                         </li>
                     </ul>
                 </div>
 
                 <div class="card-feature !p-8">
-                    <h3 class="text-2xl font-bold mb-6 text-purple-900">Conversation Intelligence</h3>
-                    <ul class="space-y-4">
+                    <h3 class="text-2xl font-bold mb-6">Conversation Intelligence</h3>
+                    <ul class="space-y-3">
                         <li class="flex items-start">
-                            <svg class="w-6 h-6 text-purple-600 mr-3 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4"></path>
-                            </svg>
-                            <div>
-                                <h4 class="font-semibold mb-1">Context Persistence</h4>
-                                <p class="text-slate-600">Conversations remember context across sessions for natural follow-ups</p>
-                            </div>
+                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                            <span>Context-aware sessions with 24-hour TTL</span>
                         </li>
                         <li class="flex items-start">
-                            <svg class="w-6 h-6 text-purple-600 mr-3 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4"></path>
-                            </svg>
-                            <div>
-                                <h4 class="font-semibold mb-1">Multi-Turn Reasoning</h4>
-                                <p class="text-slate-600">Complex financial questions resolved through progressive query refinement</p>
-                            </div>
+                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                            <span>Multi-turn reasoning with progressive query refinement</span>
                         </li>
                         <li class="flex items-start">
-                            <svg class="w-6 h-6 text-purple-600 mr-3 mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4"></path>
-                            </svg>
-                            <div>
-                                <h4 class="font-semibold mb-1">Intent Classification</h4>
-                                <p class="text-slate-600">Automatic routing of user requests to the appropriate banking tool or service</p>
-                            </div>
+                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                            <span>Automatic routing to specialized agents via intent classification</span>
+                        </li>
+                        <li class="flex items-start">
+                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                            <span>Versioned prompt templates with category management</span>
+                        </li>
+                        <li class="flex items-start">
+                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                            <span>Response caching for frequently asked questions</span>
+                        </li>
+                        <li class="flex items-start">
+                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                            <span>Event-sourced interaction auditing</span>
                         </li>
                     </ul>
                 </div>
@@ -225,95 +438,32 @@
         </div>
     </section>
 
-    <!-- Technical Features Checklist -->
+    <!-- Related Features -->
     <section class="py-20 bg-gray-50">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <h2 class="font-display text-3xl md:text-4xl font-bold text-center text-slate-900 mb-12">Technical Capabilities</h2>
-
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
-                <div class="card-feature !p-8">
-                    <h3 class="text-2xl font-bold mb-6">Natural Language Processing</h3>
-                    <ul class="space-y-3">
-                        <li class="flex items-start">
-                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
-                            </svg>
-                            <span>Natural language to SQL query translation</span>
-                        </li>
-                        <li class="flex items-start">
-                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
-                            </svg>
-                            <span>Spending categorization and trend extraction</span>
-                        </li>
-                        <li class="flex items-start">
-                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
-                            </svg>
-                            <span>Structured response formatting with charts and tables</span>
-                        </li>
-                        <li class="flex items-start">
-                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
-                            </svg>
-                            <span>Multi-language support for global user base</span>
-                        </li>
-                        <li class="flex items-start">
-                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
-                            </svg>
-                            <span>Query safety validation and injection prevention</span>
-                        </li>
-                        <li class="flex items-start">
-                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
-                            </svg>
-                            <span>Response caching for frequently asked questions</span>
-                        </li>
-                    </ul>
-                </div>
-
-                <div class="card-feature !p-8">
-                    <h3 class="text-2xl font-bold mb-6">Anomaly Detection Pipeline</h3>
-                    <ul class="space-y-3">
-                        <li class="flex items-start">
-                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
-                            </svg>
-                            <span>Real-time statistical deviation scoring</span>
-                        </li>
-                        <li class="flex items-start">
-                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
-                            </svg>
-                            <span>Behavioral baseline learning with adaptive thresholds</span>
-                        </li>
-                        <li class="flex items-start">
-                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
-                            </svg>
-                            <span>Velocity pattern analysis for rapid transaction detection</span>
-                        </li>
-                        <li class="flex items-start">
-                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
-                            </svg>
-                            <span>Geo-location impossible travel detection</span>
-                        </li>
-                        <li class="flex items-start">
-                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
-                            </svg>
-                            <span>Model ensemble with weighted confidence scoring</span>
-                        </li>
-                        <li class="flex items-start">
-                            <svg class="w-6 h-6 text-green-500 mr-3 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
-                            </svg>
-                            <span>Automated alert escalation and case management</span>
-                        </li>
-                    </ul>
-                </div>
+            <h2 class="font-display text-3xl md:text-4xl font-bold text-center text-slate-900 mb-12">Related Capabilities</h2>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+                <a href="{{ route('features.show', 'agent-protocol') }}" class="card-feature !p-6 hover:border-cyan-300 transition-colors group">
+                    <div class="w-12 h-12 bg-cyan-100 rounded-lg flex items-center justify-center mb-4">
+                        <svg class="w-6 h-6 text-cyan-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"></path></svg>
+                    </div>
+                    <h3 class="font-bold text-slate-900 mb-2 group-hover:text-cyan-700">Agent Protocol (AP2)</h3>
+                    <p class="text-sm text-slate-500">DID authentication, A2A messaging, escrow, reputation, and AP2 mandates for autonomous agent commerce.</p>
+                </a>
+                <a href="{{ route('features.show', 'machine-payments') }}" class="card-feature !p-6 hover:border-orange-300 transition-colors group">
+                    <div class="w-12 h-12 bg-orange-100 rounded-lg flex items-center justify-center mb-4">
+                        <svg class="w-6 h-6 text-orange-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z"></path></svg>
+                    </div>
+                    <h3 class="font-bold text-slate-900 mb-2 group-hover:text-orange-700">Machine Payments (MPP)</h3>
+                    <p class="text-sm text-slate-500">Multi-rail HTTP 402 payments with Stripe, USDC, Lightning, and x402 for AI agent autonomous commerce.</p>
+                </a>
+                <a href="{{ route('features.show', 'x402-protocol') }}" class="card-feature !p-6 hover:border-emerald-300 transition-colors group">
+                    <div class="w-12 h-12 bg-emerald-100 rounded-lg flex items-center justify-center mb-4">
+                        <svg class="w-6 h-6 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                    </div>
+                    <h3 class="font-bold text-slate-900 mb-2 group-hover:text-emerald-700">x402 Protocol</h3>
+                    <p class="text-sm text-slate-500">HTTP-native USDC micropayments on Base, Ethereum, Arbitrum, Solana with facilitator-verified settlement.</p>
+                </a>
             </div>
         </div>
     </section>
@@ -322,9 +472,9 @@
     <section class="bg-fa-navy relative overflow-hidden">
         <div class="absolute inset-0 bg-dot-pattern"></div>
         <div class="relative max-w-4xl mx-auto text-center px-4 sm:px-6 lg:px-8 py-20">
-            <h2 class="font-display text-3xl md:text-4xl font-bold text-white mb-4">Experience Intelligent Banking</h2>
+            <h2 class="font-display text-3xl md:text-4xl font-bold text-white mb-4">Intelligence Built Into Every Transaction</h2>
             <p class="text-lg text-slate-400 mb-10 max-w-2xl mx-auto">
-                Let AI handle the complexity while you focus on what matters. From transaction queries to fraud detection, intelligence is built into every interaction.
+                From natural language queries to autonomous agent commerce, the AI framework handles the complexity so you can focus on what matters.
             </p>
             <div class="flex flex-col sm:flex-row gap-4 justify-center">
                 <a href="{{ route('register') }}" class="btn-primary px-8 py-4 text-lg">

--- a/resources/views/features/index.blade.php
+++ b/resources/views/features/index.blade.php
@@ -361,12 +361,34 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
                         </svg>
                     </div>
-                    <h3 class="text-xl font-semibold mb-3">AI Framework</h3>
+                    <div class="flex items-center gap-2 mb-3">
+                        <h3 class="text-xl font-semibold">AI Framework</h3>
+                        <span class="inline-flex items-center px-2 py-0.5 bg-purple-100 text-purple-700 text-xs rounded-full font-medium">24 Tools</span>
+                    </div>
                     <p class="text-slate-500 mb-4">
-                        AI-powered transaction queries, MCP tool integration, ML anomaly detection, and Google A2A agent protocol.
+                        6 specialized agents, 24 MCP tools, ML anomaly detection, Temporal workflow orchestration, and multi-agent consensus engine.
                     </p>
                     <a href="{{ route('features.show', 'ai-framework') }}" class="text-purple-600 font-medium hover:text-purple-700">
                         Explore AI →
+                    </a>
+                </div>
+
+                <!-- Agent Protocol -->
+                <div class="card-feature">
+                    <div class="w-14 h-14 bg-cyan-100 rounded-lg flex items-center justify-center mb-6">
+                        <svg class="w-8 h-8 text-cyan-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"></path>
+                        </svg>
+                    </div>
+                    <div class="flex items-center gap-2 mb-3">
+                        <h3 class="text-xl font-semibold">Agent Protocol (AP2)</h3>
+                        <span class="inline-flex items-center px-2 py-0.5 bg-cyan-100 text-cyan-700 text-xs rounded-full font-medium">New</span>
+                    </div>
+                    <p class="text-slate-500 mb-4">
+                        DID authentication, A2A messaging, escrow with dispute resolution, reputation scoring, and AP2 payment mandates for autonomous agent commerce.
+                    </p>
+                    <a href="{{ route('features.show', 'agent-protocol') }}" class="text-cyan-600 font-medium hover:text-cyan-700">
+                        Explore AP2 →
                     </a>
                 </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -88,7 +88,7 @@ if (config('brand.show_promo_pages')) {
     })->name('features');
 
     Route::get('/features/{feature}', function ($feature) {
-        $validFeatures = ['gcu', 'multi-asset', 'settlements', 'governance', 'bank-integration', 'api', 'crosschain-defi', 'privacy-identity', 'mobile-payments', 'regtech-compliance', 'baas-platform', 'ai-framework', 'multi-tenancy', 'x402-protocol', 'visa-cli', 'virtuals-protocol', 'plugin-marketplace', 'machine-payments'];
+        $validFeatures = ['gcu', 'multi-asset', 'settlements', 'governance', 'bank-integration', 'api', 'crosschain-defi', 'privacy-identity', 'mobile-payments', 'regtech-compliance', 'baas-platform', 'ai-framework', 'multi-tenancy', 'x402-protocol', 'visa-cli', 'virtuals-protocol', 'plugin-marketplace', 'machine-payments', 'agent-protocol'];
 
         if (! in_array($feature, $validFeatures)) {
             abort(404);

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.0",
     "info": {
         "title": "Zelta API",
-        "description": "Agentic payments API — stablecoin-powered virtual cards, non-custodial wallet, and AI agent card issuance. Built with Laravel 12, featuring 43 DDD domains, event sourcing, CQRS, and privacy-preserving architecture.",
+        "description": "Agentic payments API — stablecoin-powered virtual cards, non-custodial wallet, and AI agent card issuance. Built with Laravel 12, featuring 49 DDD domains, event sourcing, CQRS, and privacy-preserving architecture.",
         "contact": {
             "name": "Zelta Support",
             "email": "support@finaegis.org"
@@ -11,7 +11,7 @@
             "name": "Apache 2.0",
             "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
         },
-        "version": "5.1.5"
+        "version": "6.5.0"
     },
     "servers": [
         {
@@ -26814,6 +26814,575 @@
                 ]
             }
         },
+        "/api/v1/mpp/payments": {
+            "get": {
+                "tags": [
+                    "Machine Payments"
+                ],
+                "summary": "List MPP payment history",
+                "description": "Returns paginated payment history with optional rail and status filters.",
+                "operationId": "mppPayments",
+                "parameters": [
+                    {
+                        "name": "rail",
+                        "in": "query",
+                        "description": "Filter by rail (stripe, tempo, lightning, card, x402)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "description": "Filter by status (pending, settled, failed)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Payment history",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean"
+                                        },
+                                        "data": {
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/v1/mpp/payments/stats": {
+            "get": {
+                "tags": [
+                    "Machine Payments"
+                ],
+                "summary": "Payment statistics",
+                "description": "Returns aggregate statistics: total payments, settled/failed counts, total volume, and breakdown by rail.",
+                "operationId": "mppPaymentStats",
+                "responses": {
+                    "200": {
+                        "description": "Payment stats",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean"
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "total_payments": {
+                                                    "type": "integer"
+                                                },
+                                                "settled": {
+                                                    "type": "integer"
+                                                },
+                                                "failed": {
+                                                    "type": "integer"
+                                                },
+                                                "total_settled_cents": {
+                                                    "type": "integer"
+                                                },
+                                                "by_rail": {
+                                                    "type": "object"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/v1/mpp/spending-limits": {
+            "get": {
+                "tags": [
+                    "Machine Payments"
+                ],
+                "summary": "List agent spending limits",
+                "description": "Returns all configured agent spending limits for MPP payments.",
+                "operationId": "mppSpendingLimits",
+                "responses": {
+                    "200": {
+                        "description": "Spending limits"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Machine Payments"
+                ],
+                "summary": "Set or update a spending limit",
+                "description": "Creates or updates daily and per-transaction spending limits for an agent.",
+                "operationId": "mppSetSpendingLimit",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "agent_id",
+                                    "daily_limit",
+                                    "per_tx_limit"
+                                ],
+                                "properties": {
+                                    "agent_id": {
+                                        "type": "string"
+                                    },
+                                    "daily_limit": {
+                                        "type": "integer",
+                                        "example": 5000000
+                                    },
+                                    "per_tx_limit": {
+                                        "type": "integer",
+                                        "example": 100000
+                                    },
+                                    "auto_pay": {
+                                        "type": "boolean",
+                                        "example": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Spending limit set"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/v1/mpp/spending-limits/{agentId}": {
+            "delete": {
+                "tags": [
+                    "Machine Payments"
+                ],
+                "summary": "Delete a spending limit",
+                "operationId": "mppDeleteSpendingLimit",
+                "parameters": [
+                    {
+                        "name": "agentId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Spending limit deleted"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/v1/mpp/resources": {
+            "get": {
+                "tags": [
+                    "Machine Payments"
+                ],
+                "summary": "List monetized resources",
+                "description": "Returns paginated list of API endpoints that require MPP payment. Filter active-only by default.",
+                "operationId": "mppResources",
+                "parameters": [
+                    {
+                        "name": "active_only",
+                        "in": "query",
+                        "description": "Filter to active resources only (default: true)",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Monetized resources"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Machine Payments"
+                ],
+                "summary": "Create a monetized resource",
+                "description": "Register an API endpoint for MPP payment gating. Admin only. Blocked for auth/admin/monitoring/webhook paths.",
+                "operationId": "mppCreateResource",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "method",
+                                    "path",
+                                    "amount_cents",
+                                    "currency",
+                                    "available_rails"
+                                ],
+                                "properties": {
+                                    "method": {
+                                        "type": "string",
+                                        "enum": [
+                                            "GET",
+                                            "POST",
+                                            "PUT",
+                                            "PATCH",
+                                            "DELETE"
+                                        ]
+                                    },
+                                    "path": {
+                                        "type": "string",
+                                        "example": "v1/sms/send"
+                                    },
+                                    "amount_cents": {
+                                        "type": "integer",
+                                        "example": 5000
+                                    },
+                                    "currency": {
+                                        "type": "string",
+                                        "example": "USD"
+                                    },
+                                    "available_rails": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "enum": [
+                                                "stripe",
+                                                "tempo",
+                                                "lightning",
+                                                "card",
+                                                "x402"
+                                            ]
+                                        }
+                                    },
+                                    "description": {
+                                        "type": "string",
+                                        "nullable": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Resource created"
+                    },
+                    "409": {
+                        "description": "Duplicate method+path"
+                    },
+                    "422": {
+                        "description": "Validation error or blocked path"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/v1/mpp/resources/{id}": {
+            "get": {
+                "tags": [
+                    "Machine Payments"
+                ],
+                "summary": "Get a monetized resource",
+                "operationId": "mppShowResource",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Resource details"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            },
+            "put": {
+                "tags": [
+                    "Machine Payments"
+                ],
+                "summary": "Update a monetized resource",
+                "description": "Update pricing, rails, or active status. Admin only.",
+                "operationId": "mppUpdateResource",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "amount_cents": {
+                                        "type": "integer"
+                                    },
+                                    "currency": {
+                                        "type": "string"
+                                    },
+                                    "available_rails": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "is_active": {
+                                        "type": "boolean"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Resource updated"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Machine Payments"
+                ],
+                "summary": "Delete a monetized resource",
+                "description": "Remove an API endpoint from MPP payment gating. Admin only.",
+                "operationId": "mppDeleteResource",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Resource deleted"
+                    },
+                    "404": {
+                        "description": "Not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/v1/mpp/status": {
+            "get": {
+                "tags": [
+                    "Machine Payments"
+                ],
+                "summary": "MPP protocol status",
+                "description": "Returns whether MPP is enabled, protocol version, available payment rails, and MCP binding status.",
+                "operationId": "mppStatus",
+                "responses": {
+                    "200": {
+                        "description": "Protocol status",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean"
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "enabled": {
+                                                    "type": "boolean"
+                                                },
+                                                "version": {
+                                                    "type": "integer"
+                                                },
+                                                "available_rails": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "rail_count": {
+                                                    "type": "integer"
+                                                },
+                                                "mcp_enabled": {
+                                                    "type": "boolean"
+                                                },
+                                                "spec_url": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/mpp/supported-rails": {
+            "get": {
+                "tags": [
+                    "Machine Payments"
+                ],
+                "summary": "List supported payment rails",
+                "description": "Returns detailed info for each payment rail: Stripe SPT, Tempo, Lightning, Card, and x402 USDC.",
+                "operationId": "mppSupportedRails",
+                "responses": {
+                    "200": {
+                        "description": "Rail details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean"
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "string"
+                                                    },
+                                                    "label": {
+                                                        "type": "string"
+                                                    },
+                                                    "description": {
+                                                        "type": "string"
+                                                    },
+                                                    "supports_fiat": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "supports_crypto": {
+                                                        "type": "boolean"
+                                                    },
+                                                    "currencies": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "available": {
+                                                        "type": "boolean"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/.well-known/mpp-configuration": {
+            "get": {
+                "tags": [
+                    "Machine Payments"
+                ],
+                "summary": "MPP discovery endpoint",
+                "description": "Returns the .well-known/mpp-configuration JSON for protocol discovery.",
+                "operationId": "mppWellKnown",
+                "responses": {
+                    "200": {
+                        "description": "MPP configuration JSON"
+                    }
+                }
+            }
+        },
         "/api/v1/user/preferences": {
             "get": {
                 "tags": [
@@ -39764,6 +40333,259 @@
                         "sanctum": []
                     }
                 ]
+            }
+        },
+        "/api/v1/sms/send": {
+            "post": {
+                "tags": [
+                    "SMS"
+                ],
+                "summary": "Send an SMS message",
+                "description": "Send an SMS message to a phone number. Protected by MPP payment gate — requires payment via x402, Stripe, or other configured rail.",
+                "operationId": "smsSend",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "to",
+                                    "message"
+                                ],
+                                "properties": {
+                                    "to": {
+                                        "description": "E.164 phone number",
+                                        "type": "string",
+                                        "example": "+37069912345"
+                                    },
+                                    "from": {
+                                        "description": "Sender ID (alphanumeric, max 20 chars)",
+                                        "type": "string",
+                                        "example": "Zelta"
+                                    },
+                                    "message": {
+                                        "description": "Message body (max 1600 chars)",
+                                        "type": "string",
+                                        "example": "Hello from Zelta!"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "SMS sent successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "message_id": {
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "pending",
+                                                        "sent"
+                                                    ]
+                                                },
+                                                "price_usdc": {
+                                                    "type": "string"
+                                                },
+                                                "parts": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "402": {
+                        "description": "Payment required — MPP challenge issued"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    },
+                    "503": {
+                        "description": "SMS service disabled"
+                    }
+                }
+            }
+        },
+        "/api/v1/sms/rates": {
+            "get": {
+                "tags": [
+                    "SMS"
+                ],
+                "summary": "Get SMS rates for a country",
+                "description": "Returns per-message USDC pricing for a given ISO 3166-1 alpha-2 country code.",
+                "operationId": "smsRates",
+                "parameters": [
+                    {
+                        "name": "country",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "maxLength": 2,
+                            "minLength": 2
+                        },
+                        "example": "LT"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Rate found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "country_code": {
+                                                    "type": "string"
+                                                },
+                                                "price_usdc": {
+                                                    "type": "string"
+                                                },
+                                                "currency": {
+                                                    "type": "string",
+                                                    "example": "USDC"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "No rate found for country"
+                    },
+                    "422": {
+                        "description": "Invalid country code"
+                    }
+                }
+            }
+        },
+        "/api/v1/sms/status/{messageId}": {
+            "get": {
+                "tags": [
+                    "SMS"
+                ],
+                "summary": "Get message delivery status",
+                "description": "Returns the current delivery status of a previously sent SMS message. Requires authentication.",
+                "operationId": "smsStatus",
+                "parameters": [
+                    {
+                        "name": "messageId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Message status",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "message_id": {
+                                                    "type": "string"
+                                                },
+                                                "status": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "pending",
+                                                        "sent",
+                                                        "delivered",
+                                                        "failed"
+                                                    ]
+                                                },
+                                                "delivered_at": {
+                                                    "type": "string",
+                                                    "nullable": true
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthenticated"
+                    },
+                    "404": {
+                        "description": "Message not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/v1/sms/info": {
+            "get": {
+                "tags": [
+                    "SMS"
+                ],
+                "summary": "Get SMS service info",
+                "description": "Returns provider information, enabled status, test mode flag, and supported networks.",
+                "operationId": "smsInfo",
+                "responses": {
+                    "200": {
+                        "description": "Service info",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "provider": {
+                                                    "type": "string"
+                                                },
+                                                "enabled": {
+                                                    "type": "boolean"
+                                                },
+                                                "test_mode": {
+                                                    "type": "boolean"
+                                                },
+                                                "networks": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
             }
         },
         "/api/settings": {
@@ -53462,6 +54284,58 @@
                 }
             }
         },
+        "/api/v1/webhooks/vertexsms/dlr": {
+            "post": {
+                "tags": [
+                    "SMS Webhooks"
+                ],
+                "summary": "VertexSMS delivery report webhook",
+                "description": "Receives SMS delivery status updates from VertexSMS. Verifies HMAC-SHA256 signature from X-VertexSMS-Signature header.",
+                "operationId": "vertexSmsDlr",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "message_id",
+                                    "status"
+                                ],
+                                "properties": {
+                                    "message_id": {
+                                        "type": "string"
+                                    },
+                                    "status": {
+                                        "type": "string",
+                                        "enum": [
+                                            "sent",
+                                            "delivered",
+                                            "failed"
+                                        ]
+                                    },
+                                    "delivered_at": {
+                                        "type": "string",
+                                        "nullable": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Delivery report accepted"
+                    },
+                    "401": {
+                        "description": "Invalid webhook signature"
+                    },
+                    "422": {
+                        "description": "Missing message_id"
+                    }
+                }
+            }
+        },
         "/api/workflows": {
             "get": {
                 "tags": [
@@ -60309,6 +61183,15 @@
         {
             "name": "Lending",
             "description": "P2P lending: loan applications, payments, early settlement, and loan management"
+        },
+        {
+            "name": "SMS"
+        },
+        {
+            "name": "Machine Payments"
+        },
+        {
+            "name": "SMS Webhooks"
         },
         {
             "name": "Exchange Rates",

--- a/tests/Feature/Website/AgentProtocolPageTest.php
+++ b/tests/Feature/Website/AgentProtocolPageTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use function Pest\Laravel\get;
+
+describe('Agent Protocol Feature Page', function (): void {
+    it('renders the agent protocol page', function (): void {
+        $response = get('/features/agent-protocol');
+
+        $response->assertOk();
+        $response->assertSee('Agent Protocol');
+    });
+
+    it('displays DID authentication section', function (): void {
+        $response = get('/features/agent-protocol');
+
+        $response->assertOk();
+        $response->assertSee('DID Identity');
+        $response->assertSee('DID Challenge-Response');
+    });
+
+    it('displays A2A messaging section', function (): void {
+        $response = get('/features/agent-protocol');
+
+        $response->assertOk();
+        $response->assertSee('A2A Messaging');
+    });
+
+    it('displays escrow section', function (): void {
+        $response = get('/features/agent-protocol');
+
+        $response->assertOk();
+        $response->assertSee('Escrow');
+        $response->assertSee('Dispute Resolution');
+    });
+
+    it('displays reputation system', function (): void {
+        $response = get('/features/agent-protocol');
+
+        $response->assertOk();
+        $response->assertSee('Reputation');
+        $response->assertSee('50/100');
+    });
+
+    it('displays AP2 mandate types', function (): void {
+        $response = get('/features/agent-protocol');
+
+        $response->assertOk();
+        $response->assertSee('Cart Mandate');
+        $response->assertSee('Intent Mandate');
+        $response->assertSee('Payment Mandate');
+    });
+
+    it('displays KYC tiers', function (): void {
+        $response = get('/features/agent-protocol');
+
+        $response->assertOk();
+        $response->assertSee('Basic');
+        $response->assertSee('Enhanced');
+        $response->assertSee('Full');
+    });
+
+    it('displays event-sourced aggregates', function (): void {
+        $response = get('/features/agent-protocol');
+
+        $response->assertOk();
+        $response->assertSee('Agent Identity');
+        $response->assertSee('Agent Wallet');
+        $response->assertSee('Mandates');
+    });
+
+    it('includes SEO meta tags', function (): void {
+        $response = get('/features/agent-protocol');
+
+        $response->assertOk();
+        $response->assertSee('Autonomous Agent Commerce', false);
+    });
+});

--- a/tests/Feature/Website/AiFrameworkPageTest.php
+++ b/tests/Feature/Website/AiFrameworkPageTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use function Pest\Laravel\get;
+
+describe('AI Framework Feature Page', function (): void {
+    it('renders the AI framework page', function (): void {
+        $response = get('/features/ai-framework');
+
+        $response->assertOk();
+        $response->assertSee('AI Framework');
+    });
+
+    it('displays MCP tool count', function (): void {
+        $response = get('/features/ai-framework');
+
+        $response->assertOk();
+        $response->assertSee('24 MCP Tools');
+    });
+
+    it('displays all six agents', function (): void {
+        $response = get('/features/ai-framework');
+
+        $response->assertOk();
+        $response->assertSee('General Agent');
+        $response->assertSee('Compliance Agent');
+        $response->assertSee('Financial Agent');
+        $response->assertSee('Trading Agent');
+        $response->assertSee('Transfer Agent');
+        $response->assertSee('Orchestrator');
+    });
+
+    it('displays ML detection models', function (): void {
+        $response = get('/features/ai-framework');
+
+        $response->assertOk();
+        $response->assertSee('Statistical Analysis');
+        $response->assertSee('Behavioral Profiling');
+        $response->assertSee('Velocity Checks');
+        $response->assertSee('Geo-Based Detection');
+        $response->assertSee('Ensemble Scoring');
+    });
+
+    it('links to agent protocol page', function (): void {
+        $response = get('/features/ai-framework');
+
+        $response->assertOk();
+        $response->assertSee('agent-protocol');
+    });
+
+    it('includes SEO meta tags', function (): void {
+        $response = get('/features/ai-framework');
+
+        $response->assertOk();
+        $response->assertSee('Multi-Agent Intelligence', false);
+    });
+});

--- a/tests/Feature/Website/FeaturesIndexPageTest.php
+++ b/tests/Feature/Website/FeaturesIndexPageTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use function Pest\Laravel\get;
+
+describe('Features Index Page', function (): void {
+    it('renders the features index page', function (): void {
+        $response = get('/features');
+
+        $response->assertOk();
+        $response->assertSee('49 Domain Modules');
+    });
+
+    it('lists AI Framework feature card', function (): void {
+        $response = get('/features');
+
+        $response->assertOk();
+        $response->assertSee('AI Framework');
+        $response->assertSee('24 Tools');
+    });
+
+    it('lists Agent Protocol feature card', function (): void {
+        $response = get('/features');
+
+        $response->assertOk();
+        $response->assertSee('Agent Protocol (AP2)');
+    });
+
+    it('lists Machine Payments feature card', function (): void {
+        $response = get('/features');
+
+        $response->assertOk();
+        $response->assertSee('Machine Payments');
+    });
+
+    it('lists x402 Protocol feature card', function (): void {
+        $response = get('/features');
+
+        $response->assertOk();
+        $response->assertSee('x402 Protocol');
+    });
+
+    it('returns 404 for invalid feature', function (): void {
+        $response = get('/features/nonexistent-feature');
+
+        $response->assertNotFound();
+    });
+});

--- a/tests/Unit/Domain/AI/MCP/ToolRegistryExtendedTest.php
+++ b/tests/Unit/Domain/AI/MCP/ToolRegistryExtendedTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\AI\MCP;
+
+use App\Domain\AI\Contracts\MCPToolInterface;
+use App\Domain\AI\Exceptions\ToolAlreadyRegisteredException;
+use App\Domain\AI\Exceptions\ToolNotFoundException;
+use App\Domain\AI\MCP\ToolRegistry;
+use Mockery;
+use Mockery\MockInterface;
+use Tests\TestCase;
+
+class ToolRegistryExtendedTest extends TestCase
+{
+    private ToolRegistry $registry;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->registry = new ToolRegistry();
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    /**
+     * @return MCPToolInterface&MockInterface
+     */
+    private function createMockTool(string $name, string $description = 'Test tool', string $category = 'test'): MCPToolInterface
+    {
+        /** @var MCPToolInterface&MockInterface $tool */
+        $tool = Mockery::mock(MCPToolInterface::class);
+        $tool->shouldReceive('getName')->andReturn($name);
+        $tool->shouldReceive('getDescription')->andReturn($description);
+        $tool->shouldReceive('getCategory')->andReturn($category);
+        $tool->shouldReceive('getParameters')->andReturn([]);
+        $tool->shouldReceive('getCapabilities')->andReturn(['read']);
+        $tool->shouldReceive('getInputSchema')->andReturn([]);
+        $tool->shouldReceive('getOutputSchema')->andReturn([]);
+        $tool->shouldReceive('isCacheable')->andReturn(false);
+        $tool->shouldReceive('getCacheTtl')->andReturn(0);
+
+        return $tool;
+    }
+
+    public function test_search_tools_finds_by_name(): void
+    {
+        $tool = $this->createMockTool('account.balance', 'Check account balance', 'account');
+        $this->registry->register($tool);
+
+        $results = $this->registry->searchTools('balance');
+
+        expect($results->count())->toBeGreaterThanOrEqual(1);
+    }
+
+    public function test_search_tools_finds_by_description(): void
+    {
+        $tool = $this->createMockTool('test.tool', 'Retrieve cryptocurrency prices', 'exchange');
+        $this->registry->register($tool);
+
+        $results = $this->registry->searchTools('cryptocurrency');
+
+        expect($results->count())->toBeGreaterThanOrEqual(1);
+    }
+
+    public function test_search_tools_returns_empty_for_no_match(): void
+    {
+        $tool = $this->createMockTool('simple.tool', 'Simple description', 'simple');
+        $this->registry->register($tool);
+
+        $results = $this->registry->searchTools('zzz_nonexistent_zzz');
+
+        expect($results->count())->toBe(0);
+    }
+
+    public function test_get_categories_returns_unique_categories(): void
+    {
+        $tool1 = $this->createMockTool('tool1', 'Tool 1', 'account');
+        $tool2 = $this->createMockTool('tool2', 'Tool 2', 'payment');
+        $tool3 = $this->createMockTool('tool3', 'Tool 3', 'account');
+
+        $this->registry->register($tool1);
+        $this->registry->register($tool2);
+        $this->registry->register($tool3);
+
+        $categories = $this->registry->getCategories();
+
+        expect($categories)->toContain('account');
+        expect($categories)->toContain('payment');
+        expect(count(array_unique($categories)))->toBe(count($categories));
+    }
+
+    public function test_get_tools_by_category_filters_correctly(): void
+    {
+        $tool1 = $this->createMockTool('acct.create', 'Create account', 'account');
+        $tool2 = $this->createMockTool('pay.send', 'Send payment', 'payment');
+        $tool3 = $this->createMockTool('acct.balance', 'Check balance', 'account');
+
+        $this->registry->register($tool1);
+        $this->registry->register($tool2);
+        $this->registry->register($tool3);
+
+        $accountTools = $this->registry->getToolsByCategory('account');
+
+        expect($accountTools->count())->toBe(2);
+    }
+
+    public function test_export_schema_returns_correct_structure(): void
+    {
+        $tool = $this->createMockTool('test.export', 'Export test', 'test');
+        $this->registry->register($tool);
+
+        $schema = $this->registry->exportSchema();
+
+        expect($schema)->toBeArray();
+        expect($schema)->toHaveKey('tools');
+        expect($schema)->toHaveKey('version');
+    }
+
+    public function test_get_statistics_returns_counts(): void
+    {
+        $tool1 = $this->createMockTool('stats.tool1', 'Tool 1', 'cat1');
+        $tool2 = $this->createMockTool('stats.tool2', 'Tool 2', 'cat2');
+
+        $this->registry->register($tool1);
+        $this->registry->register($tool2);
+
+        $stats = $this->registry->getStatistics();
+
+        expect($stats)->toBeArray();
+        expect($stats)->toHaveKey('total_tools');
+        expect($stats['total_tools'])->toBe(2);
+    }
+
+    public function test_register_duplicate_throws_exception(): void
+    {
+        $tool = $this->createMockTool('duplicate.tool');
+        $this->registry->register($tool);
+
+        $this->expectException(ToolAlreadyRegisteredException::class);
+
+        $duplicate = $this->createMockTool('duplicate.tool');
+        $this->registry->register($duplicate);
+    }
+
+    public function test_unregister_nonexistent_throws_exception(): void
+    {
+        $this->expectException(ToolNotFoundException::class);
+
+        $this->registry->unregister('nonexistent.tool');
+    }
+
+    public function test_get_nonexistent_throws_exception(): void
+    {
+        $this->expectException(ToolNotFoundException::class);
+
+        $this->registry->get('nonexistent.tool');
+    }
+
+    public function test_has_returns_correct_boolean(): void
+    {
+        $tool = $this->createMockTool('exists.tool');
+        $this->registry->register($tool);
+
+        expect($this->registry->has('exists.tool'))->toBeTrue();
+        expect($this->registry->has('missing.tool'))->toBeFalse();
+    }
+
+    public function test_get_all_tools_returns_all_registered(): void
+    {
+        $tool1 = $this->createMockTool('all.tool1');
+        $tool2 = $this->createMockTool('all.tool2');
+
+        $this->registry->register($tool1);
+        $this->registry->register($tool2);
+
+        $all = $this->registry->getAllTools();
+
+        expect($all)->toBeArray();
+        expect(count($all))->toBe(2);
+    }
+
+    public function test_unregister_removes_tool(): void
+    {
+        $tool = $this->createMockTool('removable.tool');
+        $this->registry->register($tool);
+
+        expect($this->registry->has('removable.tool'))->toBeTrue();
+
+        $this->registry->unregister('removable.tool');
+
+        expect($this->registry->has('removable.tool'))->toBeFalse();
+    }
+}

--- a/tests/Unit/Domain/AI/Services/ConversationServiceTest.php
+++ b/tests/Unit/Domain/AI/Services/ConversationServiceTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\AI\Services;
+
+use App\Domain\AI\Services\ConversationService;
+use Tests\TestCase;
+
+class ConversationServiceTest extends TestCase
+{
+    private ConversationService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['cache.default' => 'array']);
+        $this->service = new ConversationService();
+    }
+
+    public function test_get_or_create_returns_new_conversation(): void
+    {
+        $conversationId = 'conv-' . uniqid();
+        $result = $this->service->getOrCreate($conversationId, 1);
+
+        expect($result)->toBeArray();
+        expect($result)->toHaveKeys(['id', 'user_id', 'messages', 'created_at', 'updated_at']);
+        expect($result['id'])->toBe($conversationId);
+        expect($result['user_id'])->toBe(1);
+        expect($result['messages'])->toBeArray();
+    }
+
+    public function test_get_or_create_returns_existing_conversation(): void
+    {
+        $conversationId = 'conv-existing-' . uniqid();
+        $first = $this->service->getOrCreate($conversationId, 1);
+        $second = $this->service->getOrCreate($conversationId, 1);
+
+        expect($second['id'])->toBe($first['id']);
+        expect($second['user_id'])->toBe($first['user_id']);
+    }
+
+    public function test_get_user_conversations_returns_array(): void
+    {
+        $conversations = $this->service->getUserConversations(1, 5);
+
+        expect($conversations)->toBeArray();
+
+        if (count($conversations) > 0) {
+            $first = $conversations[0];
+            expect($first)->toHaveKeys(['id', 'title', 'last_message', 'message_count']);
+        }
+    }
+
+    public function test_get_conversation_returns_null_for_nonexistent(): void
+    {
+        $result = $this->service->getConversation('nonexistent-conv-id', 999);
+
+        // Returns either null or demo data depending on implementation
+        if ($result !== null) {
+            expect($result)->toBeArray();
+            expect($result)->toHaveKey('id');
+        } else {
+            expect($result)->toBeNull();
+        }
+    }
+
+    public function test_delete_conversation_returns_bool(): void
+    {
+        $conversationId = 'conv-delete-' . uniqid();
+        $this->service->getOrCreate($conversationId, 1);
+
+        $result = $this->service->deleteConversation($conversationId, 1);
+
+        expect($result)->toBeBool();
+    }
+
+    public function test_delete_conversation_fails_for_wrong_user(): void
+    {
+        $conversationId = 'conv-wrong-user-' . uniqid();
+        $this->service->getOrCreate($conversationId, 1);
+
+        $result = $this->service->deleteConversation($conversationId, 999);
+
+        expect($result)->toBeFalse();
+    }
+
+    public function test_get_user_conversations_respects_limit(): void
+    {
+        $conversations = $this->service->getUserConversations(1, 3);
+
+        expect($conversations)->toBeArray();
+        expect(count($conversations))->toBeLessThanOrEqual(3);
+    }
+}

--- a/tests/Unit/Domain/AI/Services/LLMFallbackTest.php
+++ b/tests/Unit/Domain/AI/Services/LLMFallbackTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\AI\Services;
+
+use App\Domain\AI\Contracts\LLMProviderInterface;
+use App\Domain\AI\Models\AiLlmUsage;
+use App\Domain\AI\Services\LLMOrchestrationService;
+use App\Domain\AI\ValueObjects\LLMResponse;
+use Mockery;
+use Mockery\MockInterface;
+use Tests\TestCase;
+
+class LLMFallbackTest extends TestCase
+{
+    private LLMOrchestrationService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['cache.default' => 'array']);
+        $this->service = app(LLMOrchestrationService::class);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_demo_mode_returns_response_without_provider(): void
+    {
+        $this->service->setDemoMode(true);
+
+        $response = $this->service->complete(
+            'You are a banking assistant.',
+            'What is my balance?'
+        );
+
+        expect($response)->toBeInstanceOf(LLMResponse::class);
+        expect($response->provider)->toBe(AiLlmUsage::PROVIDER_DEMO);
+        expect($response->isError())->toBeFalse();
+        expect($response->content)->not->toBeEmpty();
+    }
+
+    public function test_demo_mode_responds_to_transfer_keywords(): void
+    {
+        $this->service->setDemoMode(true);
+
+        $response = $this->service->complete(
+            'You are a banking assistant.',
+            'I want to transfer money to John'
+        );
+
+        expect($response)->toBeInstanceOf(LLMResponse::class);
+        expect($response->content)->not->toBeEmpty();
+    }
+
+    public function test_demo_mode_responds_to_spending_keywords(): void
+    {
+        $this->service->setDemoMode(true);
+
+        $response = $this->service->complete(
+            'You are a spending analyst.',
+            'Analyze my spending patterns'
+        );
+
+        expect($response)->toBeInstanceOf(LLMResponse::class);
+        expect($response->content)->not->toBeEmpty();
+    }
+
+    public function test_is_demo_mode_reflects_config(): void
+    {
+        $this->service->setDemoMode(true);
+        expect($this->service->isDemoMode())->toBeTrue();
+
+        $this->service->setDemoMode(false);
+        expect($this->service->isDemoMode())->toBeFalse();
+    }
+
+    public function test_get_available_providers_returns_array(): void
+    {
+        $providers = $this->service->getAvailableProviders();
+
+        expect($providers)->toBeArray();
+    }
+
+    public function test_register_provider_adds_to_available(): void
+    {
+        /** @var LLMProviderInterface&MockInterface $provider */
+        $provider = Mockery::mock(LLMProviderInterface::class);
+        $provider->shouldReceive('getName')->andReturn('test-provider');
+
+        $this->service->registerProvider('test-provider', $provider);
+
+        expect($this->service->getAvailableProviders())->toContain('test-provider');
+    }
+
+    public function test_complete_with_conversation_id(): void
+    {
+        $this->service->setDemoMode(true);
+
+        $response = $this->service->complete(
+            'You are a banking assistant.',
+            'Show my recent transactions',
+            [],
+            'conv-test-123'
+        );
+
+        expect($response)->toBeInstanceOf(LLMResponse::class);
+        expect($response->isError())->toBeFalse();
+    }
+
+    public function test_handle_failure_returns_error_response(): void
+    {
+        $this->service->setDemoMode(false);
+
+        // With no real providers configured, this should handle gracefully
+        $response = $this->service->complete(
+            'System prompt',
+            'Test message'
+        );
+
+        // Should return either a demo response or an error response, not throw
+        expect($response)->toBeInstanceOf(LLMResponse::class);
+    }
+}

--- a/tests/Unit/Helpers/SchemaHelperTest.php
+++ b/tests/Unit/Helpers/SchemaHelperTest.php
@@ -71,10 +71,7 @@ class SchemaHelperTest extends TestCase
         $this->assertEquals('https://schema.org', $schema['@context']);
         $this->assertEquals('WebSite', $schema['@type']);
         $this->assertEquals(config('brand.name', 'Zelta'), $schema['name']);
-        $this->assertArrayHasKey('potentialAction', $schema);
-        $this->assertEquals('SearchAction', $schema['potentialAction']['@type']);
-        $this->assertArrayHasKey('target', $schema['potentialAction']);
-        $this->assertStringContainsString('{search_term_string}', $schema['potentialAction']['target']['urlTemplate']);
+        $this->assertArrayHasKey('url', $schema);
     }
 
     #[Test]

--- a/tests/Unit/Infrastructure/AI/Storage/ConversationStoreExtendedTest.php
+++ b/tests/Unit/Infrastructure/AI/Storage/ConversationStoreExtendedTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Infrastructure\AI\Storage;
+
+use App\Domain\AI\ValueObjects\ConversationContext;
+use App\Infrastructure\AI\Storage\ConversationStore;
+use Illuminate\Support\Facades\Redis;
+use Tests\TestCase;
+use Throwable;
+
+class ConversationStoreExtendedTest extends TestCase
+{
+    private ConversationStore $store;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Skip if Redis is not available
+        try {
+            $connection = Redis::connection();
+            $connection->ping();
+        } catch (Throwable) {
+            $this->markTestSkipped('Redis is not available');
+        }
+
+        $this->store = app(ConversationStore::class);
+    }
+
+    public function test_store_and_retrieve_conversation(): void
+    {
+        $convId = 'test-conv-' . uniqid();
+        $context = new ConversationContext(
+            conversationId: $convId,
+            userId: 'user-123',
+        );
+
+        $this->store->store($context);
+
+        $retrieved = $this->store->retrieve($convId);
+
+        self::assertNotNull($retrieved);
+        self::assertInstanceOf(ConversationContext::class, $retrieved);
+        expect($retrieved->getConversationId())->toBe($convId);
+        expect($retrieved->getUserId())->toBe('user-123');
+
+        // Cleanup
+        $this->store->delete($convId);
+    }
+
+    public function test_retrieve_returns_null_for_missing(): void
+    {
+        $result = $this->store->retrieve('nonexistent-conv-' . uniqid());
+
+        expect($result)->toBeNull();
+    }
+
+    public function test_add_message_updates_context(): void
+    {
+        $convId = 'test-msg-' . uniqid();
+        $context = new ConversationContext(
+            conversationId: $convId,
+            userId: 'user-456',
+        );
+
+        $this->store->store($context);
+        $this->store->addMessage($convId, 'user', 'Hello, what is my balance?');
+
+        $retrieved = $this->store->retrieve($convId);
+
+        self::assertNotNull($retrieved);
+        self::assertInstanceOf(ConversationContext::class, $retrieved);
+
+        $messages = $retrieved->getMessages();
+        expect($messages)->not->toBeEmpty();
+
+        $lastMessage = end($messages);
+        if (is_array($lastMessage)) {
+            expect($lastMessage['role'])->toBe('user');
+            expect($lastMessage['content'])->toContain('balance');
+        }
+
+        // Cleanup
+        $this->store->delete($convId);
+    }
+
+    public function test_delete_removes_conversation(): void
+    {
+        $convId = 'test-delete-' . uniqid();
+        $context = new ConversationContext(
+            conversationId: $convId,
+            userId: 'user-789',
+        );
+
+        $this->store->store($context);
+        expect($this->store->retrieve($convId))->not->toBeNull();
+
+        $this->store->delete($convId);
+        expect($this->store->retrieve($convId))->toBeNull();
+    }
+
+    public function test_get_user_conversations_returns_array(): void
+    {
+        $userId = 'user-list-' . uniqid();
+        $convId = 'test-list-' . uniqid();
+        $context = new ConversationContext(
+            conversationId: $convId,
+            userId: $userId,
+        );
+
+        $this->store->store($context);
+
+        $conversations = $this->store->getUserConversations($userId, 10);
+
+        expect($conversations)->toBeArray();
+
+        // Cleanup
+        $this->store->delete($convId);
+    }
+
+    public function test_clear_user_conversations_removes_all(): void
+    {
+        $userId = 'user-clear-' . uniqid();
+
+        for ($i = 0; $i < 3; $i++) {
+            $context = new ConversationContext(
+                conversationId: 'test-clear-' . $i . '-' . uniqid(),
+                userId: $userId,
+            );
+            $this->store->store($context);
+        }
+
+        $this->store->clearUserConversations($userId);
+
+        $conversations = $this->store->getUserConversations($userId, 10);
+        expect($conversations)->toBeEmpty();
+    }
+
+    public function test_store_with_custom_ttl(): void
+    {
+        $convId = 'test-ttl-' . uniqid();
+        $context = new ConversationContext(
+            conversationId: $convId,
+            userId: 'user-ttl',
+        );
+
+        $this->store->store($context, 60);
+
+        $retrieved = $this->store->retrieve($convId);
+        expect($retrieved)->not->toBeNull();
+
+        // Cleanup
+        $this->store->delete($convId);
+    }
+}


### PR DESCRIPTION
## Summary
- **AI Framework page rewrite**: Now shows all 6 agents, 24 MCP tools, workflow engine, ML detection models, LLM integration details
- **New Agent Protocol page**: DID auth, A2A messaging, escrow, reputation, AP2 mandates (Cart/Intent/Payment), KYC tiers, 10 event-sourced aggregates
- **OpenAPI documentation**: Added annotations to 5 controllers (SMS, MPP Status/Payment/Resource, VertexSMS DLR) — 18 new endpoints in API docs
- **API version update**: OpenAPI spec 5.1.5→6.5.0, 43→49 DDD domains
- **Prompt template seeder**: 8 templates covering query, analysis, compliance, trading, transfer, anomaly detection
- **42 new tests**: ConversationService, ToolRegistry, LLM fallback, ConversationStore, feature page renders
- **Fix**: SchemaHelperTest SearchAction assertion (removed in #825)

## Test plan
- [ ] `php artisan l5-swagger:generate` — regenerates API docs with SMS/MPP endpoints
- [ ] Visit `/features/ai-framework` — shows 6 agents, 24 tools, workflow engine
- [ ] Visit `/features/agent-protocol` — shows DID, A2A, escrow, reputation, mandates
- [ ] Visit `/features` — shows both AI Framework (24 Tools badge) and Agent Protocol (New badge)
- [ ] API docs at `/developers/api-docs` — SMS and Machine Payments tags visible
- [ ] `php artisan db:seed --class=AiPromptTemplateSeeder` — seeds 8 prompt templates
- [ ] All 42 new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)