### PR TITLE
fix: address code review — DI, race conditions, duplicate code

### DIFF
--- a/app/Domain/CardIssuance/Services/JitFundingService.php
+++ b/app/Domain/CardIssuance/Services/JitFundingService.php
@@ -30,6 +30,7 @@ class JitFundingService
 
     public function __construct(
         private readonly CardIssuerInterface $cardIssuer,
+        private readonly SpendLimitEnforcementService $spendLimitService,
     ) {
     }
 
@@ -72,8 +73,7 @@ class JitFundingService
         }
 
         // 2b. Check spend limits
-        $spendLimitService = app(SpendLimitEnforcementService::class);
-        if (! $spendLimitService->checkLimit($request->cardToken, $requiredAmount)) {
+        if (! $this->spendLimitService->checkLimit($request->cardToken, $requiredAmount)) {
             return $this->decline($request, AuthorizationDecision::DECLINED_LIMIT_EXCEEDED);
         }
 
@@ -108,8 +108,7 @@ class JitFundingService
         ));
 
         // 4b. Record spend against limit tracker
-        $spendLimitService = app(SpendLimitEnforcementService::class);
-        $spendLimitService->recordSpend($request->cardToken, $requiredAmount);
+        $this->spendLimitService->recordSpend($request->cardToken, $requiredAmount);
 
         return [
             'approved' => true,

--- a/app/Domain/CardIssuance/Services/SpendLimitEnforcementService.php
+++ b/app/Domain/CardIssuance/Services/SpendLimitEnforcementService.php
@@ -17,6 +17,9 @@ use Illuminate\Support\Facades\Log;
  */
 class SpendLimitEnforcementService
 {
+    /** @var array<string, Card|null> Request-scoped card cache */
+    private array $cardCache = [];
+
     /**
      * Check if a spend amount is within the card's configured limit.
      *
@@ -26,7 +29,7 @@ class SpendLimitEnforcementService
      */
     public function checkLimit(string $cardToken, float $amount): bool
     {
-        $card = Card::where('issuer_card_token', $cardToken)->first();
+        $card = $this->resolveCard($cardToken);
 
         if ($card === null || $card->spend_limit_cents === null) {
             return true;
@@ -59,12 +62,14 @@ class SpendLimitEnforcementService
     /**
      * Record a successful spend against the card's running total.
      *
+     * Uses atomic cache operations to prevent race conditions under concurrent requests.
+     *
      * @param string $cardToken The issuer card token
      * @param float  $amount    The transaction amount in decimal (e.g. 25.50)
      */
     public function recordSpend(string $cardToken, float $amount): void
     {
-        $card = Card::where('issuer_card_token', $cardToken)->first();
+        $card = $this->resolveCard($cardToken);
 
         if ($card === null || $card->spend_limit_cents === null) {
             return;
@@ -76,17 +81,27 @@ class SpendLimitEnforcementService
         $cacheKey = $this->buildCacheKey($cardToken, $interval);
         $ttl = $this->getTtl($interval);
 
-        /** @var int $currentSpendCents */
-        $currentSpendCents = Cache::get($cacheKey, 0);
-
-        Cache::put($cacheKey, $currentSpendCents + $amountCents, $ttl);
+        // Atomic: ensure key exists with TTL, then increment
+        Cache::add($cacheKey, 0, $ttl);
+        Cache::increment($cacheKey, $amountCents);
 
         Log::info('SpendLimitEnforcement: Spend recorded', [
             'card_token'   => $cardToken,
             'interval'     => $interval,
             'amount_cents' => $amountCents,
-            'new_total'    => $currentSpendCents + $amountCents,
         ]);
+    }
+
+    /**
+     * Resolve a card by its issuer token, with request-scoped memoization.
+     */
+    private function resolveCard(string $cardToken): ?Card
+    {
+        if (! array_key_exists($cardToken, $this->cardCache)) {
+            $this->cardCache[$cardToken] = Card::where('issuer_card_token', $cardToken)->first();
+        }
+
+        return $this->cardCache[$cardToken];
     }
 
     /**

--- a/app/Domain/CrossChain/Services/Adapters/CircleCctpBridgeAdapter.php
+++ b/app/Domain/CrossChain/Services/Adapters/CircleCctpBridgeAdapter.php
@@ -233,7 +233,7 @@ class CircleCctpBridgeAdapter implements BridgeAdapterInterface
                 [
                     $encoder->encodeUint256($amountSmallest),
                     $encoder->encodeUint32($destDomain),
-                    $encoder->encodeBytes32($this->addressToBytes32($recipientAddress)),
+                    $encoder->encodeBytes32($encoder->encodeAddressAsBytes32($recipientAddress)),
                     $encoder->encodeAddress($burnToken),
                 ],
             );
@@ -461,15 +461,5 @@ class CircleCctpBridgeAdapter implements BridgeAdapterInterface
             CrossChainNetwork::BASE     => '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
             default                     => '0x' . str_repeat('0', 40),
         };
-    }
-
-    /**
-     * Convert an address to bytes32 format for CCTP mint recipient encoding.
-     */
-    private function addressToBytes32(string $address): string
-    {
-        $clean = ltrim($address, '0x');
-
-        return str_pad($clean, 64, '0', STR_PAD_LEFT);
     }
 }

--- a/app/Domain/CrossChain/Services/Adapters/WormholeBridgeAdapter.php
+++ b/app/Domain/CrossChain/Services/Adapters/WormholeBridgeAdapter.php
@@ -234,7 +234,7 @@ class WormholeBridgeAdapter implements BridgeAdapterInterface
                     $encoder->encodeAddress($tokenAddress),
                     $encoder->encodeUint256($amountWei),
                     $encoder->encodeUint16($destChainId),
-                    $encoder->encodeBytes32($this->addressToBytes32($recipientAddress)),
+                    $encoder->encodeBytes32($encoder->encodeAddressAsBytes32($recipientAddress)),
                     $encoder->encodeUint256($feeWei),
                     $encoder->encodeUint256((string) $nonce),
                 ],
@@ -411,15 +411,5 @@ class WormholeBridgeAdapter implements BridgeAdapterInterface
         $chainAddresses = $addresses[$chain->value] ?? [];
 
         return $chainAddresses[$token] ?? '0x' . str_repeat('0', 40);
-    }
-
-    /**
-     * Convert an address to bytes32 format for Wormhole recipient encoding.
-     */
-    private function addressToBytes32(string $address): string
-    {
-        $clean = ltrim($address, '0x');
-
-        return str_pad($clean, 64, '0', STR_PAD_LEFT);
     }
 }

--- a/app/Domain/DeFi/Services/Connectors/AaveV3Connector.php
+++ b/app/Domain/DeFi/Services/Connectors/AaveV3Connector.php
@@ -7,6 +7,7 @@ namespace App\Domain\DeFi\Services\Connectors;
 use App\Domain\CrossChain\Enums\CrossChainNetwork;
 use App\Domain\DeFi\Contracts\LendingProtocolInterface;
 use App\Domain\DeFi\Enums\DeFiProtocol;
+use App\Domain\DeFi\Traits\UsesDeFiConfig;
 use App\Infrastructure\Web3\AbiEncoder;
 use App\Infrastructure\Web3\EthRpcClient;
 use Illuminate\Support\Facades\Log;
@@ -22,6 +23,8 @@ use RuntimeException;
  */
 class AaveV3Connector implements LendingProtocolInterface
 {
+    use UsesDeFiConfig;
+
     private const SUPPORTED_CHAINS = ['ethereum', 'polygon', 'arbitrum', 'optimism', 'base'];
 
     public function getProtocol(): DeFiProtocol
@@ -527,28 +530,5 @@ class AaveV3Connector implements LendingProtocolInterface
 
         return $addresses[$chain->value]
             ?? '0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2';
-    }
-
-    /**
-     * Resolve token symbol to contract address on a given chain.
-     */
-    private function resolveTokenAddress(string $token, CrossChainNetwork $chain): string
-    {
-        /** @var array<string, array<string, string>> $addresses */
-        $addresses = (array) config('defi.token_addresses', []);
-        $chainAddresses = $addresses[$chain->value] ?? [];
-
-        return $chainAddresses[$token] ?? '0x' . str_repeat('0', 40);
-    }
-
-    /**
-     * Get RPC URL for a given chain from config.
-     */
-    private function getRpcUrl(CrossChainNetwork $chain): ?string
-    {
-        $key = 'defi.rpc_urls.' . $chain->value;
-        $url = config($key, '');
-
-        return $url !== '' ? (string) $url : null;
     }
 }

--- a/app/Domain/DeFi/Services/Connectors/UniswapV3Connector.php
+++ b/app/Domain/DeFi/Services/Connectors/UniswapV3Connector.php
@@ -7,6 +7,7 @@ namespace App\Domain\DeFi\Services\Connectors;
 use App\Domain\CrossChain\Enums\CrossChainNetwork;
 use App\Domain\DeFi\Contracts\SwapProtocolInterface;
 use App\Domain\DeFi\Enums\DeFiProtocol;
+use App\Domain\DeFi\Traits\UsesDeFiConfig;
 use App\Domain\DeFi\ValueObjects\SwapQuote;
 use App\Infrastructure\Web3\AbiEncoder;
 use App\Infrastructure\Web3\EthRpcClient;
@@ -24,6 +25,8 @@ use RuntimeException;
  */
 class UniswapV3Connector implements SwapProtocolInterface
 {
+    use UsesDeFiConfig;
+
     private const SUPPORTED_CHAINS = ['ethereum', 'polygon', 'arbitrum', 'optimism', 'base'];
 
     private const FEE_TIERS = [100, 500, 3000, 10000];
@@ -343,25 +346,5 @@ class UniswapV3Connector implements SwapProtocolInterface
                 'price_impact'  => $quote->priceImpact,
             ];
         }
-    }
-
-    /**
-     * Resolve token symbol to contract address on a given chain.
-     */
-    private function resolveTokenAddress(string $token, CrossChainNetwork $chain): string
-    {
-        /** @var array<string, array<string, string>> $addresses */
-        $addresses = (array) config('defi.token_addresses', []);
-        $chainAddresses = $addresses[$chain->value] ?? [];
-
-        return $chainAddresses[$token] ?? '0x' . str_repeat('0', 40);
-    }
-
-    private function getRpcUrl(CrossChainNetwork $chain): ?string
-    {
-        $key = 'defi.rpc_urls.' . $chain->value;
-        $url = config($key, '');
-
-        return $url !== '' ? (string) $url : null;
     }
 }

--- a/app/Domain/DeFi/Traits/UsesDeFiConfig.php
+++ b/app/Domain/DeFi/Traits/UsesDeFiConfig.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\DeFi\Traits;
+
+use App\Domain\CrossChain\Enums\CrossChainNetwork;
+
+/**
+ * Shared DeFi configuration helpers for protocol connectors.
+ *
+ * Provides token address resolution and RPC URL lookup from the defi config namespace.
+ */
+trait UsesDeFiConfig
+{
+    /**
+     * Resolve token symbol to contract address on a given chain.
+     */
+    private function resolveTokenAddress(string $token, CrossChainNetwork $chain): string
+    {
+        /** @var array<string, array<string, string>> $addresses */
+        $addresses = (array) config('defi.token_addresses', []);
+        $chainAddresses = $addresses[$chain->value] ?? [];
+
+        return $chainAddresses[$token] ?? '0x' . str_repeat('0', 40);
+    }
+
+    /**
+     * Get RPC URL for a given chain from config.
+     */
+    private function getRpcUrl(CrossChainNetwork $chain): ?string
+    {
+        $key = 'defi.rpc_urls.' . $chain->value;
+        $url = config($key, '');
+
+        return $url !== '' ? (string) $url : null;
+    }
+}

--- a/app/Http/Controllers/Api/Banking/BankWebhookController.php
+++ b/app/Http/Controllers/Api/Banking/BankWebhookController.php
@@ -118,7 +118,7 @@ class BankWebhookController extends Controller
     {
         $signature = $request->header('X-Webhook-Signature', '');
 
-        if ($signature === '' || $signature === null) {
+        if ($signature === '') {
             return false;
         }
 

--- a/app/Infrastructure/Web3/AbiEncoder.php
+++ b/app/Infrastructure/Web3/AbiEncoder.php
@@ -156,6 +156,21 @@ class AbiEncoder
     }
 
     /**
+     * Encode an Ethereum address as a bytes32 value (left-padded with zeros).
+     *
+     * Used by cross-chain protocols (Wormhole, CCTP) for recipient encoding.
+     *
+     * @param  string $address Hex address (with or without 0x prefix)
+     * @return string 64-char hex string (32 bytes, left-padded)
+     */
+    public function encodeAddressAsBytes32(string $address): string
+    {
+        $clean = str_replace('0x', '', $address);
+
+        return str_pad($clean, 64, '0', STR_PAD_LEFT);
+    }
+
+    /**
      * Compute the 4-byte function selector (first 4 bytes of keccak256 hash).
      *
      * @param  string $signature Function signature, e.g. "transfer(address,uint256)"

--- a/app/Infrastructure/Web3/EthRpcClient.php
+++ b/app/Infrastructure/Web3/EthRpcClient.php
@@ -35,6 +35,9 @@ class EthRpcClient
     /** @var int Retry delay in milliseconds */
     private const RETRY_DELAY_MS = 1000;
 
+    /** @var int HTTP timeout in seconds for sendTransaction (higher latency expected) */
+    private const SEND_TX_TIMEOUT = 30;
+
     /**
      * Execute an eth_call against the specified chain's RPC endpoint.
      *
@@ -112,7 +115,7 @@ class EthRpcClient
 
         $this->checkCircuitBreaker($chain);
 
-        $response = Http::timeout(30)
+        $response = Http::timeout(self::SEND_TX_TIMEOUT)
             ->retry(self::RETRY_ATTEMPTS, self::RETRY_DELAY_MS)
             ->post($rpcUrl, [
                 'jsonrpc' => '2.0',
@@ -152,6 +155,8 @@ class EthRpcClient
             return null;
         }
 
+        $this->checkCircuitBreaker($chain);
+
         $response = Http::timeout(self::HTTP_TIMEOUT)
             ->post($rpcUrl, [
                 'jsonrpc' => '2.0',
@@ -161,8 +166,12 @@ class EthRpcClient
             ]);
 
         if ($response->failed()) {
+            $this->recordFailure($chain);
+
             return null;
         }
+
+        $this->recordSuccess($chain);
 
         /** @var array<string, mixed>|null */
         return $response->json('result');
@@ -212,8 +221,8 @@ class EthRpcClient
     private function recordFailure(string $chain): void
     {
         $key = "eth_rpc_failures:{$chain}";
-        $failures = (int) Cache::get($key, 0);
-        Cache::put($key, $failures + 1, self::CIRCUIT_BREAKER_TTL);
+        Cache::add($key, 0, self::CIRCUIT_BREAKER_TTL);
+        Cache::increment($key);
     }
 
     /**

--- a/database/migrations/2026_03_27_000001_create_tenant_audit_logs_table.php
+++ b/database/migrations/2026_03_27_000001_create_tenant_audit_logs_table.php
@@ -6,8 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2026_03_27_000002_add_soft_delete_to_tenants.php
+++ b/database/migrations/2026_03_27_000002_add_soft_delete_to_tenants.php
@@ -6,8 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */

--- a/tests/Unit/Domain/CrossChain/Services/Adapters/WormholeProductionTest.php
+++ b/tests/Unit/Domain/CrossChain/Services/Adapters/WormholeProductionTest.php
@@ -7,7 +7,6 @@ use App\Domain\CrossChain\Enums\BridgeStatus;
 use App\Domain\CrossChain\Enums\CrossChainNetwork;
 use App\Domain\CrossChain\Services\Adapters\WormholeBridgeAdapter;
 use App\Infrastructure\Web3\AbiEncoder;
-use Illuminate\Support\Facades\Http;
 
 uses(Tests\TestCase::class);
 

--- a/tests/Unit/Domain/DeFi/Services/Connectors/UniswapV3ProductionTest.php
+++ b/tests/Unit/Domain/DeFi/Services/Connectors/UniswapV3ProductionTest.php
@@ -6,7 +6,6 @@ use App\Domain\CrossChain\Enums\CrossChainNetwork;
 use App\Domain\DeFi\Enums\DeFiProtocol;
 use App\Domain\DeFi\Services\Connectors\UniswapV3Connector;
 use App\Infrastructure\Web3\AbiEncoder;
-use Illuminate\Support\Facades\Http;
 
 uses(Tests\TestCase::class);
 


### PR DESCRIPTION
## Summary

- **JitFundingService**: Replace `app(SpendLimitEnforcementService::class)` service locator with proper constructor injection
- **SpendLimitEnforcementService**: Fix race condition in `recordSpend()` by using atomic `Cache::add` + `Cache::increment`; add `resolveCard()` with request-scoped memoization to eliminate duplicate DB queries
- **EthRpcClient**: Atomic failure counter in `recordFailure()`; add circuit breaker + success/failure tracking to `getTransactionReceipt()`; extract `SEND_TX_TIMEOUT` constant
- **BankWebhookController**: Remove dead `|| $signature === null` check (header default guarantees string)
- **AbiEncoder**: Add `encodeAddressAsBytes32()` method; remove duplicate `addressToBytes32()` from Wormhole and CCTP adapters
- **DeFi connectors**: Extract `UsesDeFiConfig` trait for shared `resolveTokenAddress()` and `getRpcUrl()` (removes duplication from Uniswap and Aave connectors)

## Test plan

- [x] PHPStan Level 8 passes on all 10 changed files (0 errors)
- [x] `SpendLimitEnforcementServiceTest` — 6 tests pass
- [x] `EthRpcClientTest` — 13 tests pass
- [x] `AbiEncoderTest` — 25 tests pass
- [x] php-cs-fixer clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)