### PR TITLE
feat: SMS demo seeding + mobile rewards auto-creation

### DIFF
--- a/app/Console/Commands/PopulateDemoDataCommand.php
+++ b/app/Console/Commands/PopulateDemoDataCommand.php
@@ -51,6 +51,11 @@ class PopulateDemoDataCommand extends Command
         $this->info('Creating demo users and data...');
         Artisan::call('db:seed', ['--class' => 'DemoDataSeeder'], $this->output);
 
+        // Run SMS + mobile rewards demo seeder
+        $this->info('Creating SMS & mobile rewards demo data...');
+        Artisan::call('db:seed', ['--class' => 'SmsDemoSeeder'], $this->output);
+        Artisan::call('db:seed', ['--class' => 'MobileRewardsDemoSeeder'], $this->output);
+
         // Create admin user if requested
         if ($this->option('with-admin')) {
             $this->createAdminUser();
@@ -125,6 +130,14 @@ class PopulateDemoDataCommand extends Command
         // Bank preferences
         $bankPrefCount = DB::table('user_bank_preferences')->count();
         $this->line("Bank Preferences: $bankPrefCount");
+
+        // SMS demo data
+        $smsMsgCount = DB::table('sms_messages')->where('test_mode', true)->count();
+        $this->line("SMS Demo Messages: $smsMsgCount");
+
+        // Reward profiles
+        $rewardProfileCount = DB::table('reward_profiles')->count();
+        $this->line("Reward Profiles: $rewardProfileCount");
 
         $this->newLine();
         $this->info('🔐 Demo User Credentials');

--- a/app/Console/Commands/SmsSetupDemoCommand.php
+++ b/app/Console/Commands/SmsSetupDemoCommand.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+
+/**
+ * One-shot command that bootstraps all SMS + mobile rewards demo data.
+ *
+ * Safe to run multiple times — every seeder uses firstOrCreate.
+ *
+ * Usage:
+ *   php artisan sms:setup-demo
+ *   php artisan sms:setup-demo --with-rewards
+ */
+class SmsSetupDemoCommand extends Command
+{
+    /** @var string */
+    protected $signature = 'sms:setup-demo
+                            {--with-rewards : Also seed mobile rewards demo data}';
+
+    /** @var string */
+    protected $description = 'Create x402 monetized endpoint, spending limits, and sample SMS messages for demo';
+
+    public function handle(): int
+    {
+        $this->info('SMS Demo Setup');
+        $this->line('==============');
+
+        // 1. Core SMS demo data (endpoint + limits + messages)
+        $this->info('Seeding SMS demo data...');
+        Artisan::call('db:seed', ['--class' => 'SmsDemoSeeder'], $this->output);
+
+        // 2. Rewards (opt-in, or auto-detected)
+        if ($this->option('with-rewards') || $this->rewardsDomainExists()) {
+            $this->info('Seeding mobile rewards demo data...');
+            Artisan::call('db:seed', ['--class' => 'MobileRewardsDemoSeeder'], $this->output);
+        } else {
+            $this->warn('Rewards domain not detected — skipping mobile rewards. Pass --with-rewards to force.');
+        }
+
+        // 3. Summary
+        $this->displaySummary();
+
+        $this->newLine();
+        $this->info('SMS demo setup completed!');
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Auto-detect whether the Rewards domain module is present.
+     */
+    private function rewardsDomainExists(): bool
+    {
+        return class_exists(\App\Domain\Rewards\Models\RewardQuest::class);
+    }
+
+    private function displaySummary(): void
+    {
+        $this->newLine();
+        $this->info('Summary');
+        $this->line('-------');
+
+        $endpointCount = \App\Domain\X402\Models\X402MonetizedEndpoint::where('path', 'like', '%sms%')->count();
+        $this->line("SMS monetized endpoints: {$endpointCount}");
+
+        $limitCount = \App\Domain\X402\Models\X402SpendingLimit::where('agent_type', 'sms')->count();
+        $this->line("SMS agent spending limits: {$limitCount}");
+
+        $msgCount = \App\Domain\SMS\Models\SmsMessage::where('test_mode', true)->count();
+        $this->line("Sample SMS messages: {$msgCount}");
+
+        if (class_exists(\App\Domain\Rewards\Models\RewardQuest::class)) {
+            $questCount = \App\Domain\Rewards\Models\RewardQuest::where('slug', 'like', '%sms%')->count();
+            $this->line("SMS reward quests: {$questCount}");
+
+            $profileCount = \App\Domain\Rewards\Models\RewardProfile::count();
+            $this->line("Reward profiles: {$profileCount}");
+        }
+
+        $this->newLine();
+        $this->info('Test endpoints');
+        $this->line('--------------');
+        $this->line('GET  /api/v1/sms/info   — service status');
+        $this->line('GET  /api/v1/sms/rates  — country pricing');
+        $this->line('POST /api/v1/sms/send   — send SMS (x402 gated)');
+    }
+}

--- a/database/seeders/MobileRewardsDemoSeeder.php
+++ b/database/seeders/MobileRewardsDemoSeeder.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Domain\Rewards\Models\RewardProfile;
+use App\Domain\Rewards\Models\RewardQuest;
+use App\Domain\Rewards\Models\RewardQuestCompletion;
+use App\Domain\Rewards\Models\RewardRedemption;
+use App\Domain\Rewards\Models\RewardShopItem;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+/**
+ * Seeds mobile rewards demo data on top of the base RewardsSeeder:
+ * - SMS-linked reward quests (send-sms, sms-century)
+ * - Reward tier shop items (Bronze -> Platinum)
+ * - Demo user reward profiles with XP / points / streaks
+ * - Sample quest completions and shop redemptions
+ *
+ * Depends on: RewardsSeeder (base quests + shop items), DemoDataSeeder (demo users).
+ *
+ * @see app/Domain/Rewards/ — Gamification domain
+ * @see database/seeders/RewardsSeeder.php
+ */
+class MobileRewardsDemoSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $this->seedSmsRewardQuests();
+        $this->seedRewardTierItems();
+        $this->seedDemoProfiles();
+    }
+
+    /**
+     * Add SMS-specific quests that link rewards to SMS activity.
+     */
+    private function seedSmsRewardQuests(): void
+    {
+        $quests = [
+            [
+                'slug'          => 'send-sms',
+                'title'         => 'Send Your First SMS',
+                'description'   => 'Send an SMS via the VertexSMS integration',
+                'xp_reward'     => 25,
+                'points_reward' => 50,
+                'category'      => 'onboarding',
+                'icon'          => 'chatbubble',
+                'is_repeatable' => false,
+                'is_active'     => true,
+                'sort_order'    => 7,
+                'criteria'      => ['event' => 'sms.sent', 'count' => 1],
+            ],
+            [
+                'slug'          => 'sms-century',
+                'title'         => 'SMS Century',
+                'description'   => 'Send 100 SMS messages — earn 50 bonus credits',
+                'xp_reward'     => 200,
+                'points_reward' => 500,
+                'category'      => 'milestone',
+                'icon'          => 'trophy',
+                'is_repeatable' => false,
+                'is_active'     => true,
+                'sort_order'    => 8,
+                'criteria'      => ['event' => 'sms.sent', 'count' => 100],
+            ],
+            [
+                'slug'          => 'daily-sms',
+                'title'         => 'Daily SMS',
+                'description'   => 'Send at least one SMS today',
+                'xp_reward'     => 10,
+                'points_reward' => 20,
+                'category'      => 'daily',
+                'icon'          => 'chatbubble',
+                'is_repeatable' => true,
+                'is_active'     => true,
+                'sort_order'    => 9,
+                'criteria'      => ['event' => 'sms.sent', 'count' => 1, 'period' => 'daily'],
+            ],
+        ];
+
+        foreach ($quests as $quest) {
+            RewardQuest::firstOrCreate(
+                ['slug' => $quest['slug']],
+                $quest,
+            );
+        }
+    }
+
+    /**
+     * Create tiered reward shop items (Bronze through Platinum).
+     *
+     * These represent loyalty tiers that users unlock by accumulating points.
+     */
+    private function seedRewardTierItems(): void
+    {
+        $tiers = [
+            [
+                'slug'        => 'tier-bronze',
+                'title'       => 'Bronze Tier',
+                'description' => 'Unlock 5 % fee discount on all SMS sends',
+                'points_cost' => 250,
+                'category'    => 'tiers',
+                'icon'        => 'shield',
+                'stock'       => null,
+                'is_active'   => true,
+                'sort_order'  => 10,
+                'metadata'    => ['tier_level' => 1, 'fee_discount_pct' => 5],
+            ],
+            [
+                'slug'        => 'tier-silver',
+                'title'       => 'Silver Tier',
+                'description' => 'Unlock 10 % fee discount + priority delivery',
+                'points_cost' => 750,
+                'category'    => 'tiers',
+                'icon'        => 'shield',
+                'stock'       => null,
+                'is_active'   => true,
+                'sort_order'  => 11,
+                'metadata'    => ['tier_level' => 2, 'fee_discount_pct' => 10, 'priority_delivery' => true],
+            ],
+            [
+                'slug'        => 'tier-gold',
+                'title'       => 'Gold Tier',
+                'description' => 'Unlock 20 % fee discount + priority + dedicated support',
+                'points_cost' => 2000,
+                'category'    => 'tiers',
+                'icon'        => 'star',
+                'stock'       => null,
+                'is_active'   => true,
+                'sort_order'  => 12,
+                'metadata'    => ['tier_level' => 3, 'fee_discount_pct' => 20, 'priority_delivery' => true, 'dedicated_support' => true],
+            ],
+            [
+                'slug'        => 'tier-platinum',
+                'title'       => 'Platinum Tier',
+                'description' => 'Unlock 30 % fee discount + all perks + early access',
+                'points_cost' => 5000,
+                'category'    => 'tiers',
+                'icon'        => 'diamond',
+                'stock'       => null,
+                'is_active'   => true,
+                'sort_order'  => 13,
+                'metadata'    => ['tier_level' => 4, 'fee_discount_pct' => 30, 'priority_delivery' => true, 'dedicated_support' => true, 'early_access' => true],
+            ],
+        ];
+
+        foreach ($tiers as $tier) {
+            RewardShopItem::firstOrCreate(
+                ['slug' => $tier['slug']],
+                $tier,
+            );
+        }
+    }
+
+    /**
+     * Create reward profiles for existing demo users so the
+     * mobile rewards screen displays meaningful data immediately.
+     */
+    private function seedDemoProfiles(): void
+    {
+        $profiles = [
+            // Power user — high XP, long streak, multiple completions
+            'demo.nomad@gcu.global' => [
+                'xp'                 => 475,
+                'level'              => 5,
+                'current_streak'     => 12,
+                'longest_streak'     => 18,
+                'last_activity_date' => now()->subDay(),
+                'points_balance'     => 1350,
+                'completions'        => ['first-payment', 'first-shield', 'complete-profile', 'first-card', 'send-sms'],
+                'redemptions'        => ['fee-waiver'],
+            ],
+            // New user — just started
+            'demo.user@gcu.global' => [
+                'xp'                 => 55,
+                'level'              => 1,
+                'current_streak'     => 2,
+                'longest_streak'     => 2,
+                'last_activity_date' => now(),
+                'points_balance'     => 110,
+                'completions'        => ['first-payment'],
+                'redemptions'        => [],
+            ],
+            // Business user — moderate activity
+            'demo.business@gcu.global' => [
+                'xp'                 => 260,
+                'level'              => 3,
+                'current_streak'     => 5,
+                'longest_streak'     => 9,
+                'last_activity_date' => now()->subDays(2),
+                'points_balance'     => 820,
+                'completions'        => ['first-payment', 'first-card', 'send-sms', 'complete-profile'],
+                'redemptions'        => ['priority-processing'],
+            ],
+            // Investor — redeemed tier item
+            'demo.investor@gcu.global' => [
+                'xp'                 => 380,
+                'level'              => 4,
+                'current_streak'     => 0,
+                'longest_streak'     => 14,
+                'last_activity_date' => now()->subWeek(),
+                'points_balance'     => 650,
+                'completions'        => ['first-payment', 'first-shield', 'first-card', 'complete-profile'],
+                'redemptions'        => ['tier-bronze', 'custom-badge'],
+            ],
+        ];
+
+        foreach ($profiles as $email => $data) {
+            $user = User::where('email', $email)->first();
+            if ($user === null) {
+                continue;
+            }
+
+            $profile = RewardProfile::firstOrCreate(
+                ['user_id' => $user->id],
+                [
+                    'xp'                 => $data['xp'],
+                    'level'              => $data['level'],
+                    'current_streak'     => $data['current_streak'],
+                    'longest_streak'     => $data['longest_streak'],
+                    'last_activity_date' => $data['last_activity_date'],
+                    'points_balance'     => $data['points_balance'],
+                ],
+            );
+
+            // Seed quest completions
+            foreach ($data['completions'] as $slug) {
+                $quest = RewardQuest::where('slug', $slug)->first();
+                if ($quest === null) {
+                    continue;
+                }
+
+                RewardQuestCompletion::firstOrCreate(
+                    [
+                        'reward_profile_id' => $profile->id,
+                        'quest_id'          => $quest->id,
+                    ],
+                    [
+                        'completed_at'  => now()->subDays(rand(1, 30)),
+                        'xp_earned'     => $quest->xp_reward,
+                        'points_earned' => $quest->points_reward,
+                    ],
+                );
+            }
+
+            // Seed shop redemptions
+            foreach ($data['redemptions'] as $slug) {
+                $item = RewardShopItem::where('slug', $slug)->first();
+                if ($item === null) {
+                    continue;
+                }
+
+                RewardRedemption::firstOrCreate(
+                    [
+                        'reward_profile_id' => $profile->id,
+                        'shop_item_id'      => $item->id,
+                    ],
+                    [
+                        'points_spent' => $item->points_cost,
+                        'status'       => 'fulfilled',
+                        'metadata'     => ['source' => 'demo-seeder'],
+                    ],
+                );
+            }
+        }
+    }
+}

