### PR TITLE
security: fix JIT funding TOCTOU race condition + webhook SSRF validation

### DIFF
--- a/app/Domain/AgentProtocol/Services/AgentWebhookService.php
+++ b/app/Domain/AgentProtocol/Services/AgentWebhookService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Domain\AgentProtocol\Services;
 
+use App\Infrastructure\Security\UrlValidator;
 use Exception;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
@@ -112,6 +113,9 @@ class AgentWebhookService
         array $events = [],
         ?string $secret = null
     ): bool {
+        // SSRF protection: validate endpoint URL does not resolve to private/internal IPs
+        UrlValidator::validateExternalUrl($endpoint);
+
         $cacheKey = "webhook:endpoints:{$agentId}";
         $endpoints = Cache::get($cacheKey, []);
 

--- a/app/Domain/CardIssuance/Services/JitFundingService.php
+++ b/app/Domain/CardIssuance/Services/JitFundingService.php
@@ -10,6 +10,7 @@ use App\Domain\CardIssuance\Events\AuthorizationApproved;
 use App\Domain\CardIssuance\Events\AuthorizationDeclined;
 use App\Domain\CardIssuance\ValueObjects\AuthorizationRequest;
 use App\Infrastructure\Monitoring\MetricsService;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
 use Throwable;
@@ -66,30 +67,55 @@ class JitFundingService
             return $this->decline($request, $decision);
         }
 
-        // 2. Check stablecoin balance (demo implementation)
-        $balance = $this->getStablecoinBalance($card->metadata['user_id'] ?? '');
+        // 2. Check balance + create hold atomically to prevent TOCTOU race condition.
+        //    Without a transaction lock, two concurrent authorizations could both pass
+        //    the balance check before either creates a hold, leading to double-spending.
+        $userId = $card->metadata['user_id'] ?? '';
         $requiredAmount = (float) $request->getAmountDecimal();
 
-        if ($balance < $requiredAmount) {
-            return $this->decline($request, AuthorizationDecision::DECLINED_INSUFFICIENT_FUNDS);
-        }
+        $declineReason = null;
+        $holdId = '';
 
-        // 2b. Check spend limits
-        if (! $this->spendLimitService->checkLimit($request->cardToken, $requiredAmount)) {
-            return $this->decline($request, AuthorizationDecision::DECLINED_LIMIT_EXCEEDED);
-        }
+        DB::transaction(function () use ($request, $userId, $requiredAmount, &$declineReason, &$holdId): void {
+            // Acquire row lock on account to serialize concurrent authorizations.
+            // Demo mode skips locking (no real account rows exist).
+            if (! $this->isDemoMode()) {
+                \App\Domain\Account\Models\Account::where('user_uuid', $userId)
+                    ->lockForUpdate()
+                    ->first();
+            }
 
-        // 3. Create hold on funds
-        $holdId = $this->createHold(
-            $card->metadata['user_id'] ?? '',
-            self::DEFAULT_FUNDING_TOKEN,
-            $requiredAmount,
-            [
-                'authorization_id'  => $request->authorizationId,
-                'merchant'          => $request->merchantName,
-                'merchant_category' => $request->merchantCategory,
-            ]
-        );
+            $balance = $this->getStablecoinBalance($userId);
+
+            if ($balance < $requiredAmount) {
+                $declineReason = AuthorizationDecision::DECLINED_INSUFFICIENT_FUNDS;
+
+                return;
+            }
+
+            // Check spend limits inside the lock to prevent limit bypass
+            if (! $this->spendLimitService->checkLimit($request->cardToken, $requiredAmount)) {
+                $declineReason = AuthorizationDecision::DECLINED_LIMIT_EXCEEDED;
+
+                return;
+            }
+
+            // Create hold while lock is held — guarantees no concurrent double-spend
+            $holdId = $this->createHold(
+                $userId,
+                self::DEFAULT_FUNDING_TOKEN,
+                $requiredAmount,
+                [
+                    'authorization_id'  => $request->authorizationId,
+                    'merchant'          => $request->merchantName,
+                    'merchant_category' => $request->merchantCategory,
+                ]
+            );
+        });
+
+        if ($declineReason !== null) {
+            return $this->decline($request, $declineReason);
+        }
 
         // 4. Approve transaction
         $latencyMs = (microtime(true) - $startTime) * 1000;

--- a/app/Http/Controllers/Api/V2/WebhookController.php
+++ b/app/Http/Controllers/Api/V2/WebhookController.php
@@ -7,11 +7,13 @@ namespace App\Http\Controllers\Api\V2;
 use App\Domain\Webhook\Models\Webhook;
 use App\Domain\Webhook\Models\WebhookDelivery;
 use App\Http\Controllers\Controller;
+use App\Infrastructure\Security\UrlValidator;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use OpenApi\Attributes as OA;
+use RuntimeException;
 
 #[OA\Tag(
     name: 'Webhooks',
