### PR TITLE
feat: add .well-known/x402-configuration discovery endpoint

### DIFF
--- a/app/Domain/X402/Routes/api.php
+++ b/app/Domain/X402/Routes/api.php
@@ -8,6 +8,10 @@ use App\Http\Controllers\Api\X402\X402SpendingLimitController;
 use App\Http\Controllers\Api\X402\X402StatusController;
 use Illuminate\Support\Facades\Route;
 
+// Well-known discovery endpoint
+Route::get('/.well-known/x402-configuration', [X402StatusController::class, 'wellKnown'])
+    ->name('api.x402.well-known');
+
 Route::prefix('v1/x402')->name('api.x402.')->group(function () {
     // Public endpoints
     Route::get('/status', [X402StatusController::class, 'status'])->name('status');

--- a/app/Domain/X402/Services/X402DiscoveryService.php
+++ b/app/Domain/X402/Services/X402DiscoveryService.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\X402\Services;
+
+use App\Domain\X402\Enums\X402Network;
+
+/**
+ * X402 discovery service.
+ *
+ * Generates the .well-known/x402-configuration discovery document
+ * for protocol auto-discovery, following the same pattern as MPP.
+ */
+class X402DiscoveryService
+{
+    /**
+     * Generate the .well-known/x402-configuration discovery document.
+     *
+     * @return array<string, mixed>
+     */
+    public function getWellKnownConfiguration(): array
+    {
+        return [
+            'x402_version'       => (int) config('x402.version', 2),
+            'issuer'             => config('app.url'),
+            'spec_url'           => 'https://x402.org',
+            'default_network'    => config('x402.server.default_network', 'eip155:8453'),
+            'supported_networks' => collect(X402Network::cases())->map(fn (X402Network $n): array => [
+                'id'      => $n->value,
+                'name'    => $n->label(),
+                'testnet' => $n->isTestnet(),
+            ])->values()->all(),
+            'supported_assets'  => ['USDC'],
+            'supported_schemes' => ['exact'],
+            'pay_to'            => (string) config('x402.server.pay_to', ''),
+            'facilitator'       => [
+                'url'         => config('x402.facilitator.url', 'https://x402.org/facilitator'),
+                'self_hosted' => (bool) config('x402.facilitator.self_hosted', false),
+            ],
+            'endpoints' => [
+                'status'          => url('/api/v1/x402/status'),
+                'supported'       => url('/api/v1/x402/supported'),
+                'endpoints'       => url('/api/v1/x402/endpoints'),
+                'payments'        => url('/api/v1/x402/payments'),
+                'spending_limits' => url('/api/v1/x402/spending-limits'),
+            ],
+            'contracts' => (array) config('x402.contracts', []),
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/X402/X402StatusController.php
+++ b/app/Http/Controllers/Api/X402/X402StatusController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api\X402;
 
 use App\Domain\X402\Enums\X402Network;
+use App\Domain\X402\Services\X402DiscoveryService;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use OpenApi\Attributes as OA;
@@ -78,6 +79,43 @@ class X402StatusController extends Controller
         ]),
         ])
     )]
