### PR TITLE
chore: bump SDK versions + fix PHP SDK homepage

### DIFF
--- a/sdks/javascript/package-lock.json
+++ b/sdks/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@finaegis/sdk",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@finaegis/sdk",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",

--- a/sdks/javascript/package.json
+++ b/sdks/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finaegis/sdk",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Official FinAegis JavaScript/TypeScript SDK for the FinAegis API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sdks/php/composer.json
+++ b/sdks/php/composer.json
@@ -3,7 +3,7 @@
     "description": "Official PHP SDK for the FinAegis API",
     "type": "library",
     "keywords": ["finaegis", "api", "sdk", "banking", "finance", "gcu"],
-    "homepage": "https://github.com/FinAegis/finaegis-php",
+    "homepage": "https://finaegis.org",
     "license": "MIT",
     "authors": [
         {
@@ -11,6 +11,11 @@
             "email": "sdk@finaegis.org"
         }
     ],
+    "support": {
+        "docs": "https://finaegis.org/developers",
+        "issues": "https://github.com/FinAegis/core-banking-prototype-laravel/issues",
+        "source": "https://github.com/FinAegis/php-sdk"
+    },
     "require": {
         "php": "^8.0",
         "guzzlehttp/guzzle": "^7.5",

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="finaegis",
-    version="1.0.0",
+    version="1.0.1",
     author="FinAegis",
     author_email="sdk@finaegis.org",
     description="Official Python SDK for the FinAegis API",


### PR DESCRIPTION
## Summary

- Bumps JS SDK 1.0.3 → 1.0.4, Python SDK 1.0.0 → 1.0.1 so registries get new metadata from #956.
- Fixes `sdks/php/composer.json` homepage pointing at nonexistent `github.com/FinAegis/finaegis-php` repo (parallels the Python setup.py fix in #956).
- Adds `support.docs/issues/source` to PHP SDK composer manifest.
- `sdks/javascript/package-lock.json` regenerated.

## Release plan after merge

```
sdk-v1.0.2     # payment-sdk (current latest v1.0.1)
cli-v0.2.8
js-sdk-v1.0.4
py-sdk-v1.0.1
php-sdk-v1.0.1
```

## Test plan

- [x] JSON/Python syntax validated
- [x] `npm install --package-lock-only` succeeds
- [ ] CI green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)