### PR TITLE
feat: wire device attestation + recovery shard improvements

### DIFF
--- a/app/Domain/Wallet/Routes/api.php
+++ b/app/Domain/Wallet/Routes/api.php
@@ -155,4 +155,9 @@ Route::prefix('v1/wallet')->name('mobile.wallet.')
             ->name('recovery-shard-backup.retrieve');
         Route::delete('/recovery-shard-backup', [RecoveryShardController::class, 'destroy'])
             ->name('recovery-shard-backup.destroy');
+
+        // Recovery key reconstruction (v7.2.0)
+        Route::post('/recovery/reconstruct', [RecoveryShardController::class, 'reconstruct'])
+            ->middleware('transaction.rate_limit:blockchain')
+            ->name('recovery.reconstruct');
     });

--- a/app/Http/Controllers/Api/Auth/LoginController.php
+++ b/app/Http/Controllers/Api/Auth/LoginController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Auth;
 
+use App\Domain\Mobile\Services\BiometricJWTService;
 use App\Http\Controllers\Controller;
 use App\Models\User;
 use App\Services\IpBlockingService;
@@ -19,7 +20,8 @@ class LoginController extends Controller
     use HasApiScopes;
 
     public function __construct(
-        private readonly IpBlockingService $ipBlockingService
+        private readonly IpBlockingService $ipBlockingService,
+        private readonly BiometricJWTService $biometricJWTService,
     ) {
     }
 
@@ -75,9 +77,11 @@ class LoginController extends Controller
     {
         $request->validate(
             [
-                'email'       => 'required|email',
-                'password'    => 'required',
-                'device_name' => 'string',
+                'email'              => 'required|email',
+                'password'           => 'required',
+                'device_name'        => 'string',
+                'device_attestation' => ['nullable', 'string', 'max:4096'],
+                'device_type'        => ['nullable', 'string', 'in:ios,android'],
             ]
         );
 
@@ -101,6 +105,17 @@ class LoginController extends Controller
                     'email' => ['The provided credentials are incorrect.'],
                 ]
             );
+        }
+
+        // Verify device attestation if provided and enabled
+        if ($request->filled('device_attestation') && config('mobile.attestation.enabled')) {
+            $verified = $this->biometricJWTService->verifyDeviceAttestation(
+                $request->input('device_attestation'),
+                $request->input('device_type', 'android')
+            );
+            if (! $verified) {
+                return response()->json(['success' => false, 'message' => 'Device attestation failed'], 403);
+            }
         }
 
         // Regenerate session to prevent session fixation attacks (only for web)

--- a/app/Http/Controllers/Api/Auth/PasskeyController.php
+++ b/app/Http/Controllers/Api/Auth/PasskeyController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers\Api\Auth;
 
 use App\Domain\Mobile\Exceptions\BiometricBlockedException;
 use App\Domain\Mobile\Models\MobileDevice;
+use App\Domain\Mobile\Services\BiometricJWTService;
 use App\Domain\Mobile\Services\MobileDeviceService;
 use App\Domain\Mobile\Services\PasskeyAuthenticationService;
 use App\Http\Controllers\Controller;
@@ -21,6 +22,7 @@ class PasskeyController extends Controller
     public function __construct(
         private readonly PasskeyAuthenticationService $passkeyService,
         private readonly MobileDeviceService $deviceService,
+        private readonly BiometricJWTService $biometricJWTService,
     ) {
     }
 
@@ -339,6 +341,23 @@ class PasskeyController extends Controller
                     'message' => 'Passkey verification failed. Please try again.',
                 ],
             ], 401);
