### PR TITLE
docs: bump to v7.10.7 and add Safe-Major Composer Trio release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FinAegis Core Banking Platform
 
 [![CI Pipeline](https://github.com/finaegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml/badge.svg)](https://github.com/finaegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml)
-[![Version](https://img.shields.io/badge/version-7.10.6-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-7.10.7-blue.svg)](CHANGELOG.md)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![PHP Version](https://img.shields.io/badge/php-%3E%3D8.4-8892BF.svg)](https://php.net/)
 [![Laravel Version](https://img.shields.io/badge/Laravel-12.x-FF2D20.svg)](https://laravel.com/)

--- a/resources/views/changelog.blade.php
+++ b/resources/views/changelog.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'Changelog | ' . config('brand.name', 'Zelta'),
-        'description' => 'Release history for the Zelta core banking platform. Track every feature shipped, bug fixed, and improvement made — v7.0 through v7.10.6.',
+        'description' => 'Release history for the Zelta core banking platform. Track every feature shipped, bug fixed, and improvement made — v7.0 through v7.10.7.',
         'keywords' => 'changelog, release notes, updates, ' . config('brand.name', 'Zelta') . ', version history, core banking',
     ])
 
@@ -43,6 +43,21 @@
 
             @php
                 $releases = [
+                    [
+                        'version' => 'v7.10.7',
+                        'date' => 'April 15, 2026',
+                        'label' => 'Safe-Major Composer Trio',
+                        'label_color' => 'slate',
+                        'badge_color' => 'bg-slate-100 text-slate-700 border-slate-200',
+                        'dot_color' => 'bg-slate-500',
+                        'items' => [
+                            'laravel/tinker ^2.9 → ^3.0 — Dev-only REPL. v3 requires PHP 8.4, which the project is already on. Zero runtime impact.',
+                            'resend/resend-php ^0.23.0 → ^1.0 — v1.0 is the stable release, not a breaking rewrite. Bounded to the Resend mail adapter — email verification notification path verified via the EmailVerificationControllerTest suite.',
+                            'darkaonline/l5-swagger ^10.1 → ^11.0 — Pulls in swagger-php v5, which is stricter about OpenAPI annotation validation. php artisan l5-swagger:generate regenerates a clean 2.7 MB api-docs.json.',
+                            'X402StatusController Annotation Fix — The l5-swagger upgrade surfaced one pre-existing bug: the #[OA\\Get] + #[OA\\Response] attributes for /api/v1/x402/supported were misattached to the wellKnown() method instead of supported(), because PHP attributes attach to the next declaration and the docblock between them did not reset the anchor. Old swagger-php v4 tolerated the duplicate response="200" silently; v5 errors out. Moved the attributes down to the right method — each now carries exactly one #[OA\\Get] + one #[OA\\Response(response: 200)].',
+                            'Still-Deferred Majors — Laravel 12 → 13 (ecosystem lock-step), Filament 3 → 5 (two majors), Livewire 3 → 4, Pest 3 → 4, Predis 2 → 3, Cashier 15 → 16, Scout 10 → 11, Symfony http-client 7 → 8, Tailwind 3 → 4, Vite 6 → 8 + laravel-vite-plugin 1 → 3, and @ledgerhq/hw-app-eth 6 → 7 each remain their own dedicated migration project.',
+                        ],
+                    ],
                     [
                         'version' => 'v7.10.6',
                         'date' => 'April 14, 2026',

--- a/resources/views/features/agent-protocol.blade.php
+++ b/resources/views/features/agent-protocol.blade.php
@@ -38,7 +38,7 @@
                 ]])
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-cyan-400 rounded-full mr-2"></span>
-                    v7.10.6 &middot; Autonomous Agent Commerce
+                    v7.10.7 &middot; Autonomous Agent Commerce
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">
                     Agent Protocol

--- a/resources/views/features/ai-framework.blade.php
+++ b/resources/views/features/ai-framework.blade.php
@@ -38,7 +38,7 @@
                 ]])
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.10.6 &middot; Multi-Agent Intelligence
+                    v7.10.7 &middot; Multi-Agent Intelligence
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">
                     AI Framework

--- a/resources/views/features/machine-payments.blade.php
+++ b/resources/views/features/machine-payments.blade.php
@@ -34,7 +34,7 @@
                 </div>
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.10.6 &middot; Multi-Rail Payments
+                    v7.10.7 &middot; Multi-Rail Payments
                 </div>
                 <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
                     Machine Payments Protocol

--- a/resources/views/features/x402-protocol.blade.php
+++ b/resources/views/features/x402-protocol.blade.php
@@ -36,7 +36,7 @@
                 </div>
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.10.6 &middot; Production Ready
+                    v7.10.7 &middot; Production Ready
                 </div>
                 <h1 class="font-display text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">x402 Protocol</h1>
                 <p class="text-lg text-slate-400 max-w-3xl mx-auto mb-8">

--- a/resources/views/support/faq.blade.php
+++ b/resources/views/support/faq.blade.php
@@ -13,7 +13,7 @@
     $faqData = [
         [
             'question' => 'What is the current status of ' . config('brand.name', 'Zelta') . '?',
-            'answer' => config('brand.name', 'Zelta') . ' v7.10.6 is a fully-featured open-source core banking platform with 56 domain modules. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
+            'answer' => config('brand.name', 'Zelta') . ' v7.10.7 is a fully-featured open-source core banking platform with 56 domain modules. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
         ],
         [
             'question' => 'Can I use real money on the platform?',
@@ -127,7 +127,7 @@
                     </button>
                     <div class="faq-answer px-6 py-4 bg-white rounded-b-lg">
                         <p class="text-slate-500">
-                            {{ config('brand.name', 'Zelta') }} is a fully-featured open-source core banking platform at v7.10.6. The sandbox environment lets you:
+                            {{ config('brand.name', 'Zelta') }} is a fully-featured open-source core banking platform at v7.10.7. The sandbox environment lets you:
                         </p>
                         <ul class="list-disc list-inside mt-2 text-slate-500 space-y-1">
                             <li>Explore 56 domain modules including DeFi, cross-chain, privacy, and rewards</li>


### PR DESCRIPTION
## Summary

Release bump for the three safe-judged major-version composer upgrades in #922 (laravel/tinker 3, resend/resend-php 1, darkaonline/l5-swagger 11) plus the pre-existing X402StatusController OpenAPI annotation fix that the new swagger-php v5 forced out of hiding.

- Bumps version badges across README, changelog, FAQ, and 4 feature pages from v7.10.6 → v7.10.7
- Adds v7.10.7 "Safe-Major Composer Trio" entry to `resources/views/changelog.blade.php`

## Test plan

- [x] Diff matches prior release bump pattern (7 files)
- [ ] CI green
- [ ] After merge: tag `v7.10.7` and publish GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)