### PR TITLE
fix(deps): bump axios + vite to close 5 critical + 1 high CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,11 +18,11 @@
                 "@tailwindcss/forms": "^0.5.11",
                 "@tailwindcss/typography": "^0.5.19",
                 "autoprefixer": "^10.4.27",
-                "axios": "^1.13.5",
+                "axios": "^1.15.0",
                 "laravel-vite-plugin": "^1.0",
                 "postcss": "^8.5.8",
                 "tailwindcss": "^3.4.19",
-                "vite": "^6.4.1"
+                "vite": "^6.4.2"
             }
         },
         "node_modules/@alloc/quick-lru": {
@@ -3312,14 +3312,14 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.13.6",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-            "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+            "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.11",
                 "form-data": "^4.0.5",
-                "proxy-from-env": "^1.1.0"
+                "proxy-from-env": "^2.1.0"
             }
         },
         "node_modules/balanced-match": {
@@ -5653,10 +5653,13 @@
             }
         },
         "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-            "license": "MIT"
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/public-encrypt": {
             "version": "4.0.3",
@@ -6710,9 +6713,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "6.4.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-            "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+            "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
         "@tailwindcss/forms": "^0.5.11",
         "@tailwindcss/typography": "^0.5.19",
         "autoprefixer": "^10.4.27",
-        "axios": "^1.13.5",
+        "axios": "^1.15.0",
         "laravel-vite-plugin": "^1.0",
         "postcss": "^8.5.8",
         "tailwindcss": "^3.4.19",
-        "vite": "^6.4.1"
+        "vite": "^6.4.2"
     },
     "overrides": {
-        "axios": "^1.13.5"
+        "axios": "^1.15.0"
     }
 }


### PR DESCRIPTION
## Summary

Targeted security patch. First of three dependency PRs planned as follow-ups to v7.10.3.

- **axios** `^1.13.5` → `^1.15.0` (also mirrored in `overrides`) — closes [GHSA-3p68-rc4w-qgx5](https://github.com/advisories/GHSA-3p68-rc4w-qgx5) (NO_PROXY hostname normalization bypass → SSRF, critical). The single advisory cascades through 4 `@ledgerhq/*` hardware-wallet packages, so fixing axios resolves all 5 critical entries in one shot.
- **vite** `^6.4.1` → `^6.4.2` — closes the path traversal in Optimized Deps `.map` handling (high severity).

## Before vs after

| Severity | Before | After |
|---|---|---|
| Critical | 5 | 0 |
| High | 1 | 0 |
| Moderate | 1 | 1 |
| Low | 16 | 18 |
| **Total** | **23** | **19** |

Remaining lows + the 1 moderate (`follow-redirects`) are in deep transitive dev tooling and are not security-urgent. They'll be addressed in the follow-up "general npm bump" PR.

## Scope

- Both bumps are **minor/patch** within the existing semver ranges
- **axios is a devDependency** — does not ship in Laravel runtime
- **vite is build-time only** — does not ship in Laravel runtime
- **No runtime code changes**, no application logic touched
- `overrides` entry is updated in lockstep so transitive deps can't pull in an old axios

## Test plan

- [x] `npm install` — regenerates `package-lock.json` cleanly
- [x] `npm audit` — confirms 0 critical + 0 high
- [x] `npm run build` — Vite 6.4.2 produces the same 61-module production bundle
- [ ] CI pipeline (Frontend Assets Build, Security Vulnerability Audit)

## Follow-ups planned

- PR 2: general npm bump (addresses remaining lows + moderate)
- PR 3: general composer bump (as a separate investigation — PHPStan Level 8 + 56 domains means that one needs its own review pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)