### PR TITLE
fix: code review — bcmath for money, DB transactions, XXE protection, DI, PISP permission

### DIFF
--- a/app/Domain/ISO20022/Services/MessageParser.php
+++ b/app/Domain/ISO20022/Services/MessageParser.php
@@ -54,7 +54,7 @@ final class MessageParser
      */
     private function parsePain001(string $xml): array
     {
-        $doc = new SimpleXMLElement($xml);
+        $doc = new SimpleXMLElement($xml, LIBXML_NONET);
         $ns = 'urn:iso:std:iso:20022:tech:xsd:pain.001.001.09';
 
         $root = $doc->children($ns);
@@ -102,7 +102,7 @@ final class MessageParser
      */
     private function parsePacs008(string $xml): array
     {
-        $doc = new SimpleXMLElement($xml);
+        $doc = new SimpleXMLElement($xml, LIBXML_NONET);
         $ns = 'urn:iso:std:iso:20022:tech:xsd:pacs.008.001.08';
 
         $root = $doc->children($ns);
@@ -134,7 +134,7 @@ final class MessageParser
      */
     private function parsePacs002(string $xml): array
     {
-        $doc = new SimpleXMLElement($xml);
+        $doc = new SimpleXMLElement($xml, LIBXML_NONET);
         $ns = 'urn:iso:std:iso:20022:tech:xsd:pacs.002.001.10';
 
         $root = $doc->children($ns);
@@ -177,7 +177,7 @@ final class MessageParser
      */
     private function parseGeneric(string $xml): array
     {
-        $doc = new SimpleXMLElement($xml);
+        $doc = new SimpleXMLElement($xml, LIBXML_NONET);
         $json = json_encode($doc);
 
         if ($json === false) {

--- a/app/Domain/Interledger/Services/IlpConnectorService.php
+++ b/app/Domain/Interledger/Services/IlpConnectorService.php
@@ -22,6 +22,11 @@ class IlpConnectorService
      */
     private array $connections = [];
 
+    public function __construct(
+        private readonly IlpAddressResolver $addressResolver = new IlpAddressResolver(),
+    ) {
+    }
+
     /**
      * Create a new STREAM connection to a destination ILP address.
      *
@@ -114,10 +119,8 @@ class IlpConnectorService
      */
     public function resolveAddress(string $paymentPointer): string
     {
-        $resolver = new IlpAddressResolver();
-
         if (str_starts_with($paymentPointer, '$')) {
-            return $resolver->fromPaymentPointer($paymentPointer);
+            return $this->addressResolver->fromPaymentPointer($paymentPointer);
         }
 
         // Already an ILP address.

--- a/app/Domain/Interledger/Services/OpenPaymentsService.php
+++ b/app/Domain/Interledger/Services/OpenPaymentsService.php
@@ -19,6 +19,11 @@ use App\Domain\Interledger\Enums\PaymentState;
  */
 class OpenPaymentsService
 {
+    public function __construct(
+        private readonly IlpAddressResolver $addressResolver = new IlpAddressResolver(),
+    ) {
+    }
+
     /**
      * Create an incoming payment resource at the given wallet address.
      *
@@ -117,10 +122,8 @@ class OpenPaymentsService
      */
     private function walletAddressToIlp(string $walletAddress): string
     {
-        $resolver = new IlpAddressResolver();
-
         if (str_starts_with($walletAddress, '$')) {
-            return $resolver->fromPaymentPointer($walletAddress);
+            return $this->addressResolver->fromPaymentPointer($walletAddress);
         }
 
         // Treat as a URL — strip scheme and convert to dotted segments.

--- a/app/Domain/Interledger/Services/QuoteService.php
+++ b/app/Domain/Interledger/Services/QuoteService.php
@@ -7,7 +7,11 @@ namespace App\Domain\Interledger\Services;
 use InvalidArgumentException;
 
 /**
- * Provides cross-currency rate quotes for ILP payments.
+ * Cross-currency quote service for ILP.
+ *
+ * Note: Uses float arithmetic for rate calculations in simulation mode.
+ * Production deployment should replace with bcmath or fixed-point library
+ * for amounts exceeding 15 significant digits.
  */
 class QuoteService
 {

--- a/app/Domain/Ledger/Services/Drivers/EloquentDriver.php
+++ b/app/Domain/Ledger/Services/Drivers/EloquentDriver.php
@@ -43,8 +43,12 @@ final class EloquentDriver implements LedgerDriverInterface
 
         $account = LedgerAccount::where('code', $accountCode)->first();
 
-        $totalDebit = bcadd((string) (float) ($totals->total_debit ?? 0), '0', 4);
-        $totalCredit = bcadd((string) (float) ($totals->total_credit ?? 0), '0', 4);
+        /** @var numeric-string $rawDebit */
+        $rawDebit = (string) ($totals->total_debit ?? '0');
+        /** @var numeric-string $rawCredit */
+        $rawCredit = (string) ($totals->total_credit ?? '0');
+        $totalDebit = bcadd($rawDebit, '0', 4);
+        $totalCredit = bcadd($rawCredit, '0', 4);
 
         // For debit-normal accounts (assets, expenses): balance = debits - credits
         // For credit-normal accounts (liabilities, equity, revenue): balance = credits - debits
@@ -83,8 +87,12 @@ final class EloquentDriver implements LedgerDriverInterface
             $totals = $query->selectRaw('COALESCE(SUM(debit_amount), 0) as total_debit, COALESCE(SUM(credit_amount), 0) as total_credit')
                 ->first();
 
-            $debit = bcadd((string) (float) ($totals->total_debit ?? 0), '0', 4);
-            $credit = bcadd((string) (float) ($totals->total_credit ?? 0), '0', 4);
+            /** @var numeric-string $rawDebit */
+            $rawDebit = (string) ($totals->total_debit ?? '0');
+            /** @var numeric-string $rawCredit */
+            $rawCredit = (string) ($totals->total_credit ?? '0');
+            $debit = bcadd($rawDebit, '0', 4);
+            $credit = bcadd($rawCredit, '0', 4);
 
             if ($account->isDebitNormal()) {
                 $balance = bcsub($debit, $credit, 4);

--- a/app/Domain/Ledger/Services/LedgerService.php
+++ b/app/Domain/Ledger/Services/LedgerService.php
@@ -10,6 +10,7 @@ use App\Domain\Ledger\Models\JournalEntry;
 use App\Domain\Ledger\Models\JournalLine;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use RuntimeException;
 
@@ -51,27 +52,32 @@ final class LedgerService
             throw new RuntimeException('Journal entry has zero total — at least one line must have a non-zero amount');
         }
 
-        $entry = JournalEntry::create([
-            'entry_number'    => 'JE-' . strtoupper(Str::random(8)),
-            'description'     => $description,
-            'status'          => EntryStatus::POSTED,
-            'posted_at'       => Carbon::now(),
-            'source_domain'   => $sourceDomain,
-            'source_event_id' => $sourceEventId,
-        ]);
-
-        foreach ($lines as $line) {
-            JournalLine::create([
-                'journal_entry_id' => $entry->id,
-                'account_code'     => $line['account_code'],
-                'debit_amount'     => $line['debit'],
-                'credit_amount'    => $line['credit'],
-                'currency'         => (string) config('ledger.default_currency', 'USD'),
-                'narrative'        => $line['narrative'] ?? null,
+        $entry = DB::transaction(function () use ($description, $lines, $sourceDomain, $sourceEventId): JournalEntry {
+            $entry = JournalEntry::create([
+                'entry_number'    => 'JE-' . strtoupper(Str::random(8)),
+                'description'     => $description,
+                'status'          => EntryStatus::POSTED,
+                'posted_at'       => Carbon::now(),
+                'source_domain'   => $sourceDomain,
+                'source_event_id' => $sourceEventId,
             ]);
-        }
 
-        $entry->load('lines');
+            foreach ($lines as $line) {
+                JournalLine::create([
+                    'journal_entry_id' => $entry->id,
+                    'account_code'     => $line['account_code'],
+                    'debit_amount'     => $line['debit'],
+                    'credit_amount'    => $line['credit'],
+                    'currency'         => (string) config('ledger.default_currency', 'USD'),
+                    'narrative'        => $line['narrative'] ?? null,
+                ]);
+            }
+
+            $entry->load('lines');
+
+            return $entry;
+        });
+
         $this->driver->post($entry);
 
         return $entry;
@@ -92,10 +98,14 @@ final class LedgerService
         /** @var array<int, array{account_code: string, debit: numeric-string, credit: numeric-string, narrative?: string}> $reversalLines */
         $reversalLines = [];
         foreach ($original->lines as $line) {
+            /** @var numeric-string $creditAmt */
+            $creditAmt = (string) $line->credit_amount;
+            /** @var numeric-string $debitAmt */
+            $debitAmt = (string) $line->debit_amount;
             $reversalLines[] = [
                 'account_code' => $line->account_code,
-                'debit'        => number_format((float) $line->credit_amount, 4, '.', ''),
-                'credit'       => number_format((float) $line->debit_amount, 4, '.', ''),
+                'debit'        => bcadd($creditAmt, '0', 4),
+                'credit'       => bcadd($debitAmt, '0', 4),
                 'narrative'    => "Reversal: {$reason}",
             ];
         }

--- a/app/Domain/Microfinance/Services/LoanProvisioningService.php
+++ b/app/Domain/Microfinance/Services/LoanProvisioningService.php
@@ -8,6 +8,7 @@ use App\Domain\Microfinance\Enums\ProvisionCategory;
 use App\Domain\Microfinance\Models\LoanProvision;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use RuntimeException;
 
 class LoanProvisioningService
@@ -62,17 +63,18 @@ class LoanProvisioningService
      */
     public function reclassifyAll(): int
     {
-        $provisions = LoanProvision::all();
         $count = 0;
 
-        foreach ($provisions as $provision) {
-            $category = $this->determineCategoryFromDays($provision->days_overdue);
-            $provision->update([
-                'category'    => $category,
-                'review_date' => Carbon::today(),
-            ]);
-            $count++;
-        }
+        LoanProvision::chunkById(100, function (Collection $provisions) use (&$count): void {
+            foreach ($provisions as $provision) {
+                $category = $this->determineCategoryFromDays($provision->days_overdue);
+                $provision->update([
+                    'category'    => $category,
+                    'review_date' => Carbon::today(),
+                ]);
+                $count++;
+            }
+        });
 
         return $count;
     }
@@ -126,14 +128,21 @@ class LoanProvisioningService
             'total'       => '0.00',
         ];
 
-        $provisions = LoanProvision::all();
+        /** @var array<object{category: string, total: string}> $rows */
+        $rows = DB::table('mfi_loan_provisions')
+            ->selectRaw('category, SUM(provision_amount) as total')
+            ->groupBy('category')
+            ->get()
+            ->all();
 
-        foreach ($provisions as $provision) {
-            $cat = $provision->category->value;
+        foreach ($rows as $row) {
+            $cat = $row->category;
             if (isset($totals[$cat])) {
-                /** @var numeric-string $provAmt */
-                $provAmt = sprintf('%.10f', (float) $provision->provision_amount);
-                $totals[$cat] = bcadd($totals[$cat], $provAmt, 2);
+                /** @var numeric-string $rowTotal */
+                $rowTotal = (string) $row->total;
+                /** @var numeric-string $catTotal */
+                $catTotal = $totals[$cat];
+                $totals[$cat] = bcadd($catTotal, $rowTotal, 2);
             }
         }
 

--- a/app/Domain/Microfinance/Services/SavingsProductService.php
+++ b/app/Domain/Microfinance/Services/SavingsProductService.php
@@ -88,6 +88,10 @@ class SavingsProductService
      *
      * Formula: A = P * (1 + r/n)^(n*t) — interest = A - P
      *
+     * Note: Uses float arithmetic for exponentiation (pow). This is suitable for simulation
+     * and typical account balances. Production deployment should replace with bcmath or a
+     * fixed-point library for amounts exceeding 15 significant digits.
+     *
      * @param string $balance    Principal amount as a decimal string.
      * @param float  $annualRate Annual interest rate as a decimal (e.g. 0.12 for 12 %).
      * @param int    $days       Number of days.

--- a/app/Domain/Microfinance/Services/TellerService.php
+++ b/app/Domain/Microfinance/Services/TellerService.php
@@ -6,6 +6,7 @@ namespace App\Domain\Microfinance\Services;
 
 use App\Domain\Microfinance\Models\TellerCashier;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
 use RuntimeException;
 
 class TellerService
@@ -34,18 +35,16 @@ class TellerService
      */
     public function recordCashIn(string $tellerId, string $amount): TellerCashier
     {
-        $teller = TellerCashier::find($tellerId);
+        return DB::transaction(function () use ($tellerId, $amount): TellerCashier {
+            $teller = TellerCashier::lockForUpdate()->findOrFail($tellerId);
 
-        if ($teller === null) {
-            throw new RuntimeException("Teller not found: {$tellerId}");
-        }
+            /** @var numeric-string $vaultBalance */
+            $vaultBalance = (string) $teller->vault_balance;
+            $newBalance = bcadd($vaultBalance, $amount, 2);
+            $teller->update(['vault_balance' => $newBalance]);
 
-        /** @var numeric-string $vaultBalance */
-        $vaultBalance = (string) $teller->vault_balance;
-        $newBalance = bcadd($vaultBalance, $amount, 2);
-        $teller->update(['vault_balance' => $newBalance]);
-
-        return $teller->fresh() ?? $teller;
+            return $teller->refresh();
+        });
     }
 
     /**
@@ -57,25 +56,23 @@ class TellerService
      */
     public function recordCashOut(string $tellerId, string $amount): TellerCashier
     {
-        $teller = TellerCashier::find($tellerId);
+        return DB::transaction(function () use ($tellerId, $amount): TellerCashier {
+            $teller = TellerCashier::lockForUpdate()->findOrFail($tellerId);
 
-        if ($teller === null) {
-            throw new RuntimeException("Teller not found: {$tellerId}");
-        }
+            /** @var numeric-string $vaultBalance */
+            $vaultBalance = (string) $teller->vault_balance;
+            if (bccomp($vaultBalance, $amount, 2) < 0) {
+                throw new RuntimeException(
+                    "Insufficient vault balance. Balance: {$teller->vault_balance}, " .
+                    "requested: {$amount}."
+                );
+            }
 
-        /** @var numeric-string $vaultBalance */
-        $vaultBalance = (string) $teller->vault_balance;
-        if (bccomp($vaultBalance, $amount, 2) < 0) {
-            throw new RuntimeException(
-                "Insufficient vault balance. Balance: {$teller->vault_balance}, " .
-                "requested: {$amount}."
-            );
-        }
+            $newBalance = bcsub($vaultBalance, $amount, 2);
+            $teller->update(['vault_balance' => $newBalance]);
 
-        $newBalance = bcsub($vaultBalance, $amount, 2);
-        $teller->update(['vault_balance' => $newBalance]);
-
-        return $teller->fresh() ?? $teller;
+            return $teller->refresh();
+        });
     }
 
     /**

--- a/app/Domain/OpenBanking/Enums/ConsentPermission.php
+++ b/app/Domain/OpenBanking/Enums/ConsentPermission.php
@@ -13,6 +13,7 @@ enum ConsentPermission: string
     case READ_TRANSACTIONS_DETAIL = 'ReadTransactionsDetail';
     case READ_TRANSACTIONS_CREDITS = 'ReadTransactionsCredits';
     case READ_TRANSACTIONS_DEBITS = 'ReadTransactionsDebits';
+    case PAYMENT_INITIATION = 'PaymentInitiation';
 
     public function label(): string
     {
@@ -24,6 +25,7 @@ enum ConsentPermission: string
             self::READ_TRANSACTIONS_DETAIL  => 'Read Transactions (Detail)',
             self::READ_TRANSACTIONS_CREDITS => 'Read Transaction Credits',
             self::READ_TRANSACTIONS_DEBITS  => 'Read Transaction Debits',
+            self::PAYMENT_INITIATION        => 'Payment Initiation',
         };
     }
 }

--- a/app/Domain/OpenBanking/Services/ConsentEnforcementService.php
+++ b/app/Domain/OpenBanking/Services/ConsentEnforcementService.php
@@ -7,7 +7,7 @@ namespace App\Domain\OpenBanking\Services;
 use App\Domain\OpenBanking\Enums\ConsentStatus;
 use App\Domain\OpenBanking\Models\Consent;
 use App\Domain\OpenBanking\Models\ConsentAccessLog;
-use Carbon\Carbon;
+use Illuminate\Support\Facades\Cache;
 
 final class ConsentEnforcementService
 {
@@ -72,6 +72,10 @@ final class ConsentEnforcementService
             'endpoint'   => $endpoint,
             'ip_address' => $ipAddress,
         ]);
+
+        $key = "ob_consent_freq:{$consentId}:" . now()->format('Y-m-d');
+        Cache::add($key, 0, 86400);
+        Cache::increment($key);
     }
 
     /**
@@ -79,10 +83,10 @@ final class ConsentEnforcementService
      */
     public function checkFrequencyLimit(Consent $consent): bool
     {
-        $todayCount = ConsentAccessLog::where('consent_id', $consent->id)
-            ->whereDate('created_at', Carbon::today())
-            ->count();
+        $key = "ob_consent_freq:{$consent->id}:" . now()->format('Y-m-d');
+        Cache::add($key, 0, 86400);
+        $count = (int) Cache::get($key, 0);
 
-        return $todayCount < $consent->frequency_per_day;
+        return $count < $consent->frequency_per_day;
     }
 }

--- a/app/Domain/OpenBanking/Services/PispService.php
+++ b/app/Domain/OpenBanking/Services/PispService.php
@@ -37,7 +37,7 @@ final class PispService
         $hasAccess = $this->enforcement->validateAccess(
             $tppId,
             $userId,
-            ConsentPermission::READ_ACCOUNTS_BASIC->value,
+            ConsentPermission::PAYMENT_INITIATION->value,
         );
 
         if (! $hasAccess) {

--- a/app/Domain/PaymentRails/Services/AchService.php
+++ b/app/Domain/PaymentRails/Services/AchService.php
@@ -8,6 +8,7 @@ use App\Domain\PaymentRails\Enums\AchSecCode;
 use App\Domain\PaymentRails\Enums\RailStatus;
 use App\Domain\PaymentRails\Models\AchBatch;
 use App\Domain\PaymentRails\Models\AchEntry;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 /**
@@ -29,7 +30,7 @@ final class AchService
      *   22 = checking account credit (deposit)
      *   32 = savings account credit
      *
-     * @param  string $amount  Dollar amount, e.g. "250.00"
+     * @param  numeric-string $amount  Dollar amount, e.g. "250.00"
      */
     public function originateCredit(
         int $userId,
@@ -39,6 +40,9 @@ final class AchService
         string $name,
         string $secCode = 'PPD',
     ): AchBatch {
+        /** @var numeric-string $numericAmount */
+        $numericAmount = $amount;
+
         return $this->createBatch(
             userId: $userId,
             secCode: $secCode,
@@ -46,7 +50,7 @@ final class AchService
                 [
                     'routing_number'   => $routingNumber,
                     'account_number'   => $accountNumber,
-                    'amount'           => $amount,
+                    'amount'           => $numericAmount,
                     'transaction_code' => '22', // Checking account credit
                     'name'             => $name,
                 ],
@@ -61,7 +65,7 @@ final class AchService
      *   27 = checking account debit
      *   37 = savings account debit
      *
-     * @param  string $amount  Dollar amount, e.g. "250.00"
+     * @param  numeric-string $amount  Dollar amount, e.g. "250.00"
      */
     public function originateDebit(
         int $userId,
@@ -71,6 +75,9 @@ final class AchService
         string $name,
         string $secCode = 'PPD',
     ): AchBatch {
+        /** @var numeric-string $numericAmount */
+        $numericAmount = $amount;
+
         return $this->createBatch(
             userId: $userId,
             secCode: $secCode,
@@ -78,7 +85,7 @@ final class AchService
                 [
                     'routing_number'   => $routingNumber,
                     'account_number'   => $accountNumber,
-                    'amount'           => $amount,
+                    'amount'           => $numericAmount,
                     'transaction_code' => '27', // Checking account debit
                     'name'             => $name,
                 ],
@@ -102,7 +109,7 @@ final class AchService
      * @param array<int, array{
      *     routing_number: string,
      *     account_number: string,
-     *     amount: string,
+     *     amount: numeric-string,
      *     transaction_code: string,
      *     name: string,
      *     individual_id?: string
@@ -117,59 +124,66 @@ final class AchService
         // Validate SEC code
         AchSecCode::from($secCode);
 
+        /** @var numeric-string $totalDebit */
         $totalDebit = '0.00';
+        /** @var numeric-string $totalCredit */
         $totalCredit = '0.00';
 
         foreach ($entries as $entry) {
             $code = $entry['transaction_code'];
+            /** @var numeric-string $amount */
             $amount = $entry['amount'];
 
             // Debit codes: 27 (checking), 37 (savings), 23/33 (prenote debit)
             if (in_array($code, ['27', '37', '23', '33'], true)) {
+                /** @var numeric-string $totalDebit */
                 $totalDebit = $this->addAmounts($totalDebit, $amount);
             } else {
                 // Credit codes: 22 (checking), 32 (savings), etc.
+                /** @var numeric-string $totalCredit */
                 $totalCredit = $this->addAmounts($totalCredit, $amount);
             }
         }
 
-        $batch = AchBatch::create([
-            'batch_id'        => Str::uuid()->toString(),
-            'user_id'         => $userId,
-            'sec_code'        => $secCode,
-            'status'          => RailStatus::PENDING,
-            'entry_count'     => count($entries),
-            'total_debit'     => $totalDebit,
-            'total_credit'    => $totalCredit,
-            'same_day'        => $sameDay,
-            'settlement_date' => null,
-        ]);
-
-        $traceSeq = 1;
-        $origDfi = str_pad(
-            substr((string) config('payment_rails.ach.originating_dfi', ''), 0, 8),
-            8,
-            '0',
-            STR_PAD_LEFT,
-        );
-
-        foreach ($entries as $entry) {
-            $traceNumber = $origDfi . str_pad((string) $traceSeq++, 7, '0', STR_PAD_LEFT);
-
-            AchEntry::create([
-                'batch_id'         => $batch->id,
-                'trace_number'     => $traceNumber,
-                'routing_number'   => $entry['routing_number'],
-                'account_number'   => $entry['account_number'],
-                'amount'           => $entry['amount'],
-                'transaction_code' => $entry['transaction_code'],
-                'individual_name'  => $entry['name'],
-                'individual_id'    => $entry['individual_id'] ?? null,
-                'status'           => RailStatus::PENDING,
+        return DB::transaction(function () use ($userId, $secCode, $entries, $sameDay, $totalDebit, $totalCredit): AchBatch {
+            $batch = AchBatch::create([
+                'batch_id'        => Str::uuid()->toString(),
+                'user_id'         => $userId,
+                'sec_code'        => $secCode,
+                'status'          => RailStatus::PENDING,
+                'entry_count'     => count($entries),
+                'total_debit'     => $totalDebit,
+                'total_credit'    => $totalCredit,
+                'same_day'        => $sameDay,
+                'settlement_date' => null,
             ]);
-        }
 
-        return $batch->fresh() ?? $batch;
+            $traceSeq = 1;
+            $origDfi = str_pad(
+                substr((string) config('payment_rails.ach.originating_dfi', ''), 0, 8),
+                8,
+                '0',
+                STR_PAD_LEFT,
+            );
+
+            foreach ($entries as $entry) {
+                $traceNumber = $origDfi . str_pad((string) $traceSeq++, 7, '0', STR_PAD_LEFT);
+
+                AchEntry::create([
+                    'batch_id'         => $batch->id,
+                    'trace_number'     => $traceNumber,
+                    'routing_number'   => $entry['routing_number'],
+                    'account_number'   => $entry['account_number'],
+                    'amount'           => $entry['amount'],
+                    'transaction_code' => $entry['transaction_code'],
+                    'individual_name'  => $entry['name'],
+                    'individual_id'    => $entry['individual_id'] ?? null,
+                    'status'           => RailStatus::PENDING,
+                ]);
+            }
+
+            return $batch->fresh() ?? $batch;
+        });
     }
 
     /**
@@ -242,11 +256,13 @@ final class AchService
 
     /**
      * Add two decimal-string amounts together, returning a decimal string.
+     *
+     * @param  numeric-string $a
+     * @param  numeric-string $b
+     * @return numeric-string
      */
     private function addAmounts(string $a, string $b): string
     {
-        $result = (float) $a + (float) $b;
-
-        return number_format($result, 2, '.', '');
+        return bcadd($a, $b, 2);
     }
 }

--- a/app/Domain/PaymentRails/Services/FedNowService.php
+++ b/app/Domain/PaymentRails/Services/FedNowService.php
@@ -122,7 +122,7 @@ final class FedNowService
     public function processStatusReport(string $xml): array
     {
         try {
-            $element = new SimpleXMLElement($xml);
+            $element = new SimpleXMLElement($xml, LIBXML_NONET);
         } catch (Exception $e) {
             throw new RuntimeException('Invalid Pacs.002 XML: ' . $e->getMessage(), 0, $e);
         }

--- a/tests/Unit/Domain/OpenBanking/Enums/ConsentStatusTest.php
+++ b/tests/Unit/Domain/OpenBanking/Enums/ConsentStatusTest.php
@@ -27,9 +27,11 @@ it('identifies active status', function (): void {
 });
 
 it('has all consent permissions', function (): void {
-    expect(ConsentPermission::cases())->toHaveCount(7);
+    expect(ConsentPermission::cases())->toHaveCount(8);
     expect(ConsentPermission::READ_BALANCES->value)->toBe('ReadBalances');
     expect(ConsentPermission::READ_BALANCES->label())->toBe('Read Balances');
+    expect(ConsentPermission::PAYMENT_INITIATION->value)->toBe('PaymentInitiation');
+    expect(ConsentPermission::PAYMENT_INITIATION->label())->toBe('Payment Initiation');
 });
 
 it('has open banking standards', function (): void {


### PR DESCRIPTION
## Summary

Addresses 11 code review findings across 7 domains. All fixes verified with PHPStan Level 8 and domain unit tests.

### Critical fixes (5)

- **ACH float arithmetic** (`AchService`): replaced `(float) + (float)` in `addAmounts` with `bcadd($a, $b, 2)`; also wrapped `createBatch` AchBatch + AchEntry creation in `DB::transaction()`
- **Ledger reversal precision** (`LedgerService`): replaced `number_format((float) $line->credit_amount, 4)` with `bcadd((string) $line->credit_amount, '0', 4)`; wrapped `post()` JournalEntry + JournalLine creation in `DB::transaction()`
- **Teller race conditions** (`TellerService`): wrapped `recordCashIn` and `recordCashOut` in `DB::transaction()` with `lockForUpdate()` to prevent TOCTOU
- **PISP wrong permission** (`ConsentPermission` + `PispService`): added `PAYMENT_INITIATION = 'PaymentInitiation'` case; updated `PispService::initiatePayment()` to check `PAYMENT_INITIATION` instead of `READ_ACCOUNTS_BASIC`
- **XXE protection** (`MessageParser`, `FedNowService`): all `new SimpleXMLElement($xml)` calls now use `LIBXML_NONET` flag

### Important fixes (6)

- **QuoteService**: added PHPDoc float-limitation notice on class
- **SavingsProductService**: added PHPDoc float-limitation notice on `compoundInterest()`
- **IlpConnectorService + OpenPaymentsService**: injected `IlpAddressResolver` via constructor (removes `new` in hot-path methods)
- **EloquentDriver**: removed `(float)` cast from DB aggregates; use `@var numeric-string` instead
- **ConsentEnforcementService**: replaced DB `COUNT` query in `checkFrequencyLimit()` with atomic `Cache::add` + `Cache::get` counter; `logAccess()` increments the same key
- **LoanProvisioningService**: `reclassifyAll()` now uses `chunkById(100, ...)` instead of `all()`; `getTotalProvisions()` uses a single `DB::table(...)->selectRaw('category, SUM(...)')` aggregation query

## Test plan

- [x] `./vendor/bin/php-cs-fixer fix` — 0 files changed (clean)
- [x] `XDEBUG_MODE=off vendor/bin/phpstan analyse` — No errors (Level 8)
- [x] `./vendor/bin/pest` domain tests (Ledger, PaymentRails, OpenBanking, Microfinance, ISO20022, Interledger) — 152 passed (1 pre-existing SQLite migration timeout in `ReconciliationServiceTest`, unrelated to this PR)
- [x] `ConsentStatusTest` updated: count 7→8 for new `PAYMENT_INITIATION` case

🤖 Generated with [Claude Code](https://claude.com/claude-code)