--- a/database/seeders/SmsDemoSeeder.php
+++ b/database/seeders/SmsDemoSeeder.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Domain\SMS\Models\SmsMessage;
+use App\Domain\X402\Models\X402MonetizedEndpoint;
+use App\Domain\X402\Models\X402SpendingLimit;
+use Illuminate\Database\Seeder;
+
+/**
+ * Seeds demo data for the SMS domain:
+ * - X402 monetized endpoint for POST /api/v1/sms/send
+ * - Agent spending limits for demo SMS usage
+ * - Sample SMS messages in various delivery statuses
+ *
+ * @see app/Domain/SMS/ — VertexSMS integration
+ * @see docs/BACKEND_PRODUCTION_HANDOVER.md (vertexsms-partnership)
+ */
+class SmsDemoSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $this->seedMonetizedEndpoint();
+        $this->seedSpendingLimits();
+        $this->seedSampleMessages();
+    }
+
+    /**
+     * Register the SMS send endpoint as an x402-monetized resource.
+     *
+     * Price: $0.05 USDC per request (50 000 atomic units, 6 decimals).
+     */
+    private function seedMonetizedEndpoint(): void
+    {
+        X402MonetizedEndpoint::firstOrCreate(
+            [
+                'method' => 'POST',
+                'path'   => '/api/v1/sms/send',
+            ],
+            [
+                'price'       => '50000',
+                'network'     => 'eip155:8453',
+                'asset'       => 'USDC',
+                'scheme'      => 'exact',
+                'description' => 'Send an SMS via VertexSMS (per-message pricing)',
+                'mime_type'   => 'application/json',
+                'is_active'   => true,
+                'extra'       => [
+                    'provider'         => 'vertexsms',
+                    'supports_testnet' => true,
+                    'rate_card_url'    => '/api/v1/sms/rates',
+                ],
+            ],
+        );
+    }
+
+    /**
+     * Create default spending limits for the demo SMS agent.
+     *
+     * - Daily budget: $10 USDC (10 000 000 atomic)
+     * - Per-tx limit: $0.50 USDC (500 000 atomic) — covers multi-part
+     * - Auto-pay enabled so the demo flow is frictionless
+     */
+    private function seedSpendingLimits(): void
+    {
+        X402SpendingLimit::firstOrCreate(
+            [
+                'agent_id'   => 'demo-sms-agent',
+                'agent_type' => 'sms',
+            ],
+            [
+                'daily_limit'           => '10000000',
+                'spent_today'           => '0',
+                'per_transaction_limit' => '500000',
+                'auto_pay_enabled'      => true,
+                'limit_resets_at'       => now()->addDay(),
+            ],
+        );
+    }
+
+    /**
+     * Insert sample SMS messages across all four statuses so
+     * dashboards and API consumers see realistic data immediately.
+     */
+    private function seedSampleMessages(): void
+    {
+        $messages = [
+            // --- delivered ---
+            [
+                'provider'     => 'vertexsms',
+                'provider_id'  => 'demo-vtx-001',
+                'to'           => '+37069912345',
+                'from'         => 'Zelta',
+                'message'      => 'Your OTP code is 483920. Valid for 5 minutes.',
+                'parts'        => 1,
+                'status'       => SmsMessage::STATUS_DELIVERED,
+                'price_usdc'   => '48000',
+                'country_code' => 'LT',
+                'payment_rail' => 'x402',
+                'payment_id'   => 'demo-pay-001',
+                'test_mode'    => true,
+                'delivered_at' => now()->subHours(2),
+            ],
+            [
+                'provider'     => 'vertexsms',
+                'provider_id'  => 'demo-vtx-002',
+                'to'           => '+49170123456',
+                'from'         => 'Zelta',
+                'message'      => 'Payment of 250.00 GCU received. Ref: TXN-8829.',
+                'parts'        => 1,
+                'status'       => SmsMessage::STATUS_DELIVERED,
+                'price_usdc'   => '72000',
+                'country_code' => 'DE',
+                'payment_rail' => 'x402',
+                'payment_id'   => 'demo-pay-002',
+                'test_mode'    => true,
+                'delivered_at' => now()->subHours(5),
+            ],
+            // --- sent (awaiting DLR) ---
+            [
+                'provider'     => 'vertexsms',
+                'provider_id'  => 'demo-vtx-003',
+                'to'           => '+34612345678',
+                'from'         => 'Zelta',
+                'message'      => 'Your weekly account summary is ready. Log in to view.',
+                'parts'        => 1,
+                'status'       => SmsMessage::STATUS_SENT,
+                'price_usdc'   => '55000',
+                'country_code' => 'ES',
+                'payment_rail' => 'mpp',
+                'payment_id'   => 'demo-pay-003',
+                'test_mode'    => true,
+            ],
+            [
+                'provider'     => 'vertexsms',
+                'provider_id'  => 'demo-vtx-004',
+                'to'           => '+33612345678',
+                'from'         => 'Zelta',
+                'message'      => 'Suspicious login attempt detected. Reply BLOCK to freeze account.',
+                'parts'        => 1,
+                'status'       => SmsMessage::STATUS_SENT,
+                'price_usdc'   => '58000',
+                'country_code' => 'FR',
+                'payment_rail' => 'x402',
+                'payment_id'   => 'demo-pay-004',
+                'test_mode'    => true,
+            ],
+            // --- failed ---
+            [
+                'provider'     => 'vertexsms',
+                'provider_id'  => 'demo-vtx-005',
+                'to'           => '+447911123456',
+                'from'         => 'Zelta',
+                'message'      => 'Your card ending in 4829 has been activated.',
+                'parts'        => 1,
+                'status'       => SmsMessage::STATUS_FAILED,
+                'price_usdc'   => '62000',
+                'country_code' => 'GB',
+                'payment_rail' => 'x402',
+                'payment_id'   => 'demo-pay-005',
+                'test_mode'    => true,
+            ],
+            // --- pending ---
+            [
+                'provider'     => 'vertexsms',
+                'provider_id'  => 'demo-vtx-006',
+                'to'           => '+37069998877',
+                'from'         => 'Zelta',
+                'message'      => 'Reminder: Your GCU staking rewards have been distributed.',
+                'parts'        => 1,
+                'status'       => SmsMessage::STATUS_PENDING,
+                'price_usdc'   => '48000',
+                'country_code' => 'LT',
+                'payment_rail' => 'mpp',
+                'payment_id'   => 'demo-pay-006',
+                'test_mode'    => true,
+            ],
+            // --- multi-part message ---
+            [
+                'provider'     => 'vertexsms',
+                'provider_id'  => 'demo-vtx-007',
+                'to'           => '+37069912345',
+                'from'         => 'Zelta',
+                'message'      => 'Dear valued customer, your cross-border transfer of 1,500.00 EUR to DE89370400440532013000 has been processed. The exchange rate used was 1 EUR = 1.0842 GCU. Settlement will complete within 2 business days. Reference: XFR-20260324-7891. Contact support@zelta.app for questions.',
+                'parts'        => 2,
+                'status'       => SmsMessage::STATUS_DELIVERED,
+                'price_usdc'   => '96000',
+                'country_code' => 'LT',
+                'payment_rail' => 'x402',
+                'payment_id'   => 'demo-pay-007',
+                'test_mode'    => true,
+                'delivered_at' => now()->subDay(),
+            ],
+        ];
+
+        foreach ($messages as $msg) {
+            SmsMessage::firstOrCreate(
+                ['provider_id' => $msg['provider_id']],
+                $msg,
+            );
+        }
+    }
+}

