### PR TITLE
fix(onboarding): remove broken tour stub from dashboard welcome modal

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -8,12 +8,6 @@
                 <span class="text-sm text-gray-600 dark:text-gray-400">
                     Welcome back, {{ Auth::user()->name }}!
                 </span>
-                <button onclick="startTour()" class="text-sm bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 transition">
-                    <svg class="w-4 h-4 inline-block mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                    </svg>
-                    Take Tour
-                </button>
             </div>
         </div>
     </x-slot>
@@ -395,7 +389,6 @@
         }
 
         function startOnboarding() {
-            // Mark onboarding as started
             fetch('/onboarding/complete', {
                 method: 'POST',
                 headers: {
@@ -408,20 +401,12 @@
             .then(response => response.json())
             .then(data => {
                 document.getElementById('welcome-modal').style.display = 'none';
-                // Redirect to KYC page
                 window.location.href = '/compliance/kyc';
             })
             .catch(error => {
-                console.error('Error:', error);
+                console.error('Onboarding error:', error);
                 document.getElementById('welcome-modal').style.display = 'none';
-                startTour();
             });
-        }
-
-        function startTour() {
-            // This would integrate with a tour library like Intro.js or Shepherd.js
-            alert('Starting your ' . config('brand.name', 'Zelta') . ' tour! Let\'s explore the platform together.');
-            // In a real implementation, this would start an interactive tour
         }
     </script>
 </x-app-layout>


### PR DESCRIPTION
## Summary

- Removes the "Take Tour" header button and `startTour()` placeholder from `resources/views/dashboard.blade.php`
- The placeholder contained PHP string-concat (`.`) dropped into a raw `<script>` block, which JS parses as member access on a string literal and throws `TypeError` at runtime whenever invoked
- Also strips the `startTour()` call from `startOnboarding()`'s `.catch` branch, so a failed `/onboarding/complete` POST no longer cascades into a second error
- A real interactive tour (Shepherd.js / Intro.js etc.) is a separate feature and needs to be brainstormed before building — removing the stub is the honest minimum fix

## Context

Discovered while investigating why a client (VertexSMS) couldn't get past the "Welcome to FinAegis" step after registering. `closeWelcomeModal()` already works correctly; the observable failure mode for the user was either `startTour()` throwing from the header button or from the `.catch` branch. Registration itself was verified working end-to-end (`RegistrationTest` 3/3 passing).

## Test plan

- [x] `./vendor/bin/pest tests/Feature/RegistrationTest.php` — 3 passed, 1 skipped
- [x] `view('dashboard')->render()` with `has_completed_onboarding = false` — `Take Tour`, `startTour`, and the PHP-concat line all absent; `startOnboarding` / `closeWelcomeModal` / csrf meta still present
- [ ] Manual: register a fresh user in a demo env, confirm "Start Setup" redirects to `/compliance/kyc` and "Skip for Now" dismisses the modal
- [ ] Manual: confirm no dashboard regressions (header layout, banners still render)

🤖 Generated with [Claude Code](https://claude.com/claude-code)