### PR TITLE
docs: bump to v7.10.4 and add Frontend Security Patch release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FinAegis Core Banking Platform
 
 [![CI Pipeline](https://github.com/finaegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml/badge.svg)](https://github.com/finaegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml)
-[![Version](https://img.shields.io/badge/version-7.10.3-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-7.10.4-blue.svg)](CHANGELOG.md)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![PHP Version](https://img.shields.io/badge/php-%3E%3D8.4-8892BF.svg)](https://php.net/)
 [![Laravel Version](https://img.shields.io/badge/Laravel-12.x-FF2D20.svg)](https://laravel.com/)

--- a/resources/views/changelog.blade.php
+++ b/resources/views/changelog.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'Changelog | ' . config('brand.name', 'Zelta'),
-        'description' => 'Release history for the Zelta core banking platform. Track every feature shipped, bug fixed, and improvement made — v7.0 through v7.10.3.',
+        'description' => 'Release history for the Zelta core banking platform. Track every feature shipped, bug fixed, and improvement made — v7.0 through v7.10.4.',
         'keywords' => 'changelog, release notes, updates, ' . config('brand.name', 'Zelta') . ', version history, core banking',
     ])
 
@@ -43,6 +43,20 @@
 
             @php
                 $releases = [
+                    [
+                        'version' => 'v7.10.4',
+                        'date' => 'April 14, 2026',
+                        'label' => 'Frontend Security Patch',
+                        'label_color' => 'red',
+                        'badge_color' => 'bg-red-100 text-red-700 border-red-200',
+                        'dot_color' => 'bg-red-500',
+                        'items' => [
+                            'axios Security Patch — Raised axios from ^1.13.5 to ^1.15.0 (also mirrored in the npm overrides block) to close GHSA-3p68-rc4w-qgx5, a NO_PROXY hostname normalization bypass that could be leveraged into SSRF. The single advisory cascaded through 4 @ledgerhq/* hardware-wallet packages, so bumping axios resolved all 5 critical severity entries at once.',
+                            'Vite Security Patch — Bumped Vite from ^6.4.1 to ^6.4.2 to close a high-severity path traversal in the Optimized Deps .map handling code path.',
+                            'Zero Runtime Impact — Both affected packages are dev/build-time only. axios is a devDependency and Vite is the build bundler; neither ships in the Laravel runtime. No application code or PHP dependencies were touched in this release.',
+                            'npm Audit Before/After — 23 vulnerabilities (16 low, 1 moderate, 1 high, 5 critical) → 19 vulnerabilities (18 low, 1 moderate). Remaining lows and the 1 moderate (follow-redirects) live in deep transitive dev tooling and are scheduled for the next general npm bump PR.',
+                        ],
+                    ],
                     [
                         'version' => 'v7.10.3',
                         'date' => 'April 14, 2026',

--- a/resources/views/features/agent-protocol.blade.php
+++ b/resources/views/features/agent-protocol.blade.php
@@ -38,7 +38,7 @@
                 ]])
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-cyan-400 rounded-full mr-2"></span>
-                    v7.10.3 &middot; Autonomous Agent Commerce
+                    v7.10.4 &middot; Autonomous Agent Commerce
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">
                     Agent Protocol

--- a/resources/views/features/ai-framework.blade.php
+++ b/resources/views/features/ai-framework.blade.php
@@ -38,7 +38,7 @@
                 ]])
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.10.3 &middot; Multi-Agent Intelligence
+                    v7.10.4 &middot; Multi-Agent Intelligence
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">
                     AI Framework

--- a/resources/views/features/machine-payments.blade.php
+++ b/resources/views/features/machine-payments.blade.php
@@ -34,7 +34,7 @@
                 </div>
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.10.3 &middot; Multi-Rail Payments
+                    v7.10.4 &middot; Multi-Rail Payments
                 </div>
                 <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
                     Machine Payments Protocol

--- a/resources/views/features/x402-protocol.blade.php
+++ b/resources/views/features/x402-protocol.blade.php
@@ -36,7 +36,7 @@
                 </div>
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.10.3 &middot; Production Ready
+                    v7.10.4 &middot; Production Ready
                 </div>
                 <h1 class="font-display text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">x402 Protocol</h1>
                 <p class="text-lg text-slate-400 max-w-3xl mx-auto mb-8">

--- a/resources/views/support/faq.blade.php
+++ b/resources/views/support/faq.blade.php
@@ -13,7 +13,7 @@
     $faqData = [
         [
             'question' => 'What is the current status of ' . config('brand.name', 'Zelta') . '?',
-            'answer' => config('brand.name', 'Zelta') . ' v7.10.3 is a fully-featured open-source core banking platform with 56 domain modules. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
+            'answer' => config('brand.name', 'Zelta') . ' v7.10.4 is a fully-featured open-source core banking platform with 56 domain modules. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
         ],
         [
             'question' => 'Can I use real money on the platform?',
@@ -127,7 +127,7 @@
                     </button>
                     <div class="faq-answer px-6 py-4 bg-white rounded-b-lg">
                         <p class="text-slate-500">
-                            {{ config('brand.name', 'Zelta') }} is a fully-featured open-source core banking platform at v7.10.3. The sandbox environment lets you:
+                            {{ config('brand.name', 'Zelta') }} is a fully-featured open-source core banking platform at v7.10.4. The sandbox environment lets you:
                         </p>
                         <ul class="list-disc list-inside mt-2 text-slate-500 space-y-1">
                             <li>Explore 56 domain modules including DeFi, cross-chain, privacy, and rewards</li>


### PR DESCRIPTION
## Summary

- Patch release for the axios + Vite CVE fixes merged in #916
- Bumps version badges across README, changelog, FAQ, and 4 feature pages from v7.10.3 → v7.10.4
- Adds v7.10.4 "Frontend Security Patch" entry to `resources/views/changelog.blade.php`
- No runtime code changes in this PR — the actual fix lives in #916

## Release summary

Closes 5 critical + 1 high npm audit findings that all traced back to two devDependencies: axios (SSRF via NO_PROXY hostname normalization bypass, GHSA-3p68-rc4w-qgx5, cascading through 4 @ledgerhq/* hardware-wallet packages) and Vite (path traversal in Optimized Deps `.map` handling).

Both affected packages are dev/build-time only — axios is a devDependency, Vite is the build bundler; neither ships in the Laravel runtime.

## Test plan

- [x] Diff stat matches prior bump PRs (7 files, 22/8 lines)
- [x] Changelog entry follows the established format (label, date, color, items) and uses the red "security patch" color code to make the scope visually distinct from feature releases
- [ ] CI green
- [ ] After merge: tag `v7.10.4` and create GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)