### PR TITLE
fix(monorepo-split): pin splitsh/lite to v1.0.1

### DIFF
--- a/.github/workflows/monorepo-split.yml
+++ b/.github/workflows/monorepo-split.yml
@@ -36,7 +36,9 @@ jobs:
 
       - name: Install splitsh/lite
         run: |
-          curl -fsSL https://github.com/splitsh/lite/releases/download/v2.0.0/lite_linux_amd64.tar.gz | tar xz
+          # splitsh/lite v2.0.0 ships no pre-built binaries; v1.0.1 is the last
+          # tag with Linux amd64 artifacts and is what Symfony/Laravel still use.
+          curl -fsSL https://github.com/splitsh/lite/releases/download/v1.0.1/lite_linux_amd64.tar.gz | tar xz
           sudo mv splitsh-lite /usr/local/bin/
           splitsh-lite --version || true
 


### PR DESCRIPTION
## Summary

When #938 merged, the new \`monorepo-split.yml\` fired and all three matrix jobs failed in 11 seconds:
\`\`\`
curl: (22) The requested URL returned error: 404
\`\`\`

Root cause: \`splitsh/lite v2.0.0\` was released with **zero binary assets** — they shipped no \`lite_linux_amd64.tar.gz\`. v1.0.1 is the last release with prebuilt binaries and is what Symfony/Laravel still pin to.

## Fix

Change the download URL from \`v2.0.0\` to \`v1.0.1\`. Splitsh output format hasn't changed.

## After merge

The workflow re-fires on the merge commit (main branch push). If \`MIRROR_PAT\` is set, mirrors get populated. If not, it fails at push step with a clear auth error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)