### PR TITLE
docs: bump to v7.10.5 and add npm Dependency Sweep release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FinAegis Core Banking Platform
 
 [![CI Pipeline](https://github.com/finaegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml/badge.svg)](https://github.com/finaegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml)
-[![Version](https://img.shields.io/badge/version-7.10.4-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-7.10.5-blue.svg)](CHANGELOG.md)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![PHP Version](https://img.shields.io/badge/php-%3E%3D8.4-8892BF.svg)](https://php.net/)
 [![Laravel Version](https://img.shields.io/badge/Laravel-12.x-FF2D20.svg)](https://laravel.com/)

--- a/resources/views/changelog.blade.php
+++ b/resources/views/changelog.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'Changelog | ' . config('brand.name', 'Zelta'),
-        'description' => 'Release history for the Zelta core banking platform. Track every feature shipped, bug fixed, and improvement made — v7.0 through v7.10.4.',
+        'description' => 'Release history for the Zelta core banking platform. Track every feature shipped, bug fixed, and improvement made — v7.0 through v7.10.5.',
         'keywords' => 'changelog, release notes, updates, ' . config('brand.name', 'Zelta') . ', version history, core banking',
     ])
 
@@ -43,6 +43,21 @@
 
             @php
                 $releases = [
+                    [
+                        'version' => 'v7.10.5',
+                        'date' => 'April 14, 2026',
+                        'label' => 'npm Dependency Sweep',
+                        'label_color' => 'slate',
+                        'badge_color' => 'bg-slate-100 text-slate-700 border-slate-200',
+                        'dot_color' => 'bg-slate-500',
+                        'items' => [
+                            'npm Semver-Safe Update — Ran npm update within the existing package.json ranges, which pulled minor/patch bumps for @ledgerhq/hw-transport-webusb (6.32.0 → 6.33.0), autoprefixer (10.4.27 → 10.5.0), postcss (8.5.8 → 8.5.9), plus transitive dedup across the @ledgerhq/* tree.',
+                            'Lockfile Dedup — package-lock.json shrank by ~500 lines as newer axios/vite/ledger versions consolidated redundant transitive dep trees.',
+                            'follow-redirects Cleared — The remaining moderate-severity follow-redirects advisory carried over from the v7.10.4 cycle was resolved by this update. Audit now reports zero critical, zero high, zero moderate — 18 lows remain in deep transitive dev tooling.',
+                            'Zero Runtime Impact — Lockfile-only change. No package.json edits, no application code touched. Production bundle rebuilds byte-equivalent under the existing Vite 6.4.2 configuration.',
+                            'Out of Scope — Major-version bumps (@ledgerhq/hw-app-eth 6.x → 7.x, laravel-vite-plugin 1.x → 3.x, tailwindcss 3.x → 4.x, vite 6.x → 8.x) are deliberately deferred. Each is a dedicated migration project — Tailwind v4 and the laravel-vite-plugin/vite alignment in particular need their own brainstorming pass.',
+                        ],
+                    ],
                     [
                         'version' => 'v7.10.4',
                         'date' => 'April 14, 2026',

--- a/resources/views/features/agent-protocol.blade.php
+++ b/resources/views/features/agent-protocol.blade.php
@@ -38,7 +38,7 @@
                 ]])
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-cyan-400 rounded-full mr-2"></span>
-                    v7.10.4 &middot; Autonomous Agent Commerce
+                    v7.10.5 &middot; Autonomous Agent Commerce
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">
                     Agent Protocol

--- a/resources/views/features/ai-framework.blade.php
+++ b/resources/views/features/ai-framework.blade.php
@@ -38,7 +38,7 @@
                 ]])
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.10.4 &middot; Multi-Agent Intelligence
+                    v7.10.5 &middot; Multi-Agent Intelligence
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">
                     AI Framework

--- a/resources/views/features/machine-payments.blade.php
+++ b/resources/views/features/machine-payments.blade.php
@@ -34,7 +34,7 @@
                 </div>
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.10.4 &middot; Multi-Rail Payments
+                    v7.10.5 &middot; Multi-Rail Payments
                 </div>
                 <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
                     Machine Payments Protocol

--- a/resources/views/features/x402-protocol.blade.php
+++ b/resources/views/features/x402-protocol.blade.php
@@ -36,7 +36,7 @@
                 </div>
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.10.4 &middot; Production Ready
+                    v7.10.5 &middot; Production Ready
                 </div>
                 <h1 class="font-display text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">x402 Protocol</h1>
                 <p class="text-lg text-slate-400 max-w-3xl mx-auto mb-8">

--- a/resources/views/support/faq.blade.php
+++ b/resources/views/support/faq.blade.php
@@ -13,7 +13,7 @@
     $faqData = [
         [
             'question' => 'What is the current status of ' . config('brand.name', 'Zelta') . '?',
-            'answer' => config('brand.name', 'Zelta') . ' v7.10.4 is a fully-featured open-source core banking platform with 56 domain modules. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
+            'answer' => config('brand.name', 'Zelta') . ' v7.10.5 is a fully-featured open-source core banking platform with 56 domain modules. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
         ],
         [
             'question' => 'Can I use real money on the platform?',
@@ -127,7 +127,7 @@
                     </button>
                     <div class="faq-answer px-6 py-4 bg-white rounded-b-lg">
                         <p class="text-slate-500">
-                            {{ config('brand.name', 'Zelta') }} is a fully-featured open-source core banking platform at v7.10.4. The sandbox environment lets you:
+                            {{ config('brand.name', 'Zelta') }} is a fully-featured open-source core banking platform at v7.10.5. The sandbox environment lets you:
                         </p>
                         <ul class="list-disc list-inside mt-2 text-slate-500 space-y-1">
                             <li>Explore 56 domain modules including DeFi, cross-chain, privacy, and rewards</li>


### PR DESCRIPTION
## Summary

Release bump for the semver-safe npm update merged in #918. Lockfile-only change with no runtime impact.

- Bumps version badges across README, changelog, FAQ, and 4 feature pages from v7.10.4 → v7.10.5
- Adds v7.10.5 "npm Dependency Sweep" entry to `resources/views/changelog.blade.php`

## Release summary

`npm update` pulled minor/patch bumps within existing `package.json` ranges (`@ledgerhq/hw-transport-webusb` 6.32.0 → 6.33.0, `autoprefixer` 10.4.27 → 10.5.0, `postcss` 8.5.8 → 8.5.9) plus transitive dedup. `package-lock.json` shrunk by ~500 lines. `follow-redirects` moderate advisory is cleared — audit now reports 0 critical / 0 high / 0 moderate.

## Test plan

- [x] Diff stat matches prior bump PRs (7 files, ~23/8 lines)
- [x] Changelog entry follows the established format
- [ ] CI green
- [ ] After merge: tag `v7.10.5` and create GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)