### PR TITLE
fix: post-phase review v7.2-v7.7 — update domain/GraphQL counts and register missing schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FinAegis Core Banking Platform
 
 [![CI Pipeline](https://github.com/finaegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml/badge.svg)](https://github.com/finaegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml)
-[![Version](https://img.shields.io/badge/version-6.5.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-7.7.0-blue.svg)](CHANGELOG.md)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![PHP Version](https://img.shields.io/badge/php-%3E%3D8.4-8892BF.svg)](https://php.net/)
 [![Laravel Version](https://img.shields.io/badge/Laravel-12.x-FF2D20.svg)](https://laravel.com/)
@@ -20,7 +20,7 @@ FinAegis provides the foundation for building digital banking applications. The 
 
 | Challenge | FinAegis Solution |
 |-----------|-------------------|
-| Building financial systems from scratch | 49 production-ready domain modules |
+| Building financial systems from scratch | 56 production-ready domain modules |
 | Audit trail requirements | Event sourcing with domain-specific event tables |
 | Complex multi-step transactions | Saga pattern with automatic compensation |
 | Regulatory compliance | Built-in KYC/AML, SOC 2, PCI DSS, GDPR (v3.5.0) |
@@ -30,10 +30,10 @@ FinAegis provides the foundation for building digital banking applications. The 
 | Privacy-preserving transactions | ZK-KYC, Merkle trees, ERC-4337 gas abstraction (v2.4.0-v2.6.0) |
 | Multi-jurisdiction RegTech | MiFID II, MiCA, FATF Travel Rule, 4-jurisdiction adapters (v2.8.0) |
 | Cross-chain & DeFi | Bridge protocols, DEX aggregation, yield optimization (v3.0.0) |
-| Modular plugin architecture | 49 domains with manifests, enable/disable, dependency resolution (v3.2.0) |
+| Modular plugin architecture | 56 domains with manifests, enable/disable, dependency resolution (v3.2.0) |
 | Compliance certification | SOC 2 Type II, PCI DSS readiness, multi-region deployment (v3.5.0) |
-| GraphQL API | Schema-first Lighthouse PHP, 39 domains, subscriptions (v4.0.0+) |
-| Event Store v2 | Domain routing (49 domains), upcasting, migration tooling (v4.0.0) |
+| GraphQL API | Schema-first Lighthouse PHP, 43 domains, subscriptions (v4.0.0+) |
+| Event Store v2 | Domain routing (56 domains), upcasting, migration tooling (v4.0.0) |
 | Plugin Marketplace | Manager, loader, sandbox, security scanner (v4.0.0) |
 | Event streaming | Redis Streams publisher/consumer, live dashboard (v5.0.0) |
 | API monetization | x402 protocol: HTTP-native micropayments with USDC on Base (v5.2.0) |
@@ -59,7 +59,7 @@ FinAegis provides the foundation for building digital banking applications. The 
 FinAegis uses a modular plugin system where each domain is a self-contained module:
 
 ```bash
-php artisan domain:list              # List all 49 domain modules with status
+php artisan domain:list              # List all 56 domain modules with status
 php artisan module:enable exchange   # Enable a module
 php artisan module:disable exchange  # Disable a module (preserves data)
 php artisan domain:verify exchange   # Verify module health
@@ -88,7 +88,7 @@ curl -X POST http://localhost:8000/graphql \
   -d '{"query": "{ accounts { id name balance currency } }"}'
 ```
 
-- **39 domain schemas** — Account, AgentProtocol, AI, Asset, Banking, Basket, Batch, CardIssuance, Cgo, Commerce, Compliance, CrossChain, Custodian, DeFi, Exchange, FinancialInstitution, Fraud, Governance, KeyManagement, Lending, MachinePay, Mobile, MobilePayment, Payment, Privacy, Product, RegTech, Regulatory, Relayer, Stablecoin, Treasury, TrustCert, User, Wallet, X402
+- **43 domain schemas** — Account, AgentProtocol, AI, Asset, Banking, Basket, Batch, CardIssuance, Cgo, Commerce, Compliance, CrossChain, Custodian, DeFi, Exchange, FinancialInstitution, Fraud, Governance, Interledger, ISO20022, KeyManagement, Ledger, Lending, MachinePay, Microfinance, Mobile, MobilePayment, OpenBanking, Payment, PaymentRails, Privacy, Product, RegTech, Regulatory, Relayer, SMS, Stablecoin, Treasury, TrustCert, User, Wallet, X402
 - **Subscriptions** — Real-time updates via WebSocket (account updates, wallet changes, compliance alerts, order matching)
 - **DataLoaders** — N+1 query prevention with batched loading
 - **Security** — `@guard(with: ["sanctum"])`, query cost analysis, introspection control
@@ -303,9 +303,9 @@ See [Domain Management Guide](docs/06-DEVELOPMENT/DOMAIN_MANAGEMENT.md) for deta
 - **Event Sourcing** - Domain-specific event tables with Event Store v2, replay, and upcasting (v4.0.0)
 - **CQRS** - Separated read/write models for optimal performance
 - **Saga Pattern** - Distributed transactions with automatic rollback
-- **DDD** - 49 bounded contexts with clear boundaries
+- **DDD** - 56 bounded contexts with clear boundaries
 - **Multi-Tenancy** - Team-based data isolation with stancl/tenancy v3.9
-- **GraphQL** - Schema-first Lighthouse PHP across 39 domains with subscriptions (v4.0.0+)
+- **GraphQL** - Schema-first Lighthouse PHP across 43 domains with subscriptions (v4.0.0+)
 - **Event Streaming** - Redis Streams publisher/consumer with live dashboard (v5.0.0)
 
 See [Architecture Decision Records](docs/ADR/) for detailed design rationale.

--- a/app/Http/Controllers/Api/Documentation/OpenApiDoc.php
+++ b/app/Http/Controllers/Api/Documentation/OpenApiDoc.php
@@ -5,9 +5,9 @@ namespace App\Http\Controllers\Api\Documentation;
 use OpenApi\Attributes as OA;
 
 #[OA\Info(
-    version: '6.5.0',
+    version: '7.7.0',
     title: 'Zelta API',
-    description: 'Agentic payments API — stablecoin-powered virtual cards, non-custodial wallet, and AI agent card issuance. Built with Laravel 12, featuring 49 DDD domains, event sourcing, CQRS, and privacy-preserving architecture.',
+    description: 'Core banking API — stablecoin-powered virtual cards, non-custodial wallet, AI agent card issuance, ISO 20022, Open Banking, US Payment Rails, Interledger, and Microfinance. Built with Laravel 12, featuring 56 DDD domains, event sourcing, CQRS, and privacy-preserving architecture.',
     contact: new OA\Contact(email: 'support@finaegis.org', name: 'Zelta Support'),
     license: new OA\License(name: 'Apache 2.0', url: 'https://www.apache.org/licenses/LICENSE-2.0.html'),
 )]

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -39,3 +39,13 @@ scalar DateTime @scalar(class: "Nuwave\\Lighthouse\\Schema\\Types\\Scalars\\Date
 #import payment-rails.graphql
 #import ledger.graphql
 #import microfinance.graphql
+#import ai.graphql
+#import asset.graphql
+#import commerce.graphql
+#import custodian.graphql
+#import governance.graphql
+#import key-management.graphql
+#import privacy.graphql
+#import regtech.graphql
+#import relayer.graphql
+#import sms.graphql

--- a/resources/views/about.blade.php
+++ b/resources/views/about.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'About ' . config('brand.name', 'Zelta') . ' - Open Source Core Banking Infrastructure',
-        'description' => config('brand.name', 'Zelta') . ' is an open-source core banking platform with 49 DDD domains, event sourcing, CQRS, and the Global Currency Unit. Built with Laravel for fintech developers.',
+        'description' => config('brand.name', 'Zelta') . ' is an open-source core banking platform with 56 DDD domains, event sourcing, CQRS, and the Global Currency Unit. Built with Laravel for fintech developers.',
         'keywords' => config('brand.name', 'Zelta') . ' about, open source banking, core banking platform, GCU, event sourcing, CQRS, Laravel banking, DDD, fintech infrastructure',
     ])
 
@@ -47,7 +47,7 @@
                 <div class="animate-on-scroll">
                     <h2 class="font-display text-3xl lg:text-4xl font-bold text-slate-900 mb-6">What Is {{ config('brand.name', 'Zelta') }}?</h2>
                     <p class="text-lg text-slate-600 mb-4 leading-relaxed">
-                        {{ config('brand.name', 'Zelta') }} is a core banking platform built with Laravel, implementing event sourcing, CQRS, domain-driven design, and AI agent integration across 49 bounded contexts.
+                        {{ config('brand.name', 'Zelta') }} is a core banking platform built with Laravel, implementing event sourcing, CQRS, domain-driven design, and AI agent integration across 56 bounded contexts.
                     </p>
                     <p class="text-lg text-slate-600 mb-6 leading-relaxed">
                         At its heart is the <strong>Global Currency Unit (GCU)</strong>&mdash;a democratically governed basket currency where users vote on composition from six global reserve assets.
@@ -147,7 +147,7 @@
                     ['title' => 'Banking API Patterns', 'desc' => 'Open Banking-compliant API adapters including Ondato KYC, Chainalysis sanctions screening, and Marqeta card issuing for real-world integration patterns.'],
                     ['title' => 'Cross-Chain & DeFi', 'desc' => 'Bridge protocols (Wormhole, LayerZero, Axelar), DEX aggregation via Uniswap/Aave/Curve/Lido, cross-chain swaps, and multi-chain portfolio management.'],
                     ['title' => 'Privacy & Identity', 'desc' => 'ZK-KYC proofs, Merkle tree commitments, soulbound tokens, W3C verifiable credentials, Shamir secret sharing, and delegated proof verification.'],
-                    ['title' => 'GraphQL API', 'desc' => 'Lighthouse-powered GraphQL covering 39 domains with real-time subscriptions, N+1 safe DataLoaders, and cursor-based pagination alongside REST/OpenAPI.'],
+                    ['title' => 'GraphQL API', 'desc' => 'Lighthouse-powered GraphQL covering 43 domains with real-time subscriptions, N+1 safe DataLoaders, and cursor-based pagination alongside REST/OpenAPI.'],
                     ['title' => 'Plugin Marketplace', 'desc' => 'Extensible plugin system with sandboxed execution, static security scanning, hook-based integration points, and a manager UI for discovering and installing plugins.'],
                     ['title' => 'Event Streaming', 'desc' => 'Redis Streams-powered event streaming with a live dashboard, consumer groups, backpressure handling, and dead-letter queues for reliable event processing.'],
                     ['title' => 'Compliance Certification', 'desc' => 'SOC 2 Type II and PCI DSS readiness tooling, GDPR enhanced privacy (ROPA, DPIA, breach notification, consent v2), and multi-region deployment support.'],

--- a/resources/views/ai-framework/demo.blade.php
+++ b/resources/views/ai-framework/demo.blade.php
@@ -136,7 +136,7 @@
                     </div>
                     <h3 class="text-xl font-semibold mb-3">Full API Access</h3>
                     <p class="text-slate-500 mb-4">
-                        Agents have access to the complete {{ config('brand.name', 'Zelta') }} API surface: 1,350+ REST endpoints and 39 GraphQL domain schemas with real-time subscriptions.
+                        Agents have access to the complete {{ config('brand.name', 'Zelta') }} API surface: 1,400+ REST endpoints and 43 GraphQL domain schemas with real-time subscriptions.
                     </p>
                     <code class="text-sm text-cyan-600 bg-cyan-50 px-3 py-1 rounded">REST + GraphQL</code>
                 </div>

--- a/resources/views/ai-framework/docs.blade.php
+++ b/resources/views/ai-framework/docs.blade.php
@@ -80,7 +80,7 @@
                                 </li>
                                 <li class="flex items-start">
                                     <svg class="w-5 h-5 text-blue-500 mr-2 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
-                                    <span><strong>Full API Surface:</strong> 1,350+ REST endpoints and 39 GraphQL domains</span>
+                                    <span><strong>Full API Surface:</strong> 1,400+ REST endpoints and 43 GraphQL domains</span>
                                 </li>
                             </ul>
                         </div>

--- a/resources/views/developers/api-docs.blade.php
+++ b/resources/views/developers/api-docs.blade.php
@@ -61,7 +61,7 @@
                         <h2 class="text-3xl font-bold text-gray-900 mb-8">Getting Started</h2>
                         
                         <div class="prose prose-lg max-w-none">
-                            <p>The {{ config('brand.name', 'Zelta') }} API provides programmatic access to our multi-asset banking platform spanning 49 DDD domains with over 1,350 routes. Our API is organized around REST principles with predictable, resource-oriented URLs. Domains include core banking, CrossChain bridging, DeFi protocols, RegTech compliance, Mobile Payment, Partner BaaS, and AI-powered queries.</p>
+                            <p>The {{ config('brand.name', 'Zelta') }} API provides programmatic access to our multi-asset banking platform spanning 56 DDD domains with over 1,400 routes. Our API is organized around REST principles with predictable, resource-oriented URLs. Domains include core banking, CrossChain bridging, DeFi protocols, RegTech compliance, Mobile Payment, Partner BaaS, ISO 20022, Open Banking, US Payment Rails, and AI-powered queries.</p>
                             
                             <h3>Base URL</h3>
                             <x-code-block language="plaintext">
@@ -1250,8 +1250,8 @@ curl -H "Authorization: Bearer your_api_key" \
                         <h2 class="text-3xl font-bold text-gray-900 mb-8">GraphQL API</h2>
 
                         <div class="prose prose-lg max-w-none mb-8">
-                            <p>Schema-first GraphQL API powered by Lighthouse PHP. Provides queries, mutations, and subscriptions across 39 domain schemas with DataLoader-optimized resolvers and WebSocket-based real-time subscriptions.</p>
-                            <p class="text-sm text-gray-500">39 domain schemas &middot; Queries, Mutations, Subscriptions</p>
+                            <p>Schema-first GraphQL API powered by Lighthouse PHP. Provides queries, mutations, and subscriptions across 43 domain schemas with DataLoader-optimized resolvers and WebSocket-based real-time subscriptions.</p>
+                            <p class="text-sm text-gray-500">43 domain schemas &middot; Queries, Mutations, Subscriptions</p>
                         </div>
 
                         <div class="space-y-8">
@@ -1263,7 +1263,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                         <span class="ml-2 font-mono text-sm">/graphql</span>
                                     </div>
                                 </div>
-                                <p class="text-gray-600 mb-4">Execute a GraphQL query or mutation against the unified schema. Supports all 39 domain schemas including Account, AgentProtocol, Basket, Batch, CardIssuance, Cgo, Compliance, CrossChain, DeFi, Exchange, FinancialInstitution, Product, Regulatory, User, Wallet, and more.</p>
+                                <p class="text-gray-600 mb-4">Execute a GraphQL query or mutation against the unified schema. Supports all 43 domain schemas including Account, AgentProtocol, Basket, Batch, CardIssuance, Cgo, Compliance, CrossChain, DeFi, Exchange, FinancialInstitution, ISO20022, OpenBanking, PaymentRails, Microfinance, Interledger, Ledger, Regulatory, User, Wallet, and more.</p>
                                 <x-code-block language="bash">
 curl -X POST \
   -H "Authorization: Bearer your_api_key" \
@@ -1572,7 +1572,7 @@ if (response.status === 402) {
                                 <li><a href="#mobile-payment" class="text-violet-600 hover:text-violet-800 flex justify-between"><span>Mobile Payment</span><span class="text-gray-400">25+ routes</span></a></li>
                                 <li><a href="#partner-baas" class="text-rose-600 hover:text-rose-800 flex justify-between"><span>Partner BaaS</span><span class="text-gray-400">24 routes</span></a></li>
                                 <li><a href="#ai" class="text-gray-600 hover:text-gray-800 flex justify-between"><span>AI Query</span><span class="text-gray-400">2 routes</span></a></li>
-                                <li><a href="#graphql" class="text-sky-600 hover:text-sky-800 flex justify-between"><span>GraphQL</span><span class="text-gray-400">39 domains</span></a></li>
+                                <li><a href="#graphql" class="text-sky-600 hover:text-sky-800 flex justify-between"><span>GraphQL</span><span class="text-gray-400">43 domains</span></a></li>
                                 <li><a href="#event-streaming" class="text-lime-600 hover:text-lime-800 flex justify-between"><span>Event Streaming</span><span class="text-gray-400">5 endpoints</span></a></li>
                                 <li><a href="#x402" class="text-emerald-600 hover:text-emerald-800 flex justify-between"><span>x402 Protocol</span><span class="text-gray-400">15+ endpoints</span></a></li>
                             </ul>

--- a/resources/views/developers/graphql.blade.php
+++ b/resources/views/developers/graphql.blade.php
@@ -7,7 +7,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'GraphQL API - ' . $brand . ' Developer Documentation',
-        'description' => $brand . ' GraphQL API — 39 domain schemas, real-time subscriptions, Lighthouse PHP powered.',
+        'description' => $brand . ' GraphQL API — 43 domain schemas, real-time subscriptions, Lighthouse PHP powered.',
         'keywords' => $brand . ', GraphQL, API, Lighthouse, subscriptions, queries, mutations',
     ])
 @endsection
@@ -33,10 +33,10 @@
     </div>
     <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
         <div class="text-center">
-            <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-white/10 text-white/80 border border-white/20 mb-4">39 Domain Schemas</span>
+            <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-white/10 text-white/80 border border-white/20 mb-4">43 Domain Schemas</span>
             <h1 class="text-4xl md:text-5xl font-extrabold tracking-tight mb-4">GraphQL API</h1>
             <p class="text-xl text-white/80 max-w-2xl mx-auto">
-                Query 39 domains with a single endpoint. Real-time subscriptions, Sanctum auth, and Lighthouse-powered schema composition.
+                Query 43 domains with a single endpoint. Real-time subscriptions, Sanctum auth, and Lighthouse-powered schema composition.
             </p>
         </div>
     </div>
@@ -132,7 +132,7 @@
 <section class="bg-slate-50 py-16">
     <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
         <h2 class="text-3xl font-bold mb-4">Domain Schemas</h2>
-        <p class="text-slate-600 mb-8">39 domain-specific schemas composed into one unified GraphQL endpoint. Each domain provides queries, mutations, and types scoped to its bounded context.</p>
+        <p class="text-slate-600 mb-8">43 domain-specific schemas composed into one unified GraphQL endpoint. Each domain provides queries, mutations, and types scoped to its bounded context.</p>
 
         @php
         $schemaGroups = [

--- a/resources/views/developers/index.blade.php
+++ b/resources/views/developers/index.blade.php
@@ -434,7 +434,7 @@
                 <!-- Platform API Area Cards -->
                 <div class="mt-16">
                     <h3 class="text-2xl font-bold text-slate-900 mb-2 text-center">Platform API Areas</h3>
-                    <p class="text-slate-500 text-center mb-8">Explore the full breadth of the {{ config('brand.name', 'Zelta') }} platform across 49 DDD domains</p>
+                    <p class="text-slate-500 text-center mb-8">Explore the full breadth of the {{ config('brand.name', 'Zelta') }} platform across 56 DDD domains</p>
                     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
 
                         <!-- CrossChain -->
@@ -563,10 +563,10 @@
                                     </div>
                                     <div>
                                         <h4 class="text-lg font-semibold text-slate-900">GraphQL API</h4>
-                                        <span class="text-xs text-slate-400">39 domains</span>
+                                        <span class="text-xs text-slate-400">43 domains</span>
                                     </div>
                                 </div>
-                                <p class="text-slate-500 text-sm mb-3">Schema-first GraphQL via Lighthouse PHP with queries, mutations, subscriptions, and DataLoaders across 39 domain schemas.</p>
+                                <p class="text-slate-500 text-sm mb-3">Schema-first GraphQL via Lighthouse PHP with queries, mutations, subscriptions, and DataLoaders across 43 domain schemas.</p>
                                 <span class="text-sky-600 text-sm font-medium group-hover:text-sky-700">View endpoints &rarr;</span>
                             </div>
                         </a>
@@ -695,7 +695,7 @@
             <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                 <div class="grid grid-cols-2 md:grid-cols-5 gap-8 text-center">
                     <div>
-                        <div class="text-4xl md:text-5xl font-bold mb-2">1,350+</div>
+                        <div class="text-4xl md:text-5xl font-bold mb-2">1,400+</div>
                         <p class="text-indigo-200 flex items-center justify-center">
                             <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>

--- a/resources/views/features/index.blade.php
+++ b/resources/views/features/index.blade.php
@@ -251,7 +251,7 @@
                     </div>
                     <h3 class="text-xl font-semibold mb-3">Developer APIs</h3>
                     <p class="text-slate-500 mb-4">
-                        Full REST coverage with OpenAPI specs, GraphQL across 39 domains with real-time subscriptions, and configurable webhooks.
+                        Full REST coverage with OpenAPI specs, GraphQL across 43 domains with real-time subscriptions, and configurable webhooks.
                     </p>
                     <a href="{{ route('features.show', 'api') }}" class="text-blue-600 font-medium hover:text-blue-700">
                         View docs →
@@ -417,7 +417,7 @@
                     </div>
                     <h3 class="text-xl font-semibold mb-3">GraphQL API</h3>
                     <p class="text-slate-500 mb-4">
-                        Lighthouse-powered GraphQL covering 39 domains with real-time subscriptions, N+1 safe DataLoaders, and cursor-based pagination.
+                        Lighthouse-powered GraphQL covering 43 domains with real-time subscriptions, N+1 safe DataLoaders, and cursor-based pagination.
                     </p>
                     <a href="{{ route('features.show', 'api') }}" class="text-pink-600 font-medium hover:text-pink-700">
                         View API &rarr;

--- a/resources/views/platform/index.blade.php
+++ b/resources/views/platform/index.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => config('brand.name', 'Zelta') . ' Platform - Open Banking for Developers',
-        'description' => config('brand.name', 'Zelta') . ' Platform - Open-source core banking infrastructure with 49 DDD domains, event sourcing, REST + GraphQL APIs, and cross-chain DeFi. MIT licensed.',
+        'description' => config('brand.name', 'Zelta') . ' Platform - Open-source core banking infrastructure with 56 DDD domains, event sourcing, REST + GraphQL APIs, and cross-chain DeFi. MIT licensed.',
         'keywords' => config('brand.name', 'Zelta') . ' platform, banking infrastructure, open source banking, developer API, MIT license, core banking API, fintech development, DDD, event sourcing',
     ])
 
@@ -475,7 +475,7 @@
                             </svg>
                         </div>
                         <h3 class="text-xl font-bold mb-2">GraphQL API</h3>
-                        <p class="text-pink-100 text-sm mb-4">39 domains, subscriptions, DataLoaders, and real-time queries</p>
+                        <p class="text-pink-100 text-sm mb-4">43 domains, subscriptions, DataLoaders, and real-time queries</p>
                         <a href="{{ route('features') }}" class="text-white font-semibold hover:underline">Learn more &rarr;</a>
                     </div>
 

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => config('brand.name', 'Zelta') . ' - Open Source Core Banking Infrastructure',
-        'description' => 'Open-source core banking infrastructure with 49 DDD domains, event sourcing, cross-chain DeFi, privacy-preserving identity, RegTech compliance, AI analytics, and HTTP-native micropayments. Built with Laravel.',
+        'description' => 'Open-source core banking infrastructure with 56 DDD domains, event sourcing, cross-chain DeFi, privacy-preserving identity, RegTech compliance, AI analytics, and HTTP-native micropayments. Built with Laravel.',
         'keywords' => config('brand.name', 'Zelta') . ', open source banking, core banking infrastructure, GCU, event sourcing, DeFi, cross-chain, RegTech, banking API, Laravel fintech',
     ])
 
