### PR TITLE
fix: developer portal trust issues — honest SDK installs, correct versions, consolidated docs

### DIFF
--- a/resources/views/developers/api-docs.blade.php
+++ b/resources/views/developers/api-docs.blade.php
@@ -53,8 +53,23 @@
                     <a href="#ledger" class="text-slate-600 hover:text-slate-900">Ledger</a>
                     <a href="#microfinance" class="text-green-600 hover:text-green-800">Microfinance</a>
                     <a href="#webhooks" class="text-gray-600 hover:text-gray-900">Webhooks</a>
+                    <a href="#rate-limits" class="text-gray-600 hover:text-gray-900">Rate Limits</a>
                     <a href="#errors" class="text-gray-600 hover:text-gray-900">Errors</a>
                 </nav>
+            </div>
+        </div>
+
+        <!-- OpenAPI Spec Banner -->
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8">
+            <div class="flex items-center gap-4 p-4 bg-blue-50 border border-blue-200 rounded-lg mb-8">
+                <svg class="w-6 h-6 text-blue-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>
+                <div>
+                    <p class="font-semibold text-blue-900">OpenAPI 3.0 Specification</p>
+                    <p class="text-sm text-blue-700">Import into Postman, Insomnia, or any OpenAPI-compatible tool.</p>
+                </div>
+                <a href="/api/documentation" target="_blank" class="ml-auto px-4 py-2 bg-blue-600 text-white text-sm font-semibold rounded-lg hover:bg-blue-700 transition">
+                    View Swagger UI &rarr;
+                </a>
             </div>
         </div>
 
@@ -121,11 +136,11 @@ curl -H "Authorization: Bearer fak_your_api_key_here" \
                             </ul>
                             
                             <h3>Sandbox vs Production</h3>
-                            <p>Use these base URLs for testing and production:</p>
-                            <ul>
-                                <li><strong>Sandbox:</strong> {{ config('app.url') }}/api/v2</li>
-                                <li><strong>Production:</strong> {{ config('app.url') }}/api/v2</li>
-                            </ul>
+                            <div class="mb-2">
+                                <span class="font-semibold text-slate-700">Base URL:</span>
+                                <code class="bg-slate-100 px-2 py-1 rounded text-sm">{{ config('app.url') }}/api/v2</code>
+                            </div>
+                            <p class="text-sm text-slate-500">Sandbox and production use the same base URL. Your API key determines the environment. Sandbox keys start with <code>sk_sandbox_</code>, production keys start with <code>sk_live_</code>.</p>
                         </div>
                     </section>
 
@@ -349,7 +364,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/gcu</span>
+                                        <span class="ml-2 font-mono text-sm">/gcu</span>
                                     </div>
                                 </div>
                                 
@@ -366,7 +381,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/gcu/composition</span>
+                                        <span class="ml-2 font-mono text-sm">/gcu/composition</span>
                                     </div>
                                 </div>
                                 
@@ -432,7 +447,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/gcu/value-history</span>
+                                        <span class="ml-2 font-mono text-sm">/gcu/value-history</span>
                                     </div>
                                 </div>
                                 
@@ -461,7 +476,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/gcu/voting/proposals</span>
+                                        <span class="ml-2 font-mono text-sm">/gcu/voting/proposals</span>
                                     </div>
                                 </div>
                                 
@@ -483,7 +498,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/gcu/voting/proposals/{id}</span>
+                                        <span class="ml-2 font-mono text-sm">/gcu/voting/proposals/{id}</span>
                                     </div>
                                 </div>
                                 
@@ -500,7 +515,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-blue-100 text-blue-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/gcu/voting/proposals/{id}/vote</span>
+                                        <span class="ml-2 font-mono text-sm">/gcu/voting/proposals/{id}/vote</span>
                                     </div>
                                     <div class="text-right">
                                         <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">Requires Authentication</span>
@@ -530,7 +545,7 @@ curl -X POST \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/gcu/voting/my-votes</span>
+                                        <span class="ml-2 font-mono text-sm">/gcu/voting/my-votes</span>
                                     </div>
                                     <div class="text-right">
                                         <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">Requires Authentication</span>
@@ -737,7 +752,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/crosschain/bridge</span>
+                                        <span class="ml-2 font-mono text-sm">/crosschain/bridge</span>
                                     </div>
                                 </div>
                                 <p class="text-gray-600 mb-4">Initiate a cross-chain bridge transfer through Wormhole, LayerZero, or Axelar.</p>
@@ -761,7 +776,7 @@ curl -X POST \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/crosschain/bridge/fees</span>
+                                        <span class="ml-2 font-mono text-sm">/crosschain/bridge/fees</span>
                                     </div>
                                 </div>
                                 <p class="text-gray-600 mb-4">Compare fees and estimated times across all supported bridge protocols for a given route.</p>
@@ -776,7 +791,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/crosschain/swap</span>
+                                        <span class="ml-2 font-mono text-sm">/crosschain/swap</span>
                                     </div>
                                 </div>
                                 <p class="text-gray-600 mb-4">Execute a token swap that bridges and swaps in a single atomic operation.</p>
@@ -801,7 +816,7 @@ curl -X POST \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/crosschain/portfolio</span>
+                                        <span class="ml-2 font-mono text-sm">/crosschain/portfolio</span>
                                     </div>
                                 </div>
                                 <p class="text-gray-600 mb-4">Retrieve an aggregated portfolio view across all supported chains.</p>
@@ -828,7 +843,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/defi/swap/quote</span>
+                                        <span class="ml-2 font-mono text-sm">/defi/swap/quote</span>
                                     </div>
                                 </div>
                                 <p class="text-gray-600 mb-4">Get the best swap quote aggregated across Uniswap, Curve, and other supported DEXes.</p>
@@ -843,7 +858,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/defi/swap/execute</span>
+                                        <span class="ml-2 font-mono text-sm">/defi/swap/execute</span>
                                     </div>
                                 </div>
                                 <p class="text-gray-600 mb-4">Execute a token swap through the optimal DEX route.</p>
@@ -867,7 +882,7 @@ curl -X POST \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/defi/portfolio</span>
+                                        <span class="ml-2 font-mono text-sm">/defi/portfolio</span>
                                     </div>
                                 </div>
                                 <p class="text-gray-600 mb-4">Retrieve all DeFi positions including lending deposits, staking, liquidity pools, and yield farming.</p>
