### PR TITLE
feat: add protocol-specific subdomain routing for x402 and MPP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -466,6 +466,7 @@ X402_CLIENT_MAX_AUTO_PAY=100000
 X402_AGENT_DAILY_LIMIT=5000000
 X402_REQUIRE_APPROVAL_ABOVE=1000000
 X402_PER_TRANSACTION_LIMIT=100000
+X402_SUBDOMAIN=x402
 
 # =============================================================================
 # VISA CLI INTEGRATION
@@ -522,6 +523,7 @@ MPP_CLIENT_AUTO_PAY=false
 MPP_DAILY_LIMIT=5000
 MPP_PER_TX_LIMIT=100
 MPP_MCP_ENABLED=true
+MPP_SUBDOMAIN=mpp
 
 # =============================================================================
 # SMS SERVICE (VertexSMS)

--- a/app/Http/Middleware/ProtocolSubdomainMiddleware.php
+++ b/app/Http/Middleware/ProtocolSubdomainMiddleware.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Detects x402 or MPP protocol-specific subdomains and automatically
+ * applies the corresponding payment gate middleware.
+ *
+ * Supports subdomains like:
+ * - x402.api.zelta.app  → applies X402PaymentGateMiddleware
+ * - mpp.api.zelta.app   → applies MppPaymentGateMiddleware
+ * - x402.zelta.app      → same (api. prefix optional)
+ * - mpp.zelta.app       → same
+ */
+class ProtocolSubdomainMiddleware
+{
+    public function __construct(
+        private readonly X402PaymentGateMiddleware $x402Gate,
+        private readonly MppPaymentGateMiddleware $mppGate,
+    ) {
+    }
+
+    /**
+     * @param Closure(Request): Response $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $host = $request->getHost();
+        $x402Prefix = (string) config('x402.subdomain', 'x402');
+        $mppPrefix = (string) config('machinepay.subdomain', 'mpp');
+
+        if ($this->matchesProtocolSubdomain($host, $x402Prefix)) {
+            $request->attributes->set('payment_protocol', 'x402');
+
+            return $this->x402Gate->handle($request, $next);
+        }
+
+        if ($this->matchesProtocolSubdomain($host, $mppPrefix)) {
+            $request->attributes->set('payment_protocol', 'mpp');
+
+            return $this->mppGate->handle($request, $next);
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * Check if the host matches a protocol subdomain pattern.
+     *
+     * Matches "proto.api.domain.com" and "proto.domain.com" but excludes
+     * the plain "api." subdomain to avoid false positives.
+     */
+    private function matchesProtocolSubdomain(string $host, string $prefix): bool
+    {
+        return str_starts_with($host, "{$prefix}.api.")
+            || (str_starts_with($host, "{$prefix}.") && ! str_starts_with($host, 'api.'));
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -14,7 +14,9 @@ use Illuminate\Support\Facades\View;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         using: function () {
-            $isApiSubdomain = str_starts_with(request()->getHost(), 'api.');
+            $host = request()->getHost();
+            $isApiSubdomain = str_starts_with($host, 'api.');
+            $isProtocolSubdomain = str_starts_with($host, 'x402.') || str_starts_with($host, 'mpp.');
 
             // Health check route — must be registered inside `using` callback
             // because Laravel skips buildRoutingCallback when `using` is provided
@@ -22,8 +24,8 @@ return Application::configure(basePath: dirname(__DIR__))
                 $exception = null;
 
                 try {
-                    Event::dispatch(new DiagnosingHealth);
-                } catch (\Throwable $e) {
+                    Event::dispatch(new DiagnosingHealth());
+                } catch (Throwable $e) {
                     if (app()->hasDebugModeEnabled()) {
                         throw $e;
                     }
@@ -41,7 +43,19 @@ return Application::configure(basePath: dirname(__DIR__))
             // Always load console routes
             Route::group([], base_path('routes/console.php'));
 
-            if ($isApiSubdomain) {
+            if ($isProtocolSubdomain) {
+                // For x402.* or mpp.* subdomains, load API routes without /api prefix
+                // and auto-apply the protocol payment gate middleware via ProtocolSubdomainMiddleware
+                Route::middleware(['api', 'protocol.subdomain'])
+                    ->group(base_path('routes/api.php'));
+
+                Route::middleware(['api', 'protocol.subdomain'])
+                    ->group(base_path('routes/api-bian.php'));
+
+                Route::middleware(['api', 'protocol.subdomain'])
+                    ->prefix('v2')
+                    ->group(base_path('routes/api-v2.php'));
+            } elseif ($isApiSubdomain) {
                 // For api.* subdomain, ONLY load API routes without /api prefix
                 Route::middleware('api')
                     ->group(base_path('routes/api.php'));
@@ -117,6 +131,8 @@ return Application::configure(basePath: dirname(__DIR__))
             'x402.payment' => App\Http\Middleware\X402PaymentGateMiddleware::class,
             // Machine Payments Protocol middleware (v6.4.0)
             'mpp.payment' => App\Http\Middleware\MppPaymentGateMiddleware::class,
+            // Protocol subdomain auto-detection (v6.5.0)
+            'protocol.subdomain' => App\Http\Middleware\ProtocolSubdomainMiddleware::class,
         ]);
 
         // Prepend CORS middleware to handle it before other middleware
@@ -162,8 +178,9 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withExceptions(function (Exceptions $exceptions) {
         // Treat 'demo' environment as production for error handling
         $exceptions->shouldRenderJsonWhen(function ($request, $e) {
-            // Check if we're on the API subdomain
-            if (str_starts_with($request->getHost(), 'api.')) {
+            // Check if we're on the API or protocol subdomain
+            $reqHost = $request->getHost();
+            if (str_starts_with($reqHost, 'api.') || str_starts_with($reqHost, 'x402.') || str_starts_with($reqHost, 'mpp.')) {
                 return true;
             }
 
@@ -180,7 +197,8 @@ return Application::configure(basePath: dirname(__DIR__))
                 return $response;
             }
 
-            $isApi = $request->is('api/*') || str_starts_with($request->getHost(), 'api.') || $request->expectsJson();
+            $errHost = $request->getHost();
+            $isApi = $request->is('api/*') || str_starts_with($errHost, 'api.') || str_starts_with($errHost, 'x402.') || str_starts_with($errHost, 'mpp.') || $request->expectsJson();
             if (! $isApi) {
                 return $response;
             }
@@ -189,15 +207,15 @@ return Application::configure(basePath: dirname(__DIR__))
 
             // Map exception types to error codes
             $errorCode = match (true) {
-                $e instanceof Illuminate\Validation\ValidationException => 'VALIDATION_ERROR',
-                $e instanceof Illuminate\Auth\AuthenticationException => 'UNAUTHENTICATED',
-                $e instanceof Illuminate\Auth\Access\AuthorizationException => 'FORBIDDEN',
-                $e instanceof Illuminate\Database\Eloquent\ModelNotFoundException => 'NOT_FOUND',
-                $e instanceof Symfony\Component\HttpKernel\Exception\NotFoundHttpException => 'NOT_FOUND',
+                $e instanceof Illuminate\Validation\ValidationException                            => 'VALIDATION_ERROR',
+                $e instanceof Illuminate\Auth\AuthenticationException                              => 'UNAUTHENTICATED',
+                $e instanceof Illuminate\Auth\Access\AuthorizationException                        => 'FORBIDDEN',
+                $e instanceof Illuminate\Database\Eloquent\ModelNotFoundException                  => 'NOT_FOUND',
+                $e instanceof Symfony\Component\HttpKernel\Exception\NotFoundHttpException         => 'NOT_FOUND',
                 $e instanceof Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException => 'METHOD_NOT_ALLOWED',
-                $e instanceof Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException => 'RATE_LIMITED',
-                $e instanceof Symfony\Component\HttpKernel\Exception\HttpException => 'HTTP_ERROR',
-                default => 'SERVER_ERROR',
+                $e instanceof Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException  => 'RATE_LIMITED',
+                $e instanceof Symfony\Component\HttpKernel\Exception\HttpException                 => 'HTTP_ERROR',
+                default                                                                            => 'SERVER_ERROR',
             };
 
             // Add standardized fields without overwriting existing ones

--- a/config/machinepay.php
+++ b/config/machinepay.php
@@ -19,6 +19,9 @@ return [
 
     'version' => 1,
 
+    // Subdomain prefix for protocol-specific routing (e.g. mpp.api.zelta.app)
+    'subdomain' => env('MPP_SUBDOMAIN', 'mpp'),
+
     /*
     |--------------------------------------------------------------------------
     | Server Settings

--- a/config/x402.php
+++ b/config/x402.php
@@ -18,6 +18,9 @@ return [
 
     'version' => 2,
 
+    // Subdomain prefix for protocol-specific routing (e.g. x402.api.zelta.app)
+    'subdomain' => env('X402_SUBDOMAIN', 'x402'),
+
     /*
     |--------------------------------------------------------------------------
     | Resource Server Settings

--- a/tests/Feature/Subdomain/ProtocolSubdomainTest.php
+++ b/tests/Feature/Subdomain/ProtocolSubdomainTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Middleware\ProtocolSubdomainMiddleware;
+use App\Http\Middleware\X402PaymentGateMiddleware;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+describe('ProtocolSubdomainMiddleware', function (): void {
+    it('sets x402 payment protocol for x402.api subdomain', function (): void {
+        $middleware = app(ProtocolSubdomainMiddleware::class);
+        $request = Request::create('https://x402.api.zelta.app/v1/x402/status');
+        $request->headers->set('host', 'x402.api.zelta.app');
+
+        $response = $middleware->handle($request, function (Request $req): Response {
+            // The middleware delegates to X402PaymentGateMiddleware which may
+            // pass through if x402 is not enabled or no monetized endpoint matches
+            return new Response('ok');
+        });
+
+        expect($request->attributes->get('payment_protocol'))->toBe('x402');
+    });
+
+    it('sets mpp payment protocol for mpp.api subdomain', function (): void {
+        $middleware = app(ProtocolSubdomainMiddleware::class);
+        $request = Request::create('https://mpp.api.zelta.app/v1/mpp/status');
+        $request->headers->set('host', 'mpp.api.zelta.app');
+
+        $response = $middleware->handle($request, function (Request $req): Response {
+            return new Response('ok');
+        });
+
+        expect($request->attributes->get('payment_protocol'))->toBe('mpp');
+    });
+
+    it('sets x402 protocol for bare x402 subdomain', function (): void {
+        $middleware = app(ProtocolSubdomainMiddleware::class);
+        $request = Request::create('https://x402.zelta.app/v1/x402/status');
+        $request->headers->set('host', 'x402.zelta.app');
+
+        $response = $middleware->handle($request, function (Request $req): Response {
+            return new Response('ok');
+        });
+
+        expect($request->attributes->get('payment_protocol'))->toBe('x402');
+    });
+
+    it('does not set protocol for regular api subdomain', function (): void {
+        $middleware = app(ProtocolSubdomainMiddleware::class);
+        $request = Request::create('https://api.zelta.app/v1/x402/status');
+        $request->headers->set('host', 'api.zelta.app');
+
+        $response = $middleware->handle($request, function (Request $req): Response {
+            return new Response('ok');
+        });
+
+        expect($request->attributes->get('payment_protocol'))->toBeNull();
+    });
+
+    it('does not set protocol for main domain', function (): void {
+        $middleware = app(ProtocolSubdomainMiddleware::class);
+        $request = Request::create('https://zelta.app/api/v1/x402/status');
+        $request->headers->set('host', 'zelta.app');
+
+        $response = $middleware->handle($request, function (Request $req): Response {
+            return new Response('ok');
+        });
+
+        expect($request->attributes->get('payment_protocol'))->toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
- Adds `x402.api.zelta.app` and `mpp.api.zelta.app` as convenience subdomains
- Auto-applies the respective payment gate middleware (x402 or MPP) to all API routes
- Consumers choose their payment protocol at DNS level, inspired by AgentMail's pattern

## Changes
- **New:** `ProtocolSubdomainMiddleware` — detects `x402.*` or `mpp.*` hostname prefix, delegates to appropriate payment gate
- **Modified:** `bootstrap/app.php` — protocol subdomain detection, routing with middleware, JSON error rendering
- **Modified:** `config/x402.php` — `X402_SUBDOMAIN` env var
- **Modified:** `config/machinepay.php` — `MPP_SUBDOMAIN` env var
- **Modified:** `.env.example` — new subdomain vars
- **New:** 5 tests covering all subdomain patterns and negative cases

## Test plan
- [x] PHPStan Level 8 passes (middleware)
- [x] php-cs-fixer passes
- [x] 5 new tests pass
- [ ] CI/CD pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)