@@ -106,6 +108,16 @@ class WebhookController extends Controller
                 'is_active'   => 'boolean',
             ]
         );
+
+        // SSRF protection: validate URL does not resolve to private/internal IPs
+        try {
+            UrlValidator::validateExternalUrl($validated['url']);
+        } catch (RuntimeException $e) {
+            return response()->json(
+                ['error' => 'Invalid webhook URL: ' . $e->getMessage()],
+                422
+            );
+        }
 
         $secret = 'whsec_' . Str::random(32);
 
@@ -227,6 +239,18 @@ class WebhookController extends Controller
                 'is_active'   => 'boolean',
             ]
         );
+
+        // SSRF protection: validate URL if it's being changed
+        if (isset($validated['url'])) {
+            try {
+                UrlValidator::validateExternalUrl($validated['url']);
+            } catch (RuntimeException $e) {
+                return response()->json(
+                    ['error' => 'Invalid webhook URL: ' . $e->getMessage()],
+                    422
+                );
+            }
+        }
 
         $webhook->update($validated);
 

--- a/app/Infrastructure/Security/UrlValidator.php
+++ b/app/Infrastructure/Security/UrlValidator.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Security;
+
+use RuntimeException;
+
+/**
+ * Validates outbound URLs to prevent SSRF attacks.
+ *
+ * Rejects URLs that resolve to private/internal IP ranges, cloud metadata
+ * endpoints, and non-HTTPS schemes in production. Used for webhook
+ * registration and any user-supplied callback URLs.
+ */
+class UrlValidator
+{
+    /**
+     * Cloud metadata endpoints that must always be blocked.
+     *
+     * @var list<string>
+     */
+    private const BLOCKED_HOSTS = [
+        '169.254.169.254',           // AWS metadata
+        'metadata.google.internal',  // GCP metadata
+        '100.100.100.200',           // Alibaba metadata
+    ];
+
+    /**
+     * Validate that a URL is safe for outbound requests (not internal/private).
+     *
+     * @throws RuntimeException if the URL is invalid or points to an internal resource
+     */
+    public static function validateExternalUrl(string $url): void
+    {
+        $parsed = parse_url($url);
+        if ($parsed === false || ! isset($parsed['host'])) {
+            throw new RuntimeException('Invalid URL format');
+        }
+
+        $host = $parsed['host'];
+        $scheme = $parsed['scheme'] ?? '';
+
+        // Must be HTTPS in production
+        if (app()->environment('production') && $scheme !== 'https') {
+            throw new RuntimeException('Webhook URLs must use HTTPS in production');
+        }
+
+        // Block known metadata endpoints
+        if (in_array($host, self::BLOCKED_HOSTS, true)) {
+            throw new RuntimeException('URL points to blocked host');
+        }
+
+        // Resolve hostname and check against private ranges
+        $ips = gethostbynamel($host);
+        if ($ips === false) {
+            throw new RuntimeException('Could not resolve hostname');
+        }
+
+        foreach ($ips as $ip) {
+            if (self::isPrivateIp($ip)) {
+                throw new RuntimeException('URL resolves to private/internal IP address');
+            }
+        }
+    }
+
+    /**
+     * Check if an IP address is in a private or reserved range.
+     *
+     * Uses PHP's built-in FILTER_VALIDATE_IP with NO_PRIV_RANGE and NO_RES_RANGE
+     * flags, which covers RFC 1918, loopback, link-local, and other reserved ranges.
+     */
+    private static function isPrivateIp(string $ip): bool
+    {
+        return filter_var(
+            $ip,
+            FILTER_VALIDATE_IP,
+            FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
+        ) === false;
+    }
+}

