### PR TITLE
feat(sms): VertexSMS Q&A hardening — throttle, dedup, reconciliation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -544,6 +544,8 @@ SMS_PRICING_MARGIN=1.15
 SMS_EUR_USD_RATE=1.08
 SMS_FALLBACK_PRICE_USDC=50000
 SMS_TEST_MODE=false
+SMS_SEND_INTERVAL_MS=1000
+SMS_EXPIRE_SECONDS=259200
 
 # =============================================================================
 # CIRCLE CCTP (Native USDC Bridge)

--- a/.env.zelta.example
+++ b/.env.zelta.example
@@ -444,6 +444,26 @@ LEDGER_DRIVER=eloquent
 MFI_ENABLED=false
 
 # =============================================================================
+# SMS SERVICE (VertexSMS) — v7.10.8+
+# =============================================================================
+SMS_ENABLED=true
+SMS_PROVIDER=vertexsms
+VERTEXSMS_API_TOKEN=          # Get from VertexSMS dashboard
+VERTEXSMS_BASE_URL=https://kube-api.vertexsms.com
+VERTEXSMS_SENDER_ID=Zelta
+VERTEXSMS_ENABLED=true
+VERTEXSMS_WEBHOOK_SECRET=     # HMAC-SHA256 shared secret (X-VertexSMS-Signature)
+VERTEXSMS_WEBHOOK_IPS=178.33.133.192/28
+VERTEXSMS_DLR_URL=https://zelta.app/api/v1/webhooks/vertexsms/dlr
+VERTEXSMS_DLR_URL_TOKEN=      # Opaque token appended as ?t= on DLR callback URL
+SMS_PRICING_MARGIN=1.15
+SMS_EUR_USD_RATE=1.08
+SMS_FALLBACK_PRICE_USDC=50000
+SMS_TEST_MODE=true
+SMS_SEND_INTERVAL_MS=1000
+SMS_EXPIRE_SECONDS=259200
+
+# =============================================================================
 # POST-DEPLOYMENT
 # =============================================================================
 # After deployment, run:

--- a/app/Console/Commands/SmsReconcileCommand.php
+++ b/app/Console/Commands/SmsReconcileCommand.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\SMS\Clients\VertexSmsClient;
+use App\Domain\SMS\Models\SmsMessage;
+use App\Domain\SMS\Services\SmsService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Reconciles SMS messages stuck in "sent" past the VertexSMS expiration window.
+ *
+ * VertexSMS guarantees a final DLR (delivered or undelivered with error=2) before
+ * the expiration time (default 3 days / 259200s). If no DLR was received by then,
+ * this command polls GET /sms/status/{id} as a fallback.
+ *
+ * Safe to run on a schedule (e.g. daily). No rate limit on the status endpoint (Q11).
+ */
+class SmsReconcileCommand extends Command
+{
+    protected $signature = 'sms:reconcile
+        {--limit=100 : Maximum messages to reconcile per run}
+        {--dry-run : Show what would be reconciled without making changes}';
+
+    protected $description = 'Reconcile SMS messages with missing DLR reports by polling VertexSMS status API';
+
+    public function handle(VertexSmsClient $client, SmsService $smsService): int
+    {
+        $expireSeconds = (int) config('sms.defaults.expire_seconds', 259200);
+        $limit = (int) $this->option('limit');
+        $dryRun = (bool) $this->option('dry-run');
+
+        $cutoff = now()->subSeconds($expireSeconds);
+
+        $stale = SmsMessage::where('status', SmsMessage::STATUS_SENT)
+            ->where('provider', 'vertexsms')
+            ->where('created_at', '<', $cutoff)
+            ->orderBy('created_at')
+            ->limit($limit)
+            ->get();
+
+        if ($stale->isEmpty()) {
+            $this->info('No stale messages to reconcile.');
+
+            return self::SUCCESS;
+        }
+
+        $this->info("Found {$stale->count()} stale message(s) past {$expireSeconds}s expiration window.");
+
+        $reconciled = 0;
+        $errors = 0;
+
+        foreach ($stale as $sms) {
+            $providerId = (string) $sms->provider_id;
+
+            if ($dryRun) {
+                $this->line("  [DRY-RUN] Would reconcile: {$providerId} (created {$sms->created_at})");
+
+                continue;
+            }
+
+            try {
+                $remote = $client->getMessageStatus($providerId);
+
+                if ($remote === null) {
+                    $this->warn("  Could not fetch status for {$providerId} — skipping");
+                    $errors++;
+
+                    continue;
+                }
+
+                $smsService->handleDeliveryReport([
+                    'message_id' => $providerId,
+                    'raw_status' => $remote['status'],
+                    'error_code' => $remote['error'],
+                ]);
+
+                $reconciled++;
+                $this->line("  Reconciled {$providerId}: status={$remote['status']}, error={$remote['error']}");
+            } catch (Throwable $e) {
+                $errors++;
+                $this->error("  Failed to reconcile {$providerId}: {$e->getMessage()}");
+                Log::error('sms:reconcile failed', [
+                    'provider_id' => $providerId,
+                    'error'       => $e->getMessage(),
+                ]);
+            }
+        }
+
+        $this->info("Done. Reconciled: {$reconciled}, Errors: {$errors}");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/SmsReconcileCommand.php
+++ b/app/Console/Commands/SmsReconcileCommand.php
@@ -34,6 +34,12 @@ class SmsReconcileCommand extends Command
         $limit = (int) $this->option('limit');
         $dryRun = (bool) $this->option('dry-run');
 
+        if ($limit <= 0) {
+            $this->error('--limit must be a positive integer.');
+
+            return self::FAILURE;
+        }
+
         $cutoff = now()->subSeconds($expireSeconds);
 
         $stale = SmsMessage::where('status', SmsMessage::STATUS_SENT)
@@ -93,6 +99,6 @@ class SmsReconcileCommand extends Command
 
         $this->info("Done. Reconciled: {$reconciled}, Errors: {$errors}");
 
-        return self::SUCCESS;
+        return $errors > 0 && $reconciled === 0 ? self::FAILURE : self::SUCCESS;
     }
 }

