### PR TITLE
chore: open source health audit — license, docs, DX

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Default owners for everything
+* @YOzaz
+
+# CI/CD and infrastructure
+.github/ @YOzaz
+helm/ @YOzaz
+docker/ @YOzaz
+
+# Domain modules
+app/Domain/ @YOzaz
+
+# Public-facing views
+resources/views/ @YOzaz

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,12 +12,8 @@ updates:
     reviewers:
       - "FinAegis/maintainers"
     ignore:
-      - dependency-name: "resend/resend-php"
-        versions: [">=1.0.0"]
       - dependency-name: "symfony/http-client"
         versions: [">=8.0.0"]
-      - dependency-name: "squizlabs/php_codesniffer"
-        versions: [">=4.0.0"]
       - dependency-name: "predis/predis"
         versions: [">=3.0.0"]
       - dependency-name: "laravel/cashier"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,333 @@ All notable changes to the FinAegis Core Banking Platform will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.10.7] - 2026-04-15
+
+### Changed
+- **Safe-Major Composer Trio** — Upgraded `laravel/tinker` v2→v3, `resend/resend-php` v0→v1, `darkaonline/l5-swagger` v10→v11 (PRs #922–#923)
+- swagger-php v5 strictness fix: moved misattached `#[OA\Get]` annotation on `X402StatusController::supported()`
+
+### Fixed
+- Pre-existing OpenAPI duplicate `@OA\Response(response: 200)` on `wellKnown()` surfaced by swagger-php v5
+
+---
+
+## [7.10.6] - 2026-04-14
+
+### Changed
+- **Composer Dependency Sweep** — 230 packages upgraded within existing semver ranges (PR #919)
+- Notable: `laravel/framework` 12.55→12.56, `phpstan` 2.1.42→2.1.47, `php-cs-fixer` 3.94→3.95, `aws/aws-sdk-php` 3.373→3.379
+- php-cs-fixer 3.95.1 repo-wide reformat (65 files, whitespace-only)
+
+### Fixed
+- 6 PHPStan errors surfaced by Larastan 3.9.5 rule tightening (dead null coalesces, Collection invariance, `toThrow()` typing)
+
+---
+
+## [7.10.5] - 2026-04-14
+
+### Changed
+- **npm Dependency Sweep** — Semver-safe `npm update` + lockfile dedup (~500 lines removed) (PR #918)
+- Notable: `autoprefixer` 10.4→10.5, `postcss` 8.5.8→8.5.9, `@ledgerhq/hw-transport-webusb` 6.32→6.33
+
+### Fixed
+- Cleared remaining moderate npm audit advisory (`follow-redirects` transitive dedup)
+
+---
+
+## [7.10.4] - 2026-04-14
+
+### Fixed
+- **Frontend Security Patch** — Bumped `axios` ^1.13→^1.15 closing 5 critical SSRF advisories (GHSA-3p68-rc4w-qgx5) (PR #916)
+- Bumped `vite` ^6.4.1→^6.4.2 closing 1 high path traversal advisory
+- Both packages are dev-only; no runtime code changes
+
+---
+
+## [7.10.3] - 2026-04-14
+
+### Fixed
+- **Onboarding Welcome Modal Fix** — Removed broken `startTour()` stub that threw `TypeError` on every new registration (PR #914)
+- Stripped dead "Take Tour" header button and `startOnboarding()` `.catch` fallback
+
+---
+
+## [7.10.2] - 2026-04-13
+
+### Fixed
+- **Deployment Pipeline Fix** — First deployable release since v7.10.0 (PR #905)
+- Deploy workflow OOM: unit tests now run in batched PHP processes via `bin/pest-batch`
+- `BackpressureHandlerTest` isolation: use array cache driver in pre-deployment validation
+- `.env.example` / `.env.zelta.example` dotenv parse errors (unquoted whitespace values)
+
+---
+
+## [7.10.1] - 2026-04-13
+
+### Added
+- **Stripe Bridge Ramp** — Working Stripe Crypto Onramp integration replacing scaffolding from v7.10.0 (PR #903)
+- Platform-generic `RampProviderInterface` with `normalizeWebhookPayload()` and signature validation
+- Lazy `RampProviderRegistry` with factory closures
+- Parameterized provider-contract test suite (6 tests per provider)
+- Non-custody regression test (zero ledger/transaction row growth on ramp webhook)
+
+### Fixed
+- Stripe Crypto Onramp signature verification (`t=<ts>,v1=<hmac>` parsing with HMAC-SHA256)
+- Race-safe webhook processing (`DB::transaction()` + `lockForUpdate()` + terminal-state idempotency)
+- Real session status fetch (was returning hardcoded `pending`)
+- Provider-aware capability validation (BTC through Stripe returns 422 naming the active provider)
+
+### Removed
+- Legacy `StripeBridgeWebhookController` and its 9 dead tests
+
+---
+
+## [7.10.0] - 2026-04-08
+
+### Added
+- **Webhook Architecture Refactor** — Per-user DB-stored webhook endpoints with encrypted signing keys (PR #902)
+- `AlchemyWebhookManager`: auto-provisions per-user Alchemy webhooks with 100K address sharding
+- `SmartAccountObserver`: auto-registers EVM addresses on SmartAccount creation
+- Async webhook processing via `ProcessAlchemyWebhookJob` and `ProcessHeliusWebhookJob`
+- `evm:sync-webhooks` command for bulk EVM address sync
+- **Card Pre-Order Waitlist** — POST join (race-safe with `lockForUpdate`) + GET status
+- **Paid KYC Verification** — 3 payment methods (wallet deduction, Stripe card, IAP) with `VerificationPayment` audit table
+- `RequireKycVerification` middleware blocking Level 0 users from financial endpoints
+- **Stripe Bridge Ramp** — Replaces Onramper for fiat on/off-ramp
+
+### Changed
+- Provider separation: Alchemy handles EVM only, Helius handles Solana only
+- Unique `(tx_hash, chain)` constraint, Cache-based per-tx dedup, spam filtering, reorg detection
+- All financial amounts in Ramp domain converted to `bcmath`
+- `stripe_client_secret` encrypted at rest via Laravel `encrypted` cast
+
+---
+
+## [7.9.0] - 2026-04-04
+
+### Added
+- **Solana Wallet Integration** — Balances wired to `/wallet/balances` and `/wallet/state` endpoints
+- Helius webhook stores Solana transactions in activity feed
+- FCM push notifications for Solana transaction events
+- Alchemy Solana RPC migration (`AlchemyWebhookSyncService` for Solana address management)
+- `solana:sync` command with `--provider` flag (replaces `helius:sync`)
+- Pre-warm balance cache, transaction backfill command, `/wallet/home` route
+
+### Changed
+- Extracted `HeliusTransactionProcessor` for cleaner webhook handling
+- Extracted shared Solana constants (`SolanaTokens`, `SolanaCacheKeys`)
+- SEO overhaul across all public-facing pages (meta descriptions, branding, schema.org)
+
+### Fixed
+- 181 pre-existing PHPStan Level 8 errors resolved
+- RFC 4122 UUID generation for MariaDB compatibility
+- Duplicate processing prevention per address in Helius webhook
+- Helius API key restored as query param (their API requires it)
+
+---
+
+## [7.8.4] - 2026-04-01
+
+### Added
+- **GoPlus Address Screening** — Authenticated mode with `app_key`/`app_secret` for on-chain risk scoring
+- Multi-layer address screening: OFAC SDN list + GoPlus API for Solana and EVM addresses
+
+### Fixed
+- Missing schema.org markup and breadcrumbs on subproduct pages
+- Shared layout cleanup: broken social links, branding, redundant config calls
+- Code example fixes: double `/api/api/` URLs, `<?php` HTML escaping, env var names
+- Blade `@yield` / `@section`/`@show` SEO default fix
+- Tenant context verification skipped for global Mobile jobs
+
+---
+
+## [7.8.3] - 2026-04-01
+
+### Fixed
+- **Log Spam** — MCP tool, custodian, and exchange rate provider registration logs demoted from `info` to `debug`
+- **Blade Compile Error** — `@hasSection('seo')` with `<x-schema>` components caused ParseError; replaced with `@yield('seo', default)`
+
+---
+
+## [7.8.2] - 2026-04-01
+
+### Fixed
+- API user registration no longer blocked by Fortify web registration gate (mobile users can always register)
+- CRON expression: `fraud.batch.schedule` changed from `'hourly'` to `'0 * * * *'`
+- Log rotation: stack channel defaults to `daily` with 14-day retention
+- CORS: `X-Tenant-ID` added to allowed headers
+- Migration FK fix: `consents.tpp_id` type uuid→string to match `tpp_registrations` FK
+- PHPStan `numeric-string` type in `PaymentRailRouter`
+
+### Changed
+- **Developer Portal** — Honest SDK install commands, standardized `@zelta/sdk` naming, consolidated rate limits, OpenAPI spec link, Hello World quick start
+
+---
+
+## [7.8.1] - 2026-03-31
+
+### Added
+- **Public Changelog** — `/changelog` page with reverse-chronological release timeline (v7.0.0–v7.8.0)
+
+### Changed
+- GCU page migrated to `layouts.public` with unified navy/teal brand palette
+- Platform page: removed 14 duplicate module cards, replaced with "56 Domain Modules" CTA
+- `/features/gcu` now 301 redirects to `/gcu`
+- Sitemap and footer updated
+
+---
+
+## [7.8.0] - 2026-03-31
+
+### Added
+- **7 New Domains** — ISO 20022 Message Engine, Open Banking PSD2, ISO 8583 Card Network Processor, US Payment Rails (ACH/Fedwire/RTP/FedNow), Interledger Protocol, Double-Entry Ledger, Microfinance Suite
+- SEPA Direct Debit/Credit Transfer, intelligent payment routing with ML-style scoring
+- Developer Experience: sandbox provisioning, webhook testing, API key management
+- 7 new feature detail pages with professional copywriting
+- All 15 STRIDE threat model findings resolved (security hardening)
+- Production readiness: Helm chart v1.7.0, benchmark commands, env review
+- Device attestation wiring, recovery shard improvements, card PATCH route
+
+### Changed
+- PHPCS v4.0.1 compatibility
+- Domain count raised to 56, GraphQL schemas to 43
+- ~500 new tests across 7 domains
+
+### Fixed
+- npm audit clean, Railgun bridge patched
+- Professional copywriting pass on headlines, CTAs, meta descriptions
+- SDK install commands fixed, compliance language updated
+
+---
+
+## [6.7.0] - 2026-03-26
+
+### Added
+- **A2A Protocol** — Agent Card at `/.well-known/agent.json` with 5 skills, streaming + push notifications
+- Task lifecycle: `tasks/send`, `tasks/get`, `tasks/{id}/cancel`, `tasks/list` with 6-state machine
+- SDK Packagist workflow (tag `sdk-v1.0.0` to publish `zelta/payment-sdk`)
+- API Sandbox at `/developers/sandbox` with pre-built test examples
+- 7 smoke tests for critical page loads and API health
+
+---
+
+## [6.6.0] - 2026-03-26
+
+### Added
+- **Zelta CLI v0.2.0** — 25 commands across 8 resource groups (payments, SMS, API management)
+- **Zelta Payment SDK** — Composer-installable package with transparent x402/MPP auto-retry
+- **Solana HSM Signer** — Ed25519 hardware signing + verifier for production x402 payments
+- **WebSocket Payment Gate** — Paid channel subscriptions with `ws.payment` middleware
+- Protocol-specific subdomain routing (`x402.api.*` / `mpp.api.*`)
+- `.well-known/x402-configuration` discovery endpoint
+- CLI distribution pipeline: PHAR build, npm `@zelta/cli`, Homebrew, GitHub release
+- SMS demo seeding + mobile rewards auto-creation
+
+---
+
+## [6.5.0] - 2026-03-24
+
+### Added
+- **VertexSMS Integration** — SMS service with dynamic EUR→USDC pricing, DLR webhook handler
+- MPP-gated `POST /api/v1/sms/send` — agents pay per-SMS via any rail (USDC, Stripe, Lightning)
+- x402 USDC rail adapter bridging Coinbase x402 into MPP
+- MCP tool `sms.send` for AI agent discovery
+- Stripe Connect support for direct settlement to service providers
+- Settlement reconciliation reports by rail and country
+- AP2 SMS mandates for enterprise campaigns
+- **Mobile Launch Readiness** — Quest auto-completion triggers, Apple App Attest, Google Play Integrity, JIT Funding wiring
+
+### Fixed
+- DLR handler: `DB::transaction` + `lockForUpdate` + forward-only state machine
+- E.164 phone number validation, zero-rate pricing guard
+
+---
+
+## [6.4.3] - 2026-03-24
+
+### Fixed
+- **Swagger 403** — `public/docs/` directory conflicted with L5-Swagger `/docs` route; moved Postman collections to `public/postman/`
+- Regenerated api-docs.json (2.7MB)
+
+---
+
+## [6.4.2] - 2026-03-23
+
+### Added
+- **HyperSwitch Payment Orchestration** — Full REST API client for 150+ payment processors
+- `HyperSwitchPaymentService` with deposit/refund and customer mapping
+- `HyperSwitchWebhookController` with HMAC-SHA512 verification
+- Config: `config/hyperswitch.php` (sandbox + production, routing strategy)
+
+---
+
+## [6.4.1] - 2026-03-23
+
+### Added
+- **Helius Webhook Auto-Sync** — `HeliusWebhookSyncService` auto-registers new Solana addresses
+- `BlockchainAddressObserver` with async (queued) dispatch
+- `Cache::lock` for concurrent address additions
+- Reserved address blocklist (System Program, Token Program, USDC mint)
+- `helius:sync` command for bulk address sync
+
+### Fixed
+- Missing `module.json` for 5 domains (Ramp, Referral, Rewards, VirtualsAgent, VisaCli)
+
+---
+
+## [6.4.0] - 2026-03-23
+
+### Added
+- **Machine Payments Protocol (MPP)** — New `MachinePay` domain with Stripe SPT, Tempo, Lightning, Card rails
+- `MppPaymentGateMiddleware` with `WWW-Authenticate: Payment` / `Authorization: Payment` headers
+- HMAC-SHA256 challenge binding, RFC 9457 error responses
+- 2 MCP tools (`mpp.payment`, `mpp.discovery`)
+- **AP2 Mandates** — Cart, Intent, Payment mandates with Verifiable Digital Credentials (SD-JWT-VC)
+- `AP2PaymentBridgeService` wrapping x402 + MPP as payment methods
+- **Solana Launch** — `solana:mainnet` + `solana:devnet` in X402Network enum, Helius webhook for balance monitoring
+- Legal positioning: platform disclaimers, non-custodial language
+
+### Changed
+- Transaction-level locking on settlement idempotency
+- HMAC key separation (derived keys, never reuse app key)
+- Admin-only resource monetization, blocked sensitive paths
+- 7 dependabot PRs merged
+
+---
+
+## [6.0.0] - 2026-03-17
+
+### Added
+- **Developer Portal** — Plugin development guide, GraphQL API docs, Redis Streams docs, MCP/AI Agent tools docs
+- **Plugin Marketplace** — Public browse/search/filter, detail pages with permissions and security reviews, 2 example plugins
+- **Domain Completeness** — Webhook encrypted secrets + HMAC signing, Newsletter campaign lifecycle, Activity service, Contact ticket workflow, Performance KPI reports
+- 4 sub-product detail pages (Exchange, Lending, Stablecoins, Treasury) rebranded to Zelta
+
+### Changed
+- Complete Zelta rebrand across 71 blade templates (353 replacements)
+- New OG images, favicons (14 sizes), SEO metadata, JSON-LD schemas
+- RPC caching (~90% Alchemy reduction) + WebSocket balance events
+
+### Fixed
+- HMAC bypass, email injection, LIKE injection, URL validation
+- Flaky `UserOperationSigningServiceTest`
+
+---
+
+## [5.14.0] - 2026-03-15
+
+### Added
+- **RPC Optimization** — Cache `eth_blockNumber`, `eth_gasPrice`, `getMaxPriorityFeePerGas` with 15s TTL (~90% Alchemy call reduction)
+- **WebSocket Balance Events** — Push-based balance updates replacing 60s mobile polling (`wallet.balance_updated`, `wallet.state_changed`, `privacy.balance_updated`)
+- **Alchemy Address Activity Webhook** — `POST /api/webhooks/alchemy/address-activity` with HMAC-SHA256 verification for near-instant balance notifications
+- Plugin development guide at `/developers/plugins`
+
+### Changed
+- Balance cache TTL increased from 30s to 120s
+- `MobileWalletController` fixed to use `WalletBalanceProviderInterface`
+
+---
+
 ## [5.12.0] - 2026-03-09
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ This project adheres to a [Code of Conduct](CODE_OF_CONDUCT.md). By participatin
 
 ### Prerequisites
 
-- PHP 8.3+
+- PHP 8.4+
 - Composer 2.x
 - MySQL 8.0+ or PostgreSQL 13+
 - Redis 6.0+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+.PHONY: help setup dev build test lint fix analyse serve clean
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+setup: ## Initial project setup (composer + npm + env + migrate)
+	composer install
+	npm install
+	cp -n .env.example .env || true
+	php artisan key:generate --force
+	php artisan migrate --seed
+	npm run build
+
+dev: ## Start development servers (PHP + Vite)
+	php artisan serve & npm run dev
+
+build: ## Build production assets
+	npm run build
+
+test: ## Run all tests in parallel
+	XDEBUG_MODE=off vendor/bin/pest --parallel --stop-on-failure
+
+test-unit: ## Run unit tests only
+	XDEBUG_MODE=off vendor/bin/pest --parallel tests/Unit
+
+test-feature: ## Run feature tests only
+	XDEBUG_MODE=off vendor/bin/pest --parallel tests/Feature
+
+lint: ## Run all code quality checks
+	./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --dry-run --diff
+	XDEBUG_MODE=off vendor/bin/phpstan analyse --memory-limit=2G
+
+fix: ## Auto-fix code style
+	./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php
+
+analyse: ## Run static analysis
+	XDEBUG_MODE=off vendor/bin/phpstan analyse --memory-limit=2G
+
+serve: ## Start the development server
+	php artisan serve
+
+swagger: ## Generate Swagger/OpenAPI documentation
+	php artisan l5-swagger:generate
+
+clean: ## Clear all caches
+	php artisan cache:clear
+	php artisan config:clear
+	php artisan route:clear
+	php artisan view:clear

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ FinAegis provides the foundation for building digital banking applications. The 
 | Machine payments | MPP multi-rail (Stripe, USDC, Lightning), AP2 mandates, x402 Solana (v6.4.0) |
 | Payment orchestration | HyperSwitch 150+ connectors, smart routing, failover (v6.4.2) |
 | Mobile launch readiness | Quest auto-triggers, device attestation, JIT funding, rewards (v6.5.0) |
-| SMS multi-rail payments | VertexSMS integration, MPP-gated SMS, MCP tool for AI agents (v6.5.0) |
+| SMS multi-rail payments | VertexSMS integration, MPP-gated SMS, MCP tool for AI agents (v7.10.7) |
 | Learning modern architecture | Complete DDD + CQRS + Event Sourcing example |
 
 ---
@@ -75,7 +75,7 @@ php artisan performance:report       # Generate performance baseline
 
 ## GraphQL API (v4.0.0-v4.3.0)
 
-FinAegis provides a schema-first GraphQL API via [Lighthouse PHP](https://lighthouse-php.com/) covering 36 domains:
+FinAegis provides a schema-first GraphQL API via [Lighthouse PHP](https://lighthouse-php.com/) covering 45 domains:
 
 ```bash
 # Available at /graphql
@@ -383,7 +383,7 @@ See [Kubernetes Deployment Guide](docs/06-DEVELOPMENT/KUBERNETES.md) for details
 |-------|------------|
 | **Backend** | Laravel 12, PHP 8.4+ |
 | **Event Sourcing** | Spatie Event Sourcing with Event Store v2 (domain routing, upcasting) |
-| **GraphQL** | Lighthouse PHP (schema-first, 36 domains, subscriptions) |
+| **GraphQL** | Lighthouse PHP (schema-first, 45 domains, subscriptions) |
 | **Workflows** | Laravel Workflow (Waterline) |
 | **Multi-Tenancy** | stancl/tenancy v3.9 |
 | **Database** | MySQL 8.0+ / MariaDB 10.3+ / PostgreSQL 13+ |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,63 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    ports:
+      - "8000:8000"
+    volumes:
+      - .:/var/www/html
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      - DB_HOST=mysql
+      - DB_PORT=3306
+      - DB_DATABASE=finaegis
+      - DB_USERNAME=finaegis
+      - DB_PASSWORD=secret
+      - REDIS_HOST=redis
+      - CACHE_DRIVER=redis
+      - QUEUE_CONNECTION=redis
+      - SESSION_DRIVER=redis
+      - MAIL_MAILER=smtp
+      - MAIL_HOST=mailpit
+      - MAIL_PORT=1025
+
+  mysql:
+    image: mysql:8.0
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_DATABASE: finaegis
+      MYSQL_USER: finaegis
+      MYSQL_PASSWORD: secret
+      MYSQL_ROOT_PASSWORD: secret
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  mailpit:
+    image: axllent/mailpit
+    ports:
+      - "8025:8025"
+      - "1025:1025"
+
+volumes:
+  mysql_data:

--- a/docs/VERSION_ROADMAP.md
+++ b/docs/VERSION_ROADMAP.md
@@ -3105,5 +3105,99 @@ Findings #1-2 fixed in v7.1.1, findings #3-15 fixed in this release:
 ### Stats
 - 66 files changed, +4,739/-1,441 lines, 5 migrations, 2 queue jobs, 4 controllers, 1 middleware
 
-*Document Version: 7.10.0*
-*Updated: April 7, 2026 (v7.10.0 Webhook Architecture Refactor + Mobile Backend Handover)*
+---
+
+## Version 7.10.1 — Stripe Bridge Ramp Hardening (RELEASED)
+
+**Release Date**: April 13, 2026
+**Theme**: Production-grade Stripe Crypto Onramp integration and platform-generic ramp abstraction
+
+### Delivered Features
+- Working Stripe Crypto Onramp signature verification (HMAC-SHA256 with `t=<ts>,v1=<hmac>` parsing)
+- Race-safe webhook processing with `DB::transaction()` + `lockForUpdate()` + terminal-state idempotency
+- Platform-generic `RampProviderInterface` with `normalizeWebhookPayload()` and signature validation
+- Lazy `RampProviderRegistry` with factory closures (no fake credentials needed for inactive providers)
+- Parameterized provider-contract test suite + non-custody regression test
+- Removed legacy `StripeBridgeWebhookController` (single `/api/v1/ramp/webhook/{provider}` entry point)
+
+---
+
+## Version 7.10.2 — Deployment Pipeline Fix (RELEASED)
+
+**Release Date**: April 13, 2026
+**Theme**: First deployable release since v7.10.0
+
+### Delivered Features
+- Deploy workflow OOM fix: unit tests now run in batched PHP processes via `bin/pest-batch`
+- `BackpressureHandlerTest` isolation: array cache driver in pre-deployment validation
+- `.env.example` / `.env.zelta.example` dotenv parse errors fixed (unquoted whitespace values)
+- No runtime code changes — CI infrastructure only
+
+---
+
+## Version 7.10.3 — Onboarding Welcome Modal Fix (RELEASED)
+
+**Release Date**: April 14, 2026
+**Theme**: Unblock new-user registration by removing broken tour stub
+
+### Delivered Features
+- Removed broken `startTour()` JS stub that threw `TypeError` on every new registration
+- Stripped dead "Take Tour" header button and `startOnboarding()` `.catch` fallback
+- Blade-only fix — no backend, migration, or config changes
+
+---
+
+## Version 7.10.4 — Frontend Security Patch (RELEASED)
+
+**Release Date**: April 14, 2026
+**Theme**: Close critical and high npm audit findings in devDependencies
+
+### Delivered Features
+- Bumped `axios` ^1.13→^1.15 closing 5 critical SSRF advisories (GHSA-3p68-rc4w-qgx5)
+- Bumped `vite` ^6.4.1→^6.4.2 closing 1 high path traversal advisory
+- Both packages are dev/build-time only — no runtime code changes
+- Audit: Critical 5→0, High 1→0
+
+---
+
+## Version 7.10.5 — npm Dependency Sweep (RELEASED)
+
+**Release Date**: April 14, 2026
+**Theme**: Semver-safe npm update and lockfile dedup
+
+### Delivered Features
+- `npm update` within existing `package.json` ranges, lockfile shrank ~500 lines
+- Notable: `autoprefixer` 10.4→10.5, `postcss` 8.5.8→8.5.9, `@ledgerhq/hw-transport-webusb` 6.32→6.33
+- Cleared remaining moderate npm audit advisory (`follow-redirects` transitive dedup)
+- Audit: Moderate 1→0
+
+---
+
+## Version 7.10.6 — Composer Dependency Sweep (RELEASED)
+
+**Release Date**: April 14, 2026
+**Theme**: 230 semver-safe Composer package upgrades
+
+### Delivered Features
+- 230 packages upgraded within existing `composer.json` ranges (zero range edits)
+- Notable: `laravel/framework` 12.55→12.56, `phpstan` 2.1.42→2.1.47, `php-cs-fixer` 3.94→3.95, `aws/aws-sdk-php` 3.373→3.379
+- 6 PHPStan errors fixed (surfaced by Larastan 3.9.5 rule tightening)
+- php-cs-fixer 3.95.1 repo-wide reformat (65 files, whitespace-only)
+- Zero security advisories
+
+---
+
+## Version 7.10.7 — Safe-Major Composer Trio (RELEASED)
+
+**Release Date**: April 15, 2026
+**Theme**: Three deferred major-version Composer upgrades judged safe to take
+
+### Delivered Features
+- `laravel/tinker` v2→v3 (dev REPL, requires PHP 8.4 — already there)
+- `resend/resend-php` v0→v1 (stable release, bounded to Resend mail adapter)
+- `darkaonline/l5-swagger` v10→v11 (pulls in swagger-php v5, dev tooling)
+- Fixed pre-existing OpenAPI annotation misattachment in `X402StatusController` (surfaced by swagger-php v5 strictness)
+- Zero security advisories, zero runtime behaviour changes
+
+*Document Version: 7.10.7*
+*Updated: April 17, 2026 (v7.10.7 Safe-Major Composer Trio)*

--- a/resources/views/about.blade.php
+++ b/resources/views/about.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'About ' . config('brand.name', 'Zelta') . ' — Open Source Core Banking Infrastructure',
-        'description' => 'Learn about Zelta, the open-source core banking platform with 56 modules for payments, lending, compliance, and DeFi. MIT licensed, built with Laravel.',
+        'description' => 'Learn about Zelta, the open-source core banking platform with 56 modules for payments, lending, compliance, and DeFi. Apache-2.0 licensed, built with Laravel.',
         'keywords' => config('brand.name', 'Zelta') . ' about, open source banking, core banking platform, GCU, ISO 20022, PSD2, open banking, Interledger, microfinance, event sourcing, CQRS, Laravel banking, DDD, fintech infrastructure',
     ])
 
@@ -181,9 +181,9 @@
                 <svg class="w-12 h-12 text-slate-900 mx-auto mb-4" fill="currentColor" viewBox="0 0 24 24">
                     <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
                 </svg>
-                <h3 class="font-display text-xl font-bold text-slate-900 mb-2">MIT Licensed</h3>
+                <h3 class="font-display text-xl font-bold text-slate-900 mb-2">Apache-2.0 Licensed</h3>
                 <p class="text-slate-500 mb-6 max-w-lg mx-auto">
-                    Fork it. Learn from it. Build on it. {{ config('brand.name', 'Zelta') }} is fully open source under the MIT license.
+                    Fork it. Learn from it. Build on it. {{ config('brand.name', 'Zelta') }} is fully open source under the Apache 2.0 license.
                 </p>
                 <div class="flex flex-col sm:flex-row gap-3 justify-center">
                     <a href="{{ config('brand.github_url') }}" target="_blank" class="btn-secondary">
@@ -209,7 +209,7 @@
                 <div class="card-feature">
                     <h4 class="font-display text-base font-bold text-slate-900 mb-2">For Founders</h4>
                     <p class="text-sm text-slate-500 mb-3">
-                        Build your fintech product on battle-tested infrastructure. 56 domain modules, MIT licensed, ready to customize.
+                        Build your fintech product on battle-tested infrastructure. 56 domain modules, Apache-2.0 licensed, ready to customize.
                     </p>
                     <a href="{{ route('developers') }}" class="text-sm text-blue-600 font-semibold hover:text-blue-700 transition">
                         View Documentation &rarr;

--- a/resources/views/developers/examples.blade.php
+++ b/resources/views/developers/examples.blade.php
@@ -1591,7 +1591,7 @@ aiClient.on('tool_executed', (event) => {
   "version": "1.0.0",
   "description": "MCP tools for {{ config('brand.name', 'Zelta') }} banking operations",
   "author": "{{ config('brand.name', 'Zelta') }}",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "server": {
     "command": "node",
     "args": ["./mcp-server.js"],

--- a/resources/views/developers/index.blade.php
+++ b/resources/views/developers/index.blade.php
@@ -866,7 +866,7 @@
                         </p>
                     </div>
                     <div>
-                        <div class="text-4xl md:text-5xl font-bold mb-2">MIT</div>
+                        <div class="text-4xl md:text-5xl font-bold mb-2">Apache-2.0</div>
                         <p class="text-indigo-200 flex items-center justify-center">
                             <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"></path>

--- a/resources/views/developers/plugins.blade.php
+++ b/resources/views/developers/plugins.blade.php
@@ -109,7 +109,7 @@
   "display_name": "Payment Analytics",
   "description": "Real-time payment analytics and reporting dashboard",
   "author": "My Company",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "entry_point": "ServiceProvider",
   "permissions": [
     "database:read",
@@ -402,7 +402,7 @@ php artisan plugin:list</pre>
                     <tr><td class="px-4 py-2"><code class="code-font">display_name</code></td><td class="px-4 py-2 text-slate-500">string</td><td class="px-4 py-2 text-slate-400">No</td><td class="px-4 py-2 text-slate-600">Human-readable name (defaults to name)</td></tr>
                     <tr><td class="px-4 py-2"><code class="code-font">description</code></td><td class="px-4 py-2 text-slate-500">string</td><td class="px-4 py-2 text-slate-400">No</td><td class="px-4 py-2 text-slate-600">Plugin description</td></tr>
                     <tr><td class="px-4 py-2"><code class="code-font">author</code></td><td class="px-4 py-2 text-slate-500">string</td><td class="px-4 py-2 text-slate-400">No</td><td class="px-4 py-2 text-slate-600">Author name</td></tr>
-                    <tr><td class="px-4 py-2"><code class="code-font">license</code></td><td class="px-4 py-2 text-slate-500">string</td><td class="px-4 py-2 text-slate-400">No</td><td class="px-4 py-2 text-slate-600">License type (default: MIT)</td></tr>
+                    <tr><td class="px-4 py-2"><code class="code-font">license</code></td><td class="px-4 py-2 text-slate-500">string</td><td class="px-4 py-2 text-slate-400">No</td><td class="px-4 py-2 text-slate-600">License type (default: Apache-2.0)</td></tr>
                     <tr><td class="px-4 py-2"><code class="code-font">entry_point</code></td><td class="px-4 py-2 text-slate-500">string</td><td class="px-4 py-2 text-slate-400">No</td><td class="px-4 py-2 text-slate-600">ServiceProvider class name (default: ServiceProvider)</td></tr>
                     <tr><td class="px-4 py-2"><code class="code-font">permissions</code></td><td class="px-4 py-2 text-slate-500">string[]</td><td class="px-4 py-2 text-slate-400">No</td><td class="px-4 py-2 text-slate-600">Required permissions (see table above)</td></tr>
                     <tr><td class="px-4 py-2"><code class="code-font">dependencies</code></td><td class="px-4 py-2 text-slate-500">object</td><td class="px-4 py-2 text-slate-400">No</td><td class="px-4 py-2 text-slate-600">Semver constraints: <code class="code-font">{"vendor/name": "^1.0"}</code></td></tr>

--- a/resources/views/marketplace/index.blade.php
+++ b/resources/views/marketplace/index.blade.php
@@ -140,7 +140,7 @@
                 <!-- Footer -->
                 <div class="flex items-center justify-between text-xs text-slate-500">
                     <span>v{{ $plugin->version }}</span>
-                    <span>{{ $plugin->license ?? 'MIT' }}</span>
+                    <span>{{ $plugin->license ?? 'Apache-2.0' }}</span>
                     @if($plugin->author)
                     <span>by {{ $plugin->author }}</span>
                     @endif

--- a/resources/views/partials/footer.blade.php
+++ b/resources/views/partials/footer.blade.php
@@ -9,7 +9,7 @@
                     <span class="text-xl font-display font-bold text-white tracking-tight">{{ config('brand.name', 'Zelta') }}</span>
                 </a>
                 <p class="text-slate-500 text-sm leading-relaxed max-w-xs mb-6">
-                    Open-source core banking infrastructure for the next generation of financial services. MIT licensed.
+                    Open-source core banking infrastructure for the next generation of financial services. Apache-2.0 licensed.
                 </p>
                 <div class="flex items-center space-x-3">
                     <a href="{{ config('brand.github_url') }}" class="w-9 h-9 rounded-lg bg-white/[0.04] border border-white/[0.06] flex items-center justify-center text-slate-500 hover:text-white hover:border-white/[0.12] transition-all" aria-label="GitHub">

--- a/resources/views/platform/index.blade.php
+++ b/resources/views/platform/index.blade.php
@@ -5,8 +5,8 @@
 @section('seo')
     @include('partials.seo', [
         'title' => config('brand.name', 'Zelta') . ' Platform - Open Banking for Developers',
-        'description' => 'Zelta Platform: open-source core banking with 56 DDD domains, ISO 20022, PSD2, multi-rail payments, and cross-chain DeFi. MIT licensed, built for developers.',
-        'keywords' => config('brand.name', 'Zelta') . ' platform, banking infrastructure, open source banking, developer API, ISO 20022, PSD2, payment rails, Interledger, microfinance, ledger, MIT license, core banking API, fintech development, DDD, event sourcing',
+        'description' => 'Zelta Platform: open-source core banking with 56 DDD domains, ISO 20022, PSD2, multi-rail payments, and cross-chain DeFi. Apache-2.0 licensed, built for developers.',
+        'keywords' => config('brand.name', 'Zelta') . ' platform, banking infrastructure, open source banking, developer API, ISO 20022, PSD2, payment rails, Interledger, microfinance, ledger, Apache-2.0 license, core banking API, fintech development, DDD, event sourcing',
     ])
 
     {{-- Schema.org Markup --}}
@@ -173,7 +173,7 @@
                         <!-- Quick stats -->
                         <div class="grid grid-cols-3 gap-4 mt-12">
                             <div>
-                                <div class="text-2xl font-bold text-green-400 code-font">MIT</div>
+                                <div class="text-2xl font-bold text-green-400 code-font">Apache-2.0</div>
                                 <div class="text-sm text-gray-500">License</div>
                             </div>
                             <div>
@@ -431,7 +431,7 @@
                 <!-- GitHub Stats -->
                 <div class="grid grid-cols-3 gap-8 mt-12 max-w-2xl mx-auto">
                     <div>
-                        <div class="text-3xl font-bold">MIT</div>
+                        <div class="text-3xl font-bold">Apache-2.0</div>
                         <div class="text-gray-400">License</div>
                     </div>
                     <div>

--- a/resources/views/pricing.blade.php
+++ b/resources/views/pricing.blade.php
@@ -57,7 +57,7 @@
                         </div>
                         <ul class="space-y-3 mb-8 text-sm text-slate-600">
                             <li class="list-check">Full source code access</li>
-                            <li class="list-check">MIT License</li>
+                            <li class="list-check">Apache-2.0 License</li>
                             <li class="list-check">All 56 domain modules</li>
                             <li class="list-check">ISO 20022, Open Banking, Payment Rails</li>
                             <li class="list-check">Ledger, Microfinance, Interledger</li>
@@ -140,7 +140,7 @@
                 <div class="space-y-4">
                     @php
                         $faqs = [
-                            ['q' => 'Is the community edition really free?', 'a' => 'Yes! Our community edition is completely free and open source under the MIT license. You can use it for any purpose, including commercial projects.'],
+                            ['q' => 'Is the community edition really free?', 'a' => 'Yes! Our community edition is completely free and open source under the Apache 2.0 license. You can use it for any purpose, including commercial projects.'],
                             ['q' => "What's included in the Cloud Platform?", 'a' => 'The Cloud Platform includes managed hosting, automatic updates, daily backups, 99.9% uptime SLA, and priority support. We handle all the infrastructure so you can focus on your business.'],
                             ['q' => 'Can I switch between plans?', 'a' => "Yes. You can start with the Community Edition and upgrade to Cloud or Enterprise at any time. We provide migration tooling and support to ensure a seamless transition."],
                             ['q' => 'Do you offer discounts for non-profits?', 'a' => 'Yes, we offer special pricing for non-profit organizations and educational institutions. Contact our sales team for more information.'],

--- a/resources/views/support/contact.blade.php
+++ b/resources/views/support/contact.blade.php
@@ -225,7 +225,7 @@
                 
                 <div class="mt-8 pt-8 border-t border-gray-200 text-center">
                     <p class="text-slate-500">
-                        <span class="font-semibold">License:</span> MIT Open Source License
+                        <span class="font-semibold">License:</span> Apache-2.0 Open Source License
                     </p>
                 </div>
             </div>

--- a/resources/views/support/faq.blade.php
+++ b/resources/views/support/faq.blade.php
@@ -205,7 +205,7 @@
                     </button>
                     <div class="faq-answer px-6 py-4 bg-white rounded-b-lg">
                         <p class="text-slate-500">
-                            Yes! {{ config('brand.name', 'Zelta') }} is fully open source under the MIT license. This means:
+                            Yes! {{ config('brand.name', 'Zelta') }} is fully open source under the Apache 2.0 license. This means:
                         </p>
                         <ul class="list-disc list-inside mt-2 text-slate-500 space-y-1">
                             <li>You can view all source code on GitHub</li>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => config('brand.name', 'Zelta') . ' - Open Source Core Banking Infrastructure',
-        'description' => 'Open-source core banking platform with 56 modules: payments, lending, compliance, and DeFi. ISO 20022, PSD2, ACH, SEPA. MIT licensed, built with Laravel.',
+        'description' => 'Open-source core banking platform with 56 modules: payments, lending, compliance, and DeFi. ISO 20022, PSD2, ACH, SEPA. Apache-2.0 licensed, built with Laravel.',
         'keywords' => config('brand.name', 'Zelta') . ', open source banking, core banking infrastructure, GCU, ISO 20022, PSD2, open banking, ACH, SEPA, Interledger, microfinance, event sourcing, DeFi, RegTech, banking API, Laravel fintech',
     ])
 
@@ -32,7 +32,7 @@
                     <svg class="w-4 h-4 text-fa-teal" fill="currentColor" viewBox="0 0 20 20">
                         <path fill-rule="evenodd" d="M12.316 3.051a1 1 0 01.633 1.265l-4 12a1 1 0 11-1.898-.632l4-12a1 1 0 011.265-.633zM5.707 6.293a1 1 0 010 1.414L3.414 10l2.293 2.293a1 1 0 11-1.414 1.414l-3-3a1 1 0 010-1.414l3-3a1 1 0 011.414 0zm8.586 0a1 1 0 011.414 0l3 3a1 1 0 010 1.414l-3 3a1 1 0 11-1.414-1.414L16.586 10l-2.293-2.293a1 1 0 010-1.414z" clip-rule="evenodd"/>
                     </svg>
-                    Open Source &middot; MIT Licensed &middot; 56 Domains
+                    Open Source &middot; Apache-2.0 Licensed &middot; 56 Domains
                 </div>
 
                 <!-- Heading -->
@@ -81,7 +81,7 @@
                 <div class="animate-on-scroll">
                     <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-blue-50 text-blue-600 text-xs font-semibold mb-6">
                         <span class="w-1.5 h-1.5 rounded-full bg-blue-500"></span>
-                        MIT Licensed
+                        Apache-2.0
                     </div>
                     <h2 class="font-display text-4xl lg:text-5xl font-bold text-slate-900 tracking-tight mb-6">
                         What Is {{ config('brand.name', 'Zelta') }}?
@@ -327,7 +327,7 @@
                     ['value' => '56', 'label' => 'Domain Modules'],
                     ['value' => '45', 'label' => 'GraphQL Schemas'],
                     ['value' => '1,400+', 'label' => 'API Routes'],
-                    ['value' => 'MIT', 'label' => 'Licensed'],
+                    ['value' => 'Apache-2.0', 'label' => 'Licensed'],
                 ] as $stat)
                     <div class="text-center">
                         <div class="font-display text-4xl lg:text-5xl font-extrabold text-gradient mb-2">{{ $stat['value'] }}</div>


### PR DESCRIPTION
## Summary

Comprehensive open source health audit addressing legal, documentation, and developer experience gaps.

### Phase 1 — Legal & Accuracy
- **License fix**: MIT → Apache-2.0 across all 10 blade views (22 occurrences). LICENSE file, composer.json, package.json, and README all say Apache-2.0 but every website page said MIT.
- **README**: GraphQL "36 domains" → "45 domains" (2 places), SMS version v6.5.0 → v7.10.7
- **CONTRIBUTING.md**: PHP 8.3+ → 8.4+

### Phase 2 — Repository Presentation
- Set repo description, homepage (finaegis.org), 12 topics (banking, fintech, laravel, event-sourcing, ddd, graphql, etc.)
- Removed stale Dependabot ignores for resend-php (now v1.3.0) and phpcs (now v4.0.1)
- Added `.github/CODEOWNERS` for auto-review assignment

### Phase 3 — Documentation Freshness
- Backfilled CHANGELOG.md with 23 releases (v5.14.0 → v7.10.7)
- Updated VERSION_ROADMAP.md with v7.10.1 → v7.10.7

### Phase 4 — Developer Experience
- Added `Makefile` with 12 targets (setup, dev, test, lint, fix, analyse, swagger, clean)
- Added `docker-compose.yml` for full local dev stack (MySQL 8, Redis 7, Mailpit)

## Test plan
- [x] `php artisan view:cache` compiles all views successfully
- [x] `docker-compose.yml` validates as correct YAML
- [x] `Makefile` uses real tab characters
- [x] Zero MIT license references remain in blade views
- [x] Zero "36 domains" references remain in README
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)