### PR TITLE
release: v7.10.9 — website + docs sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the FinAegis Core Banking Platform will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.10.9] - 2026-04-19
+
+### Changed
+- **Website + docs sync for v7.10.8** — Version badges, developer-portal "Released" banner, FAQ, changelog page, VERSION_ROADMAP, and per-feature docs now reference v7.10.8 and the newly public registry install commands
+
+### Notes
+- Pure documentation release — no runtime, API, or dependency changes
+
+---
+
 ## [7.10.8] - 2026-04-19
 
 **Public SDK distribution.** Every SDK and the CLI now install from public registries. Prior `@zelta/*` references were aspirational — the npm `@zelta` scope was owned by a third party, so nothing actually shipped. This release rebuilds distribution under the `@finaegis` scope we control and wires up the Symfony/Laravel-style split-mirror pattern so Packagist can read the three PHP packages out of the monorepo.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FinAegis Core Banking Platform
 
 [![CI Pipeline](https://github.com/finaegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml/badge.svg)](https://github.com/finaegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml)
-[![Version](https://img.shields.io/badge/version-7.10.8-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-7.10.9-blue.svg)](CHANGELOG.md)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![PHP Version](https://img.shields.io/badge/php-%3E%3D8.4-8892BF.svg)](https://php.net/)
 [![Laravel Version](https://img.shields.io/badge/Laravel-12.x-FF2D20.svg)](https://laravel.com/)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FinAegis Core Banking Platform
 
 [![CI Pipeline](https://github.com/finaegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml/badge.svg)](https://github.com/finaegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml)
-[![Version](https://img.shields.io/badge/version-7.10.7-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-7.10.8-blue.svg)](CHANGELOG.md)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![PHP Version](https://img.shields.io/badge/php-%3E%3D8.4-8892BF.svg)](https://php.net/)
 [![Laravel Version](https://img.shields.io/badge/Laravel-12.x-FF2D20.svg)](https://laravel.com/)

--- a/docs/VERSION_ROADMAP.md
+++ b/docs/VERSION_ROADMAP.md
@@ -3187,6 +3187,21 @@ Findings #1-2 fixed in v7.1.1, findings #3-15 fixed in this release:
 
 ---
 
+## Version 7.10.8 — Public SDK Distribution (RELEASED)
+
+**Release Date**: April 19, 2026
+**Theme**: Every SDK and the CLI now install from public registries for the first time
+
+### Delivered Features
+- Public registry install commands (first real releases): `npm install -g @finaegis/cli`, `npm install @finaegis/sdk`, `pip install finaegis`, `composer require finaegis/payment-sdk`, `composer require finaegis/php-sdk`
+- npm scope migration `@zelta/*` → `@finaegis/*` (the `@zelta` scope was owned by a third party on npm, so prior references were aspirational). Brand name "Zelta" unchanged in UI; PSR-4 namespaces (`Zelta\\`, `FinAegis\\`) and CLI binary name (`zelta`) unchanged
+- Packagist vendor migration `zelta/*` → `finaegis/*` for the two PHP packages
+- New `.github/workflows/monorepo-split.yml` using splitsh/lite to auto-mirror `packages/zelta-{sdk,cli}/` and `sdks/php/` into dedicated Packagist-readable repos (`github.com/FinAegis/{payment-sdk,cli,php-sdk}`) on every main push and release tag
+- CLI release workflow hardened: Box 2 installer replaced with direct PHAR download from box-project/box (#937), PHAR now bundles `vendor/` so Symfony Console is present at runtime (#939), npm version field is valid semver (#936), PHAR artifact now plumbed correctly between `build-phar` and `publish-npm` so the npm tarball actually contains the binary (#936), splitsh/lite pinned to v1.0.1 (#940), cross-repo PAT push fixed (#941)
+- Zero breaking API changes — library method signatures, return types, and public interfaces unchanged
+
+---
+
 ## Version 7.10.7 — Safe-Major Composer Trio (RELEASED)
 
 **Release Date**: April 15, 2026
@@ -3221,5 +3236,5 @@ Embeddable JS widget that renders Zelta's 402 payment flow inside the partner's 
 
 ---
 
-*Document Version: 7.10.7*
-*Updated: April 18, 2026 (added Future / Unscheduled section with MPP partner models)*
+*Document Version: 7.10.8*
+*Updated: April 19, 2026 (v7.10.8 public SDK distribution release)*

--- a/resources/views/changelog.blade.php
+++ b/resources/views/changelog.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'Changelog | ' . config('brand.name', 'Zelta'),
-        'description' => 'Release history for the Zelta core banking platform. Track every feature shipped, bug fixed, and improvement made — v7.0 through v7.10.7.',
+        'description' => 'Release history for the Zelta core banking platform. Track every feature shipped, bug fixed, and improvement made — v7.0 through v7.10.8.',
         'keywords' => 'changelog, release notes, updates, ' . config('brand.name', 'Zelta') . ', version history, core banking',
     ])
 
@@ -43,6 +43,22 @@
 
             @php
                 $releases = [
+                    [
+                        'version' => 'v7.10.8',
+                        'date' => 'April 19, 2026',
+                        'label' => 'Public SDK Distribution',
+                        'label_color' => 'emerald',
+                        'badge_color' => 'bg-emerald-100 text-emerald-700 border-emerald-200',
+                        'dot_color' => 'bg-emerald-500',
+                        'items' => [
+                            'Public registry packages — every SDK and the CLI now install from public registries for the first time: <code>npm install -g @finaegis/cli</code>, <code>npm install @finaegis/sdk</code>, <code>pip install finaegis</code>, <code>composer require finaegis/payment-sdk</code>, and <code>composer require finaegis/php-sdk</code>. Prior <code>@zelta/*</code> references were aspirational — the npm <code>@zelta</code> scope was owned by a third party, so nothing actually shipped.',
+                            'npm scope migration — <code>@zelta/cli</code> → <code>@finaegis/cli</code> and <code>@zelta/sdk</code> → <code>@finaegis/sdk</code>. The user-facing brand name "Zelta" is unchanged in the UI, PSR-4 namespaces (<code>Zelta\\</code>, <code>FinAegis\\</code>) are unchanged, and the CLI binary name <code>zelta</code> is unchanged — this is purely a distribution identifier change.',
+                            'Packagist vendor migration — <code>zelta/payment-sdk</code> → <code>finaegis/payment-sdk</code>, <code>zelta/cli</code> → <code>finaegis/cli</code>. Developer portal and partner docs now show the real public install commands instead of monorepo path-repository dependencies.',
+                            'Monorepo split-mirror workflow — new <code>.github/workflows/monorepo-split.yml</code> uses splitsh/lite to auto-mirror <code>packages/zelta-{sdk,cli}/</code> and <code>sdks/php/</code> into dedicated Packagist-readable repos (<code>github.com/FinAegis/{payment-sdk,cli,php-sdk}</code>) on every main push and release tag. Packagist only reads root composer.json, so the three PHP packages need their own repos to be installable.',
+                            'CLI release pipeline fixes — replaced the decade-old Box 2 installer with a direct PHAR download from box-project/box (#937); PHAR now bundles <code>vendor/</code> so Symfony Console is actually present at runtime (#939); npm <code>version</code> field is now valid semver instead of the raw tag name (#936); PHAR artifact is uploaded in <code>build-phar</code> and downloaded in <code>publish-npm</code> so the published tarball actually contains the binary (#936); splitsh/lite pinned to v1.0.1 (#940) and checkout credential helper bypassed so the cross-repo PAT push works (#941).',
+                            'Zero breaking API changes — no library method signatures, return types, or public interfaces changed. PSR-4 namespaces, the CLI binary, and all documented APIs are byte-compatible with v7.10.7.',
+                        ],
+                    ],
                     [
                         'version' => 'v7.10.7',
                         'date' => 'April 15, 2026',

--- a/resources/views/developers/index.blade.php
+++ b/resources/views/developers/index.blade.php
@@ -137,7 +137,7 @@
                 <div class="text-center">
                     <div class="inline-flex items-center px-4 py-2 bg-white/10 backdrop-blur-sm rounded-full text-sm mb-6">
                         <span class="w-2 h-2 bg-green-400 rounded-full mr-2 animate-pulse"></span>
-                        <span>v7.10.7 Documentation — 56 Domains, 1,400+ Routes, GraphQL + REST + x402</span>
+                        <span>v7.10.8 Documentation — 56 Domains, 1,400+ Routes, GraphQL + REST + x402</span>
                     </div>
                     <h1 class="text-5xl md:text-7xl font-bold mb-6 bg-clip-text text-transparent bg-gradient-to-r from-white to-blue-200">
                         Build with 1,400+ API Routes
@@ -177,8 +177,8 @@
                     <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                     </svg>
-                    <span class="font-medium">v7.10.7 Released:</span>
-                    <span class="ml-2">VertexSMS multi-rail payments, durable workflows, SMS API documentation, Solana wallet integration, Alchemy webhook support. 56 DDD domains, 1,400+ API routes, GraphQL (45 domains), ISO 20022, ISO 8583, x402 Protocol.</span>
+                    <span class="font-medium">v7.10.8 Released:</span>
+                    <span class="ml-2">Public SDK distribution — CLI, JS/TS, Python, and PHP SDKs now install from npm, PyPI, and Packagist in one command. 56 DDD domains, 1,400+ API routes, GraphQL (45 domains), ISO 20022, ISO 8583, x402 Protocol.</span>
                 </div>
             </div>
         </section>
@@ -284,7 +284,7 @@
                                 <div id="code-step3">
                                     <div><span class="text-gray-500"># Verify the API is running (no auth needed)</span></div>
                                     <div><span class="text-gray-500">$</span> <span class="text-green-400">curl</span> <span class="text-yellow-400">http://localhost:8000/api/health</span></div>
-                                    <div><span class="text-gray-500"># {"status":"ok","version":"7.10.7"}</span></div>
+                                    <div><span class="text-gray-500"># {"status":"ok","version":"7.10.8"}</span></div>
                                     <div class="mt-2"><span class="text-gray-500"># Make an authenticated request</span></div>
                                     <div><span class="text-gray-500">$</span> <span class="text-green-400">curl</span> <span class="text-blue-400">-H</span> <span class="text-yellow-400">"Authorization: Bearer YOUR_API_KEY"</span> <span class="text-gray-400">\</span></div>
                                     <div>  <span class="text-yellow-400">http://localhost:8000/api/v2/accounts</span></div>

--- a/resources/views/features/agent-protocol.blade.php
+++ b/resources/views/features/agent-protocol.blade.php
@@ -38,7 +38,7 @@
                 ]])
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-cyan-400 rounded-full mr-2"></span>
-                    v7.10.7 &middot; Autonomous Agent Commerce
+                    v7.10.8 &middot; Autonomous Agent Commerce
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">
                     Agent Protocol

--- a/resources/views/features/ai-framework.blade.php
+++ b/resources/views/features/ai-framework.blade.php
@@ -38,7 +38,7 @@
                 ]])
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.10.7 &middot; Multi-Agent Intelligence
+                    v7.10.8 &middot; Multi-Agent Intelligence
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">
                     AI Framework

--- a/resources/views/features/machine-payments.blade.php
+++ b/resources/views/features/machine-payments.blade.php
@@ -34,7 +34,7 @@
                 </div>
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.10.7 &middot; Multi-Rail Payments
+                    v7.10.8 &middot; Multi-Rail Payments
                 </div>
                 <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
                     Machine Payments Protocol

--- a/resources/views/features/x402-protocol.blade.php
+++ b/resources/views/features/x402-protocol.blade.php
@@ -36,7 +36,7 @@
                 </div>
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.10.7 &middot; Production Ready
+                    v7.10.8 &middot; Production Ready
                 </div>
                 <h1 class="font-display text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">x402 Protocol</h1>
                 <p class="text-lg text-slate-400 max-w-3xl mx-auto mb-8">

--- a/resources/views/support/faq.blade.php
+++ b/resources/views/support/faq.blade.php
@@ -13,7 +13,7 @@
     $faqData = [
         [
             'question' => 'What is the current status of ' . config('brand.name', 'Zelta') . '?',
-            'answer' => config('brand.name', 'Zelta') . ' v7.10.7 is a fully-featured open-source core banking platform with 56 domain modules. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
+            'answer' => config('brand.name', 'Zelta') . ' v7.10.8 is a fully-featured open-source core banking platform with 56 domain modules. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
         ],
         [
             'question' => 'Can I use real money on the platform?',
@@ -127,7 +127,7 @@
                     </button>
                     <div class="faq-answer px-6 py-4 bg-white rounded-b-lg">
                         <p class="text-slate-500">
-                            {{ config('brand.name', 'Zelta') }} is a fully-featured open-source core banking platform at v7.10.7. The sandbox environment lets you:
+                            {{ config('brand.name', 'Zelta') }} is a fully-featured open-source core banking platform at v7.10.8. The sandbox environment lets you:
                         </p>
                         <ul class="list-disc list-inside mt-2 text-slate-500 space-y-1">
                             <li>Explore 56 domain modules including DeFi, cross-chain, privacy, and rewards</li>


### PR DESCRIPTION
Pure documentation release, no runtime or API changes. Updates all public-facing version references to reflect the v7.10.8 public SDK distribution milestone.