@@ -882,7 +897,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/defi/flash-loan</span>
+                                        <span class="ml-2 font-mono text-sm">/defi/flash-loan</span>
                                     </div>
                                 </div>
                                 <p class="text-gray-600 mb-4">Execute a flash loan with a sequence of operations that must complete atomically.</p>
@@ -919,7 +934,7 @@ curl -X POST \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/regtech/mifid/reports</span>
+                                        <span class="ml-2 font-mono text-sm">/regtech/mifid/reports</span>
                                     </div>
                                 </div>
                                 <p class="text-gray-600 mb-4">Submit a MiFID II transaction report to the configured National Competent Authority.</p>
@@ -941,7 +956,7 @@ curl -X POST \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/regtech/mica/check</span>
+                                        <span class="ml-2 font-mono text-sm">/regtech/mica/check</span>
                                     </div>
                                 </div>
                                 <p class="text-gray-600 mb-4">Run a MiCA compliance validation against a crypto-asset or token issuance.</p>
@@ -963,7 +978,7 @@ curl -X POST \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/regtech/travel-rule/transfers</span>
+                                        <span class="ml-2 font-mono text-sm">/regtech/travel-rule/transfers</span>
                                     </div>
                                 </div>
                                 <p class="text-gray-600 mb-4">Submit originator and beneficiary information for FATF Travel Rule compliance on cross-border transfers.</p>
@@ -987,7 +1002,7 @@ curl -X POST \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/regtech/status</span>
+                                        <span class="ml-2 font-mono text-sm">/regtech/status</span>
                                     </div>
                                 </div>
                                 <p class="text-gray-600 mb-4">Get overall compliance status across all active regulatory frameworks.</p>
@@ -1014,7 +1029,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/mobile/payments/intents</span>
+                                        <span class="ml-2 font-mono text-sm">/mobile/payments/intents</span>
                                     </div>
                                 </div>
                                 <p class="text-gray-600 mb-4">Create a new payment intent for mobile wallet transactions.</p>
@@ -1037,7 +1052,7 @@ curl -X POST \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/mobile/activity</span>
+                                        <span class="ml-2 font-mono text-sm">/mobile/activity</span>
                                     </div>
                                 </div>
                                 <p class="text-gray-600 mb-4">Retrieve the mobile wallet activity feed with payments, transfers, and notifications.</p>
@@ -1052,7 +1067,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/mobile/transfers/p2p</span>
+                                        <span class="ml-2 font-mono text-sm">/mobile/transfers/p2p</span>
                                     </div>
                                 </div>
                                 <p class="text-gray-600 mb-4">Send a peer-to-peer transfer to another mobile wallet user.</p>
@@ -1075,7 +1090,7 @@ curl -X POST \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/mobile/auth/passkey/verify</span>
+                                        <span class="ml-2 font-mono text-sm">/mobile/auth/passkey/verify</span>
                                     </div>
                                 </div>
                                 <p class="text-gray-600 mb-4">Verify a FIDO2/WebAuthn passkey for passwordless mobile authentication.</p>
@@ -1109,7 +1124,7 @@ curl -X POST \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/partner/tenants</span>
+                                        <span class="ml-2 font-mono text-sm">/partner/tenants</span>
                                     </div>
                                     <div class="text-right">
                                         <span class="inline-block bg-rose-100 text-rose-800 text-xs font-medium px-2.5 py-0.5 rounded">Partner Key Required</span>
@@ -1135,7 +1150,7 @@ curl -X POST \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/partner/sdk/generate</span>
+                                        <span class="ml-2 font-mono text-sm">/partner/sdk/generate</span>
                                     </div>
                                     <div class="text-right">
                                         <span class="inline-block bg-rose-100 text-rose-800 text-xs font-medium px-2.5 py-0.5 rounded">Partner Key Required</span>
@@ -1161,7 +1176,7 @@ curl -X POST \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-blue-100 text-blue-800 text-xs font-medium px-2.5 py-0.5 rounded">PUT</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/partner/config/whitelabel</span>
+                                        <span class="ml-2 font-mono text-sm">/partner/config/whitelabel</span>
                                     </div>
                                     <div class="text-right">
                                         <span class="inline-block bg-rose-100 text-rose-800 text-xs font-medium px-2.5 py-0.5 rounded">Partner Key Required</span>
@@ -1187,7 +1202,7 @@ curl -X PUT \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/partner/tenants</span>
+                                        <span class="ml-2 font-mono text-sm">/partner/tenants</span>
                                     </div>
                                     <div class="text-right">
                                         <span class="inline-block bg-rose-100 text-rose-800 text-xs font-medium px-2.5 py-0.5 rounded">Partner Key Required</span>
@@ -1218,7 +1233,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/ai/query</span>
+                                        <span class="ml-2 font-mono text-sm">/ai/query</span>
                                     </div>
                                 </div>
                                 <p class="text-gray-600 mb-4">Submit a natural language question about your transactions, balances, or financial activity.</p>
@@ -1239,7 +1254,7 @@ curl -X POST \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/ai/queries</span>
+                                        <span class="ml-2 font-mono text-sm">/ai/queries</span>
                                     </div>
                                 </div>
                                 <p class="text-gray-600 mb-4">Retrieve your past AI query history with cached results.</p>
@@ -1675,7 +1690,7 @@ curl -X POST \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/x402/status</span>
+                                        <span class="ml-2 font-mono text-sm">/x402/status</span>
                                     </div>
                                 </div>
                                 <p class="text-gray-600 mb-4">Get the current x402 protocol status including supported networks, assets, and facilitator connectivity.</p>
@@ -1690,7 +1705,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/x402/supported</span>
+                                        <span class="ml-2 font-mono text-sm">/x402/supported</span>
                                     </div>
                                 </div>
                                 <p class="text-gray-600 mb-4">List all supported blockchain networks and payment assets for x402 settlement.</p>
@@ -1705,7 +1720,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-orange-100 text-orange-800 text-xs font-medium px-2.5 py-0.5 rounded">POST</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/x402/endpoints</span>
+                                        <span class="ml-2 font-mono text-sm">/x402/endpoints</span>
                                     </div>
                                 </div>
                                 <p class="text-gray-600 mb-4">Register an API endpoint for x402 monetization with pricing configuration.</p>
@@ -1729,7 +1744,7 @@ curl -X POST \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/x402/payments</span>
+                                        <span class="ml-2 font-mono text-sm">/x402/payments</span>
                                     </div>
                                 </div>
                                 <p class="text-gray-600 mb-4">Retrieve payment history and settlement status for x402 transactions.</p>
