### PR TITLE
release: v7.10.2 — Deployment Pipeline Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FinAegis Core Banking Platform
 
 [![CI Pipeline](https://github.com/finaegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml/badge.svg)](https://github.com/finaegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml)
-[![Version](https://img.shields.io/badge/version-7.10.1-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-7.10.2-blue.svg)](CHANGELOG.md)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![PHP Version](https://img.shields.io/badge/php-%3E%3D8.4-8892BF.svg)](https://php.net/)
 [![Laravel Version](https://img.shields.io/badge/Laravel-12.x-FF2D20.svg)](https://laravel.com/)

--- a/resources/views/changelog.blade.php
+++ b/resources/views/changelog.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'Changelog | ' . config('brand.name', 'Zelta'),
-        'description' => 'Release history for the Zelta core banking platform. Track every feature shipped, bug fixed, and improvement made — v7.0 through v7.10.1.',
+        'description' => 'Release history for the Zelta core banking platform. Track every feature shipped, bug fixed, and improvement made — v7.0 through v7.10.2.',
         'keywords' => 'changelog, release notes, updates, ' . config('brand.name', 'Zelta') . ', version history, core banking',
     ])
 
@@ -43,6 +43,20 @@
 
             @php
                 $releases = [
+                    [
+                        'version' => 'v7.10.2',
+                        'date' => 'April 13, 2026',
+                        'label' => 'Deployment Pipeline Fix',
+                        'label_color' => 'slate',
+                        'badge_color' => 'bg-slate-100 text-slate-700 border-slate-200',
+                        'dot_color' => 'bg-slate-500',
+                        'items' => [
+                            'Deploy Pipeline — Fixed a 1GB OOM in the Pre-deployment Validation job that had been blocking the Deploy to Production workflow since v7.10.0. Unit tests now run in batched PHP processes via the shared bin/pest-batch runner, mirroring the CI Pipeline unit test step.',
+                            'Cache Driver — Switched the Pre-deployment Validation step to the array cache driver (matching .env.testing). The previous redis driver broke tests that mock the Redis facade because Cache::put silently failed through the swapped facade.',
+                            'Dotenv Quoting — Wrapped BRAND_LEGAL_JURISDICTION in .env.example and BRAND_TAGLINE in .env.zelta.example in double quotes. The unquoted whitespace was tripping vlucas/phpdotenv with "Failed to parse dotenv file. Encountered unexpected whitespace". Affects anyone copying .env.example for a fresh setup.',
+                            'First Deployable Release — v7.10.2 is the first release tag since v7.10.0 whose Deploy to Production pipeline is actually functional. v7.10.0 and v7.10.1 both had Pre-deployment Validation failures that blocked the deployment artifact build.',
+                        ],
+                    ],
                     [
                         'version' => 'v7.10.1',
                         'date' => 'April 13, 2026',

--- a/resources/views/features/agent-protocol.blade.php
+++ b/resources/views/features/agent-protocol.blade.php
@@ -38,7 +38,7 @@
                 ]])
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-cyan-400 rounded-full mr-2"></span>
-                    v7.10.1 &middot; Autonomous Agent Commerce
+                    v7.10.2 &middot; Autonomous Agent Commerce
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">
                     Agent Protocol

--- a/resources/views/features/ai-framework.blade.php
+++ b/resources/views/features/ai-framework.blade.php
@@ -38,7 +38,7 @@
                 ]])
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.10.1 &middot; Multi-Agent Intelligence
+                    v7.10.2 &middot; Multi-Agent Intelligence
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">
                     AI Framework

--- a/resources/views/features/machine-payments.blade.php
+++ b/resources/views/features/machine-payments.blade.php
@@ -34,7 +34,7 @@
                 </div>
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.10.1 &middot; Multi-Rail Payments
+                    v7.10.2 &middot; Multi-Rail Payments
                 </div>
                 <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
                     Machine Payments Protocol

--- a/resources/views/features/x402-protocol.blade.php
+++ b/resources/views/features/x402-protocol.blade.php
@@ -36,7 +36,7 @@
                 </div>
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.10.1 &middot; Production Ready
+                    v7.10.2 &middot; Production Ready
                 </div>
                 <h1 class="font-display text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">x402 Protocol</h1>
                 <p class="text-lg text-slate-400 max-w-3xl mx-auto mb-8">

--- a/resources/views/support/faq.blade.php
+++ b/resources/views/support/faq.blade.php
@@ -13,7 +13,7 @@
     $faqData = [
         [
             'question' => 'What is the current status of ' . config('brand.name', 'Zelta') . '?',
-            'answer' => config('brand.name', 'Zelta') . ' v7.10.1 is a fully-featured open-source core banking platform with 56 domain modules. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
+            'answer' => config('brand.name', 'Zelta') . ' v7.10.2 is a fully-featured open-source core banking platform with 56 domain modules. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
         ],
         [
             'question' => 'Can I use real money on the platform?',
@@ -127,7 +127,7 @@
                     </button>
                     <div class="faq-answer px-6 py-4 bg-white rounded-b-lg">
                         <p class="text-slate-500">
-                            {{ config('brand.name', 'Zelta') }} is a fully-featured open-source core banking platform at v7.10.1. The sandbox environment lets you:
+                            {{ config('brand.name', 'Zelta') }} is a fully-featured open-source core banking platform at v7.10.2. The sandbox environment lets you:
                         </p>
                         <ul class="list-disc list-inside mt-2 text-slate-500 space-y-1">
                             <li>Explore 56 domain modules including DeFi, cross-chain, privacy, and rewards</li>


### PR DESCRIPTION
## Summary
Patch release for PR #905 (deploy.yml CI fixes). Bumps version badges across README, changelog, FAQ, and 4 feature pages; adds the v7.10.2 changelog entry.

## Why a release for a CI-only change?
v7.10.2 is the first release tag since v7.10.0 whose `Deploy to Production` pipeline is actually functional. Both v7.10.0 and v7.10.1 hit the OOM / dotenv parse errors in `Pre-deployment Validation` and `Build Release Artifacts` before the deployment tarball could ever be built — so neither tag can produce a working production deployment. Tagging v7.10.2 gives operators the first release they can actually ship via the workflow.

## What's in v7.10.2
From PR #905:
- **Deploy Pipeline OOM fix** — `./vendor/bin/pest tests/Unit` replaced with batched `./bin/pest-batch` calls in fresh PHP processes. 1410 unit tests now run in ~99s.
- **Cache driver** — Pre-deployment Validation switched to array cache (matching `.env.testing`) so the BackpressureHandlerTest's Redis facade mocks don't break `Cache::put` silently.
- **Dotenv quoting** — `BRAND_LEGAL_JURISDICTION` in `.env.example` and `BRAND_TAGLINE` in `.env.zelta.example` were unquoted values containing whitespace that tripped `vlucas/phpdotenv`. Now wrapped in double quotes. Affects fresh-setup users.

No runtime code changes. No API changes. No Stripe Bridge ramp changes beyond what v7.10.1 already shipped.

## Test plan
- [x] All version badge occurrences bumped (7 files, 10 markers)
- [x] Blade syntax check on changelog passes
- [ ] CI Pipeline green on this branch
- [ ] Tag `v7.10.2` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)