### PR TITLE
fix: update stale version references and add SMS API card

### DIFF
--- a/resources/views/developers/index.blade.php
+++ b/resources/views/developers/index.blade.php
@@ -137,7 +137,7 @@
                 <div class="text-center">
                     <div class="inline-flex items-center px-4 py-2 bg-white/10 backdrop-blur-sm rounded-full text-sm mb-6">
                         <span class="w-2 h-2 bg-green-400 rounded-full mr-2 animate-pulse"></span>
-                        <span>v7.10.0 Documentation — 56 Domains, 1,400+ Routes, GraphQL + REST + x402</span>
+                        <span>v7.10.7 Documentation — 56 Domains, 1,400+ Routes, GraphQL + REST + x402</span>
                     </div>
                     <h1 class="text-5xl md:text-7xl font-bold mb-6 bg-clip-text text-transparent bg-gradient-to-r from-white to-blue-200">
                         Build with 1,400+ API Routes
@@ -177,8 +177,8 @@
                     <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                     </svg>
-                    <span class="font-medium">v7.10.0 Released:</span>
-                    <span class="ml-2">Solana wallet integration, Helius transaction monitoring, Alchemy webhook support, FCM push notifications. 56 DDD domains, 1,400+ API routes, GraphQL (45 domains), ISO 20022, ISO 8583, multi-rail payments, x402 Protocol.</span>
+                    <span class="font-medium">v7.10.7 Released:</span>
+                    <span class="ml-2">VertexSMS multi-rail payments, durable workflows, SMS API documentation, Solana wallet integration, Alchemy webhook support. 56 DDD domains, 1,400+ API routes, GraphQL (45 domains), ISO 20022, ISO 8583, x402 Protocol.</span>
                 </div>
             </div>
         </section>
@@ -284,7 +284,7 @@
                                 <div id="code-step3">
                                     <div><span class="text-gray-500"># Verify the API is running (no auth needed)</span></div>
                                     <div><span class="text-gray-500">$</span> <span class="text-green-400">curl</span> <span class="text-yellow-400">http://localhost:8000/api/health</span></div>
-                                    <div><span class="text-gray-500"># {"status":"ok","version":"7.9.0"}</span></div>
+                                    <div><span class="text-gray-500"># {"status":"ok","version":"7.10.7"}</span></div>
                                     <div class="mt-2"><span class="text-gray-500"># Make an authenticated request</span></div>
                                     <div><span class="text-gray-500">$</span> <span class="text-green-400">curl</span> <span class="text-blue-400">-H</span> <span class="text-yellow-400">"Authorization: Bearer YOUR_API_KEY"</span> <span class="text-gray-400">\</span></div>
                                     <div>  <span class="text-yellow-400">http://localhost:8000/api/v2/accounts</span></div>
@@ -600,6 +600,25 @@
                             </div>
                         </a>
 
+                        <!-- SMS -->
+                        <a href="{{ route('developers.show', 'api-docs') }}#sms" class="group block">
+                            <div class="bg-white rounded-xl border border-gray-200 p-6 hover:shadow-lg transition-all hover:-translate-y-1 h-full">
+                                <div class="flex items-center mb-3">
+                                    <div class="w-10 h-10 bg-gradient-to-br from-orange-500 to-red-600 rounded-lg flex items-center justify-center text-white mr-3">
+                                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"></path>
+                                        </svg>
+                                    </div>
+                                    <div>
+                                        <h4 class="text-lg font-semibold text-slate-900">SMS</h4>
+                                        <span class="text-xs text-slate-400">4 endpoints &middot; MPP gated</span>
+                                    </div>
+                                </div>
+                                <p class="text-slate-500 text-sm mb-3">Send SMS via VertexSMS with multi-rail payment gating (USDC, Stripe, Lightning). Delivery tracking, per-country rates, and MCP tool support.</p>
+                                <span class="text-orange-600 text-sm font-medium group-hover:text-orange-700">View endpoints &rarr;</span>
+                            </div>
+                        </a>
+
                         <!-- x402 Protocol -->
                         <a href="{{ route('developers.show', 'api-docs') }}#x402" class="group block">
                             <div class="bg-white rounded-xl border border-gray-200 p-6 hover:shadow-lg transition-all hover:-translate-y-1 h-full">
@@ -737,7 +756,8 @@
                             <p class="text-slate-500 text-sm text-center">
                                 Explore payment features: <a href="/features/x402-protocol" class="text-blue-600 hover:text-blue-800 font-medium">x402 Protocol</a> &middot;
                                 <a href="/features/machine-payments" class="text-blue-600 hover:text-blue-800 font-medium">Machine Payments</a> &middot;
-                                <a href="/features/zelta-cli" class="text-blue-600 hover:text-blue-800 font-medium">Zelta CLI</a>
+                                <a href="/features/zelta-cli" class="text-blue-600 hover:text-blue-800 font-medium">Zelta CLI</a> &middot;
+                                <a href="{{ route('developers.show', 'api-docs') }}#sms" class="text-blue-600 hover:text-blue-800 font-medium">SMS API</a>
                             </p>
                         </div>
 


### PR DESCRIPTION
## Summary
- Updated version badge from v7.10.0 to v7.10.7 on developer docs page
- Updated release status alert text to reflect v7.10.7 features (VertexSMS, durable workflows, SMS API docs)
- Fixed curl example response showing version 7.9.0 instead of 7.10.7
- Added SMS Platform API Area card linking to the SMS section in api-docs
- Added SMS API to the "Explore payment features" link row

## Test plan
- [ ] Verify developer docs page renders at /developers with correct v7.10.7 badge
- [ ] Verify SMS card appears in Platform API Areas grid and links to /developers/api-docs#sms
- [ ] Verify curl example shows version 7.10.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)