--- a/tests/Feature/Console/SmsSetupDemoCommandTest.php
+++ b/tests/Feature/Console/SmsSetupDemoCommandTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\SMS\Models\SmsMessage;
+use App\Domain\X402\Models\X402MonetizedEndpoint;
+use App\Domain\X402\Models\X402SpendingLimit;
+use Database\Seeders\DemoDataSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->seed();
+    (new DemoDataSeeder())->run();
+});
+
+it('seeds SMS demo data via artisan command', function () {
+    $this->artisan('sms:setup-demo')
+        ->assertSuccessful();
+
+    expect(X402MonetizedEndpoint::where('path', '/api/v1/sms/send')->exists())->toBeTrue();
+    expect(X402SpendingLimit::where('agent_id', 'demo-sms-agent')->exists())->toBeTrue();
+    expect(SmsMessage::where('provider_id', 'like', 'demo-vtx-%')->count())->toBe(7);
+});
+
+it('seeds rewards when --with-rewards flag is passed', function () {
+    $this->artisan('sms:setup-demo', ['--with-rewards' => true])
+        ->assertSuccessful();
+
+    expect(App\Domain\Rewards\Models\RewardQuest::where('slug', 'send-sms')->exists())->toBeTrue();
+    expect(App\Domain\Rewards\Models\RewardShopItem::where('category', 'tiers')->count())->toBe(4);
+});
+
+it('auto-detects rewards domain and seeds profiles', function () {
+    $this->artisan('sms:setup-demo')
+        ->assertSuccessful();
+
+    // Rewards domain exists in this project, so it should auto-seed
+    expect(App\Domain\Rewards\Models\RewardQuest::where('slug', 'send-sms')->exists())->toBeTrue();
+});
+
+it('is safe to run multiple times', function () {
+    $this->artisan('sms:setup-demo')->assertSuccessful();
+    $this->artisan('sms:setup-demo')->assertSuccessful();
+
+    expect(X402MonetizedEndpoint::where('path', '/api/v1/sms/send')->count())->toBe(1);
+    expect(X402SpendingLimit::where('agent_id', 'demo-sms-agent')->count())->toBe(1);
+});

