### PR TITLE
docs: bump to v7.10.3 and add Onboarding Welcome Modal Fix release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FinAegis Core Banking Platform
 
 [![CI Pipeline](https://github.com/finaegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml/badge.svg)](https://github.com/finaegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml)
-[![Version](https://img.shields.io/badge/version-7.10.2-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-7.10.3-blue.svg)](CHANGELOG.md)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![PHP Version](https://img.shields.io/badge/php-%3E%3D8.4-8892BF.svg)](https://php.net/)
 [![Laravel Version](https://img.shields.io/badge/Laravel-12.x-FF2D20.svg)](https://laravel.com/)

--- a/resources/views/changelog.blade.php
+++ b/resources/views/changelog.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'Changelog | ' . config('brand.name', 'Zelta'),
-        'description' => 'Release history for the Zelta core banking platform. Track every feature shipped, bug fixed, and improvement made — v7.0 through v7.10.2.',
+        'description' => 'Release history for the Zelta core banking platform. Track every feature shipped, bug fixed, and improvement made — v7.0 through v7.10.3.',
         'keywords' => 'changelog, release notes, updates, ' . config('brand.name', 'Zelta') . ', version history, core banking',
     ])
 
@@ -43,6 +43,20 @@
 
             @php
                 $releases = [
+                    [
+                        'version' => 'v7.10.3',
+                        'date' => 'April 14, 2026',
+                        'label' => 'Onboarding Welcome Modal Fix',
+                        'label_color' => 'slate',
+                        'badge_color' => 'bg-slate-100 text-slate-700 border-slate-200',
+                        'dot_color' => 'bg-slate-500',
+                        'items' => [
+                            'Dashboard Welcome Modal — Removed the broken "Take Tour" header button and startTour() placeholder from the new-user welcome modal. The placeholder contained PHP string-concat syntax dropped into a raw <script> block, which JavaScript parsed as member access on a string literal and threw TypeError at runtime, silently breaking the onboarding flow for every new registrant.',
+                            'Onboarding Flow — Stripped the startTour() fallback from startOnboarding()\'s .catch branch so a failed /onboarding/complete POST no longer cascades into a second runtime error.',
+                            'Registration Verified — RegistrationTest suite confirmed green end-to-end (POST /register → CreateNewUser → team provisioning → dashboard). The bug was confined to the post-registration welcome modal JavaScript, not the registration pipeline itself.',
+                            'Tour Deferred — A real interactive tour (Shepherd.js / Intro.js etc.) is parked for a future design pass. Removing the stub is the honest minimum fix.',
+                        ],
+                    ],
                     [
                         'version' => 'v7.10.2',
                         'date' => 'April 13, 2026',

--- a/resources/views/features/agent-protocol.blade.php
+++ b/resources/views/features/agent-protocol.blade.php
@@ -38,7 +38,7 @@
                 ]])
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-cyan-400 rounded-full mr-2"></span>
-                    v7.10.2 &middot; Autonomous Agent Commerce
+                    v7.10.3 &middot; Autonomous Agent Commerce
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">
                     Agent Protocol

--- a/resources/views/features/ai-framework.blade.php
+++ b/resources/views/features/ai-framework.blade.php
@@ -38,7 +38,7 @@
                 ]])
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.10.2 &middot; Multi-Agent Intelligence
+                    v7.10.3 &middot; Multi-Agent Intelligence
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">
                     AI Framework

--- a/resources/views/features/machine-payments.blade.php
+++ b/resources/views/features/machine-payments.blade.php
@@ -34,7 +34,7 @@
                 </div>
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.10.2 &middot; Multi-Rail Payments
+                    v7.10.3 &middot; Multi-Rail Payments
                 </div>
                 <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
                     Machine Payments Protocol

--- a/resources/views/features/x402-protocol.blade.php
+++ b/resources/views/features/x402-protocol.blade.php
@@ -36,7 +36,7 @@
                 </div>
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.10.2 &middot; Production Ready
+                    v7.10.3 &middot; Production Ready
                 </div>
                 <h1 class="font-display text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">x402 Protocol</h1>
                 <p class="text-lg text-slate-400 max-w-3xl mx-auto mb-8">

--- a/resources/views/support/faq.blade.php
+++ b/resources/views/support/faq.blade.php
@@ -13,7 +13,7 @@
     $faqData = [
         [
             'question' => 'What is the current status of ' . config('brand.name', 'Zelta') . '?',
-            'answer' => config('brand.name', 'Zelta') . ' v7.10.2 is a fully-featured open-source core banking platform with 56 domain modules. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
+            'answer' => config('brand.name', 'Zelta') . ' v7.10.3 is a fully-featured open-source core banking platform with 56 domain modules. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
         ],
         [
             'question' => 'Can I use real money on the platform?',
@@ -127,7 +127,7 @@
                     </button>
                     <div class="faq-answer px-6 py-4 bg-white rounded-b-lg">
                         <p class="text-slate-500">
-                            {{ config('brand.name', 'Zelta') }} is a fully-featured open-source core banking platform at v7.10.2. The sandbox environment lets you:
+                            {{ config('brand.name', 'Zelta') }} is a fully-featured open-source core banking platform at v7.10.3. The sandbox environment lets you:
                         </p>
                         <ul class="list-disc list-inside mt-2 text-slate-500 space-y-1">
                             <li>Explore 56 domain modules including DeFi, cross-chain, privacy, and rewards</li>


### PR DESCRIPTION
## Summary

- Patch release for the dashboard welcome modal fix in PR #914
- Bumps version badges across README, changelog, FAQ, and 4 feature pages from v7.10.2 → v7.10.3
- Adds v7.10.3 "Onboarding Welcome Modal Fix" entry to `resources/views/changelog.blade.php`
- No runtime code changes in this PR — the actual fix lives in #914

## Context

While investigating why a client (VertexSMS) couldn't get past the "Welcome to FinAegis" step after registering, I traced it to a placeholder `startTour()` function on the dashboard that dropped PHP string-concat syntax into a raw `<script>` block. JavaScript parsed it as member access on a string literal and threw `TypeError` whenever invoked — either directly from the "Take Tour" header button or from `startOnboarding()`'s `.catch` fallback.

Registration itself is healthy (`RegistrationTest` 3/3 green). The bug was confined to the post-registration welcome modal JS.

## Merge order

This PR depends on #914 — merge #914 first, then this PR, then cut the v7.10.3 tag. Merging this PR alone would give users a version-bumped tarball without the actual fix.

## Test plan

- [x] `git diff --stat` matches the v7.10.2 bump shape (7 files, 22/8 lines)
- [x] Changelog entry follows the established format (label, date, color, items)
- [ ] Visual check: `/changelog`, `/support/faq`, feature pages all render new version
- [ ] After #914 merges + this merges: tag `v7.10.3` and create a GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)