+    /**
+     * Well-known x402 protocol discovery endpoint.
+     */
+    #[OA\Get(
+        path: '/.well-known/x402-configuration',
+        operationId: 'x402WellKnown',
+        summary: 'x402 protocol discovery endpoint',
+        tags: ['X402 Protocol']
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'x402 protocol discovery configuration',
+        content: new OA\JsonContent(properties: [
+        new OA\Property(property: 'x402_version', type: 'integer', example: 2),
+        new OA\Property(property: 'issuer', type: 'string'),
+        new OA\Property(property: 'spec_url', type: 'string'),
+        new OA\Property(property: 'default_network', type: 'string', example: 'eip155:8453'),
+        new OA\Property(property: 'supported_networks', type: 'array', items: new OA\Items(properties: [
+        new OA\Property(property: 'id', type: 'string'),
+        new OA\Property(property: 'name', type: 'string'),
+        new OA\Property(property: 'testnet', type: 'boolean'),
+        ])),
+        new OA\Property(property: 'supported_assets', type: 'array', items: new OA\Items(type: 'string')),
+        new OA\Property(property: 'supported_schemes', type: 'array', items: new OA\Items(type: 'string')),
+        new OA\Property(property: 'facilitator', type: 'object'),
+        new OA\Property(property: 'endpoints', type: 'object'),
+        new OA\Property(property: 'contracts', type: 'object'),
+        ])
+    )]
+    public function wellKnown(X402DiscoveryService $discovery): JsonResponse
+    {
+        return response()->json($discovery->getWellKnownConfiguration());
+    }
+
+    /**
+     * Get supported networks and assets.
+     */
     public function supported(): JsonResponse
     {
         $networks = collect(X402Network::cases())->map(fn (X402Network $n) => [

--- a/app/Providers/X402ServiceProvider.php
+++ b/app/Providers/X402ServiceProvider.php
@@ -8,6 +8,7 @@ use App\Domain\X402\Contracts\FacilitatorClientInterface;
 use App\Domain\X402\Contracts\X402SignerInterface;
 use App\Domain\X402\Services\HttpFacilitatorClient;
 use App\Domain\X402\Services\X402ClientService;
+use App\Domain\X402\Services\X402DiscoveryService;
 use App\Domain\X402\Services\X402EIP712SignerService;
 use App\Domain\X402\Services\X402HeaderCodecService;
 use App\Domain\X402\Services\X402PaymentVerificationService;
@@ -49,6 +50,7 @@ class X402ServiceProvider extends ServiceProvider
         });
 
         // Register core services as singletons
+        $this->app->singleton(X402DiscoveryService::class);
         $this->app->singleton(X402HeaderCodecService::class);
         $this->app->singleton(X402PricingService::class);
 

--- a/tests/Feature/Api/X402/X402WellKnownTest.php
+++ b/tests/Feature/Api/X402/X402WellKnownTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+test('x402 well-known endpoint returns discovery configuration', function () {
+    config(['x402.enabled' => true]);
+    config(['x402.version' => 2]);
+
+    $response = $this->getJson('/api/.well-known/x402-configuration');
+
+    $response->assertOk();
+    $response->assertJsonStructure([
+        'x402_version',
+        'issuer',
+        'spec_url',
+        'default_network',
+        'supported_networks' => [
+            '*' => ['id', 'name', 'testnet'],
+        ],
+        'supported_assets',
+        'supported_schemes',
+        'pay_to',
+        'facilitator' => ['url', 'self_hosted'],
+        'endpoints'   => ['status', 'supported', 'endpoints', 'payments', 'spending_limits'],
+        'contracts',
+    ]);
+    $response->assertJsonFragment(['x402_version' => 2]);
+    $response->assertJsonFragment(['spec_url' => 'https://x402.org']);
+});
+
+test('x402 well-known endpoint includes all networks', function () {
+    $response = $this->getJson('/api/.well-known/x402-configuration');
+
+    $response->assertOk();
+
+    $networks = $response->json('supported_networks');
+    $networkIds = array_column($networks, 'id');
+
+    expect($networkIds)->toContain('eip155:8453');
+    expect($networkIds)->toContain('solana:mainnet');
+    expect($networks)->toHaveCount(8);
+});
+
+test('x402 well-known endpoint includes contracts', function () {
+    $response = $this->getJson('/api/.well-known/x402-configuration');
+
+    $response->assertOk();
+    $response->assertJsonFragment([
+        'permit2' => '0x000000000022D473030F116dDEE9F6B43aC78BA3',
+    ]);
+});
+
+test('x402 well-known endpoint does not require authentication', function () {
+    $response = $this->getJson('/api/.well-known/x402-configuration');
+
+    $response->assertOk();
+});


### PR DESCRIPTION
## Summary
- Adds `/.well-known/x402-configuration` discovery endpoint for x402 protocol auto-discovery
- Mirrors existing MPP pattern (`/.well-known/mpp-configuration` via `MppDiscoveryService`)
- Returns supported networks, facilitator config, contract addresses, and API endpoint URLs
- Public endpoint (no auth required) with OpenAPI annotations

## Changes
- **New:** `X402DiscoveryService` — generates structured discovery document
- **Modified:** `X402StatusController` — added `wellKnown()` method
- **Modified:** `X402 Routes` — registered well-known route outside prefix group
- **Modified:** `X402ServiceProvider` — registered discovery service singleton
- **New:** 4 feature tests covering structure, networks, contracts, and unauthenticated access

## Test plan
- [x] PHPStan Level 8 passes
- [x] php-cs-fixer passes
- [x] 4 new tests + 5 existing x402 tests pass (9 total)
- [ ] CI/CD pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)