### PR TITLE
chore(payment-sdk): drop hardcoded composer version

### DIFF
--- a/packages/zelta-sdk/composer.json
+++ b/packages/zelta-sdk/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "finaegis/payment-sdk",
     "description": "Zelta Payment SDK — transparent x402 and MPP payment handling for PHP",
-    "version": "1.0.0",
     "type": "library",
     "license": "Apache-2.0",
     "homepage": "https://zelta.app",


### PR DESCRIPTION
Packagist reads the version from the mirror git tag (e.g. `v1.0.1` from the `sdk-v1.0.1` monorepo tag after splitsh transform). Keeping a hardcoded `version` in composer.json risks mismatch; removing it.