### PR TITLE
fix(cli): allow dev stability for path-repo payment-sdk resolution

### DIFF
--- a/packages/zelta-cli/composer.json
+++ b/packages/zelta-cli/composer.json
@@ -25,5 +25,6 @@
         }
     },
     "bin": ["zelta"],
-    "minimum-stability": "stable"
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
Follow-up to #942. Dropping the hardcoded version field from payment-sdk unblocked Packagist but broke CLI's path-repo resolution (dev-SHA not stable). Allowing minimum-stability dev with prefer-stable true fixes the build and still prefers Packagist tagged versions when available.