--- a/tests/Feature/Seeders/MobileRewardsDemoSeederTest.php
+++ b/tests/Feature/Seeders/MobileRewardsDemoSeederTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Rewards\Models\RewardProfile;
+use App\Domain\Rewards\Models\RewardQuest;
+use App\Domain\Rewards\Models\RewardQuestCompletion;
+use App\Domain\Rewards\Models\RewardRedemption;
+use App\Domain\Rewards\Models\RewardShopItem;
+use App\Models\User;
+use Database\Seeders\DemoDataSeeder;
+use Database\Seeders\MobileRewardsDemoSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    // Base seeders (includes RewardsSeeder for quests + shop items)
+    $this->seed();
+
+    // Demo users are needed for reward profiles
+    (new DemoDataSeeder())->run();
+});
+
+it('creates SMS-specific reward quests', function () {
+    (new MobileRewardsDemoSeeder())->run();
+
+    /** @var RewardQuest $sendSms */
+    $sendSms = RewardQuest::where('slug', 'send-sms')->firstOrFail();
+    expect($sendSms->xp_reward)->toBe(25);
+    expect($sendSms->points_reward)->toBe(50);
+    expect($sendSms->category)->toBe('onboarding');
+
+    /** @var RewardQuest $smsCentury */
+    $smsCentury = RewardQuest::where('slug', 'sms-century')->firstOrFail();
+    expect($smsCentury->points_reward)->toBe(500);
+    expect($smsCentury->category)->toBe('milestone');
+    expect($smsCentury->criteria)->toBe(['event' => 'sms.sent', 'count' => 100]);
+
+    /** @var RewardQuest $dailySms */
+    $dailySms = RewardQuest::where('slug', 'daily-sms')->firstOrFail();
+    expect($dailySms->is_repeatable)->toBeTrue();
+});
+
+it('creates reward tier shop items from Bronze to Platinum', function () {
+    (new MobileRewardsDemoSeeder())->run();
+
+    $tiers = RewardShopItem::where('category', 'tiers')
+        ->orderBy('sort_order')
+        ->get();
+
+    expect($tiers)->toHaveCount(4);
+    expect($tiers->pluck('slug')->toArray())->toBe([
+        'tier-bronze',
+        'tier-silver',
+        'tier-gold',
+        'tier-platinum',
+    ]);
+
+    // Verify ascending cost
+    $costs = $tiers->pluck('points_cost')->toArray();
+    expect($costs)->toBe([250, 750, 2000, 5000]);
+
+    // Verify metadata on Gold tier
+    /** @var RewardShopItem $gold */
+    $gold = $tiers->firstWhere('slug', 'tier-gold');
+    $goldMeta = $gold->metadata ?? [];
+    expect($goldMeta['fee_discount_pct'])->toBe(20);
+    expect($goldMeta['dedicated_support'])->toBeTrue();
+});
+
+it('creates reward profiles for demo users', function () {
+    (new MobileRewardsDemoSeeder())->run();
+
+    // Power user
+    /** @var User $nomad */
+    $nomad = User::where('email', 'demo.nomad@gcu.global')->firstOrFail();
+    /** @var RewardProfile $nomadProfile */
+    $nomadProfile = RewardProfile::where('user_id', $nomad->id)->firstOrFail();
+    expect($nomadProfile->level)->toBe(5);
+    expect($nomadProfile->points_balance)->toBe(1350);
+    expect($nomadProfile->current_streak)->toBe(12);
+
+    // New user
+    /** @var User $regular */
+    $regular = User::where('email', 'demo.user@gcu.global')->firstOrFail();
+    /** @var RewardProfile $regularProfile */
+    $regularProfile = RewardProfile::where('user_id', $regular->id)->firstOrFail();
+    expect($regularProfile->level)->toBe(1);
+    expect($regularProfile->points_balance)->toBe(110);
+});
+
+it('creates quest completions for demo profiles', function () {
+    (new MobileRewardsDemoSeeder())->run();
+
+    /** @var User $nomad */
+    $nomad = User::where('email', 'demo.nomad@gcu.global')->firstOrFail();
+    /** @var RewardProfile $nomadProfile */
+    $nomadProfile = RewardProfile::where('user_id', $nomad->id)->firstOrFail();
+
+    $completions = RewardQuestCompletion::where('reward_profile_id', $nomadProfile->id)->get();
+    expect($completions->count())->toBe(5);
+
+    // Check one specific completion
+    /** @var RewardQuest $sendSmsQuest */
+    $sendSmsQuest = RewardQuest::where('slug', 'send-sms')->firstOrFail();
+    $smsCompletion = $completions->firstWhere('quest_id', $sendSmsQuest->id);
+    expect($smsCompletion)->not->toBeNull();
+    expect($smsCompletion->xp_earned)->toBe(25);
+    expect($smsCompletion->points_earned)->toBe(50);
+});
+
+it('creates shop redemptions for demo profiles', function () {
+    (new MobileRewardsDemoSeeder())->run();
+
+    /** @var User $investor */
+    $investor = User::where('email', 'demo.investor@gcu.global')->firstOrFail();
+    /** @var RewardProfile $investorProfile */
+    $investorProfile = RewardProfile::where('user_id', $investor->id)->firstOrFail();
+
+    $redemptions = RewardRedemption::where('reward_profile_id', $investorProfile->id)->get();
+    expect($redemptions->count())->toBe(2);
+
+    $tierRedemption = $redemptions->first(function ($r) {
+        /** @var RewardRedemption $r */
+        $item = RewardShopItem::find($r->shop_item_id);
+
+        return $item !== null && $item->slug === 'tier-bronze';
+    });
+    expect($tierRedemption)->not->toBeNull();
+    expect($tierRedemption->status)->toBe('fulfilled');
+});
+
+it('is idempotent on repeated runs', function () {
+    $seeder = new MobileRewardsDemoSeeder();
+    $seeder->run();
+    $seeder->run();
+
+    $smsQuests = RewardQuest::where('slug', 'like', '%sms%')->count();
+    expect($smsQuests)->toBe(3);
+
+    $tierItems = RewardShopItem::where('category', 'tiers')->count();
+    expect($tierItems)->toBe(4);
+
+    /** @var User $nomad */
+    $nomad = User::where('email', 'demo.nomad@gcu.global')->firstOrFail();
+    $profileCount = RewardProfile::where('user_id', $nomad->id)->count();
+    expect($profileCount)->toBe(1);
+});