--- a/app/Domain/Newsletter/Models/Subscriber.php
+++ b/app/Domain/Newsletter/Models/Subscriber.php
@@ -96,6 +96,8 @@ class Subscriber extends Model
 
     public const SOURCE_PARTNER = 'partner';
 
+    public const SOURCE_LANDING = 'landing';
+
     public function scopeActive($query)
     {
         return $query->where('status', self::STATUS_ACTIVE);

--- a/app/Domain/Newsletter/Models/Subscriber.php
+++ b/app/Domain/Newsletter/Models/Subscriber.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Domain\Newsletter\Models;
 
 use App\Domain\Shared\Traits\UsesTenantConnection;
@@ -97,6 +99,24 @@ class Subscriber extends Model
     public const SOURCE_PARTNER = 'partner';
 
     public const SOURCE_LANDING = 'landing';
+
+    /**
+     * Human-readable labels for all source constants.
+     *
+     * @return array<string, string>
+     */
+    public static function sourceLabels(): array
+    {
+        return [
+            self::SOURCE_BLOG       => 'Blog',
+            self::SOURCE_CGO        => 'CGO Early Access',
+            self::SOURCE_INVESTMENT => 'Investment',
+            self::SOURCE_FOOTER     => 'Footer',
+            self::SOURCE_CONTACT    => 'Contact Form',
+            self::SOURCE_PARTNER    => 'Partner Application',
+            self::SOURCE_LANDING    => 'Landing Page',
+        ];
+    }
 
     public function scopeActive($query)
     {

--- a/app/Domain/SMS/Clients/VertexSmsClient.php
+++ b/app/Domain/SMS/Clients/VertexSmsClient.php
@@ -104,6 +104,20 @@ class VertexSmsClient
             $lock->block($lockSeconds + 5);
         }
 
+        try {
+            return $this->doSendSms($to, $from, $message, $testMode);
+        } finally {
+            if (isset($lock)) {
+                $lock->release();
+            }
+        }
+    }
+
+    /**
+     * @return array{message_id: string}
+     */
+    private function doSendSms(string $to, string $from, string $message, bool $testMode): array
+    {
         $payload = [
             'to'      => $to,
             'from'    => $from,
@@ -193,6 +207,12 @@ class VertexSmsClient
     {
         $this->requireApiToken();
 
+        if ($messageId === '' || preg_match('/[^a-zA-Z0-9._-]/', $messageId)) {
+            Log::warning('VertexSMS: Invalid message ID for status query', ['message_id' => $messageId]);
+
+            return null;
+        }
+
         $response = $this->request()->get("{$this->baseUrl}/sms/status/{$messageId}");
 
         if (! $response->successful()) {
@@ -221,21 +241,22 @@ class VertexSmsClient
     /**
      * Verify a DLR webhook HMAC-SHA256 signature over the raw request body.
      *
-     * Returns true in non-production when the secret is unset so local/test
-     * webhooks can be exercised without signing.
+     * Returns true only in local/testing when the secret is unset so dev
+     * webhooks can be exercised without signing. All other environments
+     * (staging, uat, production) reject unsigned webhooks.
      */
     public function verifyWebhookSignature(string $payload, string $signature): bool
     {
         $secret = (string) config('sms.webhook.secret', '');
 
         if ($secret === '') {
-            if (app()->environment('production')) {
-                Log::error('VertexSMS: VERTEXSMS_WEBHOOK_SECRET not set in production');
-
-                return false;
+            if (app()->environment('local', 'testing')) {
+                return true;
             }
 
-            return true;
+            Log::error('VertexSMS: VERTEXSMS_WEBHOOK_SECRET not set — rejecting webhook');
+
+            return false;
         }
 
         return hash_equals(hash_hmac('sha256', $payload, $secret), $signature);

--- a/app/Domain/SMS/Clients/VertexSmsClient.php
+++ b/app/Domain/SMS/Clients/VertexSmsClient.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Domain\SMS\Clients;
 
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\URL;
@@ -95,6 +96,13 @@ class VertexSmsClient
     public function sendSms(string $to, string $from, string $message, bool $testMode = false): array
     {
         $this->requireApiToken();
+
+        $intervalMs = (int) config('sms.defaults.send_interval_ms', 1000);
+        if ($intervalMs > 0) {
+            $lockSeconds = (int) ceil($intervalMs / 1000);
+            $lock = Cache::lock('sms:vertexsms:send-throttle', $lockSeconds);
+            $lock->block($lockSeconds + 5);
+        }
 
         $payload = [
             'to'      => $to,

--- a/app/Domain/SMS/Clients/VertexSmsClient.php
+++ b/app/Domain/SMS/Clients/VertexSmsClient.php
@@ -181,6 +181,44 @@ class VertexSmsClient
     }
 
     /**
+     * Query delivery status for a single message via GET /sms/status/{id}.
+     *
+     * VertexSMS confirmed no rate limit on this endpoint (Q11). Use as
+     * reconciliation fallback for missed DLRs after the SMS expiration
+     * window (default 3 days).
+     *
+     * @return array{id: string, status: int, error: int}|null
+     */
+    public function getMessageStatus(string $messageId): ?array
+    {
+        $this->requireApiToken();
+
+        $response = $this->request()->get("{$this->baseUrl}/sms/status/{$messageId}");
+
+        if (! $response->successful()) {
+            Log::warning('VertexSMS: /sms/status failed', [
+                'message_id' => $messageId,
+                'status'     => $response->status(),
+            ]);
+
+            return null;
+        }
+
+        /** @var array<string, mixed>|null $data */
+        $data = $response->json();
+
+        if (! is_array($data) || $data === []) {
+            return null;
+        }
+
+        return [
+            'id'     => (string) ($data['id'] ?? $messageId),
+            'status' => is_numeric($data['status'] ?? null) ? (int) $data['status'] : -1,
+            'error'  => is_numeric($data['error'] ?? null) ? (int) $data['error'] : 0,
+        ];
+    }
+
+    /**
      * Verify a DLR webhook HMAC-SHA256 signature over the raw request body.
      *
      * Returns true in non-production when the secret is unset so local/test

--- a/app/Domain/SMS/Services/SmsService.php
+++ b/app/Domain/SMS/Services/SmsService.php
@@ -145,6 +145,15 @@ class SmsService
 
             $sms->update($updates);
 
+            // Alert on VertexSMS error code 24 = Account balance limit reached
+            if (($dlr['error_code'] ?? null) === 24) {
+                Log::critical('SMS: VertexSMS account balance exhausted — all further SMS will fail until topped up', [
+                    'provider_id' => $dlr['message_id'],
+                    'error_code'  => 24,
+                    'sms_id'      => $sms->id,
+                ]);
+            }
+
             if ($newStatus === SmsMessage::STATUS_DELIVERED) {
                 SmsDelivered::dispatch((string) $sms->id, $dlr['message_id']);
             } elseif ($newStatus === SmsMessage::STATUS_FAILED) {

--- a/app/Domain/SMS/Services/SmsService.php
+++ b/app/Domain/SMS/Services/SmsService.php
@@ -9,8 +9,10 @@ use App\Domain\SMS\Events\SmsDelivered;
 use App\Domain\SMS\Events\SmsFailed;
 use App\Domain\SMS\Events\SmsSent;
 use App\Domain\SMS\Models\SmsMessage;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use RuntimeException;
 
 /**
  * Core SMS business logic. Sends messages via VertexSMS,
@@ -36,6 +38,12 @@ class SmsService
         string $message,
         array $paymentMeta = [],
     ): array {
+        $dedupKey = 'sms:dedup:' . hash('sha256', $to . '|' . $from . '|' . $message);
+        if (! Cache::add($dedupKey, true, 60)) {
+            Log::warning('SMS: Duplicate send blocked', ['to' => $to, 'from' => $from]);
+            throw new RuntimeException('Duplicate SMS detected within 60-second window');
+        }
+
         $testMode = (bool) config('sms.defaults.test_mode', false);
         $priced = $this->pricing->priceFor($to, $from, $message);
 

--- a/app/Domain/SMS/Services/SmsService.php
+++ b/app/Domain/SMS/Services/SmsService.php
@@ -38,7 +38,8 @@ class SmsService
         string $message,
         array $paymentMeta = [],
     ): array {
-        $dedupKey = 'sms:dedup:' . hash('sha256', $to . '|' . $from . '|' . $message);
+        $callerId = (string) (auth()->id() ?? 'system');
+        $dedupKey = 'sms:dedup:' . hash('sha256', $callerId . '|' . $to . '|' . $from . '|' . $message);
         if (! Cache::add($dedupKey, true, 60)) {
             Log::warning('SMS: Duplicate send blocked', ['to' => $to, 'from' => $from]);
             throw new RuntimeException('Duplicate SMS detected within 60-second window');
@@ -133,14 +134,15 @@ class SmsService
                 'delivered_at' => $dlr['delivered_at'] ?? ($newStatus === SmsMessage::STATUS_DELIVERED ? now() : null),
             ];
 
-            foreach (['error_code', 'mcc', 'mnc'] as $optional) {
+            // error_code handled separately: 0 is a valid value (= success)
+            if (array_key_exists('error_code', $dlr) && $dlr['error_code'] !== null) {
+                $updates['error_code'] = $dlr['error_code'];
+            }
+
+            foreach (['mcc', 'mnc'] as $optional) {
                 if (! empty($dlr[$optional])) {
                     $updates[$optional] = $dlr[$optional];
                 }
-            }
-            // Capture explicit zero error_code (= success) — `! empty(0)` would skip it.
-            if (array_key_exists('error_code', $dlr) && $dlr['error_code'] === 0) {
-                $updates['error_code'] = 0;
             }
 
             $sms->update($updates);

--- a/app/Filament/Admin/Resources/SubscriberResource.php
+++ b/app/Filament/Admin/Resources/SubscriberResource.php
@@ -51,6 +51,7 @@ class SubscriberResource extends Resource
                                             Subscriber::SOURCE_FOOTER     => 'Footer',
                                             Subscriber::SOURCE_CONTACT    => 'Contact Form',
                                             Subscriber::SOURCE_PARTNER    => 'Partner Application',
+                                            Subscriber::SOURCE_LANDING    => 'Landing Page',
                                         ]
                                     ),
                                 Forms\Components\Select::make('status')
@@ -135,6 +136,7 @@ class SubscriberResource extends Resource
                                 Subscriber::SOURCE_FOOTER     => 'Footer',
                                 Subscriber::SOURCE_CONTACT    => 'Contact Form',
                                 Subscriber::SOURCE_PARTNER    => 'Partner Application',
+                                Subscriber::SOURCE_LANDING    => 'Landing Page',
                                 default                       => $state,
                             }
                         ),
@@ -185,6 +187,7 @@ class SubscriberResource extends Resource
                                 Subscriber::SOURCE_FOOTER     => 'Footer',
                                 Subscriber::SOURCE_CONTACT    => 'Contact Form',
                                 Subscriber::SOURCE_PARTNER    => 'Partner Application',
+                                Subscriber::SOURCE_LANDING    => 'Landing Page',
                             ]
                         ),
                     Tables\Filters\Filter::make('confirmed')

--- a/app/Filament/Admin/Resources/SubscriberResource.php
+++ b/app/Filament/Admin/Resources/SubscriberResource.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Filament\Admin\Resources;
 
 use App\Domain\Newsletter\Models\Subscriber;
@@ -43,17 +45,7 @@ class SubscriberResource extends Resource
                                     ->maxLength(255),
                                 Forms\Components\Select::make('source')
                                     ->required()
-                                    ->options(
-                                        [
-                                            Subscriber::SOURCE_BLOG       => 'Blog',
-                                            Subscriber::SOURCE_CGO        => 'CGO Early Access',
-                                            Subscriber::SOURCE_INVESTMENT => 'Investment',
-                                            Subscriber::SOURCE_FOOTER     => 'Footer',
-                                            Subscriber::SOURCE_CONTACT    => 'Contact Form',
-                                            Subscriber::SOURCE_PARTNER    => 'Partner Application',
-                                            Subscriber::SOURCE_LANDING    => 'Landing Page',
-                                        ]
-                                    ),
+                                    ->options(Subscriber::sourceLabels()),
                                 Forms\Components\Select::make('status')
                                     ->required()
                                     ->options(
@@ -129,16 +121,7 @@ class SubscriberResource extends Resource
                         ->badge()
                         ->searchable()
                         ->formatStateUsing(
-                            fn (string $state): string => match ($state) {
-                                Subscriber::SOURCE_BLOG       => 'Blog',
-                                Subscriber::SOURCE_CGO        => 'CGO Early Access',
-                                Subscriber::SOURCE_INVESTMENT => 'Investment',
-                                Subscriber::SOURCE_FOOTER     => 'Footer',
-                                Subscriber::SOURCE_CONTACT    => 'Contact Form',
-                                Subscriber::SOURCE_PARTNER    => 'Partner Application',
-                                Subscriber::SOURCE_LANDING    => 'Landing Page',
-                                default                       => $state,
-                            }
+                            fn (string $state): string => Subscriber::sourceLabels()[$state] ?? $state
                         ),
                     Tables\Columns\TextColumn::make('status')
                         ->badge()
@@ -179,17 +162,7 @@ class SubscriberResource extends Resource
                         ->default(Subscriber::STATUS_ACTIVE),
                     SelectFilter::make('source')
                         ->multiple()
-                        ->options(
-                            [
-                                Subscriber::SOURCE_BLOG       => 'Blog',
-                                Subscriber::SOURCE_CGO        => 'CGO Early Access',
-                                Subscriber::SOURCE_INVESTMENT => 'Investment',
-                                Subscriber::SOURCE_FOOTER     => 'Footer',
-                                Subscriber::SOURCE_CONTACT    => 'Contact Form',
-                                Subscriber::SOURCE_PARTNER    => 'Partner Application',
-                                Subscriber::SOURCE_LANDING    => 'Landing Page',
-                            ]
-                        ),
+                        ->options(Subscriber::sourceLabels()),
                     Tables\Filters\Filter::make('confirmed')
                         ->query(fn (Builder $query): Builder => $query->whereNotNull('confirmed_at')),
                 ]

--- a/config/sms.php
+++ b/config/sms.php
@@ -85,5 +85,6 @@ return [
         'max_message_len'  => 1600,
         'test_mode'        => (bool) env('SMS_TEST_MODE', false),
         'send_interval_ms' => (int) env('SMS_SEND_INTERVAL_MS', 1000),
+        'expire_seconds'   => (int) env('SMS_EXPIRE_SECONDS', 259200),
     ],
 ];

--- a/config/sms.php
+++ b/config/sms.php
@@ -81,8 +81,9 @@ return [
     */
 
     'defaults' => [
-        'sender_id'       => env('VERTEXSMS_SENDER_ID', 'Zelta'),
-        'max_message_len' => 1600,
-        'test_mode'       => (bool) env('SMS_TEST_MODE', false),
+        'sender_id'        => env('VERTEXSMS_SENDER_ID', 'Zelta'),
+        'max_message_len'  => 1600,
+        'test_mode'        => (bool) env('SMS_TEST_MODE', false),
+        'send_interval_ms' => (int) env('SMS_SEND_INTERVAL_MS', 1000),
     ],
 ];

--- a/docs/partners/VERTEXSMS_Q13_BIDIRECTIONAL_MCP.md
+++ b/docs/partners/VERTEXSMS_Q13_BIDIRECTIONAL_MCP.md
@@ -1,0 +1,72 @@
+# Q13: Bidirectional MCP Setup — Details for VertexSMS
+
+**Context:** VertexSMS asked for more details on what the bidirectional setup involves before committing.
+
+---
+
+## What "Bidirectional" Means
+
+Right now the plan is one-directional:
+- **Zelta → VertexSMS**: AI agents call Zelta's MCP `send_sms` tool, which internally calls VertexSMS API to deliver the SMS.
+
+Bidirectional adds the reverse:
+- **VertexSMS → Zelta**: VertexSMS appears as a discoverable service provider *inside* Zelta's MCP ecosystem. Any Zelta-connected agent can discover VertexSMS as an SMS rail alongside other future providers.
+
+## What VertexSMS Would Provide
+
+| Item | Description | Effort |
+|------|------------|--------|
+| **Sandbox API token** | A test-mode token for our MCP server to call your API | 0 — you already gave us one |
+| **Signed DLR callbacks** | HMAC-SHA256 on DLR webhooks (already confirmed in Q2) | 0 — already agreed |
+| **Rate card endpoint** | `GET /rates/?format=json` (already exists) | 0 |
+| **Logo + description** | Brand assets for the provider listing (64x64 icon, one-line tagline) | 5 minutes |
+
+**Total effort from VertexSMS: near zero** — everything technical is already in place.
+
+## What Zelta Builds (Already Done)
+
+- `SmsSendTool` MCP tool is registered and exposes `send_sms` with payment auto-handling
+- VertexSMS client is wired as the SMS provider behind this tool
+- Any MCP-compatible client (Claude, GPT, custom agents) can discover the tool via standard MCP manifest at `https://zelta.app/.well-known/mcp-manifest.json`
+
+## What "Discoverable" Means for VertexSMS
+
+When an AI agent connects to Zelta's MCP server, it sees available tools:
+
+```json
+{
+  "tools": [
+    {
+      "name": "send_sms",
+      "description": "Send SMS via VertexSMS. Pay per-message via USDC, Stripe, or Lightning.",
+      "provider": "VertexSMS",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "to": { "type": "string", "description": "E.164 phone number" },
+          "from": { "type": "string", "description": "Sender ID" },
+          "message": { "type": "string", "description": "Message body" }
+        },
+        "required": ["to", "message"]
+      }
+    }
+  ]
+}
+```
+
+The agent doesn't need to know about VertexSMS directly — it discovers SMS capability through Zelta's tool registry. Payment is handled transparently by Zelta's SDK.
+
+## Benefits for VertexSMS
+
+1. **Zero integration work** — everything is already built on our side
+2. **New distribution channel** — every Zelta-connected AI agent is a potential VertexSMS customer
+3. **No API changes** — we call your existing `POST /sms` endpoint
+4. **Revenue from day one** — agents pay per-message, settlement to your account via Stripe Connect or USDC
+
+## Next Step
+
+If you're open to this, we just need:
+1. Confirmation we can list "VertexSMS" as the provider name in the tool description
+2. A small logo/icon for the provider listing (optional, we can use a text placeholder)
+
+No code changes or API work needed from your side.

--- a/tests/Feature/Console/SmsReconcileCommandTest.php
+++ b/tests/Feature/Console/SmsReconcileCommandTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\SMS\Models\SmsMessage;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function (): void {
+    config([
+        'sms.providers.vertexsms.api_token' => 'test-token',
+        'sms.providers.vertexsms.base_url'  => 'https://kube-api.vertexsms.com',
+        'sms.defaults.expire_seconds'       => 259200,
+        'sms.defaults.send_interval_ms'     => 0,
+        'sms.webhook.dlr_url'               => '',
+        'sms.webhook.dlr_url_token'         => '',
+        'cache.default'                     => 'array',
+    ]);
+});
+
+describe('sms:reconcile command', function (): void {
+    it('reconciles stale sent messages past expiration window', function (): void {
+        $sms = SmsMessage::create([
+            'provider'     => 'vertexsms',
+            'provider_id'  => 'recon-001',
+            'to'           => '+37069912345',
+            'from'         => 'Zelta',
+            'message'      => 'Reconcile test',
+            'parts'        => 1,
+            'status'       => SmsMessage::STATUS_SENT,
+            'price_usdc'   => '48000',
+            'country_code' => 'LT',
+            'test_mode'    => true,
+        ]);
+        $sms->forceFill(['created_at' => now()->subDays(4)])->saveQuietly();
+
+        Http::fake([
+            'kube-api.vertexsms.com/sms/status/recon-001*' => Http::response([
+                'id'     => 'recon-001',
+                'status' => 1,
+                'error'  => 0,
+            ], 200),
+        ]);
+
+        $this->artisan('sms:reconcile')
+            ->assertExitCode(0);
+
+        $sms->refresh();
+        expect($sms->status)->toBe(SmsMessage::STATUS_DELIVERED);
+    });
+
+    it('marks undelivered messages as failed', function (): void {
+        $sms = SmsMessage::create([
+            'provider'     => 'vertexsms',
+            'provider_id'  => 'recon-002',
+            'to'           => '+37069912345',
+            'from'         => 'Zelta',
+            'message'      => 'Failed reconcile',
+            'parts'        => 1,
+            'status'       => SmsMessage::STATUS_SENT,
+            'price_usdc'   => '48000',
+            'country_code' => 'LT',
+            'test_mode'    => true,
+        ]);
+        $sms->forceFill(['created_at' => now()->subDays(4)])->saveQuietly();
+
+        Http::fake([
+            'kube-api.vertexsms.com/sms/status/recon-002*' => Http::response([
+                'id'     => 'recon-002',
+                'status' => 2,
+                'error'  => 2,
+            ], 200),
+        ]);
+
+        $this->artisan('sms:reconcile')
+            ->assertExitCode(0);
+
+        $sms->refresh();
+        expect($sms->status)->toBe(SmsMessage::STATUS_FAILED);
+        expect($sms->error_code)->toBe(2);
+    });
+
+    it('skips messages within the expiration window', function (): void {
+        $sms = SmsMessage::create([
+            'provider'     => 'vertexsms',
+            'provider_id'  => 'recon-003',
+            'to'           => '+37069912345',
+            'from'         => 'Zelta',
+            'message'      => 'Too recent',
+            'parts'        => 1,
+            'status'       => SmsMessage::STATUS_SENT,
+            'price_usdc'   => '48000',
+            'country_code' => 'LT',
+            'test_mode'    => true,
+        ]);
+        $sms->forceFill(['created_at' => now()->subHours(1)])->saveQuietly();
+
+        Http::fake();
+
+        $this->artisan('sms:reconcile')
+            ->assertExitCode(0);
+
+        Http::assertNothingSent();
+    });
+
+    it('does nothing when no stale messages exist', function (): void {
+        Http::fake();
+
+        $this->artisan('sms:reconcile')
+            ->assertExitCode(0);
+
+        Http::assertNothingSent();
+    });
+});

--- a/tests/Feature/Domain/SMS/SmsServiceDedupTest.php
+++ b/tests/Feature/Domain/SMS/SmsServiceDedupTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\SMS\Services\SmsService;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function (): void {
+    config([
+        'sms.enabled'                       => true,
+        'sms.default_provider'              => 'vertexsms',
+        'sms.defaults.test_mode'            => true,
+        'sms.defaults.send_interval_ms'     => 0,
+        'sms.providers.vertexsms.api_token' => 'test-token',
+        'sms.providers.vertexsms.base_url'  => 'https://kube-api.vertexsms.com',
+        'sms.webhook.dlr_url'               => 'https://example.com/dlr',
+        'sms.webhook.dlr_url_token'         => '',
+        'cache.default'                     => 'array',
+    ]);
+    Cache::flush();
+});
+
+describe('SmsService dedup guard', function (): void {
+    it('rejects duplicate send within 60s window', function (): void {
+        Http::fake([
+            'kube-api.vertexsms.com/sms/cost' => Http::response([[
+                'parts' => 1, 'countryISO' => 'LT', 'mccmnc' => '24601',
+                'pricePerPart' => 0.035, 'totalPrice' => 0.035, 'currency' => 'EUR',
+            ]], 200),
+            'kube-api.vertexsms.com/sms' => Http::response(['dedup-msg-1'], 200),
+        ]);
+
+        $service = app(SmsService::class);
+
+        // First send succeeds
+        $result = $service->send('+37069912345', 'Zelta', 'Hello dedup');
+        expect($result['message_id'])->toBe('dedup-msg-1');
+
+        // Duplicate within 60s throws
+        expect(fn () => $service->send('+37069912345', 'Zelta', 'Hello dedup'))
+            ->toThrow(RuntimeException::class, 'Duplicate SMS detected');
+    });
+
+    it('allows same message to different recipients', function (): void {
+        Http::fake([
+            'kube-api.vertexsms.com/sms/cost' => Http::response([[
+                'parts' => 1, 'countryISO' => 'LT', 'mccmnc' => '24601',
+                'pricePerPart' => 0.035, 'totalPrice' => 0.035, 'currency' => 'EUR',
+            ]], 200),
+            'kube-api.vertexsms.com/sms' => Http::sequence()
+                ->push(['msg-a'], 200)
+                ->push(['msg-b'], 200),
+        ]);
+
+        $service = app(SmsService::class);
+
+        $a = $service->send('+37069912345', 'Zelta', 'Same message');
+        $b = $service->send('+37069900000', 'Zelta', 'Same message');
+
+        expect($a['message_id'])->toBe('msg-a');
+        expect($b['message_id'])->toBe('msg-b');
+    });
+});

--- a/tests/Feature/Domain/SMS/SmsServiceDedupTest.php
+++ b/tests/Feature/Domain/SMS/SmsServiceDedupTest.php
@@ -25,7 +25,7 @@ describe('SmsService dedup guard', function (): void {
     it('rejects duplicate send within 60s window', function (): void {
         Http::fake([
             'kube-api.vertexsms.com/sms/cost' => Http::response([[
-                'parts' => 1, 'countryISO' => 'LT', 'mccmnc' => '24601',
+                'parts'        => 1, 'countryISO' => 'LT', 'mccmnc' => '24601',
                 'pricePerPart' => 0.035, 'totalPrice' => 0.035, 'currency' => 'EUR',
             ]], 200),
             'kube-api.vertexsms.com/sms' => Http::response(['dedup-msg-1'], 200),
@@ -45,7 +45,7 @@ describe('SmsService dedup guard', function (): void {
     it('allows same message to different recipients', function (): void {
         Http::fake([
             'kube-api.vertexsms.com/sms/cost' => Http::response([[
-                'parts' => 1, 'countryISO' => 'LT', 'mccmnc' => '24601',
+                'parts'        => 1, 'countryISO' => 'LT', 'mccmnc' => '24601',
                 'pricePerPart' => 0.035, 'totalPrice' => 0.035, 'currency' => 'EUR',
             ]], 200),
             'kube-api.vertexsms.com/sms' => Http::sequence()

--- a/tests/Feature/Domain/SMS/SmsServiceDlrErrorTest.php
+++ b/tests/Feature/Domain/SMS/SmsServiceDlrErrorTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\SMS\Models\SmsMessage;
+use App\Domain\SMS\Services\SmsService;
+use Illuminate\Support\Facades\Log;
+
+beforeEach(function (): void {
+    config(['cache.default' => 'array']);
+});
+
+describe('SmsService DLR error-24 alerting', function (): void {
+    it('logs critical when error code 24 (balance exhausted) arrives', function (): void {
+        Log::shouldReceive('critical')
+            ->once()
+            ->withArgs(function (string $message, array $context): bool {
+                return str_contains($message, 'balance')
+                    && ($context['error_code'] ?? null) === 24;
+            });
+        Log::shouldReceive('info')->andReturnNull();
+        Log::shouldReceive('warning')->andReturnNull();
+        Log::shouldReceive('debug')->andReturnNull();
+
+        SmsMessage::create([
+            'provider'     => 'vertexsms',
+            'provider_id'  => 'err24-msg-001',
+            'to'           => '+37069912345',
+            'from'         => 'Zelta',
+            'message'      => 'Balance test',
+            'parts'        => 1,
+            'status'       => SmsMessage::STATUS_SENT,
+            'price_usdc'   => '48000',
+            'country_code' => 'LT',
+            'test_mode'    => true,
+        ]);
+
+        app(SmsService::class)->handleDeliveryReport([
+            'message_id' => 'err24-msg-001',
+            'raw_status' => 2,
+            'error_code' => 24,
+        ]);
+    });
+
+    it('does not log critical for other error codes', function (): void {
+        Log::shouldReceive('critical')->never();
+        Log::shouldReceive('info')->andReturnNull();
+        Log::shouldReceive('warning')->andReturnNull();
+        Log::shouldReceive('debug')->andReturnNull();
+
+        SmsMessage::create([
+            'provider'     => 'vertexsms',
+            'provider_id'  => 'err42-msg-001',
+            'to'           => '+37069912345',
+            'from'         => 'Zelta',
+            'message'      => 'Other error test',
+            'parts'        => 1,
+            'status'       => SmsMessage::STATUS_SENT,
+            'price_usdc'   => '48000',
+            'country_code' => 'LT',
+            'test_mode'    => true,
+        ]);
+
+        app(SmsService::class)->handleDeliveryReport([
+            'message_id' => 'err42-msg-001',
+            'raw_status' => 2,
+            'error_code' => 42,
+        ]);
+    });
+});

--- a/tests/Feature/Domain/SMS/VertexSmsClientStatusTest.php
+++ b/tests/Feature/Domain/SMS/VertexSmsClientStatusTest.php
@@ -26,7 +26,7 @@ describe('VertexSmsClient::getMessageStatus', function (): void {
 
         $result = (new VertexSmsClient())->getMessageStatus('12345');
 
-        expect($result)->not->toBeNull();
+        assert(is_array($result));
         expect($result['id'])->toBe('12345');
         expect($result['status'])->toBe(1);
         expect($result['error'])->toBe(0);
@@ -43,6 +43,7 @@ describe('VertexSmsClient::getMessageStatus', function (): void {
 
         $result = (new VertexSmsClient())->getMessageStatus('67890');
 
+        assert(is_array($result));
         expect($result['status'])->toBe(2);
         expect($result['error'])->toBe(24);
     });

--- a/tests/Feature/Domain/SMS/VertexSmsClientStatusTest.php
+++ b/tests/Feature/Domain/SMS/VertexSmsClientStatusTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\SMS\Clients\VertexSmsClient;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function (): void {
+    config([
+        'sms.providers.vertexsms.api_token' => 'test-token',
+        'sms.providers.vertexsms.base_url'  => 'https://kube-api.vertexsms.com',
+        'sms.webhook.dlr_url'               => '',
+        'sms.webhook.dlr_url_token'         => '',
+    ]);
+});
+
+describe('VertexSmsClient::getMessageStatus', function (): void {
+    it('returns parsed status for a delivered message', function (): void {
+        Http::fake([
+            'kube-api.vertexsms.com/sms/status/12345*' => Http::response([
+                'id'     => 12345,
+                'status' => 1,
+                'error'  => 0,
+            ], 200),
+        ]);
+
+        $result = (new VertexSmsClient())->getMessageStatus('12345');
+
+        expect($result)->not->toBeNull();
+        expect($result['id'])->toBe('12345');
+        expect($result['status'])->toBe(1);
+        expect($result['error'])->toBe(0);
+    });
+
+    it('returns parsed status for a failed message', function (): void {
+        Http::fake([
+            'kube-api.vertexsms.com/sms/status/67890*' => Http::response([
+                'id'     => 67890,
+                'status' => 2,
+                'error'  => 24,
+            ], 200),
+        ]);
+
+        $result = (new VertexSmsClient())->getMessageStatus('67890');
+
+        expect($result['status'])->toBe(2);
+        expect($result['error'])->toBe(24);
+    });
+
+    it('returns null on non-2xx response', function (): void {
+        Http::fake([
+            'kube-api.vertexsms.com/sms/status/99999*' => Http::response('Not found', 404),
+        ]);
+
+        $result = (new VertexSmsClient())->getMessageStatus('99999');
+
+        expect($result)->toBeNull();
+    });
+});

--- a/tests/Feature/Domain/SMS/VertexSmsClientTest.php
+++ b/tests/Feature/Domain/SMS/VertexSmsClientTest.php
@@ -142,3 +142,22 @@ describe('VertexSmsClient::verifyDlrUrlToken', function (): void {
         expect((new VertexSmsClient())->verifyDlrUrlToken('wrong-token'))->toBeFalse();
     });
 });
+
+describe('VertexSmsClient::sendSms throttle', function (): void {
+    it('acquires a cache lock before sending', function (): void {
+        config([
+            'sms.defaults.send_interval_ms' => 1000,
+            'cache.default'                 => 'array',
+        ]);
+
+        Http::fake([
+            'kube-api.vertexsms.com/sms' => Http::response(['throttle-msg-1'], 200),
+        ]);
+
+        $client = new VertexSmsClient();
+        $result = $client->sendSms('37069912345', 'Zelta', 'Throttle test');
+
+        expect($result['message_id'])->toBe('throttle-msg-1');
+        Http::assertSentCount(1);
+    });
+});


### PR DESCRIPTION
## Summary

Hardens the SMS domain based on answers received from VertexSMS developers (Ernestas). Six functional changes + code quality pass.

### Changes by VertexSMS Q&A answer:

- **Q6 (1 SMS/sec limit)**: Added `Cache::lock` outbound throttle in `VertexSmsClient::sendSms()`, configurable via `SMS_SEND_INTERVAL_MS` env var (default 1000ms)
- **Q8 (error 24 — balance exhausted)**: `Log::critical` alert when DLR arrives with error code 24, so monitoring catches it immediately
- **Q10 (no idempotency keys)**: Client-side dedup guard via `Cache::add` in `SmsService::send()` — prevents duplicate sends for same `(to, from, message)` tuple within 60s window
- **Q11 (SMS expiration + reconciliation)**: New `sms:reconcile` artisan command polls `GET /sms/status/{id}` for messages stuck in "sent" past the 3-day expiration window. Supports `--dry-run` and `--limit` options. Added `getMessageStatus()` to `VertexSmsClient`.
- **Q13 (bidirectional MCP)**: Drafted response document explaining the setup for VertexSMS

### Also:

- **Subscriber landing source fix**: Added `SOURCE_LANDING` constant + Filament admin display for early-access form submissions

## Test plan

- [x] 48 SMS tests pass (12 new across 4 test files)
- [x] PHPStan Level 8 clean (0 errors)
- [x] php-cs-fixer clean
- [ ] Verify `sms:reconcile --dry-run` on staging with test data
- [ ] Verify "Landing Page" source appears in `/admin/subscribers`
- [ ] Verify `ADMIN_MODULES` includes "Marketing" on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)