### PR TITLE
fix(cli): include vendor/ in PHAR build

### DIFF
--- a/packages/zelta-cli/box.json
+++ b/packages/zelta-cli/box.json
@@ -3,7 +3,8 @@
     "output": "builds/zelta.phar",
     "directories": [
         "app",
-        "config"
+        "config",
+        "vendor"
     ],
     "files": [
         "zelta"


### PR DESCRIPTION
## Summary

\`cli-v0.2.3\` failed at the PHAR verification step with:
\`\`\`
Class "Symfony\Component\Console\Application" not found
\`\`\`

Root cause: \`box.json\` listed only \`app/\` and \`config/\` under \`directories\`, so the composer \`vendor/\` tree was never bundled into the PHAR. The Box 2→4 fix in #937 unblocked the build, exposing this older packaging bug.

## Fix

Add \`vendor\` to \`box.json\`'s \`directories\` array.

## Verified locally

\`\`\`
composer install --no-dev --optimize-autoloader
php /tmp/box.phar compile    # 449 files, 498.74KB
php builds/zelta.phar list   # prints command list, no class errors
\`\`\`

## After merge

Tag \`cli-v0.2.4\` to retry the publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)