### PR TITLE
docs: bump to v7.10.6 and add Composer Dependency Sweep release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FinAegis Core Banking Platform
 
 [![CI Pipeline](https://github.com/finaegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml/badge.svg)](https://github.com/finaegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml)
-[![Version](https://img.shields.io/badge/version-7.10.5-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-7.10.6-blue.svg)](CHANGELOG.md)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![PHP Version](https://img.shields.io/badge/php-%3E%3D8.4-8892BF.svg)](https://php.net/)
 [![Laravel Version](https://img.shields.io/badge/Laravel-12.x-FF2D20.svg)](https://laravel.com/)

--- a/resources/views/changelog.blade.php
+++ b/resources/views/changelog.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'Changelog | ' . config('brand.name', 'Zelta'),
-        'description' => 'Release history for the Zelta core banking platform. Track every feature shipped, bug fixed, and improvement made — v7.0 through v7.10.5.',
+        'description' => 'Release history for the Zelta core banking platform. Track every feature shipped, bug fixed, and improvement made — v7.0 through v7.10.6.',
         'keywords' => 'changelog, release notes, updates, ' . config('brand.name', 'Zelta') . ', version history, core banking',
     ])
 
@@ -43,6 +43,21 @@
 
             @php
                 $releases = [
+                    [
+                        'version' => 'v7.10.6',
+                        'date' => 'April 14, 2026',
+                        'label' => 'Composer Dependency Sweep',
+                        'label_color' => 'slate',
+                        'badge_color' => 'bg-slate-100 text-slate-700 border-slate-200',
+                        'dot_color' => 'bg-slate-500',
+                        'items' => [
+                            'Composer Semver-Safe Update — 230 packages upgraded within the existing composer.json ranges. Notable bumps include Laravel 12.55.1 → 12.56.0, Filament 3.3.49 → 3.3.50, Livewire 3.7.11 → 3.7.15, Larastan 3.9.3 → 3.9.5, PHPStan 2.1.42 → 2.1.47, php-cs-fixer 3.94.2 → 3.95.1, AWS SDK 3.373.8 → 3.379.0, Lighthouse 6.65.0 → 6.66.0, Behat 3.29.0 → 3.30.0, Laravel Passport 13.6.0 → 13.7.4, plus 220+ smaller / transitive bumps.',
+                            'PHPStan Level 8 Kept Clean — Larastan 3.9.5 tightened several rules, surfacing 6 pre-existing errors across RecordPaymentActivity, MessageDeliveryWorkflow, RegulatoryCalendarService, BasketController, StatusController, and the Account Exceptions test. All fixed in-PR per the CLAUDE.md policy against suppression — dead null-coalesces removed, Collection covariance resolved by closure type hints and by flattening to plain arrays where invariance bit, and the Pest toThrow() dead-code false positive worked around with try/catch assertions.',
+                            'php-cs-fixer 3.95.1 Repo-Wide Reformat — The new fixer version tightened match-arm alignment, flagging 65 files where existing match expressions had inconsistent whitespace around the fat arrow. 218 insertions / 218 deletions — pure whitespace normalization, no semantic changes.',
+                            'Zero Security Advisories — composer update reported "No security vulnerability advisories found." No CVE-driven bumps in this release; strictly maintenance within the Laravel 12 / PHP 8.4 line.',
+                            'Out of Scope — Major-version backend bumps are each dedicated migration projects and deliberately deferred: Laravel 12 → 13, Filament 3 → 5 (two majors), Livewire 3 → 4, Pest 3 → 4, Predis 2 → 3, Cashier 15 → 16, Scout 10 → 11, Tinker 2 → 3, Symfony http-client 7 → 8, L5-Swagger 10 → 11, Resend 0 → 1. Each of these needs its own migration plan and review pass.',
+                        ],
+                    ],
                     [
                         'version' => 'v7.10.5',
                         'date' => 'April 14, 2026',

--- a/resources/views/features/agent-protocol.blade.php
+++ b/resources/views/features/agent-protocol.blade.php
@@ -38,7 +38,7 @@
                 ]])
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-cyan-400 rounded-full mr-2"></span>
-                    v7.10.5 &middot; Autonomous Agent Commerce
+                    v7.10.6 &middot; Autonomous Agent Commerce
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">
                     Agent Protocol

--- a/resources/views/features/ai-framework.blade.php
+++ b/resources/views/features/ai-framework.blade.php
@@ -38,7 +38,7 @@
                 ]])
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.10.5 &middot; Multi-Agent Intelligence
+                    v7.10.6 &middot; Multi-Agent Intelligence
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">
                     AI Framework

