### PR TITLE
fix(cli-release): swap Box 2 installer for direct PHAR download

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -34,9 +34,9 @@ jobs:
 
       - name: Download Box
         run: |
-          curl -LSs https://box-project.github.io/box2/installer.php | php
-          mv box.phar /usr/local/bin/box
+          curl -fsSL https://github.com/box-project/box/releases/latest/download/box.phar -o /usr/local/bin/box
           chmod +x /usr/local/bin/box
+          box --version
 
       - name: Build PHAR
         working-directory: packages/zelta-cli


### PR DESCRIPTION
## Summary

\`cli-v0.2.2\` failed on \`Build PHAR\` with:
\`\`\`
[InvalidArgumentException]
Command "compile" is not defined.
\`\`\`

Root cause: the workflow pulled Box via \`https://box-project.github.io/box2/installer.php\` — the Box 2 installer from a decade ago. Whatever binary it actually installs today doesn't register a \`compile\` command.

## Fix

Download the Box PHAR directly from the official \`box-project/box\` releases (Box 4, canonical distribution, still exposes \`compile\`). Added a \`box --version\` sanity check so install problems surface immediately.

## After merge

Tag \`cli-v0.2.3\`. But **npm publish will still fail until \`NPM_TOKEN\` is regenerated as an Automation token** — current token is a classic one, and npm now returns 403 requiring 2FA bypass for publishes. PyPI is unaffected (\`finaegis 1.0.0\` already live ✅).

## Test plan

- [x] YAML lint
- [ ] Merge → tag \`cli-v0.2.3\` → PHAR builds successfully
- [ ] After NPM_TOKEN rotation → \`@finaegis/cli\` + \`@finaegis/sdk\` publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)