### PR TITLE
fix: point package docs to finaegis.org, add Developers footer link

### DIFF
--- a/config/brand.php
+++ b/config/brand.php
@@ -31,6 +31,8 @@ return [
 
     'github_url' => env('BRAND_GITHUB_URL', 'https://github.com/FinAegis/core-banking-prototype-laravel'),
 
+    'docs_url' => env('BRAND_DOCS_URL', 'https://finaegis.org/developers'),
+
     'ga_id' => env('GOOGLE_ANALYTICS_ID', 'G-X65KH9NFMY'),
 
     'google_site_verification' => env('GOOGLE_SITE_VERIFICATION', ''),

--- a/packages/zelta-cli/README.md
+++ b/packages/zelta-cli/README.md
@@ -48,9 +48,9 @@ zelta pay:stats --json --period day | jq -e '.failed == 0'
 
 ## Documentation
 
-- [Zelta CLI Feature Page](https://zelta.app/features/zelta-cli)
-- [Developer Docs](https://zelta.app/developers)
-- [x402 Protocol](https://zelta.app/features/x402-protocol)
+- [Zelta CLI Feature Page](https://finaegis.org/features/zelta-cli)
+- [Developer Docs](https://finaegis.org/developers)
+- [x402 Protocol](https://finaegis.org/features/x402-protocol)
 
 ## License
 

--- a/packages/zelta-cli/composer.json
+++ b/packages/zelta-cli/composer.json
@@ -4,8 +4,9 @@
     "type": "project",
     "license": "Apache-2.0",
     "keywords": ["cli", "payments", "x402", "mpp", "fintech"],
-    "homepage": "https://zelta.app",
+    "homepage": "https://finaegis.org",
     "support": {
+        "docs": "https://finaegis.org/developers",
         "issues": "https://github.com/FinAegis/core-banking-prototype-laravel/issues",
         "source": "https://github.com/FinAegis/cli"
     },

--- a/packages/zelta-sdk/README.md
+++ b/packages/zelta-sdk/README.md
@@ -38,7 +38,7 @@ echo $result->paid;       // true
 
 ## Documentation
 
-Full documentation is available at [zelta.app/developers](https://zelta.app/developers).
+Full documentation is available at [finaegis.org/developers](https://finaegis.org/developers).
 
 ## License
 

--- a/packages/zelta-sdk/composer.json
+++ b/packages/zelta-sdk/composer.json
@@ -3,16 +3,17 @@
     "description": "Zelta Payment SDK — transparent x402 and MPP payment handling for PHP",
     "type": "library",
     "license": "Apache-2.0",
-    "homepage": "https://zelta.app",
+    "homepage": "https://finaegis.org",
     "authors": [
         {
             "name": "FinAegis Contributors",
-            "email": "dev@zelta.app"
+            "email": "sdk@finaegis.org"
         }
     ],
     "support": {
-        "docs": "https://zelta.app/developers",
-        "issues": "https://github.com/FinAegis/core-banking-prototype-laravel/issues"
+        "docs": "https://finaegis.org/developers",
+        "issues": "https://github.com/FinAegis/core-banking-prototype-laravel/issues",
+        "source": "https://github.com/FinAegis/payment-sdk"
     },
     "require": {
         "php": "^8.4",

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -813,6 +813,7 @@
             <p class="text-sm opacity-40">&copy; {{ date('Y') }} {{ $brand }}. All rights reserved.</p>
             <div class="flex gap-6">
                 <a href="mailto:{{ config('brand.support_email', 'info@zelta.app') }}" class="text-sm opacity-40 hover:opacity-100 transition-opacity">Contact</a>
+                <a href="{{ config('brand.docs_url') }}" class="text-sm opacity-40 hover:opacity-100 transition-opacity" rel="noopener">Developers</a>
                 <a href="{{ route('legal.privacy') }}" class="text-sm opacity-40 hover:opacity-100 transition-opacity">Privacy</a>
                 <a href="{{ route('legal.terms') }}" class="text-sm opacity-40 hover:opacity-100 transition-opacity">Terms</a>
             </div>

--- a/sdks/javascript/package.json
+++ b/sdks/javascript/package.json
@@ -27,7 +27,7 @@
     "url": "git+https://github.com/FinAegis/core-banking-prototype-laravel.git",
     "directory": "sdks/javascript"
   },
-  "homepage": "https://zelta.app/developers",
+  "homepage": "https://finaegis.org/developers",
   "bugs": {
     "url": "https://github.com/FinAegis/core-banking-prototype-laravel/issues"
   },

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -11,7 +11,7 @@ setup(
     description="Official Python SDK for the FinAegis API",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/FinAegis/finaegis-python",
+    url="https://finaegis.org/developers",
     packages=find_packages(),
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -46,8 +46,9 @@ setup(
         ]
     },
     project_urls={
-        "Bug Reports": "https://github.com/FinAegis/finaegis-python/issues",
-        "Source": "https://github.com/FinAegis/finaegis-python",
-        "Documentation": "https://docs.finaegis.org/sdks/python",
+        "Homepage": "https://finaegis.org",
+        "Documentation": "https://finaegis.org/developers",
+        "Source": "https://github.com/FinAegis/core-banking-prototype-laravel/tree/main/sdks/python",
+        "Bug Reports": "https://github.com/FinAegis/core-banking-prototype-laravel/issues",
     },
 )


### PR DESCRIPTION
## Summary

- Published packages (`@finaegis/cli`, `@finaegis/sdk`, `finaegis/payment-sdk`, `finaegis/cli`, `finaegis/php-sdk`, `finaegis`) referenced `zelta.app/developers` in READMEs + composer/npm metadata, but that path redirects home in production (`SHOW_PROMO_PAGES=false`). Developer docs live on `finaegis.org` (promo pages always on) — switch package-consumer-facing URLs there.
- Added one unobtrusive `Developers` link in the Zelta.app landing footer → `finaegis.org/developers` (new `brand.docs_url` config key, overridable).
- Also fixes `sdks/python/setup.py` pointing at nonexistent `github.com/FinAegis/finaegis-python` repo.

## Why not ungate /developers on zelta.app instead?

Keeps `zelta.app` the clean consumer product surface (Stripe/Wise/Revolut pattern). Package ecosystem (`@finaegis`, `finaegis/*`, `finaegis`) already lives under the FinAegis brand — point docs there for naming coherence.

## Test plan

- [x] `php -r json_decode` — all 3 JSON configs parse
- [x] `python3 ast.parse setup.py` — valid syntax
- [x] `config('brand.docs_url')` resolves to `https://finaegis.org/developers`
- [x] php-cs-fixer clean
- [ ] CI green before merge

## Release plan

After merge:
- Bump patch versions on packages that changed (sdk, cli, php-sdk, js-sdk, py-sdk)
- Re-tag mirrors so Packagist / npm / PyPI pick up new metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)