@@ -1744,7 +1759,7 @@ curl -H "Authorization: Bearer your_api_key" \
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
                                     <div>
                                         <span class="inline-block bg-green-100 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded">GET</span>
-                                        <span class="ml-2 font-mono text-sm">/v2/x402/spending-limits</span>
+                                        <span class="ml-2 font-mono text-sm">/x402/spending-limits</span>
                                     </div>
                                 </div>
                                 <p class="text-gray-600 mb-4">View and manage spending limits for automated x402 payments including AI agent budgets.</p>
@@ -1796,6 +1811,38 @@ if (response.status === 402) {
                             </div>
                         </div>
                     </section>
+
+                    <section id="rate-limits" class="mb-16">
+                        <h2 class="text-3xl font-bold text-gray-900 mb-8">Rate Limits</h2>
+                        <div class="prose prose-lg max-w-none mb-6">
+                            <p>All API requests are rate limited. Limits apply per API key and are enforced on a sliding window.</p>
+                        </div>
+                        <div class="border rounded-lg overflow-hidden mb-6">
+                            <table class="w-full text-sm">
+                                <thead class="bg-gray-50">
+                                    <tr>
+                                        <th class="px-4 py-3 text-left font-semibold text-gray-700">Endpoint Type</th>
+                                        <th class="px-4 py-3 text-left font-semibold text-gray-700">Limit</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-gray-200">
+                                    <tr><td class="px-4 py-3 text-gray-700">REST API</td><td class="px-4 py-3"><code class="bg-gray-100 px-2 py-0.5 rounded">1,000 requests/hour per API key</code></td></tr>
+                                    <tr><td class="px-4 py-3 text-gray-700">GraphQL (authenticated)</td><td class="px-4 py-3"><code class="bg-gray-100 px-2 py-0.5 rounded">120 queries/minute</code></td></tr>
+                                    <tr><td class="px-4 py-3 text-gray-700">GraphQL (guest)</td><td class="px-4 py-3"><code class="bg-gray-100 px-2 py-0.5 rounded">30 queries/minute</code></td></tr>
+                                    <tr><td class="px-4 py-3 text-gray-700">Webhooks</td><td class="px-4 py-3"><code class="bg-gray-100 px-2 py-0.5 rounded">100 deliveries/minute per endpoint</code></td></tr>
+                                    <tr><td class="px-4 py-3 text-gray-700">Burst (sliding window)</td><td class="px-4 py-3"><code class="bg-gray-100 px-2 py-0.5 rounded">100 requests/minute</code></td></tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <div class="bg-gray-50 rounded-lg p-4">
+                            <p class="text-sm font-semibold text-gray-700 mb-2">Rate limit headers included in every response:</p>
+                            <div class="space-y-1 font-mono text-sm text-gray-600">
+                                <div><code>X-RateLimit-Limit</code> — Maximum requests allowed in the window</div>
+                                <div><code>X-RateLimit-Remaining</code> — Requests remaining in the current window</div>
+                                <div><code>X-RateLimit-Reset</code> — Unix timestamp when the window resets</div>
+                            </div>
+                        </div>
+                    </section>
                 </div>
 
                 <!-- Sidebar -->
@@ -1836,7 +1883,7 @@ if (response.status === 402) {
                             <h3 class="text-lg font-semibold text-blue-900 mb-4">OpenAPI Specification</h3>
                             <p class="text-blue-800 mb-4">Download the OpenAPI specification file or view it in your preferred API client.</p>
                             <div class="flex gap-3">
-                                <a href="/docs/api-docs.json" download="finaegis-api-v2.json" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition duration-200">
+                                <a href="/docs/api-docs.json" download="zelta-api-v2.json" class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition duration-200">
                                     Download OpenAPI JSON
                                 </a>
                                 <a href="/api/documentation" target="_blank" class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 transition duration-200">

--- a/resources/views/developers/examples.blade.php
+++ b/resources/views/developers/examples.blade.php
@@ -240,10 +240,11 @@
                             <!-- JavaScript -->
                             <div id="create-js" class="tab-content active animate-fade-in">
                                 <x-code-block language="javascript">
-import { {{ config('brand.name', 'Zelta') }} } from '@finaegis/sdk';
+// Install: npm install ./sdks/javascript (from monorepo)
+import { {{ config('brand.name', 'Zelta') }} } from '@zelta/sdk';
 
 const client = new {{ config('brand.name', 'Zelta') }}({
-  apiKey: process.env.FINAEGIS_API_KEY,
+  apiKey: process.env.ZELTA_API_KEY,
   baseURL: '{{ config('app.url') }}/api/v2'
 });
 
@@ -283,11 +284,12 @@ createAccountAndCheckBalance();
                             <!-- Python -->
                             <div id="create-py" class="tab-content animate-fade-in">
                                 <x-code-block language="python">
-from finaegis import {{ config('brand.name', 'Zelta') }}
+# Install: pip install ./sdks/python (from monorepo)
+from zelta import {{ config('brand.name', 'Zelta') }}
 import os
 
 client = {{ config('brand.name', 'Zelta') }}(
-    api_key=os.environ['FINAEGIS_API_KEY'],
+    api_key=os.environ['ZELTA_API_KEY'],
     base_url='{{ config('app.url') }}/api/v2'
 )
 
@@ -324,12 +326,14 @@ create_account_and_check_balance()
                             <!-- PHP -->
                             <div id="create-php" class="tab-content animate-fade-in">
                                 <x-code-block language="php">
+<?php
+// Install: composer require zelta/payment-sdk --repository='{"type":"path","url":"packages/zelta-sdk"}'
 require_once 'vendor/autoload.php';
 
-use {{ config('brand.name', 'Zelta') }}\Client;
+use Zelta\PaymentSDK\Client;
 
 $client = new Client([
-    'apiKey' => $_ENV['FINAEGIS_API_KEY'],
+    'apiKey' => $_ENV['ZELTA_API_KEY'],
     'baseURL' => '{{ config('app.url') }}/api/v2'
 ]);
 
@@ -777,7 +781,7 @@ const app = express();
 
 // Middleware to verify webhook signatures
 function verifyWebhookSignature(req, res, next) {
-  const signature = req.headers['x-finaegis-signature'];
+  const signature = req.headers['x-zelta-signature'];
   const payload = JSON.stringify(req.body);
   const secret = process.env.WEBHOOK_SECRET;
   
@@ -794,7 +798,7 @@ function verifyWebhookSignature(req, res, next) {
 }
 
 // Webhook endpoint
-app.post('/webhooks/finaegis', 
+app.post('/webhooks/zelta',
   express.json(),
   verifyWebhookSignature,
   (req, res) => {
@@ -856,7 +860,7 @@ async function handleWorkflowCompleted(workflow) {
 // Configure webhook endpoints
 async function setupWebhooks() {
   const webhook = await client.webhooks.create({
-    url: 'https://yourapp.com/webhooks/finaegis',
+    url: 'https://yourapp.com/webhooks/zelta',
     events: [
       'transfer.completed',
       'transfer.failed',
@@ -921,7 +925,8 @@ async function testWebhook(webhookId) {
                             <!-- JavaScript -->
                             <div id="ai-chat-js" class="tab-content active animate-fade-in">
                                 <x-code-block language="javascript">
-import { {{ config('brand.name', 'Zelta') }}AI } from '@finaegis/ai-sdk';
+// Install: npm install ./sdks/javascript (from monorepo)
+import { {{ config('brand.name', 'Zelta') }}AI } from '@zelta/sdk';
 
 const aiClient = new {{ config('brand.name', 'Zelta') }}AI({
   apiKey: process.env.FINAEGIS_API_KEY,
@@ -1007,7 +1012,8 @@ async function streamingChat() {
                             <!-- Python -->
                             <div id="ai-chat-py" class="tab-content animate-fade-in">
                                 <x-code-block language="python">
-from finaegis_ai import {{ config('brand.name', 'Zelta') }}AI
+# Install: pip install ./sdks/python (from monorepo)
+from zelta import {{ config('brand.name', 'Zelta') }}AI
 import asyncio
 import uuid
 
@@ -1131,7 +1137,7 @@ asyncio.run(banking_conversation())
   },
   "metadata": {
     "processing_time_ms": 342,
-    "model_version": "finaegis-ai-v2.5",
+    "model_version": "zelta-ai-v2",
     "mcp_tools_available": 12,
     "workflow_id": "wf_banking_assist_789"
   }
@@ -1306,7 +1312,8 @@ handleCustomerRequest('cust_123',
                             <div id="mcp-register-js" class="tab-content active animate-fade-in">
                                 <x-code-block language="javascript">
 // Register custom MCP tools for banking operations
-import { MCPServer } from '@finaegis/mcp-sdk';
+// Install: npm install ./sdks/javascript (from monorepo)
+import { MCPServer } from '@zelta/sdk';
 
 const mcpServer = new MCPServer({
   name: 'banking-tools',
@@ -1578,7 +1585,7 @@ aiClient.on('tool_executed', (event) => {
                             <div id="mcp-manifest" class="tab-content animate-fade-in">
                                 <x-code-block language="json">
 {
-  "name": "finaegis-banking-tools",
+  "name": "zelta-banking-tools",
   "version": "1.0.0",
   "description": "MCP tools for {{ config('brand.name', 'Zelta') }} banking operations",
   "author": "{{ config('brand.name', 'Zelta') }}",
@@ -1864,7 +1871,8 @@ curl -X POST {{ config('app.url') }}/api/api/v1/crosschain/bridge/initiate \
                             <!-- JavaScript -->
                             <div id="bridge-js" class="tab-content animate-fade-in">
                                 <x-code-block language="javascript">
-import { {{ config('brand.name', 'Zelta') }} } from '@finaegis/sdk';
+// Install: npm install ./sdks/javascript (from monorepo)
+import { {{ config('brand.name', 'Zelta') }} } from '@zelta/sdk';
 
 const client = new {{ config('brand.name', 'Zelta') }}({
   apiKey: process.env.FINAEGIS_API_KEY,
@@ -1915,7 +1923,8 @@ bridgeTokens('ethereum', 'polygon', 'USDC', '1000.00');
                             <!-- Python -->
                             <div id="bridge-py" class="tab-content animate-fade-in">
                                 <x-code-block language="python">
-from finaegis import {{ config('brand.name', 'Zelta') }}
+# Install: pip install ./sdks/python (from monorepo)
+from zelta import {{ config('brand.name', 'Zelta') }}
 import os
 
 client = {{ config('brand.name', 'Zelta') }}(
@@ -2236,7 +2245,7 @@ swap_tokens('ethereum', 'WETH', 'USDC', '2.5')
                                     <p class="text-gray-600 mt-1">Validate FATF Travel Rule compliance before executing cross-border or virtual asset transfers</p>
                                 </div>
                                 <div class="flex items-center gap-2">
-                                    <span class="px-3 py-1 bg-emerald-100 text-emerald-700 rounded-full text-xs font-medium">v2.8</span>
+                                    <span class="px-3 py-1 bg-emerald-100 text-emerald-700 rounded-full text-xs font-medium">v2</span>
                                     <span class="px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-xs font-medium">POST</span>
                                 </div>
                             </div>
@@ -2461,7 +2470,7 @@ check_travel_rule_compliance({
                                     <p class="text-gray-600 mt-1">Onboard a new partner organization onto the Banking-as-a-Service platform with API keys and SDK access</p>
                                 </div>
                                 <div class="flex items-center gap-2">
-                                    <span class="px-3 py-1 bg-amber-100 text-amber-700 rounded-full text-xs font-medium">v2.9</span>
+                                    <span class="px-3 py-1 bg-amber-100 text-amber-700 rounded-full text-xs font-medium">v2</span>
                                     <span class="px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-xs font-medium">POST</span>
                                 </div>
                             </div>
@@ -2489,7 +2498,7 @@ curl -X POST {{ config('app.url') }}/api/api/v1/partner/onboard \
     "tier": "growth",
     "modules": ["accounts", "transfers", "compliance", "crosschain"],
     "sdk_languages": ["typescript", "python"],
-    "webhook_url": "https://acmefintech.com/webhooks/finaegis",
+    "webhook_url": "https://acmefintech.com/webhooks/zelta",
     "ip_whitelist": ["203.0.113.0/24"],
     "rate_limit_override": 5000,
     "metadata": {
@@ -2541,7 +2550,7 @@ onboardPartner({
   tier: 'growth',
   modules: ['accounts', 'transfers', 'compliance', 'crosschain'],
   sdkLanguages: ['typescript', 'python'],
-  webhookUrl: 'https://acmefintech.com/webhooks/finaegis',
+  webhookUrl: 'https://acmefintech.com/webhooks/zelta',
   ipWhitelist: ['203.0.113.0/24'],
   rateLimit: 5000,
   metadata: {
@@ -2590,7 +2599,7 @@ onboard_partner({
     'tier': 'growth',
     'modules': ['accounts', 'transfers', 'compliance', 'crosschain'],
     'sdk_languages': ['typescript', 'python'],
-    'webhook_url': 'https://acmefintech.com/webhooks/finaegis',
+    'webhook_url': 'https://acmefintech.com/webhooks/zelta',
     'ip_whitelist': ['203.0.113.0/24'],
     'rate_limit': 5000,
     'metadata': {
@@ -2625,15 +2634,15 @@ onboard_partner({
       {
         "language": "typescript",
         "version": "3.0.0",
-        "package_name": "@finaegis/sdk",
-        "download_url": "{{ config('app.url') }}/developers/sdks/packages/typescript/finaegis-sdk-3.0.0.tgz",
+        "package_name": "@zelta/sdk",
+        "download_url": "{{ config('app.url') }}/developers/sdks/packages/typescript/zelta-sdk-2.0.0.tgz",
         "docs_url": "{{ config('app.url') }}/developers/sdk/typescript"
       },
       {
         "language": "python",
         "version": "3.0.0",
-        "package_name": "finaegis-sdk",
-        "download_url": "{{ config('app.url') }}/developers/sdks/packages/python/finaegis-sdk-3.0.0.tar.gz",
+        "package_name": "zelta-sdk",
+        "download_url": "{{ config('app.url') }}/developers/sdks/packages/python/zelta-sdk-2.0.0.tar.gz",
         "docs_url": "{{ config('app.url') }}/developers/sdk/python"
       }
     ],
@@ -2674,7 +2683,7 @@ onboard_partner({
                                     <p class="text-gray-600 mt-1">Query transactions using natural language -- the AI engine translates to structured filters</p>
                                 </div>
                                 <div class="flex items-center gap-2">
-                                    <span class="px-3 py-1 bg-violet-100 text-violet-700 rounded-full text-xs font-medium">v2.8</span>
+                                    <span class="px-3 py-1 bg-violet-100 text-violet-700 rounded-full text-xs font-medium">v2</span>
                                     <span class="px-3 py-1 bg-blue-100 text-blue-700 rounded-full text-xs font-medium">POST</span>
                                     <span class="px-3 py-1 bg-indigo-100 text-indigo-700 rounded-full text-xs font-medium">AI</span>
                                 </div>

--- a/resources/views/developers/graphql.blade.php
+++ b/resources/views/developers/graphql.blade.php
@@ -268,6 +268,7 @@
                     <div class="flex justify-between"><span class="text-slate-600">Guest requests</span><code class="code-font bg-slate-100 px-2 py-0.5 rounded">30 / min</code></div>
                     <div class="flex justify-between"><span class="text-slate-600">Authenticated requests</span><code class="code-font bg-slate-100 px-2 py-0.5 rounded">120 / min</code></div>
                 </div>
+                <p class="text-xs text-slate-500 mt-3">See <a href="{{ route('developers.show', 'api-docs') }}#rate-limits" class="text-pink-600 hover:text-pink-800">API Docs &rarr; Rate Limits</a> for full details including REST and webhook limits.</p>
             </div>
             <div class="bg-white rounded-xl border border-slate-200 p-6">
                 <h3 class="font-semibold text-lg mb-4">Query Limits</h3>

--- a/resources/views/developers/index.blade.php
+++ b/resources/views/developers/index.blade.php
@@ -263,7 +263,7 @@
                         <div class="text-center mb-6">
                             <div class="w-20 h-20 bg-gradient-to-br from-pink-500 to-orange-600 text-white rounded-full flex items-center justify-center text-2xl font-bold mx-auto shadow-lg">3</div>
                             <h3 class="text-xl font-semibold mt-4 mb-2">Start Building</h3>
-                            <p class="text-slate-500">Create your first API request</p>
+                            <p class="text-slate-500">Verify the API is running, then make your first request</p>
                         </div>
                         <div class="code-container flex-1">
                             <div class="code-header">
@@ -282,9 +282,12 @@
                             </div>
                             <div class="p-4 font-mono text-sm">
                                 <div id="code-step3">
-                                    <div><span class="text-gray-500">$</span> <span class="text-green-400">curl</span> <span class="text-blue-400">-X</span> <span class="text-purple-400">GET</span> <span class="text-yellow-400">"http://localhost:8000/api/v1/accounts"</span> <span class="text-gray-400">\</span></div>
-                                    <div>  <span class="text-blue-400">-H</span> <span class="text-yellow-400">"Authorization: Bearer YOUR_API_KEY"</span> <span class="text-gray-400">\</span></div>
-                                    <div>  <span class="text-blue-400">-H</span> <span class="text-yellow-400">"Accept: application/json"</span></div>
+                                    <div><span class="text-gray-500"># Verify the API is running (no auth needed)</span></div>
+                                    <div><span class="text-gray-500">$</span> <span class="text-green-400">curl</span> <span class="text-yellow-400">http://localhost:8000/api/health</span></div>
+                                    <div><span class="text-gray-500"># {"status":"ok","version":"7.8.0"}</span></div>
+                                    <div class="mt-2"><span class="text-gray-500"># Make an authenticated request</span></div>
+                                    <div><span class="text-gray-500">$</span> <span class="text-green-400">curl</span> <span class="text-blue-400">-H</span> <span class="text-yellow-400">"Authorization: Bearer YOUR_API_KEY"</span> <span class="text-gray-400">\</span></div>
+                                    <div>  <span class="text-yellow-400">http://localhost:8000/api/v2/accounts</span></div>
                                 </div>
                             </div>
                         </div>
@@ -1148,9 +1151,9 @@
 <span class="text-purple-400">const</span> <span class="text-white">app</span> = <span class="text-green-400">express</span>();
 <span class="text-white">app</span>.<span class="text-green-400">use</span>(<span class="text-white">express</span>.<span class="text-green-400">json</span>());
 
-<span class="text-white">app</span>.<span class="text-green-400">post</span>(<span class="text-amber-400">'/webhooks/finaegis'</span>, (<span class="text-white">req</span>, <span class="text-white">res</span>) <span class="text-blue-400">=></span> {
+<span class="text-white">app</span>.<span class="text-green-400">post</span>(<span class="text-amber-400">'/webhooks/zelta'</span>, (<span class="text-white">req</span>, <span class="text-white">res</span>) <span class="text-blue-400">=></span> {
     <span class="text-gray-400">// Verify webhook signature</span>
-    <span class="text-purple-400">const</span> <span class="text-white">signature</span> = <span class="text-white">req</span>.<span class="text-cyan-400">headers</span>[<span class="text-amber-400">'x-finaegis-signature'</span>];
+    <span class="text-purple-400">const</span> <span class="text-white">signature</span> = <span class="text-white">req</span>.<span class="text-cyan-400">headers</span>[<span class="text-amber-400">'x-zelta-signature'</span>];
     <span class="text-purple-400">const</span> <span class="text-white">payload</span> = <span class="text-white">JSON</span>.<span class="text-green-400">stringify</span>(<span class="text-white">req</span>.<span class="text-cyan-400">body</span>);
     <span class="text-purple-400">const</span> <span class="text-white">secret</span> = <span class="text-white">process</span>.<span class="text-cyan-400">env</span>.<span class="text-cyan-400">WEBHOOK_SECRET</span>;
     

--- a/resources/views/developers/sdks.blade.php
+++ b/resources/views/developers/sdks.blade.php
@@ -183,7 +183,7 @@
                     <div class="flex flex-wrap items-center justify-center gap-3 mb-6">
                         <span class="inline-flex items-center px-4 py-2 bg-green-500/20 backdrop-blur-sm rounded-full text-sm">
                             <span class="w-2 h-2 bg-green-400 rounded-full mr-2"></span>
-                            <span>REST API v5.12</span>
+                            <span>REST API v2</span>
                         </span>
                         <span class="inline-flex items-center px-4 py-2 bg-green-500/20 backdrop-blur-sm rounded-full text-sm">
                             <span class="w-2 h-2 bg-green-400 rounded-full mr-2"></span>
@@ -219,6 +219,16 @@
                 </div>
             </div>
         </section>
+
+        <!-- SDK Source Notice -->
+        <div class="bg-amber-50 border-b border-amber-200 py-4">
+            <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                <div class="flex items-start gap-3">
+                    <svg class="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                    <p class="text-sm text-amber-800"><strong>SDKs are included in the FinAegis monorepo.</strong> They are not published to npm, Packagist, or PyPI. Install from the repository source after cloning the project.</p>
+                </div>
+            </div>
+        </div>
 
         <!-- Integration Methods -->
         <section id="integration-methods" class="py-20 bg-white">
@@ -348,16 +358,16 @@
 
                         <div class="space-y-2">
                             <div class="bg-gray-900 rounded-lg px-4 py-2 font-mono text-green-400 text-sm">
-                                <code>npm install @zelta/payment-sdk@1.0.0</code>
+                                <code>npm install ./sdks/javascript</code>
                             </div>
                             <div class="bg-gray-900 rounded-lg px-4 py-2 font-mono text-green-400 text-sm">
-                                <code>pip install zelta-payment-sdk==1.0.0</code>
+                                <code>pip install ./sdks/python</code>
                             </div>
                             <div class="bg-gray-900 rounded-lg px-4 py-2 font-mono text-green-400 text-sm">
-                                <code>composer require zelta/payment-sdk:^1.0</code>
+                                <code>composer require zelta/payment-sdk --repository='{"type":"path","url":"packages/zelta-sdk"}'</code>
                             </div>
                         </div>
-                        <p class="text-xs text-slate-400 mt-3">Packages are available from the project repository. See the installation guide for details — not published to public registries.</p>
+                        <p class="text-xs text-slate-400 mt-3">SDKs are in the monorepo — not published to public registries. Clone the repository first, then install via path dependency.</p>
                     </div>
 
 
@@ -405,7 +415,8 @@ console.<span style="color: #89ddff;">log</span>(<span style="color: #82aaff;">r
                                 <span>Python Example</span>
                                 <button class="copy-button" onclick="copyCode(this)">Copy</button>
                             </div>
-                            <pre class="code-block p-4"><code class="language-python"><span style="color: #c792ea;">from</span> <span style="color: #ffcb6b;">finaegis</span> <span style="color: #c792ea;">import</span> <span style="color: #82aaff;">MCPClient</span>
+                            <pre class="code-block p-4"><code class="language-python"><span style="color: #546e7a;"># Install: pip install ./sdks/python (from monorepo)</span>
+<span style="color: #c792ea;">from</span> <span style="color: #ffcb6b;">zelta</span> <span style="color: #c792ea;">import</span> <span style="color: #82aaff;">MCPClient</span>
 
 <span style="color: #546e7a;"># Initialize MCP client</span>
 <span style="color: #82aaff;">mcp</span> = <span style="color: #ffcb6b;">MCPClient</span>(<span style="color: #f07178;">api_key</span>=<span style="color: #c3e88d;">'your-api-key'</span>)
@@ -477,7 +488,7 @@ console.<span style="color: #89ddff;">log</span>(<span style="color: #82aaff;">r
                             <button class="copy-button" onclick="copyCode(this)">Copy</button>
                         </div>
                         <pre class="code-block p-4"><code class="language-json">{
-  <span style="color: #f07178;">"name"</span>: <span style="color: #c3e88d;">"finaegis-mcp-server"</span>,
+  <span style="color: #f07178;">"name"</span>: <span style="color: #c3e88d;">"zelta-mcp-server"</span>,
   <span style="color: #f07178;">"version"</span>: <span style="color: #c3e88d;">"1.0.0"</span>,
   <span style="color: #f07178;">"tools"</span>: [
     <span style="color: #c3e88d;">"GetAccountBalance"</span>,
@@ -523,7 +534,7 @@ console.<span style="color: #89ddff;">log</span>(<span style="color: #82aaff;">r
                 <div class="text-center mb-12">
                     <span class="inline-flex items-center px-4 py-2 bg-green-100 rounded-full text-sm font-medium text-green-700 mb-4">
                         <span class="w-2 h-2 bg-green-500 rounded-full mr-2"></span>
-                        Available Now via Partner API (v2.9+)
+                        Available Now via Partner API
                     </span>
                     <h2 class="font-display text-3xl md:text-4xl font-bold text-slate-900 mb-4">BaaS SDK Generation</h2>
                     <p class="text-xl text-slate-500 max-w-3xl mx-auto">
@@ -560,7 +571,7 @@ console.<span style="color: #89ddff;">log</span>(<span style="color: #82aaff;">r
                             </svg>
                         </div>
                         <h4 class="font-semibold text-slate-900 mb-1">Java</h4>
-                        <p class="text-xs text-gray-500">com.finaegis:sdk</p>
+                        <p class="text-xs text-gray-500">zelta:sdk</p>
                         <span class="inline-block mt-2 px-2 py-0.5 bg-amber-100 text-amber-700 rounded text-xs font-medium">Planned</span>
                     </div>
                     <div class="sdk-card bg-white rounded-xl shadow-lg p-6 text-center">
@@ -570,7 +581,7 @@ console.<span style="color: #89ddff;">log</span>(<span style="color: #82aaff;">r
                             </svg>
                         </div>
                         <h4 class="font-semibold text-slate-900 mb-1">Go</h4>
-                        <p class="text-xs text-gray-500">finaegis-go</p>
+                        <p class="text-xs text-gray-500">zelta-go</p>
                         <span class="inline-block mt-2 px-2 py-0.5 bg-amber-100 text-amber-700 rounded text-xs font-medium">Planned</span>
                     </div>
                     <div class="sdk-card bg-white rounded-xl shadow-lg p-6 text-center">
@@ -595,12 +606,12 @@ console.<span style="color: #89ddff;">log</span>(<span style="color: #82aaff;">r
 
                     <div class="bg-gray-900 rounded-lg p-6 font-mono text-green-400 text-sm overflow-x-auto mb-8">
 <pre><span class="text-gray-500"># Request SDK generation for your partner account</span>
-curl -X POST {{ config('app.url') }}/api/v1/partner/sdk/generate \
+curl -X POST {{ config('app.url') }}/api/v2/partner/sdk/generate \
   -H "Authorization: Bearer YOUR_PARTNER_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "languages": ["typescript", "python", "java", "go", "php"],
-    "api_version": "v5",
+    "api_version": "v2",
     "include_modules": ["accounts", "transfers", "crosschain", "defi", "compliance"],
     "options": {
       "include_types": true,
@@ -620,21 +631,21 @@ curl -X POST {{ config('app.url') }}/api/v1/partner/sdk/generate \
         "version": "1.0.0",
         "package_name": "@zelta/payment-sdk",
         "download_url": "{{ config('app.url') }}/developers/sdks/packages/typescript/zelta-payment-sdk-1.0.0.tgz",
-        "install_command": "npm install @zelta/payment-sdk@1.0.0"
+        "install_command": "npm install ./zelta-payment-sdk-1.0.0.tgz"
       },
       {
         "language": "python",
         "version": "1.0.0",
         "package_name": "zelta-payment-sdk",
         "download_url": "{{ config('app.url') }}/developers/sdks/packages/python/zelta-payment-sdk-1.0.0.tar.gz",
-        "install_command": "pip install zelta-payment-sdk==1.0.0"
+        "install_command": "pip install ./zelta-payment-sdk-1.0.0.tar.gz"
       },
       {
         "language": "php",
         "version": "1.0.0",
         "package_name": "zelta/payment-sdk",
         "download_url": "{{ config('app.url') }}/developers/sdks/packages/php/zelta-payment-sdk-1.0.0.zip",
-        "install_command": "composer require zelta/payment-sdk:^1.0"
+        "install_command": "composer require zelta/payment-sdk:^1.0 --repository='{\"type\":\"artifact\",\"url\":\"./\"}'"
       }
     ]
   }
@@ -643,24 +654,24 @@ curl -X POST {{ config('app.url') }}/api/v1/partner/sdk/generate \
 
                     <!-- Install Commands Grid -->
                     <h4 class="text-lg font-semibold text-slate-900 mb-4">Quick Install</h4>
-                    <p class="text-sm text-slate-500 mb-4">Included in the monorepo — install via path dependency or GitHub Packages. Not published to public registries.</p>
+                    <p class="text-sm text-slate-500 mb-4">SDKs are in the monorepo — not published to public registries. Clone the repository first, then install via path dependency.</p>
                     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
                         <div>
-                            <p class="text-sm font-medium text-slate-600 mb-2">TypeScript / JavaScript</p>
-                            <div class="bg-gray-900 rounded-lg p-4 font-mono text-green-400 text-sm">
-                                <code>npm install @zelta/payment-sdk@1.0.0</code>
+                            <p class="text-sm font-medium text-slate-600 mb-2">PHP (Composer — from monorepo)</p>
+                            <div class="bg-gray-900 rounded-lg p-4 font-mono text-green-400 text-sm overflow-x-auto">
+                                <code>composer require zelta/payment-sdk --repository='{"type":"path","url":"packages/zelta-sdk"}'</code>
                             </div>
                         </div>
                         <div>
-                            <p class="text-sm font-medium text-slate-600 mb-2">Python</p>
+                            <p class="text-sm font-medium text-slate-600 mb-2">JavaScript (from monorepo)</p>
                             <div class="bg-gray-900 rounded-lg p-4 font-mono text-green-400 text-sm">
-                                <code>pip install zelta-payment-sdk==1.0.0</code>
+                                <code>npm install ./sdks/javascript</code>
                             </div>
                         </div>
                         <div>
-                            <p class="text-sm font-medium text-slate-600 mb-2">PHP (Composer)</p>
+                            <p class="text-sm font-medium text-slate-600 mb-2">Python (from monorepo)</p>
                             <div class="bg-gray-900 rounded-lg p-4 font-mono text-green-400 text-sm">
-                                <code>composer require zelta/payment-sdk:^1.0</code>
+                                <code>pip install ./sdks/python</code>
                             </div>
                         </div>
                     </div>
@@ -696,10 +707,11 @@ curl -X POST {{ config('app.url') }}/api/v1/partner/sdk/generate \
                                 <div>
                                     <p class="text-sm font-medium text-slate-600 mb-2">TypeScript</p>
                                     <div class="bg-gray-900 rounded-lg p-6 font-mono text-green-400 text-sm overflow-x-auto">
-<pre>import { {{ config('brand.name', 'Zelta') }} } from '@zelta/payment-sdk';
+<pre>// Install: npm install ./sdks/javascript (from monorepo)
+import { {{ config('brand.name', 'Zelta') }} } from '@zelta/sdk';
 
 const client = new {{ config('brand.name', 'Zelta') }}({
-  apiKey: process.env.FINAEGIS_PARTNER_KEY,
+  apiKey: process.env.ZELTA_PARTNER_KEY,
   partnerId: 'partner_acme_abc123',
   environment: 'production', // or 'sandbox'
   modules: ['accounts', 'transfers',
@@ -710,10 +722,11 @@ const client = new {{ config('brand.name', 'Zelta') }}({
                                 <div>
                                     <p class="text-sm font-medium text-slate-600 mb-2">Python</p>
                                     <div class="bg-gray-900 rounded-lg p-6 font-mono text-green-400 text-sm overflow-x-auto">
-<pre>from finaegis import {{ config('brand.name', 'Zelta') }}
+<pre># Install: pip install ./sdks/python (from monorepo)
+from zelta import {{ config('brand.name', 'Zelta') }}
 
 client = {{ config('brand.name', 'Zelta') }}(
-    api_key=os.environ['FINAEGIS_PARTNER_KEY'],
+    api_key=os.environ['ZELTA_PARTNER_KEY'],
     partner_id='partner_acme_abc123',
     environment='production',
     modules=['accounts', 'transfers',
@@ -730,7 +743,7 @@ client = {{ config('brand.name', 'Zelta') }}(
                         <div class="bg-gradient-to-r from-cyan-600 to-teal-600 px-6 py-4">
                             <div class="flex items-center">
                                 <span class="w-8 h-8 bg-white text-cyan-600 rounded-full flex items-center justify-center font-bold text-sm mr-3">2</span>
-                                <h3 class="text-lg font-semibold text-white">Access Cross-Chain and DeFi Modules (v5.2)</h3>
+                                <h3 class="text-lg font-semibold text-white">Access Cross-Chain and DeFi Modules</h3>
                             </div>
                         </div>
                         <div class="p-6">
@@ -787,7 +800,7 @@ async function crossChainSwapWorkflow() {
                         <div class="bg-gradient-to-r from-emerald-600 to-green-600 px-6 py-4">
                             <div class="flex items-center">
                                 <span class="w-8 h-8 bg-white text-emerald-600 rounded-full flex items-center justify-center font-bold text-sm mr-3">3</span>
-                                <h3 class="text-lg font-semibold text-white">Integrate RegTech Compliance (v2.8)</h3>
+                                <h3 class="text-lg font-semibold text-white">Integrate RegTech Compliance</h3>
                             </div>
                         </div>
                         <div class="p-6">
@@ -835,7 +848,7 @@ async function compliantTransfer(transferParams) {
                         <div class="bg-gradient-to-r from-violet-600 to-purple-600 px-6 py-4">
                             <div class="flex items-center">
                                 <span class="w-8 h-8 bg-white text-violet-600 rounded-full flex items-center justify-center font-bold text-sm mr-3">4</span>
-                                <h3 class="text-lg font-semibold text-white">Use AI Transaction Queries (v2.8)</h3>
+                                <h3 class="text-lg font-semibold text-white">Use AI Transaction Queries</h3>
                             </div>
                         </div>
                         <div class="p-6">
@@ -890,7 +903,7 @@ console.log('Total volume:', insights.data.analytics.total_volume);</pre>
                             <div class="border border-gray-200 rounded-lg p-4">
                                 <h4 class="font-semibold text-slate-900 mb-1">client.regtech</h4>
                                 <p class="text-sm text-slate-500">MiFID II, MiCA, Travel Rule compliance</p>
-                                <span class="text-xs text-gray-400">v2.8+</span>
+                                <span class="text-xs text-gray-400">v2+</span>
                             </div>
                             <div class="border border-gray-200 rounded-lg p-4">
                                 <h4 class="font-semibold text-slate-900 mb-1">client.crosschain</h4>
@@ -905,12 +918,12 @@ console.log('Total volume:', insights.data.analytics.total_volume);</pre>
                             <div class="border border-gray-200 rounded-lg p-4">
                                 <h4 class="font-semibold text-slate-900 mb-1">client.ai</h4>
                                 <p class="text-sm text-slate-500">Transaction queries, spending insights</p>
-                                <span class="text-xs text-gray-400">v2.8+</span>
+                                <span class="text-xs text-gray-400">v2+</span>
                             </div>
                             <div class="border border-gray-200 rounded-lg p-4">
                                 <h4 class="font-semibold text-slate-900 mb-1">client.partner</h4>
                                 <p class="text-sm text-slate-500">SDK generation, tenant management, config</p>
-                                <span class="text-xs text-gray-400">v2.9+</span>
+                                <span class="text-xs text-gray-400">v2+</span>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary

- **SDK install commands made honest**: replaced fake public registry commands (`npm install @zelta/payment-sdk@1.0.0`, `pip install zelta-payment-sdk==1.0.0`, `composer require zelta/payment-sdk:^1.0`) with monorepo path installs (`npm install ./sdks/javascript`, `pip install ./sdks/python`, `composer require zelta/payment-sdk --repository='{"type":"path","url":"packages/zelta-sdk"}'`)
- **SDK namespace standardized**: all `@finaegis/sdk`, `from finaegis import`, `finaegis-sdk` references replaced with `@zelta/sdk`, `zelta`, `Zelta\PaymentSDK\` across all 5 developer views
- **Version references fixed**: REST API v5.12 → v2, all sub-version badges (v2.8, v2.9+, v5.2) removed — only `v2` shown
- **SDK source notice added**: prominent amber banner on sdks page — "SDKs are in the FinAegis monorepo. Not published to npm, Packagist, or PyPI."
- **Sandbox vs Production clarified**: replaced confusing duplicate URLs with single base URL + explanation that key prefix (sk_sandbox_ / sk_live_) determines environment
- **OpenAPI banner added** at top of api-docs.blade.php with Swagger UI link
- **Rate limits consolidated** in api-docs with proper table (REST 1,000/hr, GraphQL 120/min auth, webhooks 100/min); GraphQL page now cross-references instead of stating different numbers
- **Quick Start fixed**: step 3 now shows `curl /api/health` (no auth needed) then authenticated `GET /api/v2/accounts` — was showing `/api/v1/accounts`
- **Route labels normalized**: stripped 23 `/v2/` prefixes from endpoint badge spans (base URL is already `/api/v2`)
- **Webhook signatures fixed**: `x-finaegis-signature` → `x-zelta-signature`, `/webhooks/finaegis` → `/webhooks/zelta`

## Test plan

- [ ] `php artisan view:cache` completes without errors
- [ ] Grep for `@finaegis`, `from finaegis`, `v5.12` across developer views — zero results
- [ ] `/developers/sdks` shows amber source notice at top and correct monorepo install commands
- [ ] `/developers/api-docs` shows OpenAPI banner, Rate Limits section in nav, correct Sandbox/Production explanation
- [ ] Quick Start step 3 shows health check before authenticated request
- [ ] All install commands show path/monorepo installs, not public registry commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)