### PR TITLE
chore: grant contents:write in deploy.yml + ignore .claude session dir

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ env:
   NODE_VERSION: '20'
 
 permissions:
-  contents: read
+  contents: write
   deployments: write
   id-token: write
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.phpunit.cache
+/.claude
 /.worktrees
 /node_modules
 /public/build


### PR DESCRIPTION
## Summary
Two small cleanups exposed while stabilizing v7.10.2. No runtime code changes, no version bump.

### 1. `deploy.yml` permissions — `contents: read` → `contents: write`
Post-deployment Tasks fails at its `github-script` `createRelease` step on every tag push with:
\`\`\`
RequestError [HttpError]: Resource not accessible by integration
\`\`\`
Root cause: the workflow's `permissions` block (line 28-31) only grants `contents: read`. The `createRelease` API call needs `contents: write`.

This is a **pre-existing bug** that was hidden behind the Pre-deployment Validation OOM for the last 5+ main commits. It only became visible on the v7.10.2 tag push, once PR #905 fixed the upstream failure. Confirmed by checking the other workflow permissions blocks:

| Workflow | Permissions | Creates releases? |
|---|---|---|
| `deploy.yml` | ❌ `contents: read` | ✅ yes (this PR fixes it) |
| `cli-release.yml` | ✅ `contents: write` | yes |
| `sdk-release.yml` | `contents: read` | no (doesn't create releases) |
| `ci-pipeline.yml` | `contents: read` | no |
| `database-operations.yml` | `contents: read` | no |

### 2. `.gitignore` — add `/.claude`
Claude Code session state directory (tasks, planning artifacts, tool cache) was untracked but not gitignored. Same style as the existing `/.worktrees` entry two lines above.

## Scope check
Neither change is user-visible. No version bump. HEAD stays at `v7.10.2`.

## Test plan
- [x] YAML syntax check on deploy.yml
- [x] `git check-ignore -q .claude` confirms the gitignore entry works
- [ ] CI Pipeline green on this branch
- [ ] Next tag push's Post-deployment Tasks job completes cleanly (verifiable on v7.10.3 or later)

🤖 Generated with [Claude Code](https://claude.com/claude-code)