### PR TITLE
fix(cli-release): npm package homepage → finaegis.org

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -134,7 +134,7 @@ jobs:
               "url": "https://github.com/FinAegis/core-banking-prototype-laravel.git",
               "directory": "packages/zelta-cli"
             },
-            "homepage": "https://zelta.app/features/zelta-cli",
+            "homepage": "https://finaegis.org/features/zelta-cli",
             "bugs": {
               "url": "https://github.com/FinAegis/core-banking-prototype-laravel/issues"
             },


### PR DESCRIPTION
## Summary

`@finaegis/cli@0.2.8` shipped with homepage `https://zelta.app/features/zelta-cli` which redirects home on production (`SHOW_PROMO_PAGES=false`). #956 + #957 updated composer metadata and the app landing footer to finaegis.org but missed this one spot: the npm \`package.json\` is generated via heredoc inside cli-release.yml, so the composer.json homepage never reaches npm.

Fixes the generator so the next \`cli-v*\` tag publishes with the correct homepage.

## Verify

\`\`\`
npm view @finaegis/cli@0.2.8 homepage   # current (broken): zelta.app/...
# After merge + tag cli-v0.2.9:
npm view @finaegis/cli@0.2.9 homepage   # expect: finaegis.org/features/zelta-cli
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)