--- a/tests/Feature/Seeders/SmsDemoSeederTest.php
+++ b/tests/Feature/Seeders/SmsDemoSeederTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\SMS\Models\SmsMessage;
+use App\Domain\X402\Models\X402MonetizedEndpoint;
+use App\Domain\X402\Models\X402SpendingLimit;
+use Database\Seeders\SmsDemoSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->seed();
+});
+
+it('creates the SMS monetized endpoint', function () {
+    (new SmsDemoSeeder())->run();
+
+    /** @var X402MonetizedEndpoint $endpoint */
+    $endpoint = X402MonetizedEndpoint::where('path', '/api/v1/sms/send')->firstOrFail();
+
+    expect($endpoint->method)->toBe('POST');
+    expect($endpoint->price)->toBe('50000');
+    expect($endpoint->network)->toBe('eip155:8453');
+    expect($endpoint->asset)->toBe('USDC');
+    expect($endpoint->scheme)->toBe('exact');
+    expect($endpoint->is_active)->toBeTrue();
+    expect($endpoint->extra)->toHaveKey('provider', 'vertexsms');
+});
+
+it('creates a demo SMS spending limit', function () {
+    (new SmsDemoSeeder())->run();
+
+    /** @var X402SpendingLimit $limit */
+    $limit = X402SpendingLimit::where('agent_id', 'demo-sms-agent')
+        ->where('agent_type', 'sms')
+        ->firstOrFail();
+
+    expect($limit->daily_limit)->toBe('10000000');
+    expect($limit->per_transaction_limit)->toBe('500000');
+    expect($limit->auto_pay_enabled)->toBeTrue();
+    expect($limit->spent_today)->toBe('0');
+});
+
+it('seeds sample SMS messages in all four statuses', function () {
+    (new SmsDemoSeeder())->run();
+
+    $delivered = SmsMessage::where('status', SmsMessage::STATUS_DELIVERED)->count();
+    $sent = SmsMessage::where('status', SmsMessage::STATUS_SENT)->count();
+    $failed = SmsMessage::where('status', SmsMessage::STATUS_FAILED)->count();
+    $pending = SmsMessage::where('status', SmsMessage::STATUS_PENDING)->count();
+
+    expect($delivered)->toBeGreaterThanOrEqual(2);
+    expect($sent)->toBeGreaterThanOrEqual(2);
+    expect($failed)->toBeGreaterThanOrEqual(1);
+    expect($pending)->toBeGreaterThanOrEqual(1);
+});
+
+it('includes a multi-part SMS message', function () {
+    (new SmsDemoSeeder())->run();
+
+    /** @var SmsMessage $multiPart */
+    $multiPart = SmsMessage::where('parts', '>', 1)->firstOrFail();
+
+    expect($multiPart->parts)->toBe(2);
+    expect((int) $multiPart->price_usdc)->toBeGreaterThan(50000);
+});
+
+it('is idempotent on repeated runs', function () {
+    $seeder = new SmsDemoSeeder();
+    $seeder->run();
+    $seeder->run();
+
+    $endpointCount = X402MonetizedEndpoint::where('path', '/api/v1/sms/send')->count();
+    $limitCount = X402SpendingLimit::where('agent_id', 'demo-sms-agent')->count();
+    $msgCount = SmsMessage::where('provider_id', 'like', 'demo-vtx-%')->count();
+
+    expect($endpointCount)->toBe(1);
+    expect($limitCount)->toBe(1);
+    expect($msgCount)->toBe(7);
+});


