### PR TITLE
feat: expand Zelta CLI to v0.2.0 — 25 commands across 8 groups

### DIFF
--- a/packages/zelta-cli/app/Commands/Agents/DiscoverCommand.php
+++ b/packages/zelta-cli/app/Commands/Agents/DiscoverCommand.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZeltaCli\Commands\Agents;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use ZeltaCli\Concerns\HasJsonOutput;
+use ZeltaCli\Concerns\RequiresAuth;
+use ZeltaCli\Services\ApiClient;
+use ZeltaCli\Services\AuthManager;
+use ZeltaCli\Services\OutputFormatter;
+
+/**
+ * zelta agents discover [--capability payment].
+ */
+class DiscoverCommand extends Command
+{
+    use HasJsonOutput;
+    use RequiresAuth;
+
+    public function __construct()
+    {
+        parent::__construct('agents:discover');
+        $this->setDescription('Discover available AI agents');
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('capability', null, InputOption::VALUE_OPTIONAL, 'Filter by capability (e.g., payment)')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Output as JSON');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $formatter = new OutputFormatter($output);
+        $auth = new AuthManager();
+
+        if (! $this->ensureAuthenticated($auth)) {
+            return 2;
+        }
+
+        $api = new ApiClient($auth);
+        $query = array_filter(['capability' => $input->getOption('capability')]);
+        $result = $api->get('/v1/agent-protocol/agents/discover', $query);
+
+        if ($result['status'] !== 200) {
+            $formatter->error('API_ERROR', $result['body']['message'] ?? 'Failed to discover agents');
+
+            return Command::FAILURE;
+        }
+
+        $agents = $result['body']['data'] ?? [];
+
+        if ($this->shouldOutputJson($input)) {
+            $formatter->json($agents);
+        } else {
+            if ($agents === []) {
+                $formatter->success('No agents found.');
+
+                return Command::SUCCESS;
+            }
+
+            $rows = array_map(fn (array $a) => [
+                $a['did'] ?? '',
+                $a['name'] ?? '',
+                implode(', ', $a['capabilities'] ?? []),
+                $a['status'] ?? '',
+            ], $agents);
+
+            $formatter->table(['DID', 'Name', 'Capabilities', 'Status'], $rows);
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/zelta-cli/app/Commands/Agents/RegisterCommand.php
+++ b/packages/zelta-cli/app/Commands/Agents/RegisterCommand.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZeltaCli\Commands\Agents;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use ZeltaCli\Concerns\HasJsonOutput;
+use ZeltaCli\Concerns\RequiresAuth;
+use ZeltaCli\Services\ApiClient;
+use ZeltaCli\Services\AuthManager;
+use ZeltaCli\Services\OutputFormatter;
+
+/**
+ * zelta agents register --did did:web:... --name <name> --capabilities payment,messaging.
+ */
+class RegisterCommand extends Command
+{
+    use HasJsonOutput;
+    use RequiresAuth;
+
+    public function __construct()
+    {
+        parent::__construct('agents:register');
+        $this->setDescription('Register a new AI agent');
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('did', null, InputOption::VALUE_REQUIRED, 'Agent DID (e.g., did:web:example.com)')
+            ->addOption('name', null, InputOption::VALUE_REQUIRED, 'Agent display name')
+            ->addOption('capabilities', null, InputOption::VALUE_OPTIONAL, 'Comma-separated capabilities (e.g., payment,messaging)')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Output as JSON');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $formatter = new OutputFormatter($output);
+        $auth = new AuthManager();
+
+        if (! $this->ensureAuthenticated($auth)) {
+            return 2;
+        }
+
+        /** @var string|null $did */
+        $did = $input->getOption('did');
+        /** @var string|null $name */
+        $name = $input->getOption('name');
+
+        if ($did === null || $name === null) {
+            $formatter->error('VALIDATION', 'Both --did and --name are required');
+
+            return 4;
+        }
+
+        /** @var string|null $capabilities */
+        $capabilities = $input->getOption('capabilities');
+
+        $payload = [
+            'did'  => $did,
+            'name' => $name,
+        ];
+
+        if ($capabilities !== null) {
+            $payload['capabilities'] = array_map('trim', explode(',', $capabilities));
+        }
+
+        $api = new ApiClient($auth);
+        $result = $api->post('/v1/agent-protocol/agents/register', $payload);
+
+        if ($result['status'] >= 400) {
+            $formatter->error('API_ERROR', $result['body']['message'] ?? "HTTP {$result['status']}");
+
+            return Command::FAILURE;
+        }
+
+        $formatter->output($result['body']['data'] ?? $result['body'], forceJson: $this->shouldOutputJson($input));
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/zelta-cli/app/Commands/Auth/LogoutCommand.php
+++ b/packages/zelta-cli/app/Commands/Auth/LogoutCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZeltaCli\Commands\Auth;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use ZeltaCli\Services\AuthManager;
+use ZeltaCli\Services\OutputFormatter;
+
+/**
+ * zelta auth logout [--profile <name>].
+ */
+class LogoutCommand extends Command
+{
+    public function __construct()
+    {
+        parent::__construct('auth:logout');
+        $this->setDescription('Log out and clear credentials');
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('profile', 'p', InputOption::VALUE_OPTIONAL, 'Profile to log out', 'default');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $formatter = new OutputFormatter($output);
+        $auth = new AuthManager();
+
+        /** @var string $profile */
+        $profile = $input->getOption('profile') ?? 'default';
+
+        if (! $auth->isAuthenticated($profile)) {
+            $formatter->error('NOT_AUTHENTICATED', "Profile '{$profile}' is not authenticated.");
+
+            return 2;
+        }
+
+        $auth->logout($profile);
+        $formatter->success("Logged out of profile '{$profile}'.");
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/zelta-cli/app/Commands/Auth/TokenCommand.php
+++ b/packages/zelta-cli/app/Commands/Auth/TokenCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZeltaCli\Commands\Auth;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use ZeltaCli\Concerns\HasJsonOutput;
+use ZeltaCli\Concerns\RequiresAuth;
+use ZeltaCli\Services\AuthManager;
+use ZeltaCli\Services\OutputFormatter;
+
+/**
+ * zelta auth token [--unmask].
+ */
+class TokenCommand extends Command
+{
+    use HasJsonOutput;
+    use RequiresAuth;
+
+    public function __construct()
+    {
+        parent::__construct('auth:token');
+        $this->setDescription('Show the current API token');
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('unmask', null, InputOption::VALUE_NONE, 'Show the full unmasked token')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Output as JSON');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $formatter = new OutputFormatter($output);
+        $auth = new AuthManager();
+
+        if (! $this->ensureAuthenticated($auth)) {
+            return 2;
+        }
+
+        $apiKey = $auth->getApiKey() ?? '';
+        $masked = $input->getOption('unmask')
+            ? $apiKey
+            : substr($apiKey, 0, 10) . str_repeat('*', max(0, strlen($apiKey) - 10));
+
+        $data = [
+            'profile' => $auth->getActiveProfile(),
+            'token'   => $masked,
+        ];
+
+        $formatter->output($data, forceJson: $this->shouldOutputJson($input));
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/zelta-cli/app/Commands/ConfigCommand.php
+++ b/packages/zelta-cli/app/Commands/ConfigCommand.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZeltaCli\Commands;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use ZeltaCli\Concerns\HasJsonOutput;
+use ZeltaCli\Services\OutputFormatter;
+
+/**
+ * zelta config [<key>] [<value>].
+ */
+class ConfigCommand extends Command
+{
+    use HasJsonOutput;
+
+    public function __construct()
+    {
+        parent::__construct('config');
+        $this->setDescription('View or update CLI configuration');
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('key', InputArgument::OPTIONAL, 'Configuration key to get or set')
+            ->addArgument('value', InputArgument::OPTIONAL, 'Value to set')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Output as JSON');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $formatter = new OutputFormatter($output);
+        $configPath = ($_SERVER['HOME'] ?? '') . '/.zelta/config.json';
+
+        $config = [];
+        if (file_exists($configPath)) {
+            $contents = file_get_contents($configPath);
+            $decoded = json_decode($contents ?: '{}', true);
+            $config = is_array($decoded) ? $decoded : [];
+        }
+
+        /** @var string|null $key */
+        $key = $input->getArgument('key');
+        /** @var string|null $value */
+        $value = $input->getArgument('value');
+
+        // Set a value
+        if ($key !== null && $value !== null) {
+            $config[$key] = $value;
+            $dir = dirname($configPath);
+            if (! is_dir($dir)) {
+                mkdir($dir, 0700, true);
+            }
+            file_put_contents($configPath, json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+            $formatter->success("Set {$key} = {$value}");
+
+            return Command::SUCCESS;
+        }
+
+        // Get a single value
+        if ($key !== null) {
+            if (! array_key_exists($key, $config)) {
+                $formatter->error('NOT_FOUND', "Configuration key '{$key}' not set.");
+
+                return Command::FAILURE;
+            }
+
+            $formatter->output([$key => $config[$key]], forceJson: $this->shouldOutputJson($input));
+
+            return Command::SUCCESS;
+        }
+
+        // Show all config
+        if ($config === []) {
+            $formatter->success('No configuration set. Usage: zelta config <key> <value>');
+
+            return Command::SUCCESS;
+        }
+
+        $formatter->output($config, forceJson: $this->shouldOutputJson($input));
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/zelta-cli/app/Commands/Limits/ListCommand.php
+++ b/packages/zelta-cli/app/Commands/Limits/ListCommand.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZeltaCli\Commands\Limits;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use ZeltaCli\Concerns\HasJsonOutput;
+use ZeltaCli\Concerns\RequiresAuth;
+use ZeltaCli\Services\ApiClient;
+use ZeltaCli\Services\AuthManager;
+use ZeltaCli\Services\OutputFormatter;
+
+/**
+ * zelta limits list.
+ */
+class ListCommand extends Command
+{
+    use HasJsonOutput;
+    use RequiresAuth;
+
+    public function __construct()
+    {
+        parent::__construct('limits:list');
+        $this->setDescription('List spending limits');
+    }
+
+    protected function configure(): void
+    {
+        $this->configureJsonOption();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $formatter = new OutputFormatter($output);
+        $auth = new AuthManager();
+
+        if (! $this->ensureAuthenticated($auth)) {
+            return 2;
+        }
+
+        $api = new ApiClient($auth);
+        $result = $api->get('/v1/x402/spending-limits');
+
+        if ($result['status'] !== 200) {
+            $formatter->error('API_ERROR', $result['body']['message'] ?? 'Failed to fetch spending limits');
+
+            return Command::FAILURE;
+        }
+
+        $limits = $result['body']['data'] ?? [];
+
+        if ($this->shouldOutputJson($input)) {
+            $formatter->json($limits);
+        } else {
+            if ($limits === []) {
+                $formatter->success('No spending limits configured.');
+
+                return Command::SUCCESS;
+            }
+
+            $rows = array_map(fn (array $l) => [
+                $l['agent_id'] ?? '',
+                $l['daily_limit'] ?? '-',
+                $l['per_tx_limit'] ?? '-',
+                ($l['auto_pay'] ?? false) ? 'yes' : 'no',
+                $l['created_at'] ?? '',
+            ], $limits);
+
+            $formatter->table(['Agent ID', 'Daily Limit', 'Per-TX Limit', 'Auto-Pay', 'Created'], $rows);
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/zelta-cli/app/Commands/Limits/RemoveCommand.php
+++ b/packages/zelta-cli/app/Commands/Limits/RemoveCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZeltaCli\Commands\Limits;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use ZeltaCli\Concerns\HasJsonOutput;
+use ZeltaCli\Concerns\RequiresAuth;
+use ZeltaCli\Services\ApiClient;
+use ZeltaCli\Services\AuthManager;
+use ZeltaCli\Services\OutputFormatter;
+
+/**
+ * zelta limits remove <agentId> [--yes].
+ */
+class RemoveCommand extends Command
+{
+    use HasJsonOutput;
+    use RequiresAuth;
+
+    public function __construct()
+    {
+        parent::__construct('limits:remove');
+        $this->setDescription('Remove spending limits for an agent');
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('agentId', InputArgument::REQUIRED, 'Agent ID to remove limits for')
+            ->addOption('yes', 'y', InputOption::VALUE_NONE, 'Skip confirmation prompt')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Output as JSON');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $formatter = new OutputFormatter($output);
+        $auth = new AuthManager();
+
+        if (! $this->ensureAuthenticated($auth)) {
+            return 2;
+        }
+
+        /** @var string $agentId */
+        $agentId = $input->getArgument('agentId');
+
+        if (! $input->getOption('yes')) {
+            $output->writeln("Remove spending limits for agent '{$agentId}'?");
+            $output->writeln('Use --yes to skip this confirmation.');
+
+            return Command::SUCCESS;
+        }
+
+        $api = new ApiClient($auth);
+        $result = $api->delete("/v1/x402/spending-limits/{$agentId}");
+
+        if ($result['status'] >= 400) {
+            $formatter->error('API_ERROR', $result['body']['message'] ?? "HTTP {$result['status']}");
+
+            return Command::FAILURE;
+        }
+
+        $formatter->success("Spending limits removed for agent '{$agentId}'.");
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/zelta-cli/app/Commands/Limits/SetCommand.php
+++ b/packages/zelta-cli/app/Commands/Limits/SetCommand.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZeltaCli\Commands\Limits;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use ZeltaCli\Concerns\HasJsonOutput;
+use ZeltaCli\Concerns\RequiresAuth;
+use ZeltaCli\Services\ApiClient;
+use ZeltaCli\Services\AuthManager;
+use ZeltaCli\Services\OutputFormatter;
+
+/**
+ * zelta limits set <agentId> --daily <amount> --per-tx <amount> [--auto-pay].
+ */
+class SetCommand extends Command
+{
+    use HasJsonOutput;
+    use RequiresAuth;
+
+    public function __construct()
+    {
+        parent::__construct('limits:set');
+        $this->setDescription('Set spending limits for an agent');
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('agentId', InputArgument::REQUIRED, 'Agent ID to set limits for')
+            ->addOption('daily', null, InputOption::VALUE_OPTIONAL, 'Daily spending limit')
+            ->addOption('per-tx', null, InputOption::VALUE_OPTIONAL, 'Per-transaction limit')
+            ->addOption('auto-pay', null, InputOption::VALUE_NONE, 'Enable automatic payments')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Output as JSON');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $formatter = new OutputFormatter($output);
+        $auth = new AuthManager();
+
+        if (! $this->ensureAuthenticated($auth)) {
+            return 2;
+        }
+
+        /** @var string $agentId */
+        $agentId = $input->getArgument('agentId');
+
+        $payload = array_filter([
+            'agent_id'     => $agentId,
+            'daily_limit'  => $input->getOption('daily'),
+            'per_tx_limit' => $input->getOption('per-tx'),
+            'auto_pay'     => $input->getOption('auto-pay') ?: null,
+        ]);
+
+        $api = new ApiClient($auth);
+        $result = $api->post('/v1/x402/spending-limits', $payload);
+
+        if ($result['status'] >= 400) {
+            $formatter->error('API_ERROR', $result['body']['message'] ?? "HTTP {$result['status']}");
+
+            return Command::FAILURE;
+        }
+
+        $formatter->output($result['body']['data'] ?? $result['body'], forceJson: $this->shouldOutputJson($input));
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/zelta-cli/app/Commands/Pay/SendCommand.php
+++ b/packages/zelta-cli/app/Commands/Pay/SendCommand.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZeltaCli\Commands\Pay;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use ZeltaCli\Concerns\HasJsonOutput;
+use ZeltaCli\Concerns\RequiresAuth;
+use ZeltaCli\Services\ApiClient;
+use ZeltaCli\Services\AuthManager;
+use ZeltaCli\Services\OutputFormatter;
+
+/**
+ * zelta pay send <url> [--amount <n>] [--network eip155:8453] [--yes].
+ */
+class SendCommand extends Command
+{
+    use HasJsonOutput;
+    use RequiresAuth;
+
+    public function __construct()
+    {
+        parent::__construct('pay:send');
+        $this->setDescription('Pay for an API endpoint via x402');
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('url', InputArgument::REQUIRED, 'Target URL that requires payment')
+            ->addOption('amount', null, InputOption::VALUE_OPTIONAL, 'Payment amount override')
+            ->addOption('network', 'n', InputOption::VALUE_OPTIONAL, 'Network (e.g., eip155:8453)', 'eip155:8453')
+            ->addOption('yes', 'y', InputOption::VALUE_NONE, 'Skip confirmation prompt')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Output as JSON');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $formatter = new OutputFormatter($output);
+        $auth = new AuthManager();
+
+        if (! $this->ensureAuthenticated($auth)) {
+            return 2;
+        }
+
+        /** @var string $url */
+        $url = $input->getArgument('url');
+        /** @var string $network */
+        $network = $input->getOption('network') ?? 'eip155:8453';
+
+        $api = new ApiClient($auth);
+
+        // First attempt — may return 402
+        $result = $api->get($url);
+
+        if ($result['status'] === 402) {
+            $paymentInfo = $result['body'];
+            $amount = $input->getOption('amount') ?? ($paymentInfo['amount'] ?? 'unknown');
+
+            if (! $input->getOption('yes')) {
+                $output->writeln("Payment required: {$amount} on {$network}");
+                $output->writeln('Use --yes to confirm payment.');
+
+                return Command::SUCCESS;
+            }
+
+            // Retry with payment
+            $payResult = $api->post('/v1/x402/payments', [
+                'url'     => $url,
+                'amount'  => $amount,
+                'network' => $network,
+            ]);
+
+            if ($payResult['status'] >= 400) {
+                $formatter->error('PAYMENT_FAILED', $payResult['body']['message'] ?? "HTTP {$payResult['status']}");
+
+                return 3;
+            }
+
+            $formatter->output($payResult['body']['data'] ?? $payResult['body'], forceJson: $this->shouldOutputJson($input));
+
+            return Command::SUCCESS;
+        }
+
+        if ($result['status'] >= 400) {
+            $formatter->error('API_ERROR', $result['body']['message'] ?? "HTTP {$result['status']}");
+
+            return Command::FAILURE;
+        }
+
+        $formatter->output($result['body']['data'] ?? $result['body'], forceJson: $this->shouldOutputJson($input));
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/zelta-cli/app/Commands/Pay/StatusCommand.php
+++ b/packages/zelta-cli/app/Commands/Pay/StatusCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZeltaCli\Commands\Pay;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use ZeltaCli\Concerns\HasJsonOutput;
+use ZeltaCli\Concerns\RequiresAuth;
+use ZeltaCli\Services\ApiClient;
+use ZeltaCli\Services\AuthManager;
+use ZeltaCli\Services\OutputFormatter;
+
+/**
+ * zelta pay status <paymentId>.
+ */
+class StatusCommand extends Command
+{
+    use HasJsonOutput;
+    use RequiresAuth;
+
+    public function __construct()
+    {
+        parent::__construct('pay:status');
+        $this->setDescription('Check payment status');
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('paymentId', InputArgument::REQUIRED, 'Payment ID to check')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Output as JSON');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $formatter = new OutputFormatter($output);
+        $auth = new AuthManager();
+
+        if (! $this->ensureAuthenticated($auth)) {
+            return 2;
+        }
+
+        /** @var string $paymentId */
+        $paymentId = $input->getArgument('paymentId');
+
+        $api = new ApiClient($auth);
+        $result = $api->get("/v1/x402/payments/{$paymentId}");
+
+        if ($result['status'] !== 200) {
+            $formatter->error('API_ERROR', $result['body']['message'] ?? 'Failed to fetch payment status');
+
+            return Command::FAILURE;
+        }
+
+        $formatter->output($result['body']['data'] ?? $result['body'], forceJson: $this->shouldOutputJson($input));
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/zelta-cli/app/Commands/Sdk/GenerateCommand.php
+++ b/packages/zelta-cli/app/Commands/Sdk/GenerateCommand.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZeltaCli\Commands\Sdk;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use ZeltaCli\Concerns\HasJsonOutput;
+use ZeltaCli\Concerns\RequiresAuth;
+use ZeltaCli\Services\ApiClient;
+use ZeltaCli\Services\AuthManager;
+use ZeltaCli\Services\OutputFormatter;
+
+/**
+ * zelta sdk generate <language> [--output <dir>].
+ */
+class GenerateCommand extends Command
+{
+    use HasJsonOutput;
+    use RequiresAuth;
+
+    private const SUPPORTED_LANGUAGES = ['typescript', 'python', 'java', 'go', 'csharp', 'php'];
+
+    public function __construct()
+    {
+        parent::__construct('sdk:generate');
+        $this->setDescription('Generate a typed SDK for the Zelta API');
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('language', InputArgument::REQUIRED, 'Target language: ' . implode(', ', self::SUPPORTED_LANGUAGES))
+            ->addOption('output', 'o', InputOption::VALUE_OPTIONAL, 'Output directory', '.')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Output as JSON');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $formatter = new OutputFormatter($output);
+        $auth = new AuthManager();
+
+        /** @var string $language */
+        $language = $input->getArgument('language');
+
+        if (! in_array($language, self::SUPPORTED_LANGUAGES, true)) {
+            $formatter->error('VALIDATION', "Unsupported language '{$language}'. Supported: " . implode(', ', self::SUPPORTED_LANGUAGES));
+
+            return 4;
+        }
+
+        /** @var string $outputDir */
+        $outputDir = $input->getOption('output') ?? '.';
+
+        // Try local artisan command if available
+        $artisanPath = getcwd() . '/artisan';
+        if (file_exists($artisanPath)) {
+            $output->writeln("<info>Generating {$language} SDK via local artisan...</info>");
+            $exitCode = 0;
+            passthru("php artisan sdk:generate {$language} --output=" . escapeshellarg($outputDir), $exitCode);
+
+            return $exitCode === 0 ? Command::SUCCESS : Command::FAILURE;
+        }
+
+        // Fallback to API
+        if (! $this->ensureAuthenticated($auth)) {
+            return 2;
+        }
+
+        $api = new ApiClient($auth);
+        $result = $api->post('/v1/admin/sdk/generate', [
+            'language' => $language,
+            'output'   => $outputDir,
+        ]);
+
+        if ($result['status'] >= 400) {
+            $formatter->error('API_ERROR', $result['body']['message'] ?? "HTTP {$result['status']}");
+
+            return Command::FAILURE;
+        }
+
+        $formatter->output($result['body']['data'] ?? $result['body'], forceJson: $this->shouldOutputJson($input));
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/zelta-cli/app/Commands/Sms/StatusCommand.php
+++ b/packages/zelta-cli/app/Commands/Sms/StatusCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZeltaCli\Commands\Sms;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use ZeltaCli\Concerns\HasJsonOutput;
+use ZeltaCli\Concerns\RequiresAuth;
+use ZeltaCli\Services\ApiClient;
+use ZeltaCli\Services\AuthManager;
+use ZeltaCli\Services\OutputFormatter;
+
+/**
+ * zelta sms status <messageId>.
+ */
+class StatusCommand extends Command
+{
+    use HasJsonOutput;
+    use RequiresAuth;
+
+    public function __construct()
+    {
+        parent::__construct('sms:status');
+        $this->setDescription('Check SMS delivery status');
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('messageId', InputArgument::REQUIRED, 'Message ID to check')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Output as JSON');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $formatter = new OutputFormatter($output);
+        $auth = new AuthManager();
+
+        if (! $this->ensureAuthenticated($auth)) {
+            return 2;
+        }
+
+        /** @var string $messageId */
+        $messageId = $input->getArgument('messageId');
+
+        $api = new ApiClient($auth);
+        $result = $api->get("/v1/sms/status/{$messageId}");
+
+        if ($result['status'] !== 200) {
+            $formatter->error('API_ERROR', $result['body']['message'] ?? 'Failed to fetch message status');
+
+            return Command::FAILURE;
+        }
+
+        $formatter->output($result['body']['data'] ?? $result['body'], forceJson: $this->shouldOutputJson($input));
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/zelta-cli/app/Commands/Wallet/BalanceCommand.php
+++ b/packages/zelta-cli/app/Commands/Wallet/BalanceCommand.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZeltaCli\Commands\Wallet;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use ZeltaCli\Concerns\HasJsonOutput;
+use ZeltaCli\Concerns\RequiresAuth;
+use ZeltaCli\Services\ApiClient;
+use ZeltaCli\Services\AuthManager;
+use ZeltaCli\Services\OutputFormatter;
+
+/**
+ * zelta wallet balance.
+ */
+class BalanceCommand extends Command
+{
+    use HasJsonOutput;
+    use RequiresAuth;
+
+    public function __construct()
+    {
+        parent::__construct('wallet:balance');
+        $this->setDescription('Show wallet balances');
+    }
+
+    protected function configure(): void
+    {
+        $this->configureJsonOption();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $formatter = new OutputFormatter($output);
+        $auth = new AuthManager();
+
+        if (! $this->ensureAuthenticated($auth)) {
+            return 2;
+        }
+
+        $api = new ApiClient($auth);
+        $result = $api->get('/v1/wallet/balances');
+
+        if ($result['status'] !== 200) {
+            $formatter->error('API_ERROR', $result['body']['message'] ?? 'Failed to fetch balances');
+
+            return Command::FAILURE;
+        }
+
+        $balances = $result['body']['data'] ?? [];
+
+        if ($this->shouldOutputJson($input)) {
+            $formatter->json($balances);
+        } else {
+            if ($balances === []) {
+                $formatter->success('No balances found.');
+
+                return Command::SUCCESS;
+            }
+
+            $rows = array_map(fn (array $b) => [
+                $b['token'] ?? '',
+                $b['balance'] ?? '0',
+                $b['network'] ?? '',
+                $b['address'] ?? '',
+            ], $balances);
+
+            $formatter->table(['Token', 'Balance', 'Network', 'Address'], $rows);
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/zelta-cli/app/Commands/Wallet/SendCommand.php
+++ b/packages/zelta-cli/app/Commands/Wallet/SendCommand.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZeltaCli\Commands\Wallet;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use ZeltaCli\Concerns\HasJsonOutput;
+use ZeltaCli\Concerns\RequiresAuth;
+use ZeltaCli\Services\ApiClient;
+use ZeltaCli\Services\AuthManager;
+use ZeltaCli\Services\OutputFormatter;
+
+/**
+ * zelta wallet send --to <address> --amount <n> --token USDC --network eip155:8453 [--yes].
+ */
+class SendCommand extends Command
+{
+    use HasJsonOutput;
+    use RequiresAuth;
+
+    public function __construct()
+    {
+        parent::__construct('wallet:send');
+        $this->setDescription('Send tokens from your wallet');
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'Recipient address')
+            ->addOption('amount', null, InputOption::VALUE_REQUIRED, 'Amount to send')
+            ->addOption('token', null, InputOption::VALUE_OPTIONAL, 'Token symbol', 'USDC')
+            ->addOption('network', 'n', InputOption::VALUE_OPTIONAL, 'Network (e.g., eip155:8453)', 'eip155:8453')
+            ->addOption('yes', 'y', InputOption::VALUE_NONE, 'Skip confirmation prompt')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Output as JSON');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $formatter = new OutputFormatter($output);
+        $auth = new AuthManager();
+
+        if (! $this->ensureAuthenticated($auth)) {
+            return 2;
+        }
+
+        /** @var string|null $to */
+        $to = $input->getOption('to');
+        /** @var string|null $amount */
+        $amount = $input->getOption('amount');
+
+        if ($to === null || $amount === null) {
+            $formatter->error('VALIDATION', 'Both --to and --amount are required');
+
+            return 4;
+        }
+
+        /** @var string $token */
+        $token = $input->getOption('token') ?? 'USDC';
+        /** @var string $network */
+        $network = $input->getOption('network') ?? 'eip155:8453';
+
+        // Confirm before sending unless --yes
+        if (! $input->getOption('yes')) {
+            $output->writeln("Transfer {$amount} {$token} to {$to} on {$network}");
+            $output->writeln('Use --yes to skip this confirmation.');
+
+            return Command::SUCCESS;
+        }
+
+        $api = new ApiClient($auth);
+        $result = $api->post('/v1/wallet/transfers', [
+            'to'      => $to,
+            'amount'  => $amount,
+            'token'   => $token,
+            'network' => $network,
+        ]);
+
+        if ($result['status'] >= 400) {
+            $formatter->error('API_ERROR', $result['body']['message'] ?? "HTTP {$result['status']}");
+
+            return Command::FAILURE;
+        }
+
+        $formatter->output($result['body']['data'] ?? $result['body'], forceJson: $this->shouldOutputJson($input));
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/zelta-cli/app/Commands/Wallet/TokensCommand.php
+++ b/packages/zelta-cli/app/Commands/Wallet/TokensCommand.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZeltaCli\Commands\Wallet;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use ZeltaCli\Concerns\HasJsonOutput;
+use ZeltaCli\Concerns\RequiresAuth;
+use ZeltaCli\Services\ApiClient;
+use ZeltaCli\Services\AuthManager;
+use ZeltaCli\Services\OutputFormatter;
+
+/**
+ * zelta wallet tokens.
+ */
+class TokensCommand extends Command
+{
+    use HasJsonOutput;
+    use RequiresAuth;
+
+    public function __construct()
+    {
+        parent::__construct('wallet:tokens');
+        $this->setDescription('List available tokens and their addresses');
+    }
+
+    protected function configure(): void
+    {
+        $this->configureJsonOption();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $formatter = new OutputFormatter($output);
+        $auth = new AuthManager();
+
+        if (! $this->ensureAuthenticated($auth)) {
+            return 2;
+        }
+
+        $api = new ApiClient($auth);
+        $result = $api->get('/v1/wallet/tokens');
+
+        if ($result['status'] !== 200) {
+            $formatter->error('API_ERROR', $result['body']['message'] ?? 'Failed to fetch tokens');
+
+            return Command::FAILURE;
+        }
+
+        $tokens = $result['body']['data'] ?? [];
+
+        if ($this->shouldOutputJson($input)) {
+            $formatter->json($tokens);
+        } else {
+            if ($tokens === []) {
+                $formatter->success('No tokens found.');
+
+                return Command::SUCCESS;
+            }
+
+            $rows = array_map(fn (array $t) => [
+                $t['symbol'] ?? '',
+                $t['name'] ?? '',
+                $t['address'] ?? '',
+                $t['network'] ?? '',
+                (string) ($t['decimals'] ?? ''),
+            ], $tokens);
+
+            $formatter->table(['Symbol', 'Name', 'Address', 'Network', 'Decimals'], $rows);
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/zelta-cli/config/zelta.php
+++ b/packages/zelta-cli/config/zelta.php
@@ -7,5 +7,5 @@ return [
     'credentials_path' => $_SERVER['HOME'] . '/.zelta/credentials.json',
     'config_path'      => $_SERVER['HOME'] . '/.zelta/config.json',
     'timeout'          => 30,
-    'version'          => '0.1.0',
+    'version'          => '0.2.0',
 ];

--- a/packages/zelta-cli/zelta
+++ b/packages/zelta-cli/zelta
@@ -10,8 +10,18 @@ declare(strict_types=1);
  *
  * Usage:
  *   zelta auth login --key zk_live_xxx
+ *   zelta auth logout
+ *   zelta auth token --unmask
  *   zelta pay list
+ *   zelta pay send https://api.example.com/data --yes
+ *   zelta pay status <paymentId>
  *   zelta sms send --to +370xxx --message "Hello"
+ *   zelta sms status <messageId>
+ *   zelta wallet balance
+ *   zelta wallet send --to 0x... --amount 10 --token USDC --yes
+ *   zelta limits list
+ *   zelta agents discover --capability payment
+ *   zelta sdk generate typescript --output ./sdk
  *   zelta endpoints list
  *   zelta whoami
  */
@@ -28,33 +38,71 @@ foreach ([
 }
 
 use Symfony\Component\Console\Application;
+use ZeltaCli\Commands\Agents\DiscoverCommand;
+use ZeltaCli\Commands\Agents\RegisterCommand;
 use ZeltaCli\Commands\Auth\LoginCommand;
+use ZeltaCli\Commands\Auth\LogoutCommand;
 use ZeltaCli\Commands\Auth\StatusCommand;
+use ZeltaCli\Commands\Auth\TokenCommand;
 use ZeltaCli\Commands\Endpoints\ListCommand as EndpointsListCommand;
+use ZeltaCli\Commands\Limits\ListCommand as LimitsListCommand;
+use ZeltaCli\Commands\Limits\RemoveCommand as LimitsRemoveCommand;
+use ZeltaCli\Commands\Limits\SetCommand as LimitsSetCommand;
 use ZeltaCli\Commands\Pay\ListCommand as PayListCommand;
+use ZeltaCli\Commands\Pay\SendCommand as PaySendCommand;
 use ZeltaCli\Commands\Pay\StatsCommand;
+use ZeltaCli\Commands\Pay\StatusCommand as PayStatusCommand;
+use ZeltaCli\Commands\Sdk\GenerateCommand;
 use ZeltaCli\Commands\Sms\RatesCommand;
 use ZeltaCli\Commands\Sms\SendCommand;
+use ZeltaCli\Commands\Sms\StatusCommand as SmsStatusCommand;
+use ZeltaCli\Commands\Wallet\BalanceCommand;
+use ZeltaCli\Commands\Wallet\SendCommand as WalletSendCommand;
+use ZeltaCli\Commands\Wallet\TokensCommand;
+use ZeltaCli\Commands\ConfigCommand;
 use ZeltaCli\Commands\WhoamiCommand;
 
-$app = new Application('Zelta CLI', '0.1.0');
+$app = new Application('Zelta CLI', '0.2.0');
 
 // Auth
 $app->add(new LoginCommand());
+$app->add(new LogoutCommand());
 $app->add(new StatusCommand());
+$app->add(new TokenCommand());
 
 // Payments
 $app->add(new PayListCommand());
+$app->add(new PaySendCommand());
 $app->add(new StatsCommand());
+$app->add(new PayStatusCommand());
 
 // SMS
 $app->add(new SendCommand());
 $app->add(new RatesCommand());
+$app->add(new SmsStatusCommand());
+
+// Wallet
+$app->add(new BalanceCommand());
+$app->add(new WalletSendCommand());
+$app->add(new TokensCommand());
+
+// Limits
+$app->add(new LimitsListCommand());
+$app->add(new LimitsSetCommand());
+$app->add(new LimitsRemoveCommand());
+
+// Agents
+$app->add(new RegisterCommand());
+$app->add(new DiscoverCommand());
+
+// SDK
+$app->add(new GenerateCommand());
 
 // Endpoints
 $app->add(new EndpointsListCommand());
 
 // Utility
+$app->add(new ConfigCommand());
 $app->add(new WhoamiCommand());
 
 $app->run();


### PR DESCRIPTION
## Summary
- Adds **15 new commands** to the Zelta CLI (from 8 to 23 custom commands, 25 total with Symfony builtins), organized across **8 resource groups**: Auth, Pay, SMS, Wallet, Limits, Agents, SDK, Config
- Bumps CLI version from `0.1.0` to `0.2.0` in both the Application header and `config/zelta.php`
- All new commands follow the established pattern: Symfony Console 7.x with constructor-based naming, `HasJsonOutput` + `RequiresAuth` traits, `OutputFormatter` for dual-mode output, `ApiClient` for API calls

### New commands
| Group | Command | API Endpoint |
|-------|---------|-------------|
| Wallet | `wallet:balance` | `GET /v1/wallet/balances` |
| Wallet | `wallet:send` | `POST /v1/wallet/transfers` |
| Wallet | `wallet:tokens` | `GET /v1/wallet/tokens` |
| Limits | `limits:list` | `GET /v1/x402/spending-limits` |
| Limits | `limits:set` | `POST /v1/x402/spending-limits` |
| Limits | `limits:remove` | `DELETE /v1/x402/spending-limits/{agentId}` |
| Agents | `agents:register` | `POST /v1/agent-protocol/agents/register` |
| Agents | `agents:discover` | `GET /v1/agent-protocol/agents/discover` |
| SDK | `sdk:generate` | Local artisan or `POST /v1/admin/sdk/generate` |
| Auth | `auth:logout` | Local credentials |
| Auth | `auth:token` | Local credentials |
| Pay | `pay:send` | x402 payment flow |
| Pay | `pay:status` | `GET /v1/x402/payments/{id}` |
| SMS | `sms:status` | `GET /v1/sms/status/{messageId}` |
| Config | `config` | Local config file |

## Test plan
- [ ] Verify `zelta list` shows all 25 commands (23 custom + help + list)
- [ ] Verify `wallet:send` and `limits:remove` require `--yes` confirmation
- [ ] Verify `auth:token` masks the API key by default, shows with `--unmask`
- [ ] Verify `sdk:generate` detects local artisan and falls back to API
- [ ] Verify `auth:logout` clears the specified profile credentials
- [ ] Verify all commands support `--json` output mode
- [ ] Run php-cs-fixer to confirm code style compliance

🤖 Generated with [Claude Code](https://claude.com/claude-code)