@@ -87,7 +87,7 @@
                         What Is {{ config('brand.name', 'Zelta') }}?
                     </h2>
                     <p class="text-lg text-slate-600 leading-relaxed mb-6">
-                        A production-grade core banking platform built with Laravel and domain-driven design. 49 bounded contexts, event sourcing, CQRS, and every integration pattern a modern fintech needs.
+                        A production-grade core banking platform built with Laravel and domain-driven design. 56 bounded contexts, event sourcing, CQRS, and every integration pattern a modern fintech needs.
                     </p>
                     <div class="space-y-3 mb-8">
                         @foreach([
@@ -162,7 +162,7 @@
                         ['route' => 'features.show', 'slug' => 'settlements', 'title' => 'Event-Sourced Ledger', 'desc' => 'Every transaction is an immutable event. Full audit trails, point-in-time reconstruction, and replay capability.', 'icon' => 'M13 10V3L4 14h7v7l9-11h-7z', 'color' => 'emerald'],
                         ['route' => 'features.show', 'slug' => 'governance', 'title' => 'Democratic Governance', 'desc' => 'Stake-weighted voting on monetary policy. Users shape their currency through on-chain governance proposals.', 'icon' => 'M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z', 'color' => 'amber'],
                         ['route' => 'features.show', 'slug' => 'bank-integration', 'title' => 'Banking API Patterns', 'desc' => 'Open Banking-compliant API patterns with Ondato KYC, Chainalysis sanctions, and Marqeta card issuing.', 'icon' => 'M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4', 'color' => 'red'],
-                        ['route' => 'features.show', 'slug' => 'api', 'title' => 'REST, GraphQL & OpenAPI', 'desc' => 'Full REST coverage with OpenAPI specs, GraphQL across 39 domains, real-time subscriptions, and webhooks.', 'icon' => 'M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4', 'color' => 'sky'],
+                        ['route' => 'features.show', 'slug' => 'api', 'title' => 'REST, GraphQL & OpenAPI', 'desc' => 'Full REST coverage with OpenAPI specs, GraphQL across 43 domains, real-time subscriptions, and webhooks.', 'icon' => 'M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4', 'color' => 'sky'],
                         ['route' => 'ai-framework', 'slug' => null, 'title' => 'AI Agent Protocol', 'desc' => 'Google A2A protocol for autonomous agent commerce. MCP tools, spending limits, and transaction analytics.', 'icon' => 'M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z', 'color' => 'violet'],
                         ['route' => 'features.show', 'slug' => 'crosschain-defi', 'title' => 'Cross-Chain & DeFi', 'desc' => 'Bridge across Wormhole, LayerZero, Axelar. Aggregate DEX liquidity, optimize yield, manage multi-chain portfolios.', 'icon' => 'M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1', 'color' => 'orange'],
                         ['route' => 'features.show', 'slug' => 'privacy-identity', 'title' => 'Privacy & Identity', 'desc' => 'ZK-KYC proofs, RAILGUN shielded transfers, W3C verifiable credentials, soulbound tokens, Shamir key mgmt.', 'icon' => 'M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z', 'color' => 'teal'],
@@ -213,7 +213,7 @@
             <div class="text-center mb-16 animate-on-scroll">
                 <h2 class="font-display text-4xl lg:text-5xl font-bold text-white tracking-tight mb-4">Platform Architecture</h2>
                 <p class="text-lg text-slate-400 max-w-2xl mx-auto">
-                    49 bounded contexts built with DDD, event sourcing, and CQRS. Each module implements specific financial system patterns you can use independently.
+                    56 bounded contexts built with DDD, event sourcing, and CQRS. Each module implements specific financial system patterns you can use independently.
                 </p>
             </div>
 


### PR DESCRIPTION
## Summary

- **Critical fix**: Registered 10 GraphQL schemas that existed on disk but were never imported in `graphql/schema.graphql` — `ai`, `asset`, `commerce`, `custodian`, `governance`, `key-management`, `privacy`, `regtech`, `relayer`, `sms` — bringing total active schemas from 33 to 43
- **Stale copy**: Updated all "49 domains" references to "56 domains" across `welcome.blade.php`, `about.blade.php`, `platform/index.blade.php`, `features/index.blade.php`, `developers/index.blade.php`, `developers/api-docs.blade.php`, `README.md`, and `OpenApiDoc.php`
- **Stale copy**: Updated all "39 GraphQL domains/schemas" references to "43" across all views, README, and OpenApiDoc
- **Stale counts**: Updated route count from "1,350+" to "1,400+" in developer-facing pages and AI framework pages
- **Version badge**: Updated README badge and OpenApiDoc version from `6.5.0` to `7.7.0`

## Files Changed

| File | Change |
|------|--------|
| `graphql/schema.graphql` | +10 missing schema imports |
| `README.md` | Version badge 6.5.0→7.7.0, 49→56 domains, 39→43 GraphQL |
| `app/Http/Controllers/Api/Documentation/OpenApiDoc.php` | Version 6.5.0→7.7.0, 49→56 domains |
| `resources/views/welcome.blade.php` | 49→56 domains (3 locations), 39→43 GraphQL |
| `resources/views/about.blade.php` | 49→56 domains (2 locations), 39→43 GraphQL |
| `resources/views/platform/index.blade.php` | 49→56 domains, 39→43 GraphQL |
| `resources/views/features/index.blade.php` | 39→43 GraphQL (2 locations) |
| `resources/views/developers/index.blade.php` | 49→56 domains, 39→43 GraphQL, 1350→1400 routes |
| `resources/views/developers/api-docs.blade.php` | 49→56, 39→43, 1350→1400, updated schema list |
| `resources/views/developers/graphql.blade.php` | 39→43 (3 locations) |
| `resources/views/ai-framework/demo.blade.php` | 39→43 GraphQL, 1350→1400 routes |
| `resources/views/ai-framework/docs.blade.php` | 39→43 GraphQL, 1350→1400 routes |

## Test plan

- [ ] Verify `/features` page shows "56 Domain Modules" header and "43 domains" in GraphQL card
- [ ] Verify `/about` shows "56 bounded contexts" in body text and meta description
- [ ] Verify `/developers` shows "1,400+" stat and "43 domains" in GraphQL card
- [ ] Verify `/developers/graphql` hero shows "43 Domain Schemas"
- [ ] Verify GraphQL endpoint resolves queries from previously-missing schemas (governance, ai, privacy, etc.)
- [ ] Verify OpenAPI docs show version 7.7.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)