### PR DESCRIPTION
## Summary
- **SmsDemoSeeder**: Creates x402 monetized endpoint for `POST /api/v1/sms/send` ($0.05 USDC), demo agent spending limits ($10/day budget), and 7 sample SMS messages across all 4 statuses (pending, sent, delivered, failed) including a multi-part message
- **MobileRewardsDemoSeeder**: Adds SMS-linked quests (`send-sms`, `sms-century`, `daily-sms`), tiered reward shop items (Bronze/Silver/Gold/Platinum with ascending fee discounts), and reward profiles for 4 demo users with quest completions and shop redemptions
- **`sms:setup-demo` command**: One-shot artisan command that bootstraps all SMS + rewards demo data with auto-detection of the Rewards domain; safe to run multiple times (idempotent)
- **PopulateDemoDataCommand** updated to include SMS and mobile rewards seeders in the demo pipeline

## Context
From project memory: "Mobile rewards UI shipped (PR #265/#266), backend needs seeding and auto-creation before demo." This PR completes the VertexSMS partnership integration by providing the backend seeding that the mobile app requires.

## Test plan
- [x] `SmsDemoSeederTest` — 5 tests: monetized endpoint, spending limit, all 4 statuses, multi-part, idempotency
- [x] `MobileRewardsDemoSeederTest` — 6 tests: SMS quests, tier items, profiles, completions, redemptions, idempotency
- [x] `SmsSetupDemoCommandTest` — 4 tests: command execution, --with-rewards flag, auto-detection, idempotency
- [x] Existing `SmsEndpointTest` — all 17 tests still pass
- [x] Existing `DemoDataSeederTest` — all 8 tests still pass
- [x] PHPStan Level 8 — 0 errors on all new/modified files
- [x] php-cs-fixer — all files formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)