+        }
+
+        // Verify device attestation if provided and enabled
+        if ($request->filled('device_attestation') && config('mobile.attestation.enabled')) {
+            $verified = $this->biometricJWTService->verifyDeviceAttestation(
+                $request->input('device_attestation'),
+                $request->input('device_type', 'android')
+            );
+            if (! $verified) {
+                return response()->json([
+                    'success' => false,
+                    'error'   => [
+                        'code'    => 'ATTESTATION_FAILED',
+                        'message' => 'Device attestation failed.',
+                    ],
+                ], 403);
+            }
         }
 
         return response()->json([

--- a/app/Http/Controllers/Api/Auth/RegisterController.php
+++ b/app/Http/Controllers/Api/Auth/RegisterController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\Auth;
 
 use App\Actions\Fortify\CreateNewUser;
+use App\Domain\Mobile\Services\BiometricJWTService;
 use App\Http\Controllers\Controller;
 use App\Models\User;
 use App\Traits\HasApiScopes;
@@ -18,6 +19,11 @@ use OpenApi\Attributes as OA;
 class RegisterController extends Controller
 {
     use HasApiScopes;
+
+    public function __construct(
+        private readonly BiometricJWTService $biometricJWTService,
+    ) {
+    }
 
     /**
      * Register a new user.
@@ -77,8 +83,21 @@ class RegisterController extends Controller
                 'email'                => ['required', 'string', 'email', 'max:255', 'unique:users'],
                 'password'             => ['required', 'string', 'min:8', 'confirmed'],
                 'is_business_customer' => ['sometimes', 'boolean'],
+                'device_attestation'   => ['nullable', 'string', 'max:4096'],
+                'device_type'          => ['nullable', 'string', 'in:ios,android'],
             ]
         );
+
+        // Verify device attestation if provided and enabled
+        if ($request->filled('device_attestation') && config('mobile.attestation.enabled')) {
+            $verified = $this->biometricJWTService->verifyDeviceAttestation(
+                $request->input('device_attestation'),
+                $request->input('device_type', 'android')
+            );
+            if (! $verified) {
+                return response()->json(['success' => false, 'message' => 'Device attestation failed'], 403);
+            }
+        }
 
         // Use the same CreateNewUser action as Fortify for consistency
         $creator = new CreateNewUser();

--- a/app/Http/Controllers/Api/MobileController.php
+++ b/app/Http/Controllers/Api/MobileController.php
@@ -9,6 +9,7 @@ use App\Domain\Mobile\Models\MobileDeviceSession;
 use App\Domain\Mobile\Models\MobileNotificationPreference;
 use App\Domain\Mobile\Models\MobilePushNotification;
 use App\Domain\Mobile\Services\BiometricAuthenticationService;
+use App\Domain\Mobile\Services\BiometricJWTService;
 use App\Domain\Mobile\Services\MobileDeviceService;
 use App\Domain\Mobile\Services\MobileSessionService;
 use App\Domain\Mobile\Services\NotificationPreferenceService;
@@ -41,6 +42,7 @@ class MobileController extends Controller
     public function __construct(
         private readonly MobileDeviceService $deviceService,
         private readonly BiometricAuthenticationService $biometricService,
+        private readonly BiometricJWTService $biometricJWTService,
         private readonly PushNotificationService $pushService,
         private readonly MobileSessionService $sessionService,
         private readonly NotificationPreferenceService $preferenceService,
@@ -483,6 +485,22 @@ class MobileController extends Controller
                     'message' => 'Unable to verify your identity. Please try again.',
                 ],
             ], 401);
+        }
+
+        // Verify device attestation if provided and enabled
+        if ($request->filled('device_attestation') && config('mobile.attestation.enabled')) {
+            $verified = $this->biometricJWTService->verifyDeviceAttestation(
+                $request->input('device_attestation'),
+                $request->input('device_type', 'android')
+            );
+            if (! $verified) {
+                return response()->json([
+                    'error' => [
+                        'code'    => 'ATTESTATION_FAILED',
+                        'message' => 'Device attestation failed.',
+                    ],
+                ], 403);
+            }
         }
 
         return response()->json([

--- a/app/Http/Controllers/Api/Wallet/RecoveryShardController.php
+++ b/app/Http/Controllers/Api/Wallet/RecoveryShardController.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api\Wallet;
 
 use App\Domain\KeyManagement\Models\RecoveryShardCloudBackup;
+use App\Domain\KeyManagement\Services\KeyReconstructionService;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use OpenApi\Attributes as OA;
+use RuntimeException;
 
 #[OA\Tag(
     name: 'Recovery Shard Backup',
@@ -16,6 +18,11 @@ use OpenApi\Attributes as OA;
 )]
 class RecoveryShardController extends Controller
 {
+    public function __construct(
+        private readonly KeyReconstructionService $keyReconstructionService,
+    ) {
+    }
+
         #[OA\Post(
             path: '/api/v1/wallet/recovery-shard-backup',
             operationId: 'storeRecoveryShardBackup',
@@ -55,6 +62,17 @@ class RecoveryShardController extends Controller
             'encrypted_shard'      => ['nullable', 'string', 'max:65535'],
             'metadata'             => ['nullable', 'array'],
         ]);
+
+        // Verify hash matches the encrypted shard when both are provided
+        if (! empty($validated['encrypted_shard'])) {
+            $computedHash = '0x' . hash('sha256', $validated['encrypted_shard']);
+            if ($computedHash !== $validated['encrypted_shard_hash']) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Shard hash mismatch — encrypted_shard_hash does not match encrypted_shard content',
+                ], 422);
+            }
+        }
 
         $updateData = [
             'encrypted_shard_hash' => $validated['encrypted_shard_hash'],
@@ -259,5 +277,65 @@ class RecoveryShardController extends Controller
                 'encrypted_shard_hash' => $backup->encrypted_shard_hash,
             ],
         ]);
+    }
+
+        /**
+         * Reconstruct a key using device shard + recovery shard.
+         *
+         * POST /v1/wallet/recovery/reconstruct
+         */
+        #[OA\Post(
+            path: '/api/v1/wallet/recovery/reconstruct',
+            operationId: 'reconstructRecoveryKey',
+            summary: 'Reconstruct key from device and recovery shards',
+            description: 'Uses KeyReconstructionService to combine device shard + recovery shard into an ephemeral key for client-side signing.',
+            tags: ['Recovery Shard Backup'],
+            security: [['sanctum' => []]],
+            requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(required: ['device_shard', 'recovery_shard'], properties: [
+            new OA\Property(property: 'device_shard', type: 'string', description: 'Base64-encoded device shard'),
+            new OA\Property(property: 'recovery_shard', type: 'string', description: 'Base64-encoded recovery shard'),
+            ]))
+        )]
+    #[OA\Response(
+        response: 200,
+        description: 'Key reconstructed successfully',
+        content: new OA\JsonContent(properties: [
+        new OA\Property(property: 'success', type: 'boolean', example: true),
+        new OA\Property(property: 'data', type: 'object', properties: [
+        new OA\Property(property: 'reconstructed_key', type: 'string', description: 'Ephemeral key — use immediately and discard'),
+        ]),
+        ])
+    )]
+    #[OA\Response(
+        response: 422,
+        description: 'Recovery failed — invalid shards'
+    )]
+    public function reconstruct(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'device_shard'   => ['required', 'string'],
+            'recovery_shard' => ['required', 'string'],
+        ]);
+
+        /** @var \App\Models\User $user */
+        $user = $request->user();
+
+        try {
+            $result = $this->keyReconstructionService->reconstructWithRecovery(
+                (string) $user->uuid,
+                $validated['device_shard'],
+                $validated['recovery_shard']
+            );
+
+            return response()->json([
+                'success' => true,
+                'data'    => ['reconstructed_key' => $result->privateKey],
+            ]);
+        } catch (RuntimeException) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Recovery failed — invalid shards',
+            ], 422);
+        }
     }
 }

