### PR TITLE
fix: update Zelta CLI page to reflect v0.2.0 (25 commands)

### DIFF
--- a/resources/views/features/index.blade.php
+++ b/resources/views/features/index.blade.php
@@ -503,7 +503,7 @@
                     </div>
                     <div class="flex items-center gap-2 mb-3">
                         <h3 class="text-xl font-semibold">Zelta CLI</h3>
-                        <span class="inline-flex items-center px-2 py-0.5 bg-emerald-100 text-emerald-700 text-xs rounded-full font-medium">v0.1.0</span>
+                        <span class="inline-flex items-center px-2 py-0.5 bg-emerald-100 text-emerald-700 text-xs rounded-full font-medium">v0.2.0</span>
                     </div>
                     <p class="text-slate-500 mb-4">
                         Manage payments, SMS, wallets, and API monetization from the terminal. Built for humans and AI agents with dual output: tables or JSON.

--- a/resources/views/features/zelta-cli.blade.php
+++ b/resources/views/features/zelta-cli.blade.php
@@ -29,7 +29,7 @@
                 <div class="flex justify-center mb-6">
                     <span class="inline-flex items-center gap-2 px-4 py-2 bg-emerald-500/10 border border-emerald-500/20 rounded-full text-sm text-emerald-300 font-medium">
                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
-                        v0.1.0 &middot; CLI Toolkit
+                        v0.2.0 &middot; 25 Commands
                     </span>
                 </div>
                 @include('partials.breadcrumb', ['items' => [
@@ -113,8 +113,11 @@
                     <div class="w-12 h-12 bg-cyan-100 rounded-lg flex items-center justify-center mb-4">
                         <svg class="w-6 h-6 text-cyan-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
                     </div>
-                    <h3 class="text-lg font-semibold mb-2">Expanding</h3>
-                    <p class="text-slate-500 text-sm">More commands shipping in v0.2.0: wallet management, spending limits, agent registration, SDK generation, and plugin management.</p>
+                    <h3 class="text-lg font-semibold mb-2">Wallet &amp; Agents</h3>
+                    <p class="text-slate-500 text-sm">Manage wallet balances, spending limits, and agent registration. Generate SDKs in 6 languages directly from the CLI.</p>
+                    <div class="space-y-1.5 font-mono text-xs mt-3">
+                        <div class="text-slate-600"><span class="text-cyan-500">wallet:balance</span> &middot; <span class="text-cyan-500">limits:set</span> &middot; <span class="text-cyan-500">agents:register</span></div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -136,7 +139,7 @@
 
 <span class="text-slate-500"># Verify installation</span>
 <span class="text-emerald-400">$</span> zelta --version
-zelta/0.1.0 linux-x64 node-v20.11.0</code></pre>
+zelta/0.2.0 linux-x64 node-v20.11.0</code></pre>
                     </div>
                 </div>
                 <div class="flex gap-6">


### PR DESCRIPTION
## Summary
Content audit found stale v0.1.0 references after CLI v0.2.0 shipped (PR #843).

## Fixes
- Hero badge: `v0.1.0 · CLI Toolkit` → `v0.2.0 · 25 Commands`
- "Expanding" card → "Wallet & Agents" with shipped command names
- Terminal preview: `zelta/0.1.0` → `zelta/0.2.0`
- Features index badge: `v0.1.0` → `v0.2.0`

## Audit Results (full codebase)
- PHPStan Level 8: 3,801 files, 0 errors
- php-cs-fixer: 4,274 files, 0 fixes needed
- All version badges: v6.5.0 (platform), v0.2.0 (CLI)
- Domain count: 49 (matches `ls -d app/Domain/*/`)
- SEO: all feature pages have unique meta + Schema.org + OG tags
- Cross-links: 4-5 per page, bidirectional

🤖 Generated with [Claude Code](https://claude.com/claude-code)