### PR TITLE
feat: split-mirror workflow for Packagist distribution

### DIFF
--- a/.github/workflows/monorepo-split.yml
+++ b/.github/workflows/monorepo-split.yml
@@ -1,0 +1,82 @@
+name: Split Monorepo Subdirs into Mirror Repos
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - 'sdk-v*'
+      - 'cli-v*'
+      - 'php-sdk-v*'
+
+permissions:
+  contents: read
+
+jobs:
+  split:
+    name: Split ${{ matrix.mirror }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - subdir: packages/zelta-sdk
+            mirror: payment-sdk
+            tag_prefix: sdk-v
+          - subdir: packages/zelta-cli
+            mirror: cli
+            tag_prefix: cli-v
+          - subdir: sdks/php
+            mirror: php-sdk
+            tag_prefix: php-sdk-v
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install splitsh/lite
+        run: |
+          curl -fsSL https://github.com/splitsh/lite/releases/download/v2.0.0/lite_linux_amd64.tar.gz | tar xz
+          sudo mv splitsh-lite /usr/local/bin/
+          splitsh-lite --version || true
+
+      - name: Split subdirectory
+        id: split
+        env:
+          SUBDIR: ${{ matrix.subdir }}
+          MIRROR: ${{ matrix.mirror }}
+        run: |
+          SHA=$(splitsh-lite --prefix="${SUBDIR}" --target="refs/heads/split-${MIRROR}")
+          if [ -z "$SHA" ]; then
+            echo "splitsh-lite produced no SHA — subdirectory may be empty or missing" >&2
+            exit 1
+          fi
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "Split produced SHA: $SHA"
+
+      - name: Push split main to mirror
+        env:
+          PAT: ${{ secrets.MIRROR_PAT }}
+          MIRROR: ${{ matrix.mirror }}
+          SPLIT_SHA: ${{ steps.split.outputs.sha }}
+        run: |
+          git push "https://x-access-token:${PAT}@github.com/FinAegis/${MIRROR}.git" \
+            "${SPLIT_SHA}:refs/heads/main" --force
+
+      - name: Push tag to mirror
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          PAT: ${{ secrets.MIRROR_PAT }}
+          MIRROR: ${{ matrix.mirror }}
+          TAG_PREFIX: ${{ matrix.tag_prefix }}
+          SPLIT_SHA: ${{ steps.split.outputs.sha }}
+        run: |
+          REF="${GITHUB_REF#refs/tags/}"
+          if [[ "$REF" == ${TAG_PREFIX}* ]]; then
+            MIRROR_TAG="v${REF#${TAG_PREFIX}}"
+            echo "Pushing tag ${MIRROR_TAG} to FinAegis/${MIRROR}"
+            git push "https://x-access-token:${PAT}@github.com/FinAegis/${MIRROR}.git" \
+              "${SPLIT_SHA}:refs/tags/${MIRROR_TAG}"
+          else
+            echo "Tag ${REF} does not match prefix ${TAG_PREFIX} — skipping tag push for this mirror"
+          fi

--- a/.github/workflows/sdk-php-release.yml
+++ b/.github/workflows/sdk-php-release.yml
@@ -26,9 +26,13 @@ jobs:
         run: composer install --no-dev
 
       - name: Notify Packagist
+        env:
+          PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
+          PACKAGIST_TOKEN: ${{ secrets.PACKAGIST_TOKEN }}
         run: |
-          curl -X POST "https://packagist.org/api/update-package?username=${{ secrets.PACKAGIST_USERNAME }}&apiToken=${{ secrets.PACKAGIST_TOKEN }}" \
-            -d '{"repository":{"url":"https://github.com/FinAegis/core-banking-prototype-laravel"}}'
+          curl -X POST "https://packagist.org/api/update-package?username=${PACKAGIST_USERNAME}&apiToken=${PACKAGIST_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d '{"repository":{"url":"https://github.com/FinAegis/php-sdk"}}'
 
       - name: Summary
         run: |

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -26,9 +26,13 @@ jobs:
         run: composer install --no-dev
 
       - name: Notify Packagist
+        env:
+          PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
+          PACKAGIST_TOKEN: ${{ secrets.PACKAGIST_TOKEN }}
         run: |
-          curl -X POST "https://packagist.org/api/update-package?username=${{ secrets.PACKAGIST_USERNAME }}&apiToken=${{ secrets.PACKAGIST_TOKEN }}" \
-            -d '{"repository":{"url":"https://github.com/FinAegis/core-banking-prototype-laravel"}}'
+          curl -X POST "https://packagist.org/api/update-package?username=${PACKAGIST_USERNAME}&apiToken=${PACKAGIST_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d '{"repository":{"url":"https://github.com/FinAegis/payment-sdk"}}'
 
       - name: Extract version
         id: version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,9 @@ Brand in UI stays "Zelta" — only distribution package identifiers use the `@fi
 | Packagist | `finaegis/php-sdk` | `php-sdk-v*` |
 | PyPI | `finaegis` | `py-sdk-v*` |
 
-Required repo secrets for release workflows: `NPM_TOKEN`, `PYPI_TOKEN`, `PACKAGIST_USERNAME`, `PACKAGIST_TOKEN`.
+Required repo secrets for release workflows: `NPM_TOKEN` (must be npm **Automation** token — classic tokens get 403 under 2FA), `PYPI_TOKEN`, `PACKAGIST_USERNAME`, `PACKAGIST_TOKEN`, `MIRROR_PAT` (fine-grained PAT with Contents:write on `FinAegis/payment-sdk`, `FinAegis/cli`, `FinAegis/php-sdk`).
+
+Packagist sources the three PHP packages from **split-mirror repos**, not the monorepo — Packagist only reads root `composer.json`. The `monorepo-split.yml` workflow auto-pushes `packages/zelta-sdk/`, `packages/zelta-cli/`, `sdks/php/` into their respective mirrors on every `main` push and release tag (via `splitsh/lite`). Mirror tags use a stripped prefix: `sdk-v1.0.1` → mirror tag `v1.0.1`.
 
 ## Notes
 

--- a/sdks/javascript/package.json
+++ b/sdks/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finaegis/sdk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Official FinAegis JavaScript/TypeScript SDK for interacting with the FinAegis API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Follow-up to the Packagist naming confusion: **Packagist only reads root \`composer.json\`**, so it can't register packages from monorepo subdirectories. Your existing submission ate the root name (\`finaegis/core-banking-prototype-laravel\`) because Packagist saw only the root manifest.

This PR implements the **Symfony/Laravel split-mirror pattern**: each subdirectory is auto-pushed into a dedicated read-only mirror repo, which is what Packagist actually registers against.

## What gets mirrored

| Monorepo subdir | Mirror repo | Packagist name |
|---|---|---|
| \`packages/zelta-sdk/\` | \`FinAegis/payment-sdk\` | \`finaegis/payment-sdk\` |
| \`packages/zelta-cli/\` | \`FinAegis/cli\` | \`finaegis/cli\` |
| \`sdks/php/\` | \`FinAegis/php-sdk\` | \`finaegis/php-sdk\` |

All three mirror repos already created (empty).

## How it works

\`.github/workflows/monorepo-split.yml\` runs on every push to \`main\` and on \`sdk-v*\` / \`cli-v*\` / \`php-sdk-v*\` tags. It uses **splitsh/lite** (the tool Symfony uses) to extract each subdirectory's history and force-push it to its mirror.

Tag prefixes are stripped on the mirror side:
- \`sdk-v1.0.1\` → \`FinAegis/payment-sdk\` tag \`v1.0.1\`
- \`cli-v0.2.3\` → \`FinAegis/cli\` tag \`v0.2.3\`
- \`php-sdk-v1.0.0\` → \`FinAegis/php-sdk\` tag \`v1.0.0\`

Also repoints the existing \`sdk-release.yml\` + \`sdk-php-release.yml\` Packagist notify calls at the mirror URLs (they were pointed at the monorepo, which Packagist wouldn't recognize). Moved credentials into \`env:\` blocks per workflow-injection guidance.

## Required secret

**New:** \`MIRROR_PAT\` — fine-grained PAT with \`Contents: Write\` on the three mirror repos (or classic PAT with \`repo\` scope).

## Post-merge flow

1. Merge → split workflow fires on the merge commit → mirrors populate for the first time
2. User submits each mirror to https://packagist.org/packages/submit (one-time per mirror)
3. Tag \`sdk-v1.0.1\`, \`cli-v0.2.3\`, \`php-sdk-v1.0.0\` → Packagist picks up via GitHub integration + fallback API notify

## Test plan

- [x] YAML validates for all 3 modified workflows
- [ ] Merge → monorepo-split workflow runs green for all 3 matrix entries
- [ ] Mirror repos contain expected files (no monorepo root clutter)
- [ ] Packagist accepts submissions for each mirror

🤖 Generated with [Claude Code](https://claude.com/claude-code)