--- a/app/Http/Requests/Mobile/PasskeyAuthenticateRequest.php
+++ b/app/Http/Requests/Mobile/PasskeyAuthenticateRequest.php
@@ -36,6 +36,8 @@ class PasskeyAuthenticateRequest extends BaseMobileRequest
             'authenticator_data' => ['required', 'string'],
             'client_data_json'   => ['required', 'string'],
             'signature'          => ['required', 'string'],
+            'device_attestation' => ['nullable', 'string', 'max:4096'],
+            'device_type'        => ['nullable', 'string', 'in:ios,android'],
         ];
     }
 

--- a/app/Http/Requests/Mobile/VerifyBiometricRequest.php
+++ b/app/Http/Requests/Mobile/VerifyBiometricRequest.php
@@ -31,9 +31,11 @@ class VerifyBiometricRequest extends BaseMobileRequest
     public function rules(): array
     {
         return [
-            'device_id' => ['required', 'string'],
-            'challenge' => ['required', 'string'],
-            'signature' => ['required', 'string'],
+            'device_id'          => ['required', 'string'],
+            'challenge'          => ['required', 'string'],
+            'signature'          => ['required', 'string'],
+            'device_attestation' => ['nullable', 'string', 'max:4096'],
+            'device_type'        => ['nullable', 'string', 'in:ios,android'],
         ];
     }
 

--- a/tests/Feature/Api/Wallet/RecoveryShardBlobTest.php
+++ b/tests/Feature/Api/Wallet/RecoveryShardBlobTest.php
@@ -34,7 +34,7 @@ class RecoveryShardBlobTest extends TestCase
             ->postJson('/api/v1/wallet/recovery-shard-backup', [
                 'device_id'            => 'device_001',
                 'backup_provider'      => 'icloud',
-                'encrypted_shard_hash' => hash('sha256', $shardData),
+                'encrypted_shard_hash' => '0x' . hash('sha256', $shardData),
                 'shard_version'        => 'v1',
                 'encrypted_shard'      => $shardData,
             ]);


### PR DESCRIPTION
## Summary
- Wire `BiometricJWTService::verifyDeviceAttestation()` into all auth flows (Login, Register, Biometric, Passkey)
- Add `device_attestation` + `device_type` nullable fields — gated by `MOBILE_ATTESTATION_ENABLED` config flag
- Add SHA-256 hash validation for recovery shard backup (`0x`-prefixed hash verification)
- Add `POST /v1/wallet/recovery/reconstruct` endpoint using `KeyReconstructionService::reconstructWithRecovery()`
- `/.well-known/assetlinks.json` already exists (no changes needed)

## Files Changed
- `LoginController.php` — attestation check after credential validation
- `RegisterController.php` — attestation check after validation
- `PasskeyController.php` — attestation check after WebAuthn assertion
- `MobileController.php` — attestation check after biometric verification
- `RecoveryShardController.php` — hash validation + new `reconstruct()` method
- `VerifyBiometricRequest.php` — added `device_attestation`, `device_type` rules
- `PasskeyAuthenticateRequest.php` — added `device_attestation`, `device_type` rules
- `app/Domain/Wallet/Routes/api.php` — new reconstruct route

## Test plan
- [x] PHPStan Level 8 passes on all changed files
- [x] php-cs-fixer clean
- [x] 27/27 wallet tests pass (RecoveryShardBlobTest + RecoveryShardBackupTest)
- [x] BiometricJWTServiceTest passes (attestation verification)
- [ ] Manual test: login with `device_attestation` field when `MOBILE_ATTESTATION_ENABLED=false` (should pass through)
- [ ] Manual test: login with `device_attestation` field when `MOBILE_ATTESTATION_ENABLED=true` (should verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)