### PR TITLE
fix: make release workflows actually publish

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -12,6 +12,8 @@ jobs:
   build-phar:
     name: Build PHAR Binary
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
 
@@ -21,6 +23,10 @@ jobs:
           php-version: '8.4'
           tools: composer
           extensions: json, mbstring, sodium
+
+      - name: Extract version
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/cli-v}" >> $GITHUB_OUTPUT
 
       - name: Install dependencies
         working-directory: packages/zelta-cli
@@ -42,9 +48,12 @@ jobs:
         working-directory: packages/zelta-cli
         run: php builds/zelta.phar list
 
-      - name: Extract version
-        id: version
-        run: echo "version=${GITHUB_REF#refs/tags/cli-v}" >> $GITHUB_OUTPUT
+      - name: Upload PHAR artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zelta-phar
+          path: packages/zelta-cli/builds/zelta.phar
+          retention-days: 7
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
@@ -55,6 +64,8 @@ jobs:
 
             ### Install
             ```bash
+            npm install -g @finaegis/cli
+            # or
             curl -fsSL https://cli.zelta.app/install.sh | bash
             ```
 
@@ -81,22 +92,32 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Download PHAR artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: zelta-phar
+          path: packages/zelta-cli/npm-package
+
       - name: Create npm wrapper
         working-directory: packages/zelta-cli
+        env:
+          PKG_VERSION: ${{ needs.build-phar.outputs.version }}
         run: |
           mkdir -p npm-package/bin
-          cat > npm-package/package.json << 'NPMEOF'
+          cat > npm-package/package.json << NPMEOF
           {
             "name": "@finaegis/cli",
-            "version": "${{ github.ref_name }}",
+            "version": "${PKG_VERSION}",
             "description": "Zelta CLI — manage payments, SMS, wallets, and APIs from the terminal",
             "license": "Apache-2.0",
             "bin": {
               "zelta": "./bin/zelta"
             },
-            "scripts": {
-              "postinstall": "node install.js"
-            },
+            "files": [
+              "bin/",
+              "zelta.phar",
+              "README.md"
+            ],
             "repository": {
               "type": "git",
               "url": "https://github.com/FinAegis/core-banking-prototype-laravel.git"
@@ -111,13 +132,20 @@ jobs:
           #!/usr/bin/env node
           const { execFileSync } = require('child_process');
           const path = require('path');
+          const fs = require('fs');
+          const phar = path.join(__dirname, '..', 'zelta.phar');
+          if (!fs.existsSync(phar)) {
+            console.error('Error: zelta.phar not found in package — reinstall @finaegis/cli');
+            process.exit(1);
+          }
           try {
-            execFileSync('php', [path.join(__dirname, '..', 'zelta.phar'), ...process.argv.slice(2)], { stdio: 'inherit' });
+            execFileSync('php', [phar, ...process.argv.slice(2)], { stdio: 'inherit' });
           } catch (e) {
             process.exit(e.status || 1);
           }
           BINEOF
           chmod +x npm-package/bin/zelta
+          cp README.md npm-package/README.md 2>/dev/null || echo "# @finaegis/cli" > npm-package/README.md
 
       - name: Publish to npm
         working-directory: packages/zelta-cli/npm-package
@@ -133,5 +161,4 @@ jobs:
       - name: Trigger Homebrew tap update
         run: |
           echo "Homebrew tap update would be triggered here."
-          echo "Requires: zelta-app/homebrew-tap repository with Formula/zelta.rb"
-        continue-on-error: true
+          echo "Requires: finaegis/homebrew-tap repository with Formula/zelta.rb"

--- a/packages/zelta-cli/composer.json
+++ b/packages/zelta-cli/composer.json
@@ -4,6 +4,15 @@
     "type": "project",
     "license": "Apache-2.0",
     "keywords": ["cli", "payments", "x402", "mpp", "fintech"],
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../zelta-sdk",
+            "options": {
+                "symlink": false
+            }
+        }
+    ],
     "require": {
         "php": "^8.4",
         "guzzlehttp/guzzle": "^7.0",

--- a/sdks/javascript/package.json
+++ b/sdks/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finaegis/sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Official FinAegis JavaScript/TypeScript SDK for interacting with the FinAegis API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sdks/javascript/src/types.ts
+++ b/sdks/javascript/src/types.ts
@@ -10,7 +10,7 @@ export interface FinAegisConfig {
 export interface ApiResponse<T> {
   data: T;
   meta?: Record<string, any>;
-  links?: Record<string, string>;
+  links?: Record<string, string | null>;
 }
 
 export interface PaginatedResponse<T> extends ApiResponse<T[]> {


### PR DESCRIPTION
## Summary

Removing \`continue-on-error: true\` from the release workflows (PR #935) exposed four pre-existing bugs that had been silently swallowed whenever \`cli-v0.2.0\` / \`sdk-v1.0.0\` ran previously. Both \`cli-v0.2.1\` and \`js-sdk-v1.0.0\` failed hard — fix forward.

## Bugs fixed

1. **CLI composer requires unpublished \`finaegis/payment-sdk\`** → added a \`path\` repository entry in \`packages/zelta-cli/composer.json\` pointing at \`../zelta-sdk\`. Composer now resolves it from the sibling directory during build. Verified locally with \`composer install --no-dev --dry-run\` — installs \`finaegis/payment-sdk (1.0.0)\`.

2. **Invalid npm \`version\` string** → \`cli-release.yml\` wrote \`"version": "\${{ github.ref_name }}"\` which rendered as \`cli-v0.2.1\` (not semver). Switched to the extracted \`version\` job output (passes from \`build-phar\` to \`publish-npm\` via \`outputs:\`), rendering as \`0.2.1\`.

3. **PHAR never bundled** → \`build-phar\` wrote \`builds/zelta.phar\` but \`publish-npm\` never downloaded it, so the published npm tarball had no binary. Added \`actions/upload-artifact@v4\` + \`actions/download-artifact@v4\`. Also dropped the \`postinstall: node install.js\` hook that referenced a script that was never created. \`bin/zelta\` now checks \`fs.existsSync(phar)\` and fails with a clear error instead of a cryptic PHP exception.

4. **TS type error in JS SDK** → \`PaginatedResponse<T>.links\` declared \`prev/next\` as \`string | null\` but parent \`ApiResponse<T[]>.links\` was \`Record<string, string>\`. Widened parent to \`Record<string, string | null>\`. Verified with \`npx tsc --noEmit\` — exit 0. Bumped \`@finaegis/sdk\` version to \`1.0.1\`.

## After merge

Tag \`cli-v0.2.2\` and \`js-sdk-v1.0.1\` to trigger publishes. \`sdk-v1.0.1\`, \`py-sdk-v1.0.0\`, \`php-sdk-v1.0.0\` still wait on \`PACKAGIST_USERNAME\` / \`PACKAGIST_TOKEN\` / \`PYPI_TOKEN\` secrets.

## Test plan

- [x] \`python3 -c 'import yaml; yaml.safe_load(...)'\` on updated workflow
- [x] \`composer install --no-dev --dry-run\` in \`packages/zelta-cli\` → resolves \`finaegis/payment-sdk (1.0.0)\`
- [x] \`npx tsc --noEmit\` in \`sdks/javascript\` → exit 0
- [ ] Merge → tag → workflows publish successfully
- [ ] \`npm view @finaegis/cli\` returns a real version

🤖 Generated with [Claude Code](https://claude.com/claude-code)