--- a/tests/Unit/Infrastructure/Security/UrlValidatorTest.php
+++ b/tests/Unit/Infrastructure/Security/UrlValidatorTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Infrastructure\Security\UrlValidator;
+
+uses(Tests\TestCase::class);
+
+it('rejects AWS metadata endpoint', function (): void {
+    expect(fn () => UrlValidator::validateExternalUrl('http://169.254.169.254/latest/meta-data/'))
+        ->toThrow(RuntimeException::class, 'URL points to blocked host');
+});
+
+it('rejects GCP metadata endpoint', function (): void {
+    expect(fn () => UrlValidator::validateExternalUrl('http://metadata.google.internal/computeMetadata/v1/'))
+        ->toThrow(RuntimeException::class, 'URL points to blocked host');
+});
+
+it('rejects Alibaba metadata endpoint', function (): void {
+    expect(fn () => UrlValidator::validateExternalUrl('http://100.100.100.200/latest/meta-data/'))
+        ->toThrow(RuntimeException::class, 'URL points to blocked host');
+});
+
+it('rejects loopback address 127.0.0.1', function (): void {
+    expect(fn () => UrlValidator::validateExternalUrl('http://127.0.0.1/admin'))
+        ->toThrow(RuntimeException::class, 'URL resolves to private/internal IP address');
+});
+
+it('rejects private IP 10.x.x.x', function (): void {
+    expect(fn () => UrlValidator::validateExternalUrl('http://10.0.0.1/internal'))
+        ->toThrow(RuntimeException::class, 'URL resolves to private/internal IP address');
+});
+
+it('rejects private IP 192.168.x.x', function (): void {
+    expect(fn () => UrlValidator::validateExternalUrl('http://192.168.1.1/router'))
+        ->toThrow(RuntimeException::class, 'URL resolves to private/internal IP address');
+});
+
+it('rejects private IP 172.16.x.x', function (): void {
+    expect(fn () => UrlValidator::validateExternalUrl('http://172.16.0.1/internal'))
+        ->toThrow(RuntimeException::class, 'URL resolves to private/internal IP address');
+});
+
+it('rejects 0.0.0.0', function (): void {
+    expect(fn () => UrlValidator::validateExternalUrl('http://0.0.0.0/'))
+        ->toThrow(RuntimeException::class, 'URL resolves to private/internal IP address');
+});
+
+it('rejects invalid URL format', function (): void {
+    expect(fn () => UrlValidator::validateExternalUrl('not-a-url'))
+        ->toThrow(RuntimeException::class, 'Invalid URL format');
+});
+
+it('rejects URL without host', function (): void {
+    expect(fn () => UrlValidator::validateExternalUrl('file:///etc/passwd'))
+        ->toThrow(RuntimeException::class, 'Invalid URL format');
+});
+
+it('rejects unresolvable hostname', function (): void {
+    expect(fn () => UrlValidator::validateExternalUrl('https://this-domain-definitely-does-not-exist-xyz123.invalid/webhook'))
+        ->toThrow(RuntimeException::class, 'Could not resolve hostname');
+});
+
+it('accepts valid external HTTPS URL', function (): void {
+    // example.com resolves to 93.184.216.34 — a public IP
+    UrlValidator::validateExternalUrl('https://example.com/webhook');
+
+    // If we get here without exception, the test passes
+    expect(true)->toBeTrue();
+});
+
+it('rejects non-HTTPS in production', function (): void {
+    // Temporarily set environment to production
+    app()->detectEnvironment(fn () => 'production');
+
+    expect(fn () => UrlValidator::validateExternalUrl('http://example.com/webhook'))
+        ->toThrow(RuntimeException::class, 'Webhook URLs must use HTTPS in production');
+
+    // Restore test environment
+    app()->detectEnvironment(fn () => 'testing');
+});
+
+it('allows HTTP in non-production environments', function (): void {
+    // In testing environment, HTTP should be allowed (for local dev)
+    app()->detectEnvironment(fn () => 'testing');
+
+    // example.com resolves to a public IP
+    UrlValidator::validateExternalUrl('http://example.com/webhook');
+
+    expect(true)->toBeTrue();
+});


### PR DESCRIPTION
## Summary

Fixes two **critical** findings from the STRIDE threat model analysis:

- **JIT Funding TOCTOU Race Condition**: The `authorize()` method in `JitFundingService` checked stablecoin balance and created a hold without any database lock between the two operations. Two concurrent authorization requests could both pass the balance check before either created a hold, leading to double-spending. Fixed by wrapping the critical section in `DB::transaction()` with `lockForUpdate()` on the account row to serialize concurrent requests.

- **Webhook SSRF**: Webhook callback URLs submitted by users were not validated against private IP ranges. An attacker could register a webhook URL pointing to AWS metadata (`169.254.169.254`), internal services (`10.0.0.1`), or loopback (`127.0.0.1`). Fixed by creating `UrlValidator` that rejects private/internal IPs, cloud metadata endpoints, and non-HTTPS in production. Applied to `WebhookController` (store/update) and `AgentWebhookService` registration.

## Changes

| File | Change |
|------|--------|
| `app/Domain/CardIssuance/Services/JitFundingService.php` | Wrap balance check + hold creation in `DB::transaction()` with `lockForUpdate()` |
| `app/Infrastructure/Security/UrlValidator.php` | **New** — SSRF protection helper (private IP, metadata endpoint, HTTPS enforcement) |
| `app/Http/Controllers/Api/V2/WebhookController.php` | Add SSRF validation on webhook create and update |
| `app/Domain/AgentProtocol/Services/AgentWebhookService.php` | Add SSRF validation on agent endpoint registration |
| `tests/Unit/Infrastructure/Security/UrlValidatorTest.php` | **New** — 14 tests covering all SSRF rejection cases |

## Test plan

- [x] PHPStan Level 8 passes on all modified files (0 errors)
- [x] PHP CS Fixer passes
- [x] 14 new UrlValidator tests pass (AWS/GCP/Alibaba metadata, loopback, private ranges, invalid URLs, HTTPS enforcement)
- [x] 6 existing SpendLimitEnforcementService tests still pass
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)