--- a/resources/views/features/machine-payments.blade.php
+++ b/resources/views/features/machine-payments.blade.php
@@ -34,7 +34,7 @@
                 </div>
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.10.5 &middot; Multi-Rail Payments
+                    v7.10.6 &middot; Multi-Rail Payments
                 </div>
                 <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
                     Machine Payments Protocol

--- a/resources/views/features/x402-protocol.blade.php
+++ b/resources/views/features/x402-protocol.blade.php
@@ -36,7 +36,7 @@
                 </div>
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.10.5 &middot; Production Ready
+                    v7.10.6 &middot; Production Ready
                 </div>
                 <h1 class="font-display text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">x402 Protocol</h1>
                 <p class="text-lg text-slate-400 max-w-3xl mx-auto mb-8">

--- a/resources/views/support/faq.blade.php
+++ b/resources/views/support/faq.blade.php
@@ -13,7 +13,7 @@
     $faqData = [
         [
             'question' => 'What is the current status of ' . config('brand.name', 'Zelta') . '?',
-            'answer' => config('brand.name', 'Zelta') . ' v7.10.5 is a fully-featured open-source core banking platform with 56 domain modules. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
+            'answer' => config('brand.name', 'Zelta') . ' v7.10.6 is a fully-featured open-source core banking platform with 56 domain modules. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
         ],
         [
             'question' => 'Can I use real money on the platform?',
@@ -127,7 +127,7 @@
                     </button>
                     <div class="faq-answer px-6 py-4 bg-white rounded-b-lg">
                         <p class="text-slate-500">
-                            {{ config('brand.name', 'Zelta') }} is a fully-featured open-source core banking platform at v7.10.5. The sandbox environment lets you:
+                            {{ config('brand.name', 'Zelta') }} is a fully-featured open-source core banking platform at v7.10.6. The sandbox environment lets you:
                         </p>
                         <ul class="list-disc list-inside mt-2 text-slate-500 space-y-1">
                             <li>Explore 56 domain modules including DeFi, cross-chain, privacy, and rewards</li>


### PR DESCRIPTION
## Summary

Release bump for the semver-safe composer sweep merged in #919. Includes the PHPStan fixes (larastan 3.9.5 tightening) and the 65-file php-cs-fixer 3.95.1 alignment reformat.

- Bumps version badges across README, changelog, FAQ, and 4 feature pages from v7.10.5 → v7.10.6
- Adds v7.10.6 "Composer Dependency Sweep" entry to `resources/views/changelog.blade.php`

## Release summary

230 composer packages upgraded cleanly within existing ranges. Notable bumps: Laravel 12.55.1 → 12.56.0, Filament 3.3.49 → 3.3.50, Livewire 3.7.11 → 3.7.15, Larastan 3.9.3 → 3.9.5, PHPStan 2.1.42 → 2.1.47, php-cs-fixer 3.94.2 → 3.95.1, plus 220+ transitive bumps. Zero security advisories. Laravel 13 / Filament 5 / Livewire 4 / Pest 4 majors are deliberately deferred — each is its own migration project.

## Test plan

- [x] Diff matches prior release bump pattern (7 files, 23/8 lines)
- [x] Changelog entry notes PHPStan fixes + php-cs-fixer 3.95.1 repo reformat
- [ ] CI green
- [ ] After merge: tag `v7.10.6` and publish GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)