### PR TITLE
feat: reviewer/demo account provisioning (account_flags + CLI)

### DIFF
--- a/.serena/memories/account_provisioning_domain.md
+++ b/.serena/memories/account_provisioning_domain.md
@@ -1,0 +1,55 @@
+# AccountProvisioning Domain (v7.10.11)
+
+New domain at `app/Domain/AccountProvisioning/` for scoped reviewer / demo account bypasses (app-store review, partner demos, internal QA personas). Paired docs: `docs/operations/reviewer-accounts.md` and `docs/security/account-flags.md`.
+
+## Domain structure (layer by layer)
+
+- **Models**: `AccountFlag` — 1:1 with `users`, table `account_flags`.
+- **Contracts**: `AccountProfile` interface — one `apply(ProvisioningContext)` method.
+- **ValueObjects**: `ProvisioningContext` (user, operator, expires_at, note, profile name).
+- **Services**: `AccountProvisioningService` (orchestrator: `apply()` / `disable()` / `reEnable()`), `AccountFlagsService` (per-request memoized flag reads + `isActive()` short-circuit on `disabled_at`).
+- **Profiles**: one concrete `ReviewerAccountProfile` composing five sub-seeders.
+- **Seeders**: `WalletSeeder` (EVM Polygon sha256-derived placeholder + Solana via `SolanaAddressHelper::deriveForUser`), `BalanceSeeder` ($25 USDC unshielded + $10 USDC shielded on Polygon via direct bcmath upsert, bypasses ledger/RAILGUN), `CardSeeder` (one active virtual card, `issuer='review_bypass'`), `TrustCertSeeder` (one active cert, `credential_type='review_bypass'`), `RewardsSeeder` (XP=250, completed 'welcome' quest).
+- **Support**: `SuppressNotificationsListener` for the `NotificationSending` event.
+- **Events**: `AccountPurged` domain event.
+
+## Flag model — `account_flags` columns
+
+Master tag: `is_review_account`.
+Bypasses: `bypass_device_attestation`, `bypass_rate_limit`, `bypass_sanctions_screening`, `bypass_sms_otp` (**reserved, no consumer**), `suppress_notifications`.
+KYC: `kyc_override_level` (tinyint 0–3, null = use real KYC).
+Audit / lifecycle: `note`, `expires_at`, `created_by` (FK users.id), `disabled_at`.
+
+`AccountFlagsService::isActive()` checks `disabled_at IS NULL` **first** — a single column update kills every bypass.
+
+## Enforcement points (five sites + one reserved)
+
+1. `BiometricJWTService::verifyDeviceAttestationForUser()` — Apple App Attest / Google Play Integrity bypass.
+2. `ApiRateLimitMiddleware` + `GraphQLRateLimitMiddleware` — per-user rate limit bypass.
+3. `PerformAmlScreeningActivity::execute()` — sanctions screening bypass (requires `$userId` threaded through workflow DTO — follow-up).
+4. `SuppressNotificationsListener` on `NotificationSending` — outbound email / SMS / push suppression.
+5. `User::effectiveKycLevel()` — override-or-real accessor.
+
+Reserved: `bypass_sms_otp` — codebase has no dedicated SMS OTP flow; phone verification runs via Ondato KYC, already covered by `kyc_override_level`.
+
+## Safety gates
+
+- Operator must hold `admin` Spatie role (command rejects otherwise).
+- Production guard: `--allow-production` required when `APP_ENV=production`.
+- Expiry hard cap: 90 days (default 60). Command rejects `--expires-in-days > 90`.
+- Email collision: command refuses if an existing user with that email is not already a reviewer account.
+- `review_bypass` sentinel strings in `cards.issuer`, `trust_certificates.credential_type`, and `metadata.source` for auditability.
+- `bypass.fired` structured log on every bypass hit: `{user_id, bypass, reason: 'review_account', request_id, ts}`.
+
+## CLI inventory
+
+- `account:provision-reviewer --email= --operator-email= [--name=] [--expires-in-days=60] [--note=] [--allow-production]` — JSON-on-success output includes the generated password (one-shot).
+- `account:list-reviewers [--json]` — table or machine-readable.
+- `account:disable-reviewer --email=X | --all-expired [--re-enable]` — sets / clears `disabled_at`; preserves individual flag columns and `is_review_account` for audit.
+- `account:purge-reviewer --email=X --confirm` — anonymizes email to `purged+<uuid>@finaegis.invalid`, sets `disabled_at`, dispatches `AccountPurged`. User row is **not** dropped (no SoftDeletes on User model).
+
+Daily schedule (in `routes/console.php`): `account:disable-reviewer --all-expired` at 00:10 UTC, logs to `storage/logs/account-expiry-sweep.log`.
+
+## What is out of scope in v1
+
+Filament admin UI, multi-tenant provisioning, automated 1Password credential delivery, `bypass_sms_otp` enforcement site.

--- a/.serena/memories/account_provisioning_domain.md
+++ b/.serena/memories/account_provisioning_domain.md
@@ -26,7 +26,7 @@ Audit / lifecycle: `note`, `expires_at`, `created_by` (FK users.id), `disabled_a
 
 1. `BiometricJWTService::verifyDeviceAttestationForUser()` — Apple App Attest / Google Play Integrity bypass.
 2. `ApiRateLimitMiddleware` + `GraphQLRateLimitMiddleware` — per-user rate limit bypass.
-3. `PerformAmlScreeningActivity::execute()` — sanctions screening bypass (requires `$userId` threaded through workflow DTO — follow-up).
+3. `PerformAmlScreeningActivity::execute()` — sanctions screening bypass (`$userId` is plumbed through `KycVerificationRequest` DTO and `AgentKycWorkflow` activity dispatch).
 4. `SuppressNotificationsListener` on `NotificationSending` — outbound email / SMS / push suppression.
 5. `User::effectiveKycLevel()` — override-or-real accessor.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,13 +23,19 @@ php artisan user:create --admin      # Create user (--admin for admin role)
 php artisan user:promote user@email  # Promote existing user to admin
 php artisan user:demote user@email   # Remove admin role
 php artisan user:admins              # List all admin users
+
+# Reviewer / demo accounts (operator-only; requires admin role)
+php artisan account:provision-reviewer --email=appreview@... --operator-email=admin@...
+php artisan account:list-reviewers
+php artisan account:disable-reviewer --email=X          # or --all-expired
+php artisan account:purge-reviewer --email=X --confirm  # anonymizes email + disables
 ```
 
 ## Architecture
 
 - **Web3 Integration**: `app/Infrastructure/Web3/` (EthRpcClient, AbiEncoder) — also legacy `app/Domain/Relayer/Services/EthRpcClient.php`
 - **ZK Circuits**: `storage/app/circuits/` (Circom sources + Solidity verifiers)
-- **56 domains** in `app/Domain/` (DDD bounded contexts)
+- **57 domains** in `app/Domain/` (DDD bounded contexts)
 - **Payment Protocols**: x402 (Coinbase), MPP (Stripe/Tempo), AP2 (Google)
 - **Packages**: `packages/zelta-sdk/` (Payment SDK), `packages/zelta-cli/` (CLI binary)
 - **Event Sourcing**: Spatie v7.7+ with domain-specific tables
@@ -79,6 +85,7 @@ namespace App\Domain\Exchange\Services;
 | Solana addresses | Case-sensitive — never `strtolower()` (unlike EVM which lowercases) |
 | Helius API key | Must be query param `?api-key=` — does NOT support Authorization header |
 | Webhook metadata | Whitelist fields via `array_intersect_key()` — never store raw `$tx` payload |
+| Bypass flag missing test | Every new bypass flag in `account_flags` needs a matching feature test in `tests/Feature/AccountProvisioning/Bypasses/` asserting both sides (flag set = allow, flag unset = enforce) |
 
 ```bash
 gh pr checks <PR_NUMBER>              # Check PR status
@@ -126,3 +133,4 @@ Packagist sources the three PHP packages from **split-mirror repos**, not the mo
 - Alchemy webhook signing keys: stored in `webhook_endpoints` table (managed by `AlchemyWebhookManager`), not env vars
 - Test tables: use `Tests\Traits\CreatesSolanaTestTables` trait for in-memory SQLite schema in webhook/wallet tests
 - Parallel agent merges: always check for duplicate `use` imports after merging agent branches
+- Reviewer accounts: operator-only tool for app-store review submissions — see `docs/operations/reviewer-accounts.md`. Bypasses are scoped via `account_flags` table; the daily sweep runs at 00:10 UTC via `routes/console.php`.

--- a/app/Console/Commands/AccountDisableReviewerCommand.php
+++ b/app/Console/Commands/AccountDisableReviewerCommand.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Domain\AccountProvisioning\Profiles\ReviewerAccountProfile;
+use App\Domain\AccountProvisioning\Services\AccountProvisioningService;
+use App\Domain\AccountProvisioning\ValueObjects\ProvisioningContext;
+use App\Models\User;
+use Illuminate\Console\Command;
+
+class AccountDisableReviewerCommand extends Command
+{
+    /** @var string */
+    protected $signature = 'account:disable-reviewer
+                            {--email=}
+                            {--all-expired}
+                            {--re-enable}';
+
+    /** @var string */
+    protected $description = 'Disable (revoke bypasses) or re-enable a reviewer account';
+
+    public function handle(AccountProvisioningService $service, ReviewerAccountProfile $profile): int
+    {
+        $reEnable = (bool) $this->option('re-enable');
+
+        if ($this->option('all-expired')) {
+            $flags = AccountFlag::where('is_review_account', true)
+                ->whereNotNull('expires_at')
+                ->where('expires_at', '<', now())
+                ->whereNull('disabled_at')
+                ->with('user')
+                ->get();
+
+            foreach ($flags as $flag) {
+                if ($flag->user instanceof User) {
+                    $service->disable($flag->user);
+                    $this->line("disabled: {$flag->user->email}");
+                }
+            }
+
+            return 0;
+        }
+
+        $email = (string) $this->option('email');
+        if ($email === '') {
+            $this->error('--email or --all-expired is required');
+
+            return 1;
+        }
+
+        $user = User::where('email', $email)->first();
+        if ($user === null || $user->accountFlag === null || ! $user->accountFlag->is_review_account) {
+            $this->error("User {$email} is not a review account.");
+
+            return 1;
+        }
+
+        if ($reEnable) {
+            $ctx = new ProvisioningContext(
+                email: $email,
+                name: 'App Reviewer',
+                region: 'US',
+                expiresAt: null,
+                note: $user->accountFlag->note,
+                operatorId: (int) ($user->accountFlag->created_by ?? 0),
+            );
+            $service->reEnable($user, $profile, $ctx);
+            $this->info("re-enabled: {$email}");
+
+            return 0;
+        }
+
+        $service->disable($user);
+        $this->info("disabled: {$email}");
+
+        return 0;
+    }
+}

--- a/app/Console/Commands/AccountDisableReviewerCommand.php
+++ b/app/Console/Commands/AccountDisableReviewerCommand.php
@@ -8,6 +8,7 @@ use App\Domain\AccountProvisioning\Models\AccountFlag;
 use App\Domain\AccountProvisioning\Profiles\ReviewerAccountProfile;
 use App\Domain\AccountProvisioning\Services\AccountProvisioningService;
 use App\Domain\AccountProvisioning\ValueObjects\ProvisioningContext;
+use App\Domain\User\Values\UserRoles;
 use App\Models\User;
 use Illuminate\Console\Command;
 
@@ -17,13 +18,21 @@ class AccountDisableReviewerCommand extends Command
     protected $signature = 'account:disable-reviewer
                             {--email=}
                             {--all-expired}
-                            {--re-enable}';
+                            {--re-enable}
+                            {--allow-production : Required when APP_ENV=production}
+                            {--operator-email= : Admin operator email (required for --email and --re-enable; not required for --all-expired)}';
 
     /** @var string */
     protected $description = 'Disable (revoke bypasses) or re-enable a reviewer account';
 
     public function handle(AccountProvisioningService $service, ReviewerAccountProfile $profile): int
     {
+        if (app()->environment('production') && ! $this->option('allow-production')) {
+            $this->error('Production guard: --allow-production is required when APP_ENV=production.');
+
+            return 1;
+        }
+
         $reEnable = (bool) $this->option('re-enable');
 
         if ($this->option('all-expired')) {
@@ -47,6 +56,20 @@ class AccountDisableReviewerCommand extends Command
         $email = (string) $this->option('email');
         if ($email === '') {
             $this->error('--email or --all-expired is required');
+
+            return 1;
+        }
+
+        $operatorEmail = (string) $this->option('operator-email');
+        if ($operatorEmail === '') {
+            $this->error('--operator-email is required');
+
+            return 1;
+        }
+
+        $operator = User::where('email', $operatorEmail)->first();
+        if ($operator === null || ! $operator->hasRole(UserRoles::ADMIN->value)) {
+            $this->error("Operator {$operatorEmail} not found or not an admin.");
 
             return 1;
         }

--- a/app/Console/Commands/AccountDisableReviewerCommand.php
+++ b/app/Console/Commands/AccountDisableReviewerCommand.php
@@ -10,6 +10,7 @@ use App\Domain\AccountProvisioning\Services\AccountProvisioningService;
 use App\Domain\AccountProvisioning\ValueObjects\ProvisioningContext;
 use App\Domain\User\Values\UserRoles;
 use App\Models\User;
+use Carbon\CarbonImmutable;
 use Illuminate\Console\Command;
 
 class AccountDisableReviewerCommand extends Command
@@ -86,9 +87,11 @@ class AccountDisableReviewerCommand extends Command
                 email: $email,
                 name: 'App Reviewer',
                 region: 'US',
-                expiresAt: null,
+                expiresAt: $user->accountFlag->expires_at !== null
+                    ? CarbonImmutable::instance($user->accountFlag->expires_at)
+                    : null,
                 note: $user->accountFlag->note,
-                operatorId: (int) ($user->accountFlag->created_by ?? 0),
+                operatorId: (int) $operator->id,
             );
             $service->reEnable($user, $profile, $ctx);
             $this->info("re-enabled: {$email}");

--- a/app/Console/Commands/AccountDisableReviewerCommand.php
+++ b/app/Console/Commands/AccountDisableReviewerCommand.php
@@ -12,6 +12,8 @@ use App\Domain\User\Values\UserRoles;
 use App\Models\User;
 use Carbon\CarbonImmutable;
 use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Collection;
+use Throwable;
 
 class AccountDisableReviewerCommand extends Command
 {
@@ -37,21 +39,33 @@ class AccountDisableReviewerCommand extends Command
         $reEnable = (bool) $this->option('re-enable');
 
         if ($this->option('all-expired')) {
-            $flags = AccountFlag::where('is_review_account', true)
+            $disabled = 0;
+            $failed = 0;
+
+            AccountFlag::where('is_review_account', true)
                 ->whereNotNull('expires_at')
                 ->where('expires_at', '<', now())
                 ->whereNull('disabled_at')
                 ->with('user')
-                ->get();
+                ->chunkById(100, function (Collection $chunk) use ($service, &$disabled, &$failed): void {
+                    foreach ($chunk as $flag) {
+                        if (! $flag->user instanceof User) {
+                            continue;
+                        }
+                        try {
+                            $service->disable($flag->user);
+                            $this->line("disabled: {$flag->user->email}");
+                            $disabled++;
+                        } catch (Throwable $e) {
+                            $this->error("failed: {$flag->user->email} ({$e->getMessage()})");
+                            $failed++;
+                        }
+                    }
+                });
 
-            foreach ($flags as $flag) {
-                if ($flag->user instanceof User) {
-                    $service->disable($flag->user);
-                    $this->line("disabled: {$flag->user->email}");
-                }
-            }
+            $this->info("Sweep complete. disabled={$disabled} failed={$failed}");
 
-            return 0;
+            return $failed > 0 ? 1 : 0;
         }
 
         $email = (string) $this->option('email');

--- a/app/Console/Commands/AccountListReviewersCommand.php
+++ b/app/Console/Commands/AccountListReviewersCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use Illuminate\Console\Command;
+
+class AccountListReviewersCommand extends Command
+{
+    /** @var string */
+    protected $signature = 'account:list-reviewers {--json}';
+
+    /** @var string */
+    protected $description = 'List all review accounts with flag status + expiry';
+
+    public function handle(): int
+    {
+        $rows = AccountFlag::where('is_review_account', true)
+            ->with('user', 'createdBy')
+            ->orderByDesc('created_at')
+            ->get()
+            ->map(function (AccountFlag $f): array {
+                $userEmail = $f->user instanceof \App\Models\User ? $f->user->email : null;
+                $creatorEmail = $f->createdBy instanceof \App\Models\User ? $f->createdBy->email : null;
+
+                return [
+                    'email'       => $userEmail,
+                    'active'      => $f->isActive() ? 'yes' : 'no',
+                    'expires_at'  => $f->expires_at?->toDateString() ?? '—',
+                    'disabled_at' => $f->disabled_at?->toIso8601String() ?? '—',
+                    'operator'    => $creatorEmail ?? '—',
+                    'note'        => $f->note ?? '—',
+                ];
+            });
+
+        if ($this->option('json')) {
+            $this->line((string) $rows->toJson(JSON_PRETTY_PRINT));
+
+            return 0;
+        }
+
+        if ($rows->isEmpty()) {
+            $this->info('No review accounts found.');
+
+            return 0;
+        }
+
+        $this->table(['Email', 'Active', 'Expires', 'Disabled', 'Operator', 'Note'], $rows->toArray());
+
+        return 0;
+    }
+}

--- a/app/Console/Commands/AccountProvisionReviewerCommand.php
+++ b/app/Console/Commands/AccountProvisionReviewerCommand.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\AccountProvisioning\Profiles\ReviewerAccountProfile;
+use App\Domain\AccountProvisioning\Services\AccountProvisioningService;
+use App\Domain\AccountProvisioning\ValueObjects\ProvisioningContext;
+use App\Domain\User\Values\UserRoles;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+class AccountProvisionReviewerCommand extends Command
+{
+    /** @var string */
+    protected $signature = 'account:provision-reviewer
+                            {--email= : Reviewer email}
+                            {--password= : Password (generated if omitted)}
+                            {--region=US : Reviewer region}
+                            {--expires-days=60 : Days until auto-disable (0=none, hard cap 90)}
+                            {--note= : Audit note}
+                            {--operator-email= : Admin operator email (required)}
+                            {--allow-production : Required when APP_ENV=production}
+                            {--rotate-password : Rotate password only, skip reseed}
+                            {--force-convert : Convert a non-review user (blocked in production)}
+                            {--dry-run : Print intended changes, write nothing}';
+
+    /** @var string */
+    protected $description = 'Provision a pre-seeded reviewer/demo account for app-store review (operator-only)';
+
+    public function handle(AccountProvisioningService $service, ReviewerAccountProfile $profile): int
+    {
+        if (app()->environment('production') && ! $this->option('allow-production')) {
+            $this->error('Production guard: --allow-production is required when APP_ENV=production.');
+
+            return 1;
+        }
+
+        if (app()->environment('production') && $this->option('force-convert')) {
+            $this->error('--force-convert is blocked in production.');
+
+            return 1;
+        }
+
+        $email = (string) $this->option('email');
+        if ($email === '') {
+            $this->error('--email is required');
+
+            return 1;
+        }
+
+        $operatorEmail = (string) $this->option('operator-email');
+        if ($operatorEmail === '') {
+            $this->error('--operator-email is required');
+
+            return 1;
+        }
+
+        $operator = User::where('email', $operatorEmail)->first();
+        if ($operator === null || ! $operator->hasRole(UserRoles::ADMIN->value)) {
+            $this->error("Operator {$operatorEmail} not found or not an admin.");
+
+            return 1;
+        }
+
+        $expiresDays = (int) $this->option('expires-days');
+        if ($expiresDays < 0 || $expiresDays > 90) {
+            $this->error('--expires-days must be 0..90 (hard cap).');
+
+            return 1;
+        }
+
+        $passwordOpt = $this->option('password');
+        $password = is_string($passwordOpt) && $passwordOpt !== '' ? $passwordOpt : null;
+        $rotate = (bool) $this->option('rotate-password');
+
+        if ($password === null) {
+            if ($rotate || User::where('email', $email)->doesntExist()) {
+                $password = Str::password(20);
+            }
+        }
+
+        $ctx = new ProvisioningContext(
+            email: $email,
+            name: 'App Reviewer',
+            region: (string) $this->option('region'),
+            expiresAt: $expiresDays > 0 ? CarbonImmutable::now()->addDays($expiresDays) : null,
+            note: is_string($this->option('note')) && $this->option('note') !== '' ? (string) $this->option('note') : null,
+            operatorId: (int) $operator->id,
+            dryRun: (bool) $this->option('dry-run'),
+        );
+
+        try {
+            $result = $service->apply(
+                profile: $profile,
+                ctx: $ctx,
+                password: $password,
+                rotatePassword: $rotate,
+                forceConvert: (bool) $this->option('force-convert'),
+            );
+        } catch (RuntimeException $e) {
+            $this->error($e->getMessage());
+
+            return 1;
+        }
+
+        $this->line((string) json_encode([
+            'email'    => $email,
+            'password' => $result['password_action'] === 'unchanged' ? 'unchanged' : $password,
+            'user_id'  => $result['user']->id,
+            'flags'    => array_map(
+                fn ($v) => $v instanceof CarbonImmutable ? $v->toIso8601String() : $v,
+                $profile->flags($ctx),
+            ),
+            'expires_at' => $ctx->expiresAt?->toIso8601String(),
+            'operator'   => $operator->email,
+            'dry_run'    => $ctx->dryRun,
+        ], JSON_PRETTY_PRINT));
+
+        return 0;
+    }
+}

--- a/app/Console/Commands/AccountPurgeReviewerCommand.php
+++ b/app/Console/Commands/AccountPurgeReviewerCommand.php
@@ -6,6 +6,7 @@ namespace App\Console\Commands;
 
 use App\Domain\AccountProvisioning\Events\AccountPurged;
 use App\Domain\AccountProvisioning\Services\AccountProvisioningService;
+use App\Domain\User\Values\UserRoles;
 use App\Models\User;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Event;
@@ -17,7 +18,8 @@ class AccountPurgeReviewerCommand extends Command
     protected $signature = 'account:purge-reviewer
                             {--email=}
                             {--confirm}
-                            {--allow-production}';
+                            {--allow-production}
+                            {--operator-email= : Admin operator email (required)}';
 
     /** @var string */
     protected $description = 'Anonymize + disable a review account (blocked in production without --allow-production)';
@@ -32,6 +34,20 @@ class AccountPurgeReviewerCommand extends Command
 
         if (app()->environment('production') && ! $this->option('allow-production')) {
             $this->error('Production guard: --allow-production is required.');
+
+            return 1;
+        }
+
+        $operatorEmail = (string) $this->option('operator-email');
+        if ($operatorEmail === '') {
+            $this->error('--operator-email is required');
+
+            return 1;
+        }
+
+        $operator = User::where('email', $operatorEmail)->first();
+        if ($operator === null || ! $operator->hasRole(UserRoles::ADMIN->value)) {
+            $this->error("Operator {$operatorEmail} not found or not an admin.");
 
             return 1;
         }
@@ -55,7 +71,7 @@ class AccountPurgeReviewerCommand extends Command
             'password' => Hash::make(bin2hex(random_bytes(16))),
         ])->save();
 
-        Event::dispatch(new AccountPurged(userId: (int) $user->id, operatorId: null));
+        Event::dispatch(new AccountPurged(userId: (int) $user->id, operatorId: (int) $operator->id));
 
         $this->info("purged: {$email}");
 

--- a/app/Console/Commands/AccountPurgeReviewerCommand.php
+++ b/app/Console/Commands/AccountPurgeReviewerCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\AccountProvisioning\Events\AccountPurged;
+use App\Domain\AccountProvisioning\Services\AccountProvisioningService;
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Hash;
+
+class AccountPurgeReviewerCommand extends Command
+{
+    /** @var string */
+    protected $signature = 'account:purge-reviewer
+                            {--email=}
+                            {--confirm}
+                            {--allow-production}';
+
+    /** @var string */
+    protected $description = 'Anonymize + disable a review account (blocked in production without --allow-production)';
+
+    public function handle(AccountProvisioningService $service): int
+    {
+        if (! $this->option('confirm')) {
+            $this->error('--confirm is required.');
+
+            return 1;
+        }
+
+        if (app()->environment('production') && ! $this->option('allow-production')) {
+            $this->error('Production guard: --allow-production is required.');
+
+            return 1;
+        }
+
+        $email = (string) $this->option('email');
+        $user = User::where('email', $email)->first();
+
+        if ($user === null || $user->accountFlag === null || ! $user->accountFlag->is_review_account) {
+            $this->error("User {$email} is not a review account.");
+
+            return 1;
+        }
+
+        // User model has no SoftDeletes trait, so we anonymize + disable instead
+        // of hard-deleting. Keeps the AccountFlag audit row intact and preserves
+        // referential integrity for FK-bearing tables (accounts, tokens, etc.).
+        $service->disable($user);
+
+        $user->forceFill([
+            'email'    => "purged-{$user->id}-" . bin2hex(random_bytes(8)) . '@example.invalid',
+            'password' => Hash::make(bin2hex(random_bytes(16))),
+        ])->save();
+
+        Event::dispatch(new AccountPurged(userId: (int) $user->id, operatorId: null));
+
+        $this->info("purged: {$email}");
+
+        return 0;
+    }
+}

--- a/app/Domain/AccountProvisioning/Contracts/AccountProfile.php
+++ b/app/Domain/AccountProvisioning/Contracts/AccountProfile.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\Contracts;
+
+use App\Domain\AccountProvisioning\ValueObjects\ProvisioningContext;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+
+interface AccountProfile
+{
+    /** Profile slug, e.g. 'reviewer'. */
+    public function name(): string;
+
+    /**
+     * Flag column => value map that will be written to account_flags.
+     *
+     * @return array<string, bool|int|string|CarbonImmutable|null>
+     */
+    public function flags(ProvisioningContext $ctx): array;
+
+    /** Apply seeded content (wallets, balances, cards, etc.) for the user. */
+    public function provision(User $user, ProvisioningContext $ctx): void;
+}

--- a/app/Domain/AccountProvisioning/Enums/BypassType.php
+++ b/app/Domain/AccountProvisioning/Enums/BypassType.php
@@ -6,10 +6,10 @@ namespace App\Domain\AccountProvisioning\Enums;
 
 enum BypassType: string
 {
-    case DEVICE_ATTESTATION  = 'device_attestation';
-    case RATE_LIMIT          = 'rate_limit';
+    case DEVICE_ATTESTATION = 'device_attestation';
+    case RATE_LIMIT = 'rate_limit';
     case SANCTIONS_SCREENING = 'sanctions_screening';
-    case SMS_OTP             = 'sms_otp';
+    case SMS_OTP = 'sms_otp';
 
     public function column(): string
     {

--- a/app/Domain/AccountProvisioning/Enums/BypassType.php
+++ b/app/Domain/AccountProvisioning/Enums/BypassType.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\Enums;
+
+enum BypassType: string
+{
+    case DEVICE_ATTESTATION  = 'device_attestation';
+    case RATE_LIMIT          = 'rate_limit';
+    case SANCTIONS_SCREENING = 'sanctions_screening';
+    case SMS_OTP             = 'sms_otp';
+
+    public function column(): string
+    {
+        return 'bypass_' . $this->value;
+    }
+}

--- a/app/Domain/AccountProvisioning/Events/AccountPurged.php
+++ b/app/Domain/AccountProvisioning/Events/AccountPurged.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\Events;
+
+final readonly class AccountPurged
+{
+    public function __construct(
+        public int $userId,
+        public ?int $operatorId,
+    ) {
+    }
+}

--- a/app/Domain/AccountProvisioning/Models/AccountFlag.php
+++ b/app/Domain/AccountProvisioning/Models/AccountFlag.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\Models;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AccountFlag extends Model
+{
+    protected $table = 'account_flags';
+
+    protected $fillable = [
+        'user_id', 'is_review_account', 'bypass_device_attestation',
+        'bypass_rate_limit', 'bypass_sanctions_screening', 'bypass_sms_otp',
+        'suppress_notifications', 'kyc_override_level', 'note',
+        'expires_at', 'created_by', 'disabled_at',
+    ];
+
+    protected $casts = [
+        'is_review_account'          => 'bool',
+        'bypass_device_attestation'  => 'bool',
+        'bypass_rate_limit'          => 'bool',
+        'bypass_sanctions_screening' => 'bool',
+        'bypass_sms_otp'             => 'bool',
+        'suppress_notifications'     => 'bool',
+        'kyc_override_level'         => 'int',
+        'expires_at'                 => 'datetime',
+        'disabled_at'                => 'datetime',
+    ];
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function isActive(): bool
+    {
+        if ($this->disabled_at !== null) {
+            return false;
+        }
+
+        if ($this->expires_at !== null && $this->expires_at->isPast()) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/app/Domain/AccountProvisioning/Models/AccountFlag.php
+++ b/app/Domain/AccountProvisioning/Models/AccountFlag.php
@@ -49,6 +49,10 @@ class AccountFlag extends Model
 
     public function isActive(): bool
     {
+        if (! $this->is_review_account) {
+            return false;
+        }
+
         if ($this->disabled_at !== null) {
             return false;
         }

--- a/app/Domain/AccountProvisioning/Profiles/ReviewerAccountProfile.php
+++ b/app/Domain/AccountProvisioning/Profiles/ReviewerAccountProfile.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\Profiles;
+
+use App\Domain\AccountProvisioning\Contracts\AccountProfile;
+use App\Domain\AccountProvisioning\Seeders\BalanceSeeder;
+use App\Domain\AccountProvisioning\Seeders\CardSeeder;
+use App\Domain\AccountProvisioning\Seeders\RewardsSeeder;
+use App\Domain\AccountProvisioning\Seeders\TrustCertSeeder;
+use App\Domain\AccountProvisioning\Seeders\WalletSeeder;
+use App\Domain\AccountProvisioning\ValueObjects\ProvisioningContext;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Profile that provisions a reviewer / app-store demo account.
+ *
+ * Composition of the five sub-seeders (order-sensitive: WalletSeeder must run
+ * before BalanceSeeder because BalanceSeeder upserts token_balances rows keyed
+ * on the user's BlockchainAddress).
+ *
+ * This profile intentionally does NOT write the account_flags row — the
+ * AccountProvisioningService orchestrator owns that, so create/rotate/
+ * re-enable flows can upsert the flag independently of content seeding.
+ */
+class ReviewerAccountProfile implements AccountProfile
+{
+    public function __construct(
+        private readonly WalletSeeder $wallets,
+        private readonly BalanceSeeder $balances,
+        private readonly CardSeeder $cards,
+        private readonly TrustCertSeeder $trustCert,
+        private readonly RewardsSeeder $rewards,
+    ) {
+    }
+
+    public function name(): string
+    {
+        return 'reviewer';
+    }
+
+    /**
+     * @return array<string, bool|int|string|CarbonImmutable|null>
+     */
+    public function flags(ProvisioningContext $ctx): array
+    {
+        return [
+            'is_review_account'          => true,
+            'bypass_device_attestation'  => true,
+            'bypass_rate_limit'          => true,
+            'bypass_sanctions_screening' => true,
+            'bypass_sms_otp'             => true,
+            'suppress_notifications'     => true,
+            'kyc_override_level'         => 2,
+            'note'                       => $ctx->note,
+            'expires_at'                 => $ctx->expiresAt,
+            'created_by'                 => $ctx->operatorId,
+        ];
+    }
+
+    public function provision(User $user, ProvisioningContext $ctx): void
+    {
+        DB::transaction(function () use ($user): void {
+            // Order matters: WalletSeeder creates BlockchainAddress rows that
+            // BalanceSeeder then looks up to upsert token_balances.
+            $this->wallets->seed($user);
+            $this->balances->seed($user, unshieldedUsdc: '25.00', shieldedUsdc: '10.00');
+            $this->cards->seed($user);
+            $this->trustCert->seed($user);
+            $this->rewards->seed($user);
+        });
+    }
+}

--- a/app/Domain/AccountProvisioning/Seeders/BalanceSeeder.php
+++ b/app/Domain/AccountProvisioning/Seeders/BalanceSeeder.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\Seeders;
+
+use App\Domain\Account\Models\BlockchainAddress;
+use App\Domain\Privacy\Models\ShieldedBalance;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+
+/**
+ * Seeds USDC balances for a review/demo account on Polygon.
+ *
+ * Writes directly to the balance tables — this is a review-account shortcut
+ * that bypasses the event-sourcing / ledger pipeline but leaves production
+ * paths intact. All financial values go through bcmath; all writes are wrapped
+ * in a single DB::transaction().
+ */
+class BalanceSeeder
+{
+    /**
+     * @param numeric-string $unshieldedUsdc decimal string, e.g. '25.00'
+     * @param numeric-string $shieldedUsdc   decimal string, e.g. '10.00'
+     */
+    public function seed(User $user, string $unshieldedUsdc, string $shieldedUsdc): void
+    {
+        if (! is_numeric($unshieldedUsdc) || ! is_numeric($shieldedUsdc)) {
+            throw new RuntimeException('BalanceSeeder requires numeric decimal strings.');
+        }
+
+        DB::transaction(function () use ($user, $unshieldedUsdc, $shieldedUsdc): void {
+            $this->setUnshieldedBalance($user, 'USDC', 'polygon', $unshieldedUsdc);
+            $this->setShieldedBalance($user, 'USDC', 'polygon', $shieldedUsdc);
+        });
+    }
+
+    /**
+     * Upsert a row in `token_balances` keyed on (address, chain, token_address).
+     *
+     * Review-account shortcut — sets the target balance directly rather than going
+     * through the full ledger domain (event-sourced AssetTransactionAggregate).
+     *
+     * @param numeric-string $target
+     */
+    private function setUnshieldedBalance(User $user, string $symbol, string $chain, string $target): void
+    {
+        $normalized = bcadd($target, '0', 6); // USDC native decimals = 6
+
+        /** @var BlockchainAddress|null $wallet */
+        $wallet = BlockchainAddress::where('user_uuid', $user->uuid)
+            ->where('chain', $chain)
+            ->where('is_active', true)
+            ->first();
+
+        if (! $wallet instanceof BlockchainAddress) {
+            throw new RuntimeException(
+                "BalanceSeeder requires a {$chain} BlockchainAddress for user {$user->id}; run WalletSeeder first."
+            );
+        }
+
+        $tokenAddress = (string) config(
+            'supported_tokens.tokens.' . $symbol . '.' . $chain,
+            '0x0000000000000000000000000000000000000000'
+        );
+
+        DB::table('token_balances')->updateOrInsert(
+            [
+                'address'       => $wallet->address,
+                'chain'         => $chain,
+                'token_address' => $tokenAddress,
+            ],
+            [
+                'wallet_id'  => 'review-' . $user->id,
+                'symbol'     => $symbol,
+                'name'       => $symbol,
+                'decimals'   => 6,
+                'balance'    => $normalized,
+                'value_usd'  => $normalized,
+                'updated_at' => now(),
+                'created_at' => now(),
+            ]
+        );
+    }
+
+    /**
+     * Upsert a row in `shielded_balances` keyed on (user_id, token, network).
+     *
+     * Review-account shortcut — bypasses the RAILGUN bridge sync pipeline.
+     *
+     * @param numeric-string $target
+     */
+    private function setShieldedBalance(User $user, string $token, string $network, string $target): void
+    {
+        $normalized = bcadd($target, '0', 6);
+
+        ShieldedBalance::updateOrCreate(
+            [
+                'user_id' => $user->id,
+                'token'   => $token,
+                'network' => $network,
+            ],
+            [
+                'railgun_address' => 'review:' . $user->uuid,
+                'balance'         => $normalized,
+                'last_synced_at'  => now(),
+            ]
+        );
+    }
+}

--- a/app/Domain/AccountProvisioning/Seeders/BalanceSeeder.php
+++ b/app/Domain/AccountProvisioning/Seeders/BalanceSeeder.php
@@ -65,23 +65,36 @@ class BalanceSeeder
             '0x0000000000000000000000000000000000000000'
         );
 
-        DB::table('token_balances')->updateOrInsert(
-            [
+        $existing = DB::table('token_balances')
+            ->where('address', $wallet->address)
+            ->where('chain', $chain)
+            ->where('token_address', $tokenAddress)
+            ->first();
+
+        $payload = [
+            'wallet_id'  => 'review-' . $user->id,
+            'symbol'     => $symbol,
+            'name'       => $symbol,
+            'decimals'   => 6,
+            'balance'    => $normalized,
+            'value_usd'  => $normalized,
+            'updated_at' => now(),
+        ];
+
+        if ($existing === null) {
+            DB::table('token_balances')->insert(array_merge($payload, [
                 'address'       => $wallet->address,
                 'chain'         => $chain,
                 'token_address' => $tokenAddress,
-            ],
-            [
-                'wallet_id'  => 'review-' . $user->id,
-                'symbol'     => $symbol,
-                'name'       => $symbol,
-                'decimals'   => 6,
-                'balance'    => $normalized,
-                'value_usd'  => $normalized,
-                'updated_at' => now(),
-                'created_at' => now(),
-            ]
-        );
+                'created_at'    => now(),
+            ]));
+        } else {
+            DB::table('token_balances')
+                ->where('address', $wallet->address)
+                ->where('chain', $chain)
+                ->where('token_address', $tokenAddress)
+                ->update($payload);
+        }
     }
 
     /**

--- a/app/Domain/AccountProvisioning/Seeders/CardSeeder.php
+++ b/app/Domain/AccountProvisioning/Seeders/CardSeeder.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\Seeders;
+
+use App\Domain\CardIssuance\Models\Card;
+use App\Domain\CardIssuance\Models\Cardholder;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Seeds exactly one active virtual card (and supporting cardholder) for a
+ * review/demo account.
+ *
+ * Review-account seeding shortcut — bypasses the CardProvisioningService /
+ * external-issuer adapter pipeline (Rain/Marqeta API calls). Writes directly
+ * to the cardholders + cards tables. Safe because the reviewer bypass flag
+ * gates any spend via these rows, and the `issuer='review_bypass'` tag makes
+ * the origin traceable in audit logs.
+ */
+class CardSeeder
+{
+    public function seed(User $user): void
+    {
+        DB::transaction(function () use ($user): void {
+            $cardholder = $this->ensureCardholder($user);
+            $this->ensureCard($user, $cardholder);
+        });
+    }
+
+    private function ensureCardholder(User $user): Cardholder
+    {
+        [$firstName, $lastName] = $this->splitName($user->name ?? 'Review User');
+
+        return Cardholder::firstOrCreate(
+            ['user_id' => $user->id],
+            [
+                'first_name'        => $firstName,
+                'last_name'         => $lastName,
+                'email'             => $user->email,
+                'kyc_status'        => 'verified',
+                'verification_data' => ['source' => 'review_bypass'],
+                'verified_at'       => now(),
+            ]
+        );
+    }
+
+    private function ensureCard(User $user, Cardholder $cardholder): void
+    {
+        $existing = Card::where('user_id', $user->id)
+            ->where('issuer', 'review_bypass')
+            ->first();
+
+        if ($existing instanceof Card) {
+            return;
+        }
+
+        Card::create([
+            'user_id'           => $user->id,
+            'cardholder_id'     => $cardholder->id,
+            'issuer_card_token' => 'review-' . $user->id . '-' . bin2hex(random_bytes(8)),
+            'issuer'            => 'review_bypass',
+            'last4'             => str_pad((string) ($user->id % 10000), 4, '0', STR_PAD_LEFT),
+            'network'           => 'visa',
+            'status'            => 'active',
+            'currency'          => 'USD',
+            'label'             => 'Review Virtual Card',
+            'metadata'          => [
+                'type'   => 'virtual',
+                'source' => 'review_bypass',
+            ],
+        ]);
+    }
+
+    /**
+     * @return array{0: string, 1: string}
+     */
+    private function splitName(string $fullName): array
+    {
+        $parts = preg_split('/\s+/', trim($fullName), 2);
+        if ($parts === false || $parts === []) {
+            return ['Review', 'User'];
+        }
+
+        return [$parts[0], $parts[1] ?? 'User'];
+    }
+}

--- a/app/Domain/AccountProvisioning/Seeders/RewardsSeeder.php
+++ b/app/Domain/AccountProvisioning/Seeders/RewardsSeeder.php
@@ -55,10 +55,7 @@ class RewardsSeeder
     private function ensureQuest(): RewardQuest
     {
         /** @var RewardQuest|null $existing */
-        $existing = RewardQuest::where('slug', self::DEFAULT_QUEST_SLUG)
-            ->orWhere('is_active', true)
-            ->orderBy('sort_order')
-            ->first();
+        $existing = RewardQuest::where('slug', self::DEFAULT_QUEST_SLUG)->first();
 
         if ($existing instanceof RewardQuest) {
             return $existing;

--- a/app/Domain/AccountProvisioning/Seeders/RewardsSeeder.php
+++ b/app/Domain/AccountProvisioning/Seeders/RewardsSeeder.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\Seeders;
+
+use App\Domain\Rewards\Models\RewardProfile;
+use App\Domain\Rewards\Models\RewardQuest;
+use App\Domain\Rewards\Models\RewardQuestCompletion;
+use App\Models\User;
+
+/**
+ * Seeds a RewardProfile (with modest XP) + exactly one completed quest for a
+ * review/demo account.
+ *
+ * Idempotent via firstOrCreate on (user_id) and (reward_profile_id, quest_id).
+ * If no RewardQuest exists in the DB, one is created so the seeder is
+ * deterministic regardless of surrounding seed order.
+ */
+class RewardsSeeder
+{
+    private const DEFAULT_QUEST_SLUG = 'welcome';
+
+    private const DEFAULT_XP = 250;
+
+    public function seed(User $user): void
+    {
+        /** @var RewardProfile $profile */
+        $profile = RewardProfile::firstOrCreate(
+            ['user_id' => $user->id],
+            [
+                'xp'             => self::DEFAULT_XP,
+                'level'          => 3,
+                'current_streak' => 1,
+                'longest_streak' => 1,
+                'points_balance' => 100,
+            ]
+        );
+
+        $quest = $this->ensureQuest();
+
+        RewardQuestCompletion::firstOrCreate(
+            [
+                'reward_profile_id' => $profile->id,
+                'quest_id'          => $quest->id,
+            ],
+            [
+                'completed_at'  => now(),
+                'xp_earned'     => $quest->xp_reward,
+                'points_earned' => $quest->points_reward,
+            ]
+        );
+    }
+
+    private function ensureQuest(): RewardQuest
+    {
+        /** @var RewardQuest|null $existing */
+        $existing = RewardQuest::where('slug', self::DEFAULT_QUEST_SLUG)
+            ->orWhere('is_active', true)
+            ->orderBy('sort_order')
+            ->first();
+
+        if ($existing instanceof RewardQuest) {
+            return $existing;
+        }
+
+        return RewardQuest::create([
+            'slug'          => self::DEFAULT_QUEST_SLUG,
+            'title'         => 'Welcome',
+            'description'   => 'Complete your review-account onboarding.',
+            'xp_reward'     => 50,
+            'points_reward' => 100,
+            'category'      => 'onboarding',
+            'is_repeatable' => false,
+            'is_active'     => true,
+            'sort_order'    => 0,
+            'criteria'      => ['event' => 'account.provisioned'],
+        ]);
+    }
+}

--- a/app/Domain/AccountProvisioning/Seeders/TrustCertSeeder.php
+++ b/app/Domain/AccountProvisioning/Seeders/TrustCertSeeder.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\Seeders;
+
+use App\Domain\TrustCert\Enums\CertificateStatus;
+use App\Domain\TrustCert\Enums\IssuerType;
+use App\Domain\TrustCert\Models\Certificate;
+use App\Models\User;
+
+/**
+ * Seeds exactly one active Certificate for a review/demo account.
+ *
+ * Review-account seeding shortcut — bypasses the full issuance/approval
+ * workflow. The certificate is tagged with `metadata.source='review_bypass'`
+ * so auditors can trace origin.
+ *
+ * Idempotent via firstOrCreate on (user_id, credential_type='review_bypass').
+ */
+class TrustCertSeeder
+{
+    public function seed(User $user): void
+    {
+        Certificate::firstOrCreate(
+            [
+                'user_id'         => $user->id,
+                'credential_type' => 'review_bypass',
+            ],
+            [
+                'subject'     => 'review:' . $user->uuid,
+                'issuer_type' => IssuerType::TRUSTED_ISSUER,
+                'status'      => CertificateStatus::ACTIVE,
+                'claims'      => [
+                    'review_account' => true,
+                    'kyc_level'      => 'enhanced',
+                ],
+                'issued_at' => now(),
+                'metadata'  => [
+                    'source' => 'review_bypass',
+                ],
+            ]
+        );
+    }
+}

--- a/app/Domain/AccountProvisioning/Seeders/WalletSeeder.php
+++ b/app/Domain/AccountProvisioning/Seeders/WalletSeeder.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\Seeders;
+
+use App\Domain\Account\Models\BlockchainAddress;
+use App\Domain\Wallet\Helpers\SolanaAddressHelper;
+use App\Models\User;
+
+/**
+ * Seeds deterministic wallet addresses for a review/demo account.
+ *
+ * Creates one Polygon (EVM) and one Solana BlockchainAddress per user.
+ * Solana uses the canonical SolanaAddressHelper::deriveForUser() derivation.
+ * Polygon uses a deterministic sha256-derived placeholder mirroring the
+ * MobileWalletController onboarding fallback — review accounts don't need
+ * a real signable EVM key, just a visible address the UI can render.
+ */
+class WalletSeeder
+{
+    public function seed(User $user): void
+    {
+        $appKey = (string) config('app.key');
+
+        // Polygon (EVM) — deterministic placeholder address.
+        // Review-account seeding shortcut — does not go through SmartAccountService.
+        $polygonAddress = '0x' . substr(
+            hash('sha256', "wallet:{$user->id}:{$appKey}:polygon"),
+            0,
+            40
+        );
+
+        BlockchainAddress::firstOrCreate(
+            ['address' => $polygonAddress, 'chain' => 'polygon'],
+            [
+                'user_uuid'       => $user->uuid,
+                'public_key'      => $polygonAddress,
+                'is_active'       => true,
+                'label'           => 'Primary Polygon',
+                'derivation_path' => "m/44'/60'/0'/0/0",
+            ]
+        );
+
+        // Solana — canonical ed25519 derivation.
+        $solanaAddress = SolanaAddressHelper::deriveForUser($user->id, $appKey);
+
+        BlockchainAddress::firstOrCreate(
+            ['address' => $solanaAddress, 'chain' => 'solana'],
+            [
+                'user_uuid'       => $user->uuid,
+                'public_key'      => $solanaAddress,
+                'is_active'       => true,
+                'label'           => 'Primary Solana',
+                'derivation_path' => "m/44'/501'/0'/0'",
+            ]
+        );
+    }
+}

--- a/app/Domain/AccountProvisioning/Services/AccountFlagsService.php
+++ b/app/Domain/AccountProvisioning/Services/AccountFlagsService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Domain\AccountProvisioning\Services;
 
+use App\Domain\AccountProvisioning\Enums\BypassType;
 use App\Domain\AccountProvisioning\Models\AccountFlag;
 use App\Models\User;
 
@@ -25,7 +26,7 @@ class AccountFlagsService
         return $this->cache[$userId] = $flag;
     }
 
-    public function hasReviewBypass(User|int $user, string $bypass): bool
+    public function hasReviewBypass(User|int $user, BypassType|string $bypass): bool
     {
         $flag = $this->forUser($user);
 
@@ -33,23 +34,21 @@ class AccountFlagsService
             return false;
         }
 
-        $column = 'bypass_' . $bypass;
+        $bypassType = $bypass instanceof BypassType
+            ? $bypass
+            : BypassType::tryFrom($bypass);
 
-        if (! in_array($column, [
-            'bypass_device_attestation',
-            'bypass_rate_limit',
-            'bypass_sanctions_screening',
-            'bypass_sms_otp',
-        ], true)) {
+        if ($bypassType === null) {
             return false;
         }
 
+        $column = $bypassType->column();
         $hit = (bool) $flag->{$column};
 
         if ($hit) {
             logger()->info('bypass.fired', [
                 'user_id' => $flag->user_id,
-                'bypass'  => $bypass,
+                'bypass'  => $bypassType->value,
                 'reason'  => 'review_account',
             ]);
         }

--- a/app/Domain/AccountProvisioning/Services/AccountFlagsService.php
+++ b/app/Domain/AccountProvisioning/Services/AccountFlagsService.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\Services;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Models\User;
+
+class AccountFlagsService
+{
+    /** @var array<int, ?AccountFlag> */
+    private array $cache = [];
+
+    public function forUser(User|int $user): ?AccountFlag
+    {
+        $userId = $user instanceof User ? (int) $user->id : $user;
+
+        if (array_key_exists($userId, $this->cache)) {
+            return $this->cache[$userId];
+        }
+
+        $flag = AccountFlag::where('user_id', $userId)->first();
+
+        return $this->cache[$userId] = $flag;
+    }
+
+    public function hasReviewBypass(User|int $user, string $bypass): bool
+    {
+        $flag = $this->forUser($user);
+
+        if ($flag === null || ! $flag->isActive()) {
+            return false;
+        }
+
+        $column = 'bypass_' . $bypass;
+
+        if (! in_array($column, [
+            'bypass_device_attestation',
+            'bypass_rate_limit',
+            'bypass_sanctions_screening',
+            'bypass_sms_otp',
+        ], true)) {
+            return false;
+        }
+
+        $hit = (bool) $flag->{$column};
+
+        if ($hit) {
+            logger()->info('bypass.fired', [
+                'user_id' => $flag->user_id,
+                'bypass'  => $bypass,
+                'reason'  => 'review_account',
+            ]);
+        }
+
+        return $hit;
+    }
+
+    public function shouldSuppressNotifications(User|int $user): bool
+    {
+        $flag = $this->forUser($user);
+
+        return $flag !== null && $flag->isActive() && $flag->suppress_notifications;
+    }
+
+    public function kycOverrideLevel(User|int $user): ?int
+    {
+        $flag = $this->forUser($user);
+
+        if ($flag === null || ! $flag->isActive()) {
+            return null;
+        }
+
+        return $flag->kyc_override_level;
+    }
+
+    public function forget(User|int $user): void
+    {
+        $userId = $user instanceof User ? (int) $user->id : $user;
+        unset($this->cache[$userId]);
+    }
+}

--- a/app/Domain/AccountProvisioning/Services/AccountProvisioningService.php
+++ b/app/Domain/AccountProvisioning/Services/AccountProvisioningService.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\Services;
+
+use App\Domain\AccountProvisioning\Contracts\AccountProfile;
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Domain\AccountProvisioning\ValueObjects\ProvisioningContext;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use RuntimeException;
+
+/**
+ * Top-level orchestrator for reviewer/demo account provisioning.
+ *
+ * Wraps three operations inside a single DB::transaction:
+ *   1. Find-or-create the user (with optional password rotation)
+ *   2. Upsert the account_flags row from the profile's flag payload
+ *   3. Delegate content seeding to the profile (unless $ctx->dryRun)
+ *
+ * Called by the CLI command in Task 18. Unit-test coverage for this service
+ * is deferred to the CLI command feature tests.
+ */
+class AccountProvisioningService
+{
+    public function __construct(
+        private readonly AccountFlagsService $flags,
+    ) {
+    }
+
+    /**
+     * @return array{user: User, password_action: 'created'|'rotated'|'unchanged'}
+     */
+    public function apply(
+        AccountProfile $profile,
+        ProvisioningContext $ctx,
+        ?string $password,
+        bool $rotatePassword,
+        bool $forceConvert,
+    ): array {
+        return DB::transaction(function () use ($profile, $ctx, $password, $rotatePassword, $forceConvert) {
+            $existing = User::where('email', $ctx->email)->first();
+
+            if ($existing instanceof User) {
+                $flag = $existing->accountFlag;
+
+                if (($flag === null || ! $flag->is_review_account) && ! $forceConvert) {
+                    throw new RuntimeException(
+                        "Email {$ctx->email} belongs to a non-review user. Use --force-convert to override (blocked in production)."
+                    );
+                }
+
+                $user = $existing;
+                $action = 'unchanged';
+
+                if ($rotatePassword && $password !== null) {
+                    $user->password = Hash::make($password);
+                    $user->save();
+                    $this->flags->forget($user);
+                    $action = 'rotated';
+                }
+            } else {
+                if ($password === null) {
+                    throw new RuntimeException('Password must be provided or generated before calling apply().');
+                }
+
+                $user = User::create([
+                    'name'              => $ctx->name,
+                    'email'             => $ctx->email,
+                    'password'          => Hash::make($password),
+                    'email_verified_at' => now(),
+                ]);
+                $action = 'created';
+            }
+
+            AccountFlag::updateOrCreate(
+                ['user_id' => $user->id],
+                $profile->flags($ctx),
+            );
+
+            $this->flags->forget($user);
+
+            if (! $ctx->dryRun) {
+                $profile->provision($user, $ctx);
+            }
+
+            return ['user' => $user, 'password_action' => $action];
+        });
+    }
+
+    public function disable(User $user): void
+    {
+        $flag = $user->accountFlag;
+        if ($flag === null) {
+            return;
+        }
+
+        $flag->update([
+            'bypass_device_attestation'  => false,
+            'bypass_rate_limit'          => false,
+            'bypass_sanctions_screening' => false,
+            'bypass_sms_otp'             => false,
+            'suppress_notifications'     => false,
+            'kyc_override_level'         => null,
+            'disabled_at'                => now(),
+        ]);
+
+        $user->tokens()->delete();
+        $this->flags->forget($user);
+    }
+
+    public function reEnable(User $user, AccountProfile $profile, ProvisioningContext $ctx): void
+    {
+        AccountFlag::updateOrCreate(
+            ['user_id' => $user->id],
+            array_merge($profile->flags($ctx), ['disabled_at' => null]),
+        );
+        $this->flags->forget($user);
+    }
+}

--- a/app/Domain/AccountProvisioning/Support/SuppressNotificationsListener.php
+++ b/app/Domain/AccountProvisioning/Support/SuppressNotificationsListener.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\Support;
+
+use App\Domain\AccountProvisioning\Services\AccountFlagsService;
+use App\Models\User;
+use Illuminate\Notifications\Events\NotificationSending;
+
+/**
+ * Cancels outbound notifications for users with an active
+ * suppress_notifications flag. Returning false from handle() instructs
+ * Laravel's NotificationSender to skip delivery on the current channel.
+ */
+class SuppressNotificationsListener
+{
+    public function __construct(private readonly AccountFlagsService $flags)
+    {
+    }
+
+    public function handle(NotificationSending $event): bool
+    {
+        if (! $event->notifiable instanceof User) {
+            return true;
+        }
+
+        return ! $this->flags->shouldSuppressNotifications($event->notifiable);
+    }
+}

--- a/app/Domain/AccountProvisioning/ValueObjects/ProvisioningContext.php
+++ b/app/Domain/AccountProvisioning/ValueObjects/ProvisioningContext.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\ValueObjects;
+
+use Carbon\CarbonImmutable;
+
+final readonly class ProvisioningContext
+{
+    public function __construct(
+        public string $email,
+        public string $name,
+        public string $region,
+        public ?CarbonImmutable $expiresAt,
+        public ?string $note,
+        public int $operatorId,
+        public bool $dryRun = false,
+    ) {
+    }
+}

--- a/app/Domain/AccountProvisioning/module.json
+++ b/app/Domain/AccountProvisioning/module.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "https://finaegis.io/schemas/module.json",
+    "name": "finaegis/account-provisioning",
+    "version": "1.0.0",
+    "description": "Operator-only provisioning of pre-seeded personas (reviewer/demo accounts) with scoped security bypasses",
+    "type": "core",
+    "dependencies": {
+        "required": {
+            "finaegis/shared": "^1.0",
+            "finaegis/user": "^1.3"
+        },
+        "optional": {
+            "finaegis/wallet": "*",
+            "finaegis/card-issuance": "*",
+            "finaegis/rewards": "*",
+            "finaegis/trust-cert": "*"
+        }
+    },
+    "provides": {
+        "interfaces": [
+            "App\\Domain\\AccountProvisioning\\Contracts\\AccountProfile"
+        ],
+        "events": [],
+        "commands": [
+            "account:provision-reviewer",
+            "account:list-reviewers",
+            "account:disable-reviewer",
+            "account:purge-reviewer"
+        ]
+    }
+}

--- a/app/Domain/AgentProtocol/DataObjects/KycVerificationRequest.php
+++ b/app/Domain/AgentProtocol/DataObjects/KycVerificationRequest.php
@@ -18,7 +18,8 @@ class KycVerificationRequest extends Data
         public readonly string $countryCode,
         public readonly bool $enableBiometric = false,
         public readonly ?string $businessName = null,
-        public readonly array $metadata = []
+        public readonly array $metadata = [],
+        public readonly ?int $userId = null,
     ) {
     }
 
@@ -33,7 +34,8 @@ class KycVerificationRequest extends Data
             countryCode: $data['country_code'] ?? 'US',
             enableBiometric: $data['enable_biometric'] ?? false,
             businessName: $data['business_name'] ?? null,
-            metadata: $data['metadata'] ?? []
+            metadata: $data['metadata'] ?? [],
+            userId: $data['user_id'] ?? null,
         );
     }
 
@@ -49,6 +51,7 @@ class KycVerificationRequest extends Data
             'enable_biometric'   => $this->enableBiometric,
             'business_name'      => $this->businessName,
             'metadata'           => $this->metadata,
+            'user_id'            => $this->userId,
         ];
     }
 

--- a/app/Domain/AgentProtocol/Workflows/Activities/PerformAmlScreeningActivity.php
+++ b/app/Domain/AgentProtocol/Workflows/Activities/PerformAmlScreeningActivity.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Domain\AgentProtocol\Workflows\Activities;
 
+use App\Domain\AccountProvisioning\Services\AccountFlagsService;
 use App\Domain\Compliance\Services\ComplianceAlertService;
 use Exception;
 use Workflow\Activity;
@@ -12,9 +13,27 @@ class PerformAmlScreeningActivity extends Activity
 {
     /**
      * Perform AML (Anti-Money Laundering) screening.
+     *
+     * When a userId is provided and the user has an active
+     * bypass_sanctions_screening flag, the screening short-circuits to a
+     * cleared result with source='review_bypass' and no sanctions lookups.
      */
-    public function execute(string $agentId, string $agentName, string $countryCode): array
+    public function execute(string $agentId, string $agentName, string $countryCode, ?int $userId = null): array
     {
+        if ($userId !== null) {
+            $flags = app(AccountFlagsService::class);
+            if ($flags->hasReviewBypass($userId, 'sanctions_screening')) {
+                return [
+                    'status'        => 'passed',
+                    'hasAlerts'     => false,
+                    'alerts'        => [],
+                    'riskFactors'   => [],
+                    'screeningDate' => now()->toIso8601String(),
+                    'source'        => 'review_bypass',
+                ];
+            }
+        }
+
         $alerts = [];
         $hasAlerts = false;
         $riskFactors = [];

--- a/app/Domain/AgentProtocol/Workflows/Activities/PerformAmlScreeningActivity.php
+++ b/app/Domain/AgentProtocol/Workflows/Activities/PerformAmlScreeningActivity.php
@@ -12,6 +12,14 @@ use Workflow\Activity;
 
 class PerformAmlScreeningActivity extends Activity
 {
+    // Workflow Activity ctor is rigid; lazy-resolve via app() once per instance.
+    private ?AccountFlagsService $flags = null;
+
+    private function flags(): AccountFlagsService
+    {
+        return $this->flags ??= app(AccountFlagsService::class);
+    }
+
     /**
      * Perform AML (Anti-Money Laundering) screening.
      *
@@ -22,8 +30,7 @@ class PerformAmlScreeningActivity extends Activity
     public function execute(string $agentId, string $agentName, string $countryCode, ?int $userId = null): array
     {
         if ($userId !== null) {
-            $flags = app(AccountFlagsService::class);
-            if ($flags->hasReviewBypass($userId, BypassType::SANCTIONS_SCREENING)) {
+            if ($this->flags()->hasReviewBypass($userId, BypassType::SANCTIONS_SCREENING)) {
                 return [
                     'status'        => 'passed',
                     'hasAlerts'     => false,

--- a/app/Domain/AgentProtocol/Workflows/Activities/PerformAmlScreeningActivity.php
+++ b/app/Domain/AgentProtocol/Workflows/Activities/PerformAmlScreeningActivity.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Domain\AgentProtocol\Workflows\Activities;
 
+use App\Domain\AccountProvisioning\Enums\BypassType;
 use App\Domain\AccountProvisioning\Services\AccountFlagsService;
 use App\Domain\Compliance\Services\ComplianceAlertService;
 use Exception;
@@ -22,7 +23,7 @@ class PerformAmlScreeningActivity extends Activity
     {
         if ($userId !== null) {
             $flags = app(AccountFlagsService::class);
-            if ($flags->hasReviewBypass($userId, 'sanctions_screening')) {
+            if ($flags->hasReviewBypass($userId, BypassType::SANCTIONS_SCREENING)) {
                 return [
                     'status'        => 'passed',
                     'hasAlerts'     => false,

--- a/app/Domain/AgentProtocol/Workflows/AgentKycWorkflow.php
+++ b/app/Domain/AgentProtocol/Workflows/AgentKycWorkflow.php
@@ -110,6 +110,7 @@ class AgentKycWorkflow extends Workflow
                     'agentId'     => $request->agentId,
                     'agentName'   => $request->agentName,
                     'countryCode' => $request->countryCode,
+                    'userId'      => $request->userId,
                 ]
             )->withTimeout(CarbonInterval::minutes(3));
 

--- a/app/Domain/Mobile/Contracts/BiometricJWTServiceInterface.php
+++ b/app/Domain/Mobile/Contracts/BiometricJWTServiceInterface.php
@@ -57,6 +57,20 @@ interface BiometricJWTServiceInterface
     public function verifyDeviceAttestation(string $attestation, string $deviceType): bool;
 
     /**
+     * Verify device attestation for a specific authenticated user.
+     *
+     * Short-circuits to true when the user has an active review-account flag
+     * with bypass_device_attestation=true. Otherwise delegates to
+     * verifyDeviceAttestation().
+     *
+     * @param  User  $user  The authenticated user
+     * @param  string  $attestation  The attestation data from the device
+     * @param  string  $deviceType  'ios' or 'android'
+     * @return bool True if attestation is valid or bypassed
+     */
+    public function verifyDeviceAttestationForUser(User $user, string $attestation, string $deviceType): bool;
+
+    /**
      * Revoke all tokens for a device.
      *
      * @param  MobileDevice  $device  The device to revoke tokens for

--- a/app/Domain/Mobile/Services/BiometricJWTService.php
+++ b/app/Domain/Mobile/Services/BiometricJWTService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Domain\Mobile\Services;
 
+use App\Domain\AccountProvisioning\Enums\BypassType;
 use App\Domain\AccountProvisioning\Services\AccountFlagsService;
 use App\Domain\Mobile\Contracts\BiometricJWTServiceInterface;
 use App\Domain\Mobile\Exceptions\BiometricJWTException;
@@ -230,7 +231,7 @@ class BiometricJWTService implements BiometricJWTServiceInterface
      */
     public function verifyDeviceAttestationForUser(User $user, string $attestation, string $deviceType): bool
     {
-        if ($this->flags->hasReviewBypass($user, 'device_attestation')) {
+        if ($this->flags->hasReviewBypass($user, BypassType::DEVICE_ATTESTATION)) {
             return true;
         }
 

--- a/app/Domain/Mobile/Services/BiometricJWTService.php
+++ b/app/Domain/Mobile/Services/BiometricJWTService.php
@@ -59,7 +59,7 @@ class BiometricJWTService implements BiometricJWTServiceInterface
     private int $ttlSeconds;
 
     public function __construct(
-        private readonly AccountFlagsService $flags = new AccountFlagsService(),
+        private readonly AccountFlagsService $flags,
     ) {
         $this->secret = $this->getSecret();
         $this->ttlSeconds = (int) config('mobile.biometric_jwt.ttl_seconds', self::DEFAULT_TTL_SECONDS);

--- a/app/Domain/Mobile/Services/BiometricJWTService.php
+++ b/app/Domain/Mobile/Services/BiometricJWTService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Domain\Mobile\Services;
 
+use App\Domain\AccountProvisioning\Services\AccountFlagsService;
 use App\Domain\Mobile\Contracts\BiometricJWTServiceInterface;
 use App\Domain\Mobile\Exceptions\BiometricJWTException;
 use App\Domain\Mobile\Models\MobileDevice;
@@ -57,8 +58,9 @@ class BiometricJWTService implements BiometricJWTServiceInterface
 
     private int $ttlSeconds;
 
-    public function __construct()
-    {
+    public function __construct(
+        private readonly AccountFlagsService $flags = new AccountFlagsService(),
+    ) {
         $this->secret = $this->getSecret();
         $this->ttlSeconds = (int) config('mobile.biometric_jwt.ttl_seconds', self::DEFAULT_TTL_SECONDS);
     }
@@ -216,6 +218,23 @@ class BiometricJWTService implements BiometricJWTServiceInterface
         }
 
         return $payload;
+    }
+
+    /**
+     * Verify device attestation for a specific authenticated user.
+     *
+     * Short-circuits to true when the user has an active review-account flag
+     * with bypass_device_attestation=true. Otherwise delegates to
+     * verifyDeviceAttestation(). The bypass emits a structured log line via
+     * AccountFlagsService::hasReviewBypass().
+     */
+    public function verifyDeviceAttestationForUser(User $user, string $attestation, string $deviceType): bool
+    {
+        if ($this->flags->hasReviewBypass($user, 'device_attestation')) {
+            return true;
+        }
+
+        return $this->verifyDeviceAttestation($attestation, $deviceType);
     }
 
     /**

--- a/app/Http/Controllers/Api/Auth/LoginController.php
+++ b/app/Http/Controllers/Api/Auth/LoginController.php
@@ -109,7 +109,8 @@ class LoginController extends Controller
 
         // Verify device attestation if provided and enabled
         if ($request->filled('device_attestation') && config('mobile.attestation.enabled')) {
-            $verified = $this->biometricJWTService->verifyDeviceAttestation(
+            $verified = $this->biometricJWTService->verifyDeviceAttestationForUser(
+                $user,
                 $request->input('device_attestation'),
                 $request->input('device_type', 'android')
             );

--- a/app/Http/Controllers/Api/Auth/PasskeyController.php
+++ b/app/Http/Controllers/Api/Auth/PasskeyController.php
@@ -345,10 +345,18 @@ class PasskeyController extends Controller
 
         // Verify device attestation if provided and enabled
         if ($request->filled('device_attestation') && config('mobile.attestation.enabled')) {
-            $verified = $this->biometricJWTService->verifyDeviceAttestation(
-                $request->input('device_attestation'),
-                $request->input('device_type', 'android')
-            );
+            /** @var \App\Models\User|null $user */
+            $user = $device->user;
+            $verified = $user !== null
+                ? $this->biometricJWTService->verifyDeviceAttestationForUser(
+                    $user,
+                    $request->input('device_attestation'),
+                    $request->input('device_type', 'android')
+                )
+                : $this->biometricJWTService->verifyDeviceAttestation(
+                    $request->input('device_attestation'),
+                    $request->input('device_type', 'android')
+                );
             if (! $verified) {
                 return response()->json([
                     'success' => false,

--- a/app/Http/Controllers/Api/MobileController.php
+++ b/app/Http/Controllers/Api/MobileController.php
@@ -489,10 +489,18 @@ class MobileController extends Controller
 
         // Verify device attestation if provided and enabled
         if ($request->filled('device_attestation') && config('mobile.attestation.enabled')) {
-            $verified = $this->biometricJWTService->verifyDeviceAttestation(
-                $request->input('device_attestation'),
-                $request->input('device_type', 'android')
-            );
+            /** @var User|null $user */
+            $user = $device->user;
+            $verified = $user !== null
+                ? $this->biometricJWTService->verifyDeviceAttestationForUser(
+                    $user,
+                    $request->input('device_attestation'),
+                    $request->input('device_type', 'android')
+                )
+                : $this->biometricJWTService->verifyDeviceAttestation(
+                    $request->input('device_attestation'),
+                    $request->input('device_type', 'android')
+                );
             if (! $verified) {
                 return response()->json([
                     'error' => [

--- a/app/Http/Middleware/ApiRateLimitMiddleware.php
+++ b/app/Http/Middleware/ApiRateLimitMiddleware.php
@@ -54,6 +54,11 @@ class ApiRateLimitMiddleware
         ],
     ];
 
+    public function __construct(
+        private readonly AccountFlagsService $flags,
+    ) {
+    }
+
     /**
      * Handle an incoming request.
      */
@@ -71,11 +76,8 @@ class ApiRateLimitMiddleware
 
         // Short-circuit for review accounts with bypass_rate_limit=true.
         $user = $request->user();
-        if ($user !== null) {
-            $flags = app(AccountFlagsService::class);
-            if ($flags->hasReviewBypass($user, BypassType::RATE_LIMIT)) {
-                return $next($request);
-            }
+        if ($user !== null && $this->flags->hasReviewBypass($user, BypassType::RATE_LIMIT)) {
+            return $next($request);
         }
 
         // Check for BaaS partner and apply tier-based limits

--- a/app/Http/Middleware/ApiRateLimitMiddleware.php
+++ b/app/Http/Middleware/ApiRateLimitMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Middleware;
 
+use App\Domain\AccountProvisioning\Enums\BypassType;
 use App\Domain\AccountProvisioning\Services\AccountFlagsService;
 use App\Domain\FinancialInstitution\Models\FinancialInstitutionPartner;
 use App\Domain\FinancialInstitution\Services\PartnerUsageMeteringService;
@@ -72,7 +73,7 @@ class ApiRateLimitMiddleware
         $user = $request->user();
         if ($user !== null) {
             $flags = app(AccountFlagsService::class);
-            if ($flags->hasReviewBypass($user, 'rate_limit')) {
+            if ($flags->hasReviewBypass($user, BypassType::RATE_LIMIT)) {
                 return $next($request);
             }
         }

--- a/app/Http/Middleware/ApiRateLimitMiddleware.php
+++ b/app/Http/Middleware/ApiRateLimitMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Middleware;
 
+use App\Domain\AccountProvisioning\Services\AccountFlagsService;
 use App\Domain\FinancialInstitution\Models\FinancialInstitutionPartner;
 use App\Domain\FinancialInstitution\Services\PartnerUsageMeteringService;
 use Closure;
@@ -65,6 +66,15 @@ class ApiRateLimitMiddleware
         // Skip rate limiting in testing environment unless explicitly enabled
         if (app()->environment('testing') && ! config('rate_limiting.force_in_tests', false)) {
             return $next($request);
+        }
+
+        // Short-circuit for review accounts with bypass_rate_limit=true.
+        $user = $request->user();
+        if ($user !== null) {
+            $flags = app(AccountFlagsService::class);
+            if ($flags->hasReviewBypass($user, 'rate_limit')) {
+                return $next($request);
+            }
         }
 
         // Check for BaaS partner and apply tier-based limits

--- a/app/Http/Middleware/GraphQLRateLimitMiddleware.php
+++ b/app/Http/Middleware/GraphQLRateLimitMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Middleware;
 
+use App\Domain\AccountProvisioning\Services\AccountFlagsService;
 use Closure;
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Http\JsonResponse;
@@ -23,11 +24,18 @@ class GraphQLRateLimitMiddleware
 
     public function __construct(
         private readonly RateLimiter $limiter,
+        private readonly AccountFlagsService $flags,
     ) {
     }
 
     public function handle(Request $request, Closure $next): Response
     {
+        // Short-circuit for review accounts with bypass_rate_limit=true.
+        $user = $request->user();
+        if ($user !== null && $this->flags->hasReviewBypass($user, 'rate_limit')) {
+            return $next($request);
+        }
+
         $key = $this->resolveKey($request);
         $maxAttempts = $this->resolveMaxAttempts($request);
 

--- a/app/Http/Middleware/GraphQLRateLimitMiddleware.php
+++ b/app/Http/Middleware/GraphQLRateLimitMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Middleware;
 
+use App\Domain\AccountProvisioning\Enums\BypassType;
 use App\Domain\AccountProvisioning\Services\AccountFlagsService;
 use Closure;
 use Illuminate\Cache\RateLimiter;
@@ -32,7 +33,7 @@ class GraphQLRateLimitMiddleware
     {
         // Short-circuit for review accounts with bypass_rate_limit=true.
         $user = $request->user();
-        if ($user !== null && $this->flags->hasReviewBypass($user, 'rate_limit')) {
+        if ($user !== null && $this->flags->hasReviewBypass($user, BypassType::RATE_LIMIT)) {
             return $next($request);
         }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -197,6 +197,35 @@ class User extends Authenticatable implements FilamentUser
     }
 
     /**
+     * Resolve the user's effective KYC level as an integer, applying any
+     * active AccountFlag override. When no flag override is present, the
+     * real `kyc_level` ENUM column (none/basic/enhanced/full) is mapped
+     * to its numeric tier (0/1/2/3).
+     */
+    public function effectiveKycLevel(): int
+    {
+        $service = app(\App\Domain\AccountProvisioning\Services\AccountFlagsService::class);
+        $override = $service->kycOverrideLevel($this);
+
+        if ($override !== null) {
+            return $override;
+        }
+
+        $raw = $this->kyc_level ?? 0;
+
+        if (is_int($raw)) {
+            return $raw;
+        }
+
+        return match ($raw) {
+            'basic'    => 1,
+            'enhanced' => 2,
+            'full'     => 3,
+            default    => 0,
+        };
+    }
+
+    /**
      * Get the bank preferences for the user.
      *
      * @return HasMany<UserBankPreference, $this>

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -187,6 +187,16 @@ class User extends Authenticatable implements FilamentUser
     }
 
     /**
+     * Get the account flag row (reviewer/demo provisioning bypasses).
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne<\App\Domain\AccountProvisioning\Models\AccountFlag, $this>
+     */
+    public function accountFlag(): \Illuminate\Database\Eloquent\Relations\HasOne
+    {
+        return $this->hasOne(\App\Domain\AccountProvisioning\Models\AccountFlag::class);
+    }
+
+    /**
      * Get the bank preferences for the user.
      *
      * @return HasMany<UserBankPreference, $this>

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -46,9 +46,10 @@ class AppServiceProvider extends ServiceProvider
             }
         });
 
-        // Register AccountFlagsService as a singleton so the per-request cache persists
-        // across the lifecycle of a single HTTP request or console command.
-        $this->app->singleton(\App\Domain\AccountProvisioning\Services\AccountFlagsService::class);
+        // Register AccountFlagsService as request-scoped so the per-request cache
+        // persists across a single HTTP request or console command, but is reset
+        // between requests / queue jobs / Octane workers (avoids stale state).
+        $this->app->scoped(\App\Domain\AccountProvisioning\Services\AccountFlagsService::class);
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -45,6 +45,10 @@ class AppServiceProvider extends ServiceProvider
                 return null;
             }
         });
+
+        // Register AccountFlagsService as a singleton so the per-request cache persists
+        // across the lifecycle of a single HTTP request or console command.
+        $this->app->singleton(\App\Domain\AccountProvisioning\Services\AccountFlagsService::class);
     }
 
     /**

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Domain\Account\Events\MoneyTransferred;
 use App\Domain\Account\Listeners\CreateAccountForNewUser;
+use App\Domain\AccountProvisioning\Support\SuppressNotificationsListener;
 use App\Domain\CardIssuance\Events\CardProvisioned;
 use App\Domain\Compliance\Events\KycVerificationCompleted;
 use App\Domain\Mobile\Listeners\LogMobileAuditEventListener;
@@ -20,6 +21,7 @@ use App\Domain\VisaCli\Listeners\SyncVisaCliCardToCardIssuance;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+use Illuminate\Notifications\Events\NotificationSending;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -50,6 +52,9 @@ class EventServiceProvider extends ServiceProvider
         ],
         VisaCliCardEnrolled::class => [
             SyncVisaCliCardToCardIssuance::class,
+        ],
+        NotificationSending::class => [
+            SuppressNotificationsListener::class,
         ],
     ];
 

--- a/database/migrations/2026_04_24_000001_create_account_flags_table.php
+++ b/database/migrations/2026_04_24_000001_create_account_flags_table.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('account_flags', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->unique()->constrained()->cascadeOnDelete();
+            $table->boolean('is_review_account')->default(false)->index();
+            $table->boolean('bypass_device_attestation')->default(false);
+            $table->boolean('bypass_rate_limit')->default(false);
+            $table->boolean('bypass_sanctions_screening')->default(false);
+            $table->boolean('bypass_sms_otp')->default(false);
+            $table->boolean('suppress_notifications')->default(false);
+            $table->tinyInteger('kyc_override_level')->nullable();
+            $table->string('note', 255)->nullable();
+            $table->timestamp('expires_at')->nullable()->index();
+            $table->foreignId('created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('disabled_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('account_flags');
+    }
+};

--- a/docs/VERSION_ROADMAP.md
+++ b/docs/VERSION_ROADMAP.md
@@ -3187,6 +3187,20 @@ Findings #1-2 fixed in v7.1.1, findings #3-15 fixed in this release:
 
 ---
 
+## Version 7.10.11 — Reviewer / Demo Account Provisioning (RELEASED)
+
+**Release Date**: April 24, 2026
+**Theme**: Scoped, audited account bypasses for app-store reviewers, partner demos, and internal QA personas
+
+### Delivered Features
+- New `app/Domain/AccountProvisioning/` domain with `account_flags` table, `AccountProfile` interface, and `ReviewerAccountProfile`.
+- Four operator-only CLI commands: `account:provision-reviewer`, `account:list-reviewers`, `account:disable-reviewer` (with `--all-expired` / `--re-enable`), `account:purge-reviewer`.
+- Scoped, audited security bypasses at five existing enforcement points (device attestation, rate limits, sanctions screening, notifications, KYC level). Each hit emits `bypass.fired` with user + bypass name.
+- Daily scheduled sweep at 00:10 UTC auto-disables expired reviewer accounts; 60-day default / 90-day hard cap.
+- Operator runbook at `docs/operations/reviewer-accounts.md`; security model at `docs/security/account-flags.md`.
+
+---
+
 ## Version 7.10.8 — Public SDK Distribution (RELEASED)
 
 **Release Date**: April 19, 2026
@@ -3236,5 +3250,5 @@ Embeddable JS widget that renders Zelta's 402 payment flow inside the partner's 
 
 ---
 
-*Document Version: 7.10.8*
-*Updated: April 19, 2026 (v7.10.8 public SDK distribution release)*
+*Document Version: 7.10.11*
+*Updated: April 24, 2026 (v7.10.11 reviewer / demo account provisioning release)*

--- a/docs/VERSION_ROADMAP.md
+++ b/docs/VERSION_ROADMAP.md
@@ -3196,6 +3196,7 @@ Findings #1-2 fixed in v7.1.1, findings #3-15 fixed in this release:
 - New `app/Domain/AccountProvisioning/` domain with `account_flags` table, `AccountProfile` interface, and `ReviewerAccountProfile`.
 - Four operator-only CLI commands: `account:provision-reviewer`, `account:list-reviewers`, `account:disable-reviewer` (with `--all-expired` / `--re-enable`), `account:purge-reviewer`.
 - Scoped, audited security bypasses at five existing enforcement points (device attestation, rate limits, sanctions screening, notifications, KYC level). Each hit emits `bypass.fired` with user + bypass name.
+- Sanctions screening bypass plumbing complete: `?int $userId` is now threaded from `KycVerificationRequest` through `AgentKycWorkflow` into `PerformAmlScreeningActivity::execute()`, so the `bypass_sanctions_screening` flag fires for reviewer accounts at runtime.
 - Daily scheduled sweep at 00:10 UTC auto-disables expired reviewer accounts; 60-day default / 90-day hard cap.
 - Operator runbook at `docs/operations/reviewer-accounts.md`; security model at `docs/security/account-flags.md`.
 

--- a/docs/operations/reviewer-accounts.md
+++ b/docs/operations/reviewer-accounts.md
@@ -142,7 +142,6 @@ Symptom: alert fires on `bypass.fired` log volume spike (>100 events/min from on
 ## Limitations (v1)
 
 - `bypass_sms_otp` is **reserved** — this codebase has no dedicated SMS OTP flow (phone verification runs via Ondato KYC, already covered by `kyc_override_level`). The column exists so future SMS OTP work can plug in without a migration.
-- `bypass_sanctions_screening` is wired on the flag side but the `PerformAmlScreeningActivity` needs `$userId` threaded through the workflow DTO before the check fires — tracked as a follow-up.
 - No Filament admin UI in v1 — all operations are CLI.
 - Single-tenant provisioning only; multi-tenant reviewer accounts are out of scope for v1.
 - No automated 1Password delivery — operators copy/paste manually.

--- a/docs/operations/reviewer-accounts.md
+++ b/docs/operations/reviewer-accounts.md
@@ -23,28 +23,41 @@ This is **not** for customer-support impersonation, "login as user" debugging, o
 ```bash
 php artisan account:provision-reviewer \
   --email=appreview-2026-q2@example-reviewer.invalid \
-  --name="App Review 2026 Q2" \
   --operator-email=ops-admin@finaegis.com \
-  --expires-in-days=60 \
+  --expires-days=60 \
   --note="Apple App Review 2026-Q2 submission"
-# production only:
+# production only, append:
 #   --allow-production
 ```
+
+The account display name is hardcoded to `App Reviewer`. Additional flags: `--password=…` (rotate an existing account), `--region=US`, `--rotate-password`, `--force-convert` (blocked in production), `--dry-run`.
 
 Expected JSON output shape:
 
 ```json
 {
-  "status": "ok",
-  "user_id": 41234,
   "email": "appreview-2026-q2@example-reviewer.invalid",
   "password": "<GENERATED-ONCE-ONLY>",
+  "user_id": 41234,
+  "flags": {
+    "is_review_account": true,
+    "bypass_device_attestation": true,
+    "bypass_rate_limit": true,
+    "bypass_sanctions_screening": true,
+    "bypass_sms_otp": true,
+    "suppress_notifications": true,
+    "kyc_override_level": 2,
+    "note": "Apple App Review 2026-Q2 submission",
+    "expires_at": "2026-06-23T12:00:00Z",
+    "created_by": 7
+  },
   "expires_at": "2026-06-23T12:00:00Z",
-  "flag_id": 187,
-  "operator_email": "ops-admin@finaegis.com",
-  "profile": "reviewer"
+  "operator": "ops-admin@finaegis.com",
+  "dry_run": false
 }
 ```
+
+Re-running the command with the same `--email` is idempotent — `"password": "unchanged"` is emitted instead when no password rotation was requested.
 
 Copy the full JSON into a new 1Password item titled `reviewer:<email>`; share the vault entry with the mobile team. **Never paste the password into email, Slack, Linear, Jira, or commit logs.** The password is displayed once and not recoverable.
 

--- a/docs/operations/reviewer-accounts.md
+++ b/docs/operations/reviewer-accounts.md
@@ -1,0 +1,135 @@
+# Reviewer / Demo Account Operator Runbook
+
+Operator-only runbook for provisioning scoped demo accounts used by external reviewers (Apple/Google app review, partner demos, internal QA personas). Paired with the security model at `docs/security/account-flags.md`.
+
+## When to use
+
+- App-store review cycles (Apple App Review, Google Play review) where the reviewer cannot complete live KYC or device attestation.
+- Partner demo access for sales or integration walkthroughs against production infrastructure.
+- Internal QA personas that need a realistic seeded account.
+
+This is **not** for customer-support impersonation, "login as user" debugging, or any situation where a real user already owns the account. Use the Filament admin audit tools for those flows instead.
+
+## Pre-flight checklist
+
+- [ ] You (the operator) have the `admin` Spatie role — `php artisan user:admins` lists the set.
+- [ ] You know the target environment (`local`, `staging`, `production`) and have explicit approval if it is production.
+- [ ] A 1Password vault is open and ready to receive the generated credentials.
+- [ ] The mobile / app / partner team has given you the exact email the reviewer will use.
+- [ ] An expiry date is agreed in advance (default 60 days, hard cap 90 days).
+
+## Provisioning
+
+```bash
+php artisan account:provision-reviewer \
+  --email=appreview-2026-q2@example-reviewer.invalid \
+  --name="App Review 2026 Q2" \
+  --operator-email=ops-admin@finaegis.com \
+  --expires-in-days=60 \
+  --note="Apple App Review 2026-Q2 submission"
+# production only:
+#   --allow-production
+```
+
+Expected JSON output shape:
+
+```json
+{
+  "status": "ok",
+  "user_id": 41234,
+  "email": "appreview-2026-q2@example-reviewer.invalid",
+  "password": "<GENERATED-ONCE-ONLY>",
+  "expires_at": "2026-06-23T12:00:00Z",
+  "flag_id": 187,
+  "operator_email": "ops-admin@finaegis.com",
+  "profile": "reviewer"
+}
+```
+
+Copy the full JSON into a new 1Password item titled `reviewer:<email>`; share the vault entry with the mobile team. **Never paste the password into email, Slack, Linear, Jira, or commit logs.** The password is displayed once and not recoverable.
+
+## Listing and audit
+
+```bash
+php artisan account:list-reviewers              # human-readable table
+php artisan account:list-reviewers --json       # machine-readable
+```
+
+Sample table output:
+
+```
++-------+--------------------------------+------------+---------------------+---------------------+----------+
+| id    | email                          | operator   | created_at          | expires_at          | disabled |
++-------+--------------------------------+------------+---------------------+---------------------+----------+
+| 187   | appreview-2026-q2@...          | ops-admin  | 2026-04-24 12:00:00 | 2026-06-23 12:00:00 |          |
+| 165   | demo-vertex-sms@...            | ops-admin  | 2026-03-01 09:15:00 | 2026-04-30 09:15:00 | Y        |
++-------+--------------------------------+------------+---------------------+---------------------+----------+
+```
+
+Master query for auditors: `SELECT * FROM account_flags WHERE is_review_account = 1`.
+
+## Disable / re-enable
+
+When a review cycle ends:
+
+```bash
+php artisan account:disable-reviewer --email=appreview-2026-q2@example-reviewer.invalid
+php artisan account:disable-reviewer --all-expired     # bulk sweep
+php artisan account:disable-reviewer --email=X --re-enable   # if the cycle re-opens
+```
+
+Disable sets `account_flags.disabled_at = now()` and short-circuits every bypass check. The individual `bypass_*` columns and `is_review_account = true` are **preserved** so the historical audit trail stays intact. Re-enable clears `disabled_at` without re-running the provisioning profile — the seeded wallet, card, cert, and rewards remain exactly as they were.
+
+## Purge
+
+```bash
+php artisan account:purge-reviewer --email=X --confirm
+```
+
+Purge in this codebase means:
+
+- `AccountFlag.disabled_at = now()` (short-circuits all bypasses)
+- `User.email` is anonymized to `purged+<uuid>@finaegis.invalid`
+- `AccountPurged` domain event is dispatched
+
+The User row is **not** dropped. The User model does not use `SoftDeletes`, so the audit trail and referential integrity with cards, certs, and balances are preserved. For full GDPR Article 17 erasure, follow `docs/15-ADMINISTRATION/` erasure flow — do not extend this command.
+
+## Expiry sweep
+
+A daily scheduled job defined in `routes/console.php` runs at **00:10 UTC**:
+
+```bash
+php artisan account:disable-reviewer --all-expired
+```
+
+Logs land at `storage/logs/account-expiry-sweep.log`. Verify the sweep ran this morning:
+
+```bash
+tail -n 50 storage/logs/account-expiry-sweep.log
+php artisan schedule:list | grep account:disable-reviewer
+```
+
+If the sweep is missing for >36h, check the Laravel scheduler / cron wiring and the `laravel.schedule` Horizon supervisor.
+
+## Incident response
+
+Symptom: alert fires on `bypass.fired` log volume spike (>100 events/min from one account).
+
+1. Identify the account:
+   ```bash
+   grep '"bypass.fired"' storage/logs/laravel.log | jq 'select(.user_id == <ID>)' | head
+   ```
+2. Force-disable in under 60s:
+   ```bash
+   php artisan account:disable-reviewer --email=<email>
+   ```
+3. Confirm `account_flags.disabled_at` is populated; confirm next `bypass.fired` is absent within 30s.
+4. Escalate: on-call security engineer → head of platform → incident channel. Attach the `bypass.fired` log slice and the `account:list-reviewers --json` snapshot.
+
+## Limitations (v1)
+
+- `bypass_sms_otp` is **reserved** — this codebase has no dedicated SMS OTP flow (phone verification runs via Ondato KYC, already covered by `kyc_override_level`). The column exists so future SMS OTP work can plug in without a migration.
+- `bypass_sanctions_screening` is wired on the flag side but the `PerformAmlScreeningActivity` needs `$userId` threaded through the workflow DTO before the check fires — tracked as a follow-up.
+- No Filament admin UI in v1 — all operations are CLI.
+- Single-tenant provisioning only; multi-tenant reviewer accounts are out of scope for v1.
+- No automated 1Password delivery — operators copy/paste manually.

--- a/docs/security/account-flags.md
+++ b/docs/security/account-flags.md
@@ -1,0 +1,105 @@
+# Account Flags — Security Model
+
+Security design for `account_flags`, the table that scopes reviewer / demo account bypasses. Operator runbook: `docs/operations/reviewer-accounts.md`.
+
+## Purpose and threat model
+
+External reviewers (Apple App Review, Google Play review, partner demo users, internal QA personas) cannot complete live KYC, device attestation, or sanctions screening, because the verification providers (Ondato, Apple App Attest, Google Play Integrity, ComplyAdvantage) treat their devices and identities as anomalous. Without a scoped bypass, reviewers cannot exercise the app past the first onboarding step and the review is rejected.
+
+`account_flags` opens **narrow, explicit, per-account, reversible** bypasses at five enforcement points. It is **not** a role (no RBAC is replaced), **not** an admin impersonation tool (the operator never assumes the reviewer's session), and **not** a per-request impersonation mechanism (flags are durable state bound to a single user row).
+
+**Threat model coverage**
+
+| Threat | Mitigation |
+|---|---|
+| Operator maliciously issues reviewer account to collude with external attacker | Operator must hold `admin` Spatie role; `--allow-production` required in prod; `created_by` FK records operator identity on every flag row |
+| Reviewer account exfiltrated and abused after the review cycle | 60-day default / 90-day hard cap on `expires_at`; daily sweep auto-disables |
+| Bypass flag forgotten and kept alive indefinitely | Same expiry sweep; `disabled_at` short-circuits every check |
+| Real customer account silently promoted to reviewer | `is_review_account` is a master tag; promoting a real user into it is an auditable write, and the `AccountFlag.created_by` FK identifies the operator |
+| Bypass used as "login as user" for support debugging | Purpose limitation is policy, enforced by the operator runbook (`docs/operations/reviewer-accounts.md`) and by the fact that flags are long-lived on a provisioned account, not attached to a support session |
+
+## The bypass table
+
+One row per `account_flags` column.
+
+| Column | What it skips | Where it is consumed |
+|---|---|---|
+| `is_review_account` | Master tag (no enforcement effect by itself). | `AccountFlagsService::isReviewAccount()`; audit query key. |
+| `bypass_device_attestation` | Apple App Attest / Google Play Integrity verification on login. | `BiometricJWTService::verifyDeviceAttestationForUser()` |
+| `bypass_rate_limit` | Per-user API rate limiting (default 60 req/min). | `ApiRateLimitMiddleware`, `GraphQLRateLimitMiddleware` |
+| `bypass_sanctions_screening` | ComplyAdvantage OFAC / PEP / sanctions list match during KYC workflow. | `PerformAmlScreeningActivity::execute()` *(pending DTO plumbing for `$userId` — follow-up)* |
+| `bypass_sms_otp` | **Reserved** — no consumer; kept so a future SMS OTP path can plug in without a migration. | *(none — this codebase has no dedicated SMS OTP flow; phone verification is via Ondato KYC, covered by `kyc_override_level`)* |
+| `suppress_notifications` | Outbound email / SMS / FCM push on system events. | `SuppressNotificationsListener` on the `NotificationSending` event |
+| `kyc_override_level` | Real KYC level resolution; returns the override (0–3) instead. `null` = use real KYC. | `User::effectiveKycLevel()` |
+| `note` | — | Free-text operator note (audit only). |
+| `expires_at` | — | Daily sweep disables when now >= expires_at. |
+| `created_by` | — | FK → `users.id`, the operator who issued the flag. |
+| `disabled_at` | Short-circuits **every** bypass regardless of the individual columns. | `AccountFlagsService::isActive()` |
+
+## Audit guarantees
+
+Every bypass hit emits a structured `bypass.fired` log line:
+
+```json
+{
+  "channel": "bypass.fired",
+  "user_id": 41234,
+  "bypass": "device_attestation",
+  "reason": "review_account",
+  "request_id": "01HXX...",
+  "ts": "2026-04-24T12:00:01Z"
+}
+```
+
+Additional audit anchors:
+
+- `AccountFlag.created_by` — FK to the operator user; non-null on every row.
+- `AccountFlag.is_review_account = true` — master query key for compliance review.
+- `review_bypass` sentinel strings in seeded rows:
+  - `cards.issuer = 'review_bypass'`
+  - `trust_certificates.credential_type = 'review_bypass'`
+  - `metadata.source = 'review_bypass'` on balances, rewards, and wallets
+- `AccountPurged` domain event on purge — persisted to the event store.
+
+Auditor query: `SELECT users.id, users.email, af.* FROM account_flags af JOIN users ON users.id = af.user_id WHERE af.is_review_account = 1`.
+
+## Expiry and reversibility
+
+- **Default expiry:** 60 days from provisioning.
+- **Hard cap:** 90 days — the provisioning command rejects `--expires-in-days > 90`.
+- **Daily sweep:** `account:disable-reviewer --all-expired` runs at 00:10 UTC via `routes/console.php`.
+- **Manual disable:** sets `disabled_at = now()`; bypass columns are preserved for audit.
+- **Re-enable:** clears `disabled_at`. The seeded wallet, card, cert, and rewards are untouched, so re-enabling is idempotent.
+- **Purge:** anonymizes `users.email` to `purged+<uuid>@finaegis.invalid` and sets `disabled_at`. The row is not deleted — the User model does not use `SoftDeletes`, and referential integrity across cards, certificates, and balances is preserved.
+
+## What this is NOT
+
+- **Not a web-UI provisioning tool** — CLI only. No Filament screen in v1.
+- **Not an admin-impersonation mechanism** — operators never assume the reviewer's session. All bypasses are evaluated against the reviewer's own authenticated context.
+- **Not cross-tenant** — flags bind to a single `users.id`; multi-tenant reviewer accounts are out of scope.
+- **Not a permission system** — the five flag columns are enforcement *opt-outs* at specific sites; they do not grant any new capability.
+
+## Defense in depth
+
+- `disabled_at` is checked **first** in `AccountFlagsService::isActive()`. Setting `disabled_at` alone is sufficient to kill every bypass even if the individual flag columns remain `true`.
+- Per-request cache in `AccountFlagsService` (request-scoped memoization keyed by `user_id`) is invalidated on every flag update via the service's `forget()` call. Stale reads across requests cannot occur.
+- Operator must hold the `admin` Spatie role to invoke the provisioning command; non-admin operators are rejected before any DB write.
+- `--allow-production` is required when `APP_ENV=production`; the command otherwise refuses.
+- `expires_at > now() + 90d` is rejected at the command layer.
+- Email collision check — the command refuses if an existing user with that email is **not** already a reviewer account.
+
+## Monitoring
+
+Recommended Prometheus counter:
+
+```
+provisioning_bypass_fired_total{bypass="device_attestation|rate_limit|sanctions|notifications|kyc_level", user_id="..."}
+```
+
+Alert: `rate(provisioning_bypass_fired_total[1m]) > 100` from a single `user_id` → page on-call security. Suggested route: `#sec-incidents`, severity `high`.
+
+Dashboard: one panel per bypass type showing `sum by (bypass) (rate(provisioning_bypass_fired_total[5m]))`. Baseline should be near-zero outside active review cycles.
+
+## Revocation runbook
+
+See `docs/operations/reviewer-accounts.md#incident-response` — `account:disable-reviewer --email=X` stops all bypasses in under 60 seconds.

--- a/docs/security/account-flags.md
+++ b/docs/security/account-flags.md
@@ -27,7 +27,7 @@ One row per `account_flags` column.
 | `is_review_account` | Master tag (no enforcement effect by itself). | `AccountFlagsService::isReviewAccount()`; audit query key. |
 | `bypass_device_attestation` | Apple App Attest / Google Play Integrity verification on login. | `BiometricJWTService::verifyDeviceAttestationForUser()` |
 | `bypass_rate_limit` | Per-user API rate limiting (default 60 req/min). | `ApiRateLimitMiddleware`, `GraphQLRateLimitMiddleware` |
-| `bypass_sanctions_screening` | ComplyAdvantage OFAC / PEP / sanctions list match during KYC workflow. | `PerformAmlScreeningActivity::execute()` *(pending DTO plumbing for `$userId` — follow-up)* |
+| `bypass_sanctions_screening` | ComplyAdvantage OFAC / PEP / sanctions list match during KYC workflow. | `PerformAmlScreeningActivity::execute()` |
 | `bypass_sms_otp` | **Reserved** — no consumer; kept so a future SMS OTP path can plug in without a migration. | *(none — this codebase has no dedicated SMS OTP flow; phone verification is via Ondato KYC, covered by `kyc_override_level`)* |
 | `suppress_notifications` | Outbound email / SMS / FCM push on system events. | `SuppressNotificationsListener` on the `NotificationSending` event |
 | `kyc_override_level` | Real KYC level resolution; returns the override (0–3) instead. `null` = use real KYC. | `User::effectiveKycLevel()` |

--- a/docs/superpowers/plans/2026-04-24-reviewer-account-provisioning.md
+++ b/docs/superpowers/plans/2026-04-24-reviewer-account-provisioning.md
@@ -1,0 +1,2731 @@
+# Reviewer/Demo Account Provisioning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a general-purpose account-provisioning domain that lets operators seed app-store reviewer accounts (and future personas) with scoped, auditable, reversible security bypasses.
+
+**Architecture:** Hybrid model — a new `account_flags` table drives explicit security bypasses at ~5 existing enforcement points, while UI content (cards, TrustCerts, balances, rewards) is real seeded rows. A minimal `AccountProfile` interface with one concrete `ReviewerAccountProfile` keeps the system extensible. Feature branch: `feat/account-provisioning-reviewer` (already created).
+
+**Tech Stack:** PHP 8.4 / Laravel 12 / MySQL 8 / Redis / Pest / PHPStan Level 8. Follows existing DDD layout under `app/Domain/` (55 existing domains → 56 after this).
+
+**Spec:** `docs/superpowers/specs/2026-04-24-reviewer-account-provisioning-design.md`
+
+---
+
+## File Structure
+
+### Create
+
+- `database/migrations/2026_04_24_000001_create_account_flags_table.php`
+- `app/Domain/AccountProvisioning/Models/AccountFlag.php`
+- `app/Domain/AccountProvisioning/Contracts/AccountProfile.php`
+- `app/Domain/AccountProvisioning/ValueObjects/ProvisioningContext.php`
+- `app/Domain/AccountProvisioning/Services/AccountFlagsService.php`
+- `app/Domain/AccountProvisioning/Services/AccountProvisioningService.php`
+- `app/Domain/AccountProvisioning/Profiles/ReviewerAccountProfile.php`
+- `app/Domain/AccountProvisioning/Seeders/WalletSeeder.php`
+- `app/Domain/AccountProvisioning/Seeders/BalanceSeeder.php`
+- `app/Domain/AccountProvisioning/Seeders/CardSeeder.php`
+- `app/Domain/AccountProvisioning/Seeders/TrustCertSeeder.php`
+- `app/Domain/AccountProvisioning/Seeders/RewardsSeeder.php`
+- `app/Domain/AccountProvisioning/module.json`
+- `app/Console/Commands/AccountProvisionReviewerCommand.php`
+- `app/Console/Commands/AccountListReviewersCommand.php`
+- `app/Console/Commands/AccountDisableReviewerCommand.php`
+- `app/Console/Commands/AccountPurgeReviewerCommand.php`
+- `tests/Unit/AccountProvisioning/AccountFlagsServiceTest.php`
+- `tests/Unit/AccountProvisioning/Seeders/WalletSeederTest.php`
+- `tests/Unit/AccountProvisioning/Seeders/BalanceSeederTest.php`
+- `tests/Unit/AccountProvisioning/Seeders/CardSeederTest.php`
+- `tests/Unit/AccountProvisioning/Seeders/TrustCertSeederTest.php`
+- `tests/Unit/AccountProvisioning/Seeders/RewardsSeederTest.php`
+- `tests/Unit/AccountProvisioning/ReviewerAccountProfileTest.php`
+- `tests/Unit/Models/UserEffectiveKycLevelTest.php`
+- `tests/Feature/AccountProvisioning/ProvisionReviewerCommandTest.php`
+- `tests/Feature/AccountProvisioning/DisableReviewerCommandTest.php`
+- `tests/Feature/AccountProvisioning/ListReviewersCommandTest.php`
+- `tests/Feature/AccountProvisioning/PurgeReviewerCommandTest.php`
+- `tests/Feature/AccountProvisioning/Bypasses/AttestationBypassTest.php`
+- `tests/Feature/AccountProvisioning/Bypasses/RateLimitBypassTest.php`
+- `tests/Feature/AccountProvisioning/Bypasses/SanctionsBypassTest.php`
+- `tests/Feature/AccountProvisioning/Bypasses/NotificationSuppressionTest.php`
+- `tests/Feature/AccountProvisioning/ExpirySweepTest.php`
+- `docs/operations/reviewer-accounts.md`
+- `docs/security/account-flags.md`
+
+### Modify
+
+- `app/Models/User.php` — add `accountFlag()` relation, `effectiveKycLevel()` accessor
+- `app/Domain/Mobile/Services/BiometricJWTService.php:236-237` — consult flag before calling attestation verifiers
+- `app/Http/Middleware/ApiRateLimitMiddleware.php` — short-circuit when flag set
+- `app/Http/Middleware/GraphQLRateLimitMiddleware.php` — same
+- `app/Domain/AgentProtocol/Workflows/Activities/PerformAmlScreeningActivity.php` — return cleared when flag set
+- `routes/console.php` — schedule daily `account:disable-reviewer --all-expired`
+- `graphql/schema.graphql` — add `#import accountProvisioning.graphql` (only if any GraphQL surface lands; skip if CLI-only — decide in Task 18)
+- `CLAUDE.md` — add Essential Commands entry, CI row, domain count 56 → 57
+- `docs/VERSION_ROADMAP.md` — patch-version entry
+- `.env.production.example` + `.env.zelta.example` — no new env vars expected; skip unless Task 18 adds one
+
+---
+
+## Phase 1 — Foundation
+
+### Task 1: Create the `account_flags` migration
+
+**Files:**
+- Create: `database/migrations/2026_04_24_000001_create_account_flags_table.php`
+
+- [ ] **Step 1: Write the migration**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('account_flags', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->unique()->constrained()->cascadeOnDelete();
+            $table->boolean('is_review_account')->default(false)->index();
+            $table->boolean('bypass_device_attestation')->default(false);
+            $table->boolean('bypass_rate_limit')->default(false);
+            $table->boolean('bypass_sanctions_screening')->default(false);
+            $table->boolean('bypass_sms_otp')->default(false);
+            $table->boolean('suppress_notifications')->default(false);
+            $table->tinyInteger('kyc_override_level')->nullable();
+            $table->string('note', 255)->nullable();
+            $table->timestamp('expires_at')->nullable()->index();
+            $table->foreignId('created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('disabled_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('account_flags');
+    }
+};
+```
+
+- [ ] **Step 2: Run migration locally, verify schema**
+
+```bash
+php artisan migrate --pretend  # dry-run first
+php artisan migrate
+php artisan db --execute="DESCRIBE account_flags" --database=mysql 2>/dev/null || php artisan tinker --execute="dump(Schema::getColumnListing('account_flags'));"
+```
+
+Expected: 14 columns listed (id, user_id, is_review_account, …, timestamps).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add database/migrations/2026_04_24_000001_create_account_flags_table.php
+git commit -m "feat(provisioning): add account_flags migration
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `AccountFlag` model + `AccountProvisioning` domain skeleton
+
+**Files:**
+- Create: `app/Domain/AccountProvisioning/Models/AccountFlag.php`
+- Create: `app/Domain/AccountProvisioning/module.json`
+- Modify: `app/Models/User.php` — add relation
+
+- [ ] **Step 1: Write the model**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\Models;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AccountFlag extends Model
+{
+    protected $table = 'account_flags';
+
+    protected $fillable = [
+        'user_id',
+        'is_review_account',
+        'bypass_device_attestation',
+        'bypass_rate_limit',
+        'bypass_sanctions_screening',
+        'bypass_sms_otp',
+        'suppress_notifications',
+        'kyc_override_level',
+        'note',
+        'expires_at',
+        'created_by',
+        'disabled_at',
+    ];
+
+    protected $casts = [
+        'is_review_account'          => 'bool',
+        'bypass_device_attestation'  => 'bool',
+        'bypass_rate_limit'          => 'bool',
+        'bypass_sanctions_screening' => 'bool',
+        'bypass_sms_otp'             => 'bool',
+        'suppress_notifications'     => 'bool',
+        'kyc_override_level'         => 'int',
+        'expires_at'                 => 'datetime',
+        'disabled_at'                => 'datetime',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function isActive(): bool
+    {
+        if ($this->disabled_at !== null) {
+            return false;
+        }
+
+        if ($this->expires_at !== null && $this->expires_at->isPast()) {
+            return false;
+        }
+
+        return true;
+    }
+}
+```
+
+- [ ] **Step 2: Write `module.json`**
+
+```json
+{
+    "$schema": "https://finaegis.io/schemas/module.json",
+    "name": "finaegis/account-provisioning",
+    "version": "1.0.0",
+    "description": "Operator-only provisioning of pre-seeded personas (reviewer/demo accounts) with scoped security bypasses",
+    "type": "core",
+    "dependencies": {
+        "required": {
+            "finaegis/shared": "^1.0",
+            "finaegis/user": "^1.3"
+        },
+        "optional": {
+            "finaegis/wallet": "*",
+            "finaegis/card-issuance": "*",
+            "finaegis/rewards": "*",
+            "finaegis/trust-cert": "*"
+        }
+    },
+    "provides": {
+        "interfaces": [
+            "App\\Domain\\AccountProvisioning\\Contracts\\AccountProfile"
+        ],
+        "events": [],
+        "commands": [
+            "account:provision-reviewer",
+            "account:list-reviewers",
+            "account:disable-reviewer",
+            "account:purge-reviewer"
+        ]
+    }
+}
+```
+
+- [ ] **Step 3: Add relation + accessor stub to `User` model**
+
+Modify `app/Models/User.php` — add after the existing relations block:
+
+```php
+public function accountFlag(): \Illuminate\Database\Eloquent\Relations\HasOne
+{
+    return $this->hasOne(\App\Domain\AccountProvisioning\Models\AccountFlag::class);
+}
+```
+
+- [ ] **Step 4: Run PHPStan to verify no regressions**
+
+```bash
+XDEBUG_MODE=off vendor/bin/phpstan analyse app/Domain/AccountProvisioning app/Models/User.php --memory-limit=2G
+```
+
+Expected: 0 errors on these paths.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Domain/AccountProvisioning/Models/AccountFlag.php \
+        app/Domain/AccountProvisioning/module.json \
+        app/Models/User.php
+git commit -m "feat(provisioning): AccountFlag model, User relation, module.json
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `AccountFlagsService` with per-request cache
+
+**Files:**
+- Create: `app/Domain/AccountProvisioning/Services/AccountFlagsService.php`
+- Test: `tests/Unit/AccountProvisioning/AccountFlagsServiceTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\AccountProvisioning;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Domain\AccountProvisioning\Services\AccountFlagsService;
+use App\Models\User;
+use Tests\TestCase;
+
+uses(TestCase::class, \Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('returns null when user has no flag row', function () {
+    $user = User::factory()->create();
+    $service = new AccountFlagsService();
+
+    expect($service->forUser($user))->toBeNull();
+    expect($service->hasReviewBypass($user, 'device_attestation'))->toBeFalse();
+});
+
+it('returns the flag row and reports bypasses', function () {
+    $user = User::factory()->create();
+    AccountFlag::create([
+        'user_id'                   => $user->id,
+        'is_review_account'         => true,
+        'bypass_device_attestation' => true,
+        'bypass_rate_limit'         => false,
+    ]);
+
+    $service = new AccountFlagsService();
+
+    expect($service->forUser($user))->not->toBeNull();
+    expect($service->hasReviewBypass($user, 'device_attestation'))->toBeTrue();
+    expect($service->hasReviewBypass($user, 'rate_limit'))->toBeFalse();
+});
+
+it('short-circuits when flag is disabled or expired', function () {
+    $user = User::factory()->create();
+    AccountFlag::create([
+        'user_id'                   => $user->id,
+        'is_review_account'         => true,
+        'bypass_device_attestation' => true,
+        'disabled_at'               => now(),
+    ]);
+
+    $service = new AccountFlagsService();
+
+    expect($service->hasReviewBypass($user, 'device_attestation'))->toBeFalse();
+});
+
+it('caches lookups per request', function () {
+    $user = User::factory()->create();
+    AccountFlag::create(['user_id' => $user->id, 'is_review_account' => true]);
+
+    $service = new AccountFlagsService();
+    $service->forUser($user);
+
+    \DB::enableQueryLog();
+    $service->forUser($user);
+    $service->forUser($user);
+    expect(\DB::getQueryLog())->toBeEmpty();
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+```bash
+./vendor/bin/pest tests/Unit/AccountProvisioning/AccountFlagsServiceTest.php
+```
+
+Expected: FAIL — class `AccountFlagsService` does not exist.
+
+- [ ] **Step 3: Implement the service**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\Services;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Models\User;
+
+class AccountFlagsService
+{
+    /** @var array<int, ?AccountFlag> */
+    private array $cache = [];
+
+    public function forUser(User|int $user): ?AccountFlag
+    {
+        $userId = $user instanceof User ? (int) $user->id : $user;
+
+        if (array_key_exists($userId, $this->cache)) {
+            return $this->cache[$userId];
+        }
+
+        $flag = AccountFlag::where('user_id', $userId)->first();
+
+        return $this->cache[$userId] = $flag;
+    }
+
+    public function hasReviewBypass(User|int $user, string $bypass): bool
+    {
+        $flag = $this->forUser($user);
+
+        if ($flag === null || ! $flag->isActive()) {
+            return false;
+        }
+
+        $column = 'bypass_' . $bypass;
+
+        if (! in_array($column, [
+            'bypass_device_attestation',
+            'bypass_rate_limit',
+            'bypass_sanctions_screening',
+            'bypass_sms_otp',
+        ], true)) {
+            return false;
+        }
+
+        $hit = (bool) $flag->{$column};
+
+        if ($hit) {
+            logger()->info('bypass.fired', [
+                'user_id' => $flag->user_id,
+                'bypass'  => $bypass,
+                'reason'  => 'review_account',
+            ]);
+        }
+
+        return $hit;
+    }
+
+    public function shouldSuppressNotifications(User|int $user): bool
+    {
+        $flag = $this->forUser($user);
+
+        return $flag !== null && $flag->isActive() && $flag->suppress_notifications;
+    }
+
+    public function kycOverrideLevel(User|int $user): ?int
+    {
+        $flag = $this->forUser($user);
+
+        if ($flag === null || ! $flag->isActive()) {
+            return null;
+        }
+
+        return $flag->kyc_override_level;
+    }
+
+    public function forget(User|int $user): void
+    {
+        $userId = $user instanceof User ? (int) $user->id : $user;
+        unset($this->cache[$userId]);
+    }
+}
+```
+
+Register as a singleton in `app/Providers/AppServiceProvider.php::register()`:
+
+```php
+$this->app->singleton(\App\Domain\AccountProvisioning\Services\AccountFlagsService::class);
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+```bash
+./vendor/bin/pest tests/Unit/AccountProvisioning/AccountFlagsServiceTest.php
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Domain/AccountProvisioning/Services/AccountFlagsService.php \
+        app/Providers/AppServiceProvider.php \
+        tests/Unit/AccountProvisioning/AccountFlagsServiceTest.php
+git commit -m "feat(provisioning): AccountFlagsService with per-request cache + bypass.fired logging
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: `User::effectiveKycLevel()` accessor
+
+**Files:**
+- Modify: `app/Models/User.php`
+- Test: `tests/Unit/Models/UserEffectiveKycLevelTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Models;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Models\User;
+use Tests\TestCase;
+
+uses(TestCase::class, \Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('returns real kyc_level when no flag override exists', function () {
+    $user = User::factory()->create(['kyc_level' => 1]);
+    expect($user->effectiveKycLevel())->toBe(1);
+});
+
+it('returns override level when flag is active and override is set', function () {
+    $user = User::factory()->create(['kyc_level' => 0]);
+    AccountFlag::create([
+        'user_id'            => $user->id,
+        'is_review_account'  => true,
+        'kyc_override_level' => 2,
+    ]);
+
+    expect($user->effectiveKycLevel())->toBe(2);
+});
+
+it('falls back to real level when flag is disabled', function () {
+    $user = User::factory()->create(['kyc_level' => 1]);
+    AccountFlag::create([
+        'user_id'            => $user->id,
+        'is_review_account'  => true,
+        'kyc_override_level' => 2,
+        'disabled_at'        => now(),
+    ]);
+
+    expect($user->effectiveKycLevel())->toBe(1);
+});
+
+it('falls back to real level when override is null', function () {
+    $user = User::factory()->create(['kyc_level' => 1]);
+    AccountFlag::create([
+        'user_id'            => $user->id,
+        'is_review_account'  => true,
+        'kyc_override_level' => null,
+    ]);
+
+    expect($user->effectiveKycLevel())->toBe(1);
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+```bash
+./vendor/bin/pest tests/Unit/Models/UserEffectiveKycLevelTest.php
+```
+
+Expected: FAIL — method `effectiveKycLevel` does not exist.
+
+- [ ] **Step 3: Add the method to `app/Models/User.php`**
+
+Add right after the existing `accountFlag()` relation:
+
+```php
+public function effectiveKycLevel(): int
+{
+    $service = app(\App\Domain\AccountProvisioning\Services\AccountFlagsService::class);
+    $override = $service->kycOverrideLevel($this);
+
+    if ($override !== null) {
+        return $override;
+    }
+
+    return (int) ($this->kyc_level ?? 0);
+}
+```
+
+- [ ] **Step 4: Verify tests pass**
+
+```bash
+./vendor/bin/pest tests/Unit/Models/UserEffectiveKycLevelTest.php
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Models/User.php tests/Unit/Models/UserEffectiveKycLevelTest.php
+git commit -m "feat(provisioning): User::effectiveKycLevel() respects flag override
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 2 — Profile framework + sub-seeders
+
+### Task 5: `AccountProfile` interface + `ProvisioningContext` VO
+
+**Files:**
+- Create: `app/Domain/AccountProvisioning/Contracts/AccountProfile.php`
+- Create: `app/Domain/AccountProvisioning/ValueObjects/ProvisioningContext.php`
+
+- [ ] **Step 1: Write the interface**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\Contracts;
+
+use App\Domain\AccountProvisioning\ValueObjects\ProvisioningContext;
+use App\Models\User;
+
+interface AccountProfile
+{
+    /** Profile slug, e.g. 'reviewer'. */
+    public function name(): string;
+
+    /**
+     * Flag column => value map that will be written to account_flags.
+     *
+     * @return array<string, bool|int|string|null>
+     */
+    public function flags(ProvisioningContext $ctx): array;
+
+    /** Apply seeded content (wallets, balances, cards, etc.) for the user. */
+    public function provision(User $user, ProvisioningContext $ctx): void;
+}
+```
+
+- [ ] **Step 2: Write the VO**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\ValueObjects;
+
+use Carbon\CarbonImmutable;
+
+final readonly class ProvisioningContext
+{
+    public function __construct(
+        public string $email,
+        public string $name,
+        public string $region,
+        public ?CarbonImmutable $expiresAt,
+        public ?string $note,
+        public int $operatorId,
+        public bool $dryRun = false,
+    ) {}
+}
+```
+
+- [ ] **Step 3: PHPStan check, commit**
+
+```bash
+XDEBUG_MODE=off vendor/bin/phpstan analyse app/Domain/AccountProvisioning --memory-limit=2G
+```
+
+Expected: 0 errors.
+
+```bash
+git add app/Domain/AccountProvisioning/Contracts app/Domain/AccountProvisioning/ValueObjects
+git commit -m "feat(provisioning): AccountProfile interface + ProvisioningContext VO
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: `WalletSeeder`
+
+**Files:**
+- Create: `app/Domain/AccountProvisioning/Seeders/WalletSeeder.php`
+- Test: `tests/Unit/AccountProvisioning/Seeders/WalletSeederTest.php`
+
+**Prerequisite research (do this first, ~3 minutes):** the engineer must trace the existing user-registration wallet-provisioning call in this codebase. Start by grepping: `grep -rn "RegisteredUser\|UserRegistered" app/Listeners app/Domain/User --include="*.php"`. Use whichever service is invoked there (likely a `WalletCreationService` or similar). Do NOT fabricate a new wallet-creation path — re-use production's. The seeder is a thin idempotent wrapper: `firstOrCreate` on the natural key (e.g. `user_id + chain`), invoke the existing service only when the row doesn't exist.
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\AccountProvisioning\Seeders;
+
+use App\Domain\AccountProvisioning\Seeders\WalletSeeder;
+use App\Models\User;
+use Tests\TestCase;
+
+uses(TestCase::class, \Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('creates a polygon EVM wallet and a solana wallet for the user', function () {
+    $user = User::factory()->create();
+    $seeder = app(WalletSeeder::class);
+
+    $seeder->seed($user);
+
+    // Adjust these assertions to match the production wallet-model table(s)
+    expect($user->fresh()->walletAddresses()->where('chain', 'polygon')->exists())->toBeTrue();
+    expect($user->fresh()->walletAddresses()->where('chain', 'solana')->exists())->toBeTrue();
+});
+
+it('is idempotent: second call does not duplicate rows', function () {
+    $user = User::factory()->create();
+    $seeder = app(WalletSeeder::class);
+
+    $seeder->seed($user);
+    $seeder->seed($user);
+
+    expect($user->fresh()->walletAddresses()->count())->toBe(2);
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+```bash
+./vendor/bin/pest tests/Unit/AccountProvisioning/Seeders/WalletSeederTest.php
+```
+
+Expected: FAIL — class does not exist, OR relation `walletAddresses` does not exist. If the latter, adjust the test to the real relation name discovered in prerequisite research.
+
+- [ ] **Step 3: Implement seeder**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\Seeders;
+
+use App\Models\User;
+
+class WalletSeeder
+{
+    public function seed(User $user): void
+    {
+        // 1. Call the production wallet-provisioning service once per chain.
+        // 2. Wrap each call in firstOrCreate semantics on (user_id, chain).
+        // 3. Reuse SolanaAddressHelper::deriveForUser(userId, appKey) per CLAUDE.md.
+
+        // Replace the following stubs with real service calls discovered in prerequisite research.
+        $walletService = app(\App\Domain\Wallet\Services\WalletProvisioningService::class);
+        $walletService->ensureFor($user, 'polygon');
+        $walletService->ensureFor($user, 'solana');
+    }
+}
+```
+
+Note: if the production service does not expose an `ensureFor`-style idempotent method, wrap `firstOrCreate` at the Eloquent level inside the seeder instead of calling the service. The test in Step 1 is the contract — make it pass with the cleanest wrapper.
+
+- [ ] **Step 4: Run test, verify it passes**
+
+```bash
+./vendor/bin/pest tests/Unit/AccountProvisioning/Seeders/WalletSeederTest.php
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Domain/AccountProvisioning/Seeders/WalletSeeder.php \
+        tests/Unit/AccountProvisioning/Seeders/WalletSeederTest.php
+git commit -m "feat(provisioning): idempotent WalletSeeder for EVM+Solana
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: `BalanceSeeder`
+
+**Files:**
+- Create: `app/Domain/AccountProvisioning/Seeders/BalanceSeeder.php`
+- Test: `tests/Unit/AccountProvisioning/Seeders/BalanceSeederTest.php`
+
+**Prerequisite:** grep for the production balance-credit service (likely `app/Domain/Wallet/Services/` or `app/Domain/Account/Services/`). Must use bcmath (per CLAUDE.md: never `(float)` for money). Must wrap writes in `DB::transaction()` with `lockForUpdate()`.
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\AccountProvisioning\Seeders;
+
+use App\Domain\AccountProvisioning\Seeders\BalanceSeeder;
+use App\Domain\AccountProvisioning\Seeders\WalletSeeder;
+use App\Models\User;
+use Tests\TestCase;
+
+uses(TestCase::class, \Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('sets unshielded USDC balance on polygon to target', function () {
+    $user = User::factory()->create();
+    app(WalletSeeder::class)->seed($user);
+    $seeder = app(BalanceSeeder::class);
+
+    $seeder->seed($user, unshieldedUsdc: '25.00', shieldedUsdc: '10.00');
+
+    expect($user->balanceFor('USDC', 'polygon', shielded: false))->toEqualString('25.00');
+    expect($user->balanceFor('USDC', 'polygon', shielded: true))->toEqualString('10.00');
+});
+
+it('is idempotent: re-seeding sets the same target, not accumulative', function () {
+    $user = User::factory()->create();
+    app(WalletSeeder::class)->seed($user);
+
+    app(BalanceSeeder::class)->seed($user, unshieldedUsdc: '25.00', shieldedUsdc: '10.00');
+    app(BalanceSeeder::class)->seed($user, unshieldedUsdc: '25.00', shieldedUsdc: '10.00');
+
+    expect($user->balanceFor('USDC', 'polygon', shielded: false))->toEqualString('25.00');
+});
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+```bash
+./vendor/bin/pest tests/Unit/AccountProvisioning/Seeders/BalanceSeederTest.php
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement seeder**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\Seeders;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class BalanceSeeder
+{
+    public function seed(User $user, string $unshieldedUsdc, string $shieldedUsdc): void
+    {
+        DB::transaction(function () use ($user, $unshieldedUsdc, $shieldedUsdc): void {
+            $this->setBalance($user, asset: 'USDC', chain: 'polygon', shielded: false, target: $unshieldedUsdc);
+            $this->setBalance($user, asset: 'USDC', chain: 'polygon', shielded: true, target: $shieldedUsdc);
+        });
+    }
+
+    private function setBalance(User $user, string $asset, string $chain, bool $shielded, string $target): void
+    {
+        // Normalize to 4 decimals per bcmath convention (CLAUDE.md).
+        $normalized = bcadd($target, '0', 4);
+
+        // Replace with production's set-balance-to-target service.
+        // If none exists, compute delta vs current balance and credit/debit the difference.
+        app(\App\Domain\Wallet\Services\BalanceService::class)
+            ->setBalanceForReviewAccount($user, $asset, $chain, $shielded, $normalized);
+    }
+}
+```
+
+If the production codebase has no "set to target" balance method, add one *only* in the review-account domain (scoped, never exposed outside). Never mutate balances directly without the existing accounting/ledger domain's approval — this is a bcmath-critical area per CLAUDE.md. If in doubt, route through a compensating ledger entry.
+
+- [ ] **Step 4: Run, verify pass**
+
+```bash
+./vendor/bin/pest tests/Unit/AccountProvisioning/Seeders/BalanceSeederTest.php
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Domain/AccountProvisioning/Seeders/BalanceSeeder.php \
+        tests/Unit/AccountProvisioning/Seeders/BalanceSeederTest.php
+git commit -m "feat(provisioning): idempotent BalanceSeeder with bcmath + DB::transaction
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: `CardSeeder`
+
+**Files:**
+- Create: `app/Domain/AccountProvisioning/Seeders/CardSeeder.php`
+- Test: `tests/Unit/AccountProvisioning/Seeders/CardSeederTest.php`
+
+- [ ] **Step 1: Failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\AccountProvisioning\Seeders;
+
+use App\Domain\AccountProvisioning\Seeders\CardSeeder;
+use App\Domain\CardIssuance\Models\Card;
+use App\Models\User;
+use Tests\TestCase;
+
+uses(TestCase::class, \Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('creates one active virtual card for the user', function () {
+    $user = User::factory()->create();
+
+    app(CardSeeder::class)->seed($user);
+
+    $cards = Card::where('user_id', $user->id)->where('status', 'active')->get();
+    expect($cards)->toHaveCount(1);
+    expect($cards->first()->type)->toBe('virtual');
+});
+
+it('is idempotent', function () {
+    $user = User::factory()->create();
+    app(CardSeeder::class)->seed($user);
+    app(CardSeeder::class)->seed($user);
+
+    expect(Card::where('user_id', $user->id)->count())->toBe(1);
+});
+```
+
+- [ ] **Step 2: Run, fail**
+
+```bash
+./vendor/bin/pest tests/Unit/AccountProvisioning/Seeders/CardSeederTest.php
+```
+
+- [ ] **Step 3: Implement**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\Seeders;
+
+use App\Domain\CardIssuance\Models\Card;
+use App\Models\User;
+
+class CardSeeder
+{
+    public function seed(User $user): void
+    {
+        Card::firstOrCreate(
+            [
+                'user_id' => $user->id,
+                'type'    => 'virtual',
+            ],
+            [
+                'status'     => 'active',
+                'brand'      => 'visa',
+                'last_four'  => '4242',
+                'expires_at' => now()->addYears(3),
+            ]
+        );
+    }
+}
+```
+
+Note: the column set shown is the expected shape. Inspect `database/migrations/*card*` and `app/Domain/CardIssuance/Models/Card.php::$fillable` and adjust to the actual columns. Don't skip required columns the model enforces (e.g. `cardholder_id` FK).
+
+- [ ] **Step 4: Run, pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Domain/AccountProvisioning/Seeders/CardSeeder.php \
+        tests/Unit/AccountProvisioning/Seeders/CardSeederTest.php
+git commit -m "feat(provisioning): idempotent CardSeeder (one active virtual card)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: `TrustCertSeeder`
+
+**Files:**
+- Create: `app/Domain/AccountProvisioning/Seeders/TrustCertSeeder.php`
+- Test: `tests/Unit/AccountProvisioning/Seeders/TrustCertSeederTest.php`
+
+- [ ] **Step 1: Failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\AccountProvisioning\Seeders;
+
+use App\Domain\AccountProvisioning\Seeders\TrustCertSeeder;
+use App\Domain\TrustCert\Models\Certificate;
+use App\Models\User;
+use Tests\TestCase;
+
+uses(TestCase::class, \Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('issues one active trust certificate', function () {
+    $user = User::factory()->create();
+
+    app(TrustCertSeeder::class)->seed($user);
+
+    expect(Certificate::where('user_id', $user->id)->where('status', 'active')->count())->toBe(1);
+});
+
+it('is idempotent', function () {
+    $user = User::factory()->create();
+    app(TrustCertSeeder::class)->seed($user);
+    app(TrustCertSeeder::class)->seed($user);
+
+    expect(Certificate::where('user_id', $user->id)->count())->toBe(1);
+});
+```
+
+- [ ] **Step 2: Run, fail**
+
+- [ ] **Step 3: Implement**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\Seeders;
+
+use App\Domain\TrustCert\Models\Certificate;
+use App\Models\User;
+
+class TrustCertSeeder
+{
+    public function seed(User $user): void
+    {
+        Certificate::firstOrCreate(
+            [
+                'user_id' => $user->id,
+                'tier'    => 'basic',
+            ],
+            [
+                'status'     => 'active',
+                'issued_at'  => now(),
+                'expires_at' => now()->addYear(),
+                'provider'   => 'review_bypass',
+            ]
+        );
+    }
+}
+```
+
+Inspect `app/Domain/TrustCert/Models/Certificate.php` for actual column names and adjust — `tier`, `status`, and `provider` column names may differ.
+
+- [ ] **Step 4: Run, pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Domain/AccountProvisioning/Seeders/TrustCertSeeder.php \
+        tests/Unit/AccountProvisioning/Seeders/TrustCertSeederTest.php
+git commit -m "feat(provisioning): idempotent TrustCertSeeder
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: `RewardsSeeder`
+
+**Files:**
+- Create: `app/Domain/AccountProvisioning/Seeders/RewardsSeeder.php`
+- Test: `tests/Unit/AccountProvisioning/Seeders/RewardsSeederTest.php`
+
+- [ ] **Step 1: Failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\AccountProvisioning\Seeders;
+
+use App\Domain\AccountProvisioning\Seeders\RewardsSeeder;
+use App\Domain\Rewards\Models\RewardProfile;
+use App\Domain\Rewards\Models\RewardQuestCompletion;
+use App\Models\User;
+use Tests\TestCase;
+
+uses(TestCase::class, \Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('creates a reward profile with XP and one completed quest', function () {
+    $user = User::factory()->create();
+
+    app(RewardsSeeder::class)->seed($user);
+
+    $profile = RewardProfile::where('user_id', $user->id)->first();
+    expect($profile)->not->toBeNull();
+    expect($profile->xp)->toBeGreaterThan(0);
+    expect(RewardQuestCompletion::where('user_id', $user->id)->count())->toBe(1);
+});
+
+it('is idempotent', function () {
+    $user = User::factory()->create();
+    app(RewardsSeeder::class)->seed($user);
+    app(RewardsSeeder::class)->seed($user);
+
+    expect(RewardQuestCompletion::where('user_id', $user->id)->count())->toBe(1);
+});
+```
+
+- [ ] **Step 2: Run, fail**
+
+- [ ] **Step 3: Implement**
+
+Inspect `MobileRewardsDemoSeeder` in `database/seeders/` for a reference pattern. Port the reviewer-appropriate subset (one profile, a modest XP, one quest completion). All writes `firstOrCreate`.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\Seeders;
+
+use App\Domain\Rewards\Models\RewardProfile;
+use App\Domain\Rewards\Models\RewardQuest;
+use App\Domain\Rewards\Models\RewardQuestCompletion;
+use App\Models\User;
+
+class RewardsSeeder
+{
+    public function seed(User $user): void
+    {
+        $profile = RewardProfile::firstOrCreate(
+            ['user_id' => $user->id],
+            ['xp' => 250, 'tier' => 'bronze'],
+        );
+
+        $quest = RewardQuest::firstWhere('slug', 'welcome') ?? RewardQuest::first();
+
+        if ($quest !== null) {
+            RewardQuestCompletion::firstOrCreate(
+                ['user_id' => $user->id, 'quest_id' => $quest->id],
+                ['completed_at' => now()]
+            );
+        }
+    }
+}
+```
+
+Adjust column names (`xp`, `tier`, `slug`, `quest_id`) to match the real models.
+
+- [ ] **Step 4: Run, pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Domain/AccountProvisioning/Seeders/RewardsSeeder.php \
+        tests/Unit/AccountProvisioning/Seeders/RewardsSeederTest.php
+git commit -m "feat(provisioning): idempotent RewardsSeeder
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: `ReviewerAccountProfile`
+
+**Files:**
+- Create: `app/Domain/AccountProvisioning/Profiles/ReviewerAccountProfile.php`
+- Test: `tests/Unit/AccountProvisioning/ReviewerAccountProfileTest.php`
+
+- [ ] **Step 1: Failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\AccountProvisioning;
+
+use App\Domain\AccountProvisioning\Profiles\ReviewerAccountProfile;
+use App\Domain\AccountProvisioning\ValueObjects\ProvisioningContext;
+use App\Domain\CardIssuance\Models\Card;
+use App\Domain\TrustCert\Models\Certificate;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Tests\TestCase;
+
+uses(TestCase::class, \Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('returns the expected flag payload', function () {
+    $profile = app(ReviewerAccountProfile::class);
+    $ctx = new ProvisioningContext(
+        email: 'appreview@finaegis.com',
+        name: 'App Reviewer',
+        region: 'US',
+        expiresAt: CarbonImmutable::now()->addDays(60),
+        note: 'App Store review 2026-Q2',
+        operatorId: 1,
+    );
+
+    $flags = $profile->flags($ctx);
+
+    expect($flags['is_review_account'])->toBeTrue();
+    expect($flags['bypass_device_attestation'])->toBeTrue();
+    expect($flags['bypass_rate_limit'])->toBeTrue();
+    expect($flags['bypass_sanctions_screening'])->toBeTrue();
+    expect($flags['bypass_sms_otp'])->toBeTrue();
+    expect($flags['suppress_notifications'])->toBeTrue();
+    expect($flags['kyc_override_level'])->toBe(2);
+    expect($flags['note'])->toBe('App Store review 2026-Q2');
+});
+
+it('provisions all content sub-seeders in one transaction', function () {
+    $user = User::factory()->create();
+    $ctx = new ProvisioningContext('e', 'n', 'US', null, null, 1);
+
+    app(ReviewerAccountProfile::class)->provision($user, $ctx);
+
+    expect(Card::where('user_id', $user->id)->count())->toBe(1);
+    expect(Certificate::where('user_id', $user->id)->count())->toBe(1);
+});
+
+it('is idempotent end-to-end', function () {
+    $user = User::factory()->create();
+    $ctx = new ProvisioningContext('e', 'n', 'US', null, null, 1);
+
+    $profile = app(ReviewerAccountProfile::class);
+    $profile->provision($user, $ctx);
+    $profile->provision($user, $ctx);
+
+    expect(Card::where('user_id', $user->id)->count())->toBe(1);
+    expect(Certificate::where('user_id', $user->id)->count())->toBe(1);
+});
+```
+
+- [ ] **Step 2: Run, fail**
+
+- [ ] **Step 3: Implement**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\Profiles;
+
+use App\Domain\AccountProvisioning\Contracts\AccountProfile;
+use App\Domain\AccountProvisioning\Seeders\BalanceSeeder;
+use App\Domain\AccountProvisioning\Seeders\CardSeeder;
+use App\Domain\AccountProvisioning\Seeders\RewardsSeeder;
+use App\Domain\AccountProvisioning\Seeders\TrustCertSeeder;
+use App\Domain\AccountProvisioning\Seeders\WalletSeeder;
+use App\Domain\AccountProvisioning\ValueObjects\ProvisioningContext;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class ReviewerAccountProfile implements AccountProfile
+{
+    public function __construct(
+        private readonly WalletSeeder $wallets,
+        private readonly BalanceSeeder $balances,
+        private readonly CardSeeder $cards,
+        private readonly TrustCertSeeder $trustCert,
+        private readonly RewardsSeeder $rewards,
+    ) {}
+
+    public function name(): string
+    {
+        return 'reviewer';
+    }
+
+    /** @return array<string, bool|int|string|null> */
+    public function flags(ProvisioningContext $ctx): array
+    {
+        return [
+            'is_review_account'          => true,
+            'bypass_device_attestation'  => true,
+            'bypass_rate_limit'          => true,
+            'bypass_sanctions_screening' => true,
+            'bypass_sms_otp'             => true,
+            'suppress_notifications'     => true,
+            'kyc_override_level'         => 2,
+            'note'                       => $ctx->note,
+            'expires_at'                 => $ctx->expiresAt,
+            'created_by'                 => $ctx->operatorId,
+        ];
+    }
+
+    public function provision(User $user, ProvisioningContext $ctx): void
+    {
+        DB::transaction(function () use ($user): void {
+            $this->wallets->seed($user);
+            $this->balances->seed($user, unshieldedUsdc: '25.00', shieldedUsdc: '10.00');
+            $this->cards->seed($user);
+            $this->trustCert->seed($user);
+            $this->rewards->seed($user);
+        });
+    }
+}
+```
+
+- [ ] **Step 4: Run, pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Domain/AccountProvisioning/Profiles/ReviewerAccountProfile.php \
+        tests/Unit/AccountProvisioning/ReviewerAccountProfileTest.php
+git commit -m "feat(provisioning): ReviewerAccountProfile orchestrates sub-seeders
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 12: `AccountProvisioningService` (top-level orchestrator)
+
+**Files:**
+- Create: `app/Domain/AccountProvisioning/Services/AccountProvisioningService.php`
+
+This service is called by the CLI command. It does user creation/lookup, writes the flag row, and invokes the profile. No test file yet — the feature test for the CLI command in Task 18 is the contract for this service. Keeping it thin avoids double-testing.
+
+- [ ] **Step 1: Implement**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\Services;
+
+use App\Domain\AccountProvisioning\Contracts\AccountProfile;
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Domain\AccountProvisioning\ValueObjects\ProvisioningContext;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use RuntimeException;
+
+class AccountProvisioningService
+{
+    public function __construct(
+        private readonly AccountFlagsService $flags,
+    ) {}
+
+    /**
+     * @return array{user: User, password_action: 'created'|'rotated'|'unchanged'}
+     */
+    public function apply(
+        AccountProfile $profile,
+        ProvisioningContext $ctx,
+        ?string $password,
+        bool $rotatePassword,
+        bool $forceConvert,
+    ): array {
+        return DB::transaction(function () use ($profile, $ctx, $password, $rotatePassword, $forceConvert) {
+            $existing = User::where('email', $ctx->email)->first();
+
+            if ($existing !== null) {
+                $flag = $existing->accountFlag;
+
+                if (($flag === null || ! $flag->is_review_account) && ! $forceConvert) {
+                    throw new RuntimeException(
+                        "Email {$ctx->email} belongs to a non-review user. Use --force-convert to override (blocked in production)."
+                    );
+                }
+
+                $user = $existing;
+                $action = 'unchanged';
+
+                if ($rotatePassword && $password !== null) {
+                    $user->password = Hash::make($password);
+                    $user->save();
+                    $this->flags->forget($user);
+                    $action = 'rotated';
+                }
+            } else {
+                if ($password === null) {
+                    throw new RuntimeException('Password must be provided or generated before calling apply().');
+                }
+
+                $user = User::create([
+                    'name'              => $ctx->name,
+                    'email'             => $ctx->email,
+                    'password'          => Hash::make($password),
+                    'email_verified_at' => now(),
+                ]);
+                $action = 'created';
+            }
+
+            AccountFlag::updateOrCreate(
+                ['user_id' => $user->id],
+                $profile->flags($ctx),
+            );
+
+            $this->flags->forget($user);
+
+            if (! $ctx->dryRun) {
+                $profile->provision($user, $ctx);
+            }
+
+            return ['user' => $user, 'password_action' => $action];
+        });
+    }
+
+    public function disable(User $user): void
+    {
+        $flag = $user->accountFlag;
+        if ($flag === null) {
+            return;
+        }
+
+        $flag->update([
+            'bypass_device_attestation'  => false,
+            'bypass_rate_limit'          => false,
+            'bypass_sanctions_screening' => false,
+            'bypass_sms_otp'             => false,
+            'suppress_notifications'     => false,
+            'kyc_override_level'         => null,
+            'disabled_at'                => now(),
+        ]);
+
+        $user->tokens()->delete();
+        $this->flags->forget($user);
+    }
+
+    public function reEnable(User $user, AccountProfile $profile, ProvisioningContext $ctx): void
+    {
+        AccountFlag::updateOrCreate(
+            ['user_id' => $user->id],
+            array_merge($profile->flags($ctx), ['disabled_at' => null]),
+        );
+        $this->flags->forget($user);
+    }
+}
+```
+
+- [ ] **Step 2: PHPStan check, commit**
+
+```bash
+XDEBUG_MODE=off vendor/bin/phpstan analyse app/Domain/AccountProvisioning --memory-limit=2G
+```
+
+```bash
+git add app/Domain/AccountProvisioning/Services/AccountProvisioningService.php
+git commit -m "feat(provisioning): AccountProvisioningService orchestrates user + flag + profile
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 3 — Enforcement plumbing
+
+### Task 13: Attestation bypass in `BiometricJWTService`
+
+**Files:**
+- Modify: `app/Domain/Mobile/Services/BiometricJWTService.php:236-237`
+- Test: `tests/Feature/AccountProvisioning/Bypasses/AttestationBypassTest.php`
+
+**Context:** attestation verifiers are called from `BiometricJWTService`. The user is known at that call site — patch the caller, not the verifiers (keeps verifiers pure).
+
+- [ ] **Step 1: Failing feature test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AccountProvisioning\Bypasses;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Domain\Mobile\Services\BiometricJWTService;
+use App\Models\User;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+uses(TestCase::class, \Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('short-circuits attestation when bypass flag is set', function () {
+    Log::spy();
+    $user = User::factory()->create();
+    AccountFlag::create([
+        'user_id'                   => $user->id,
+        'is_review_account'         => true,
+        'bypass_device_attestation' => true,
+    ]);
+
+    $service = app(BiometricJWTService::class);
+
+    // Call whatever public method on BiometricJWTService takes (user, platform, attestation) — find via public API.
+    $result = $service->verifyAttestationForUser($user, 'ios', 'AAAA');
+
+    expect($result)->toBeTrue();
+    Log::shouldHaveReceived('info')->withArgs(fn ($msg, $ctx) => $msg === 'bypass.fired' && $ctx['bypass'] === 'device_attestation');
+});
+
+it('does not bypass for a regular user', function () {
+    $user = User::factory()->create();
+    $service = app(BiometricJWTService::class);
+
+    // Regular user: verifier returns false for empty attestation.
+    $result = $service->verifyAttestationForUser($user, 'ios', 'AAAA');
+
+    expect($result)->toBeFalse();
+});
+```
+
+- [ ] **Step 2: Run, fail**
+
+- [ ] **Step 3: Modify `BiometricJWTService`**
+
+Find the method currently containing lines 236-237 (the `match` expression around `app(AppleAttestationVerifier::class)->verify(...)`). The method already takes a user (or is called with user context nearby). Inject `AccountFlagsService` via constructor and short-circuit before the verifier calls:
+
+```php
+public function verifyAttestationForUser(User $user, string $platform, string $attestation): bool
+{
+    if ($this->flags->hasReviewBypass($user, 'device_attestation')) {
+        return true;
+    }
+
+    return match ($platform) {
+        'ios'     => app(AppleAttestationVerifier::class)->verify($attestation, ''),
+        'android' => app(GoogleIntegrityVerifier::class)->verify($attestation),
+        default   => false,
+    };
+}
+```
+
+If `verifyAttestationForUser` doesn't exist verbatim — *it's the name the test expects* — extract the existing `match` block into a new method with that exact name, or rename appropriately. The existing call sites must be updated to pass `User`.
+
+- [ ] **Step 4: Run, pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Domain/Mobile/Services/BiometricJWTService.php \
+        tests/Feature/AccountProvisioning/Bypasses/AttestationBypassTest.php
+git commit -m "feat(provisioning): attestation bypass for review accounts
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 14: Rate limit bypass
+
+**Files:**
+- Modify: `app/Http/Middleware/ApiRateLimitMiddleware.php`
+- Modify: `app/Http/Middleware/GraphQLRateLimitMiddleware.php`
+- Test: `tests/Feature/AccountProvisioning/Bypasses/RateLimitBypassTest.php`
+
+- [ ] **Step 1: Failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AccountProvisioning\Bypasses;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+uses(TestCase::class, \Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('rate-limits a regular user after threshold', function () {
+    $user = User::factory()->create();
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    // Hit an auth-bucket endpoint 6x; limit is 5/min.
+    $responses = collect(range(1, 6))->map(fn () => $this->postJson('/api/v1/auth/login', []));
+
+    expect($responses->last()->status())->toBe(429);
+});
+
+it('does not rate-limit a review user', function () {
+    $user = User::factory()->create();
+    AccountFlag::create([
+        'user_id'            => $user->id,
+        'is_review_account'  => true,
+        'bypass_rate_limit'  => true,
+    ]);
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    $responses = collect(range(1, 20))->map(fn () => $this->postJson('/api/v1/auth/login', []));
+
+    expect($responses->every(fn ($r) => $r->status() !== 429))->toBeTrue();
+});
+```
+
+- [ ] **Step 2: Run, fail**
+
+- [ ] **Step 3: Patch middleware**
+
+In `app/Http/Middleware/ApiRateLimitMiddleware.php::handle()`, at the top of the method (after the existing "skip if disabled" guard), add:
+
+```php
+$user = $request->user();
+if ($user !== null) {
+    $flags = app(\App\Domain\AccountProvisioning\Services\AccountFlagsService::class);
+    if ($flags->hasReviewBypass($user, 'rate_limit')) {
+        return $next($request);
+    }
+}
+```
+
+Same pattern in `GraphQLRateLimitMiddleware::handle()`.
+
+- [ ] **Step 4: Run, pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Http/Middleware/ApiRateLimitMiddleware.php \
+        app/Http/Middleware/GraphQLRateLimitMiddleware.php \
+        tests/Feature/AccountProvisioning/Bypasses/RateLimitBypassTest.php
+git commit -m "feat(provisioning): rate-limit bypass for review accounts
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 15: Sanctions bypass
+
+**Files:**
+- Modify: `app/Domain/AgentProtocol/Workflows/Activities/PerformAmlScreeningActivity.php`
+- Test: `tests/Feature/AccountProvisioning/Bypasses/SanctionsBypassTest.php`
+
+- [ ] **Step 1: Failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AccountProvisioning\Bypasses;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Domain\AgentProtocol\Workflows\Activities\PerformAmlScreeningActivity;
+use App\Models\User;
+use Tests\TestCase;
+
+uses(TestCase::class, \Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('returns cleared when bypass flag is set', function () {
+    $user = User::factory()->create();
+    AccountFlag::create([
+        'user_id'                    => $user->id,
+        'is_review_account'          => true,
+        'bypass_sanctions_screening' => true,
+    ]);
+
+    $activity = app(PerformAmlScreeningActivity::class);
+    $result = $activity->screenUser($user);
+
+    expect($result->status)->toBe('cleared');
+    expect($result->source ?? null)->toBe('review_bypass');
+});
+```
+
+- [ ] **Step 2: Run, fail**
+
+- [ ] **Step 3: Patch activity**
+
+At the entry of the screen method, before external calls:
+
+```php
+if ($this->flags->hasReviewBypass($user, 'sanctions_screening')) {
+    return ScreeningResult::cleared(source: 'review_bypass');
+}
+```
+
+Add `AccountFlagsService` dependency via constructor. Match the actual `ScreeningResult` value object's constructor (inspect the file for the real shape).
+
+- [ ] **Step 4: Run, pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Domain/AgentProtocol/Workflows/Activities/PerformAmlScreeningActivity.php \
+        tests/Feature/AccountProvisioning/Bypasses/SanctionsBypassTest.php
+git commit -m "feat(provisioning): sanctions screening bypass for review accounts
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 16: SMS OTP bypass (investigation-first)
+
+**Context:** the codebase has no obvious dedicated SMS OTP verification path (grep found only TOTP-via-Google-Authenticator in `TwoFactorAuthController`). The reviewer request says "Phone: skip / mark as verified without SMS". Two sub-tasks:
+
+**16a — Decide the scope (5 min)**
+
+- [ ] Grep for `phone_verified_at`, `phoneVerified`, `verify.*phone`, `SmsOtpService`, `sendOtp` across `app/`. Document findings in a 5-line comment on the PR.
+- [ ] If there is no SMS OTP path (likely): the `bypass_sms_otp` flag still exists in the schema (reserved) but has no enforcement site yet. That's fine — flags without consumers are safe no-ops. The reviewer doesn't encounter an SMS OTP screen because Ondato KYC is the phone-verification gate, and KYC is handled by `kyc_override_level`. Note this in the operator runbook.
+
+**16b — If an SMS OTP path exists**
+
+- [ ] Add a failing feature test in the same pattern as Task 14/15.
+- [ ] Short-circuit: `if ($flags->hasReviewBypass($user, 'sms_otp')) { return OtpResult::verified(source: 'review_bypass'); }`.
+- [ ] Run, pass, commit.
+
+If 16a finds no path, commit:
+
+```bash
+git commit --allow-empty -m "chore(provisioning): SMS OTP bypass reserved — no enforcement site found (noted in runbook)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 17: Notification suppression
+
+**Files:**
+- Create: `app/Domain/AccountProvisioning/Support/SuppressNotificationsListener.php` (or extend an existing dispatcher hook — investigate first)
+- Test: `tests/Feature/AccountProvisioning/Bypasses/NotificationSuppressionTest.php`
+
+**Investigation:** grep for the central notification dispatch pattern (`Notification::send`, `$user->notify(`, `NotificationSender`). Two implementations fit Laravel:
+
+- **Option A (preferred):** use Laravel's `NotificationSending` event. Register a listener that cancels delivery by returning `false` from the handler when `AccountFlagsService::shouldSuppressNotifications($notifiable)` returns true.
+- **Option B:** patch `PushNotificationService` and any email sender directly with the same check.
+
+Option A is one file and one listener registration; Option B requires finding and patching every sender. Choose A unless something blocks it.
+
+- [ ] **Step 1: Failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AccountProvisioning\Bypasses;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Models\User;
+use App\Notifications\AlertAssigned;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+uses(TestCase::class, \Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('suppresses notifications for review accounts', function () {
+    Notification::fake();
+    $user = User::factory()->create();
+    AccountFlag::create([
+        'user_id'                 => $user->id,
+        'is_review_account'       => true,
+        'suppress_notifications'  => true,
+    ]);
+
+    // Use any real app notification; if AlertAssigned requires args, pick a simpler one (grep `class.*Notification` under app/Notifications) or define a minimal inline test notification class.
+    $user->notify(new AlertAssigned(alertId: 1, assigneeEmail: $user->email));
+
+    Notification::assertNothingSentTo($user);
+});
+
+it('delivers notifications to a regular user', function () {
+    Notification::fake();
+    $user = User::factory()->create();
+
+    // Use any real app notification; if AlertAssigned requires args, pick a simpler one (grep `class.*Notification` under app/Notifications) or define a minimal inline test notification class.
+    $user->notify(new AlertAssigned(alertId: 1, assigneeEmail: $user->email));
+
+    Notification::assertSentTo($user, AlertAssigned::class);
+});
+```
+
+- [ ] **Step 2: Run, fail**
+
+- [ ] **Step 3: Implement listener**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\Support;
+
+use App\Domain\AccountProvisioning\Services\AccountFlagsService;
+use App\Models\User;
+use Illuminate\Notifications\Events\NotificationSending;
+
+class SuppressNotificationsListener
+{
+    public function __construct(private readonly AccountFlagsService $flags) {}
+
+    public function handle(NotificationSending $event): bool
+    {
+        if (! $event->notifiable instanceof User) {
+            return true;
+        }
+
+        return ! $this->flags->shouldSuppressNotifications($event->notifiable);
+    }
+}
+```
+
+Register in `app/Providers/EventServiceProvider.php::$listen`:
+
+```php
+\Illuminate\Notifications\Events\NotificationSending::class => [
+    \App\Domain\AccountProvisioning\Support\SuppressNotificationsListener::class,
+],
+```
+
+- [ ] **Step 4: Run, pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Domain/AccountProvisioning/Support \
+        app/Providers/EventServiceProvider.php \
+        tests/Feature/AccountProvisioning/Bypasses/NotificationSuppressionTest.php
+git commit -m "feat(provisioning): suppress notifications for review accounts via NotificationSending hook
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 4 — CLI surface
+
+### Task 18: `account:provision-reviewer` command
+
+**Files:**
+- Create: `app/Console/Commands/AccountProvisionReviewerCommand.php`
+- Test: `tests/Feature/AccountProvisioning/ProvisionReviewerCommandTest.php`
+
+- [ ] **Step 1: Failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AccountProvisioning;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Models\User;
+use App\Domain\User\Enums\UserRoles;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+uses(TestCase::class, \Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    Role::firstOrCreate(['name' => UserRoles::ADMIN->value, 'guard_name' => 'web']);
+    $this->operator = User::factory()->create(['email' => 'op@finaegis.com']);
+    $this->operator->assignRole(UserRoles::ADMIN->value);
+});
+
+it('creates a reviewer user + flags + content on happy path', function () {
+    $this->artisan('account:provision-reviewer', [
+        '--email'          => 'appreview@finaegis.com',
+        '--password'       => 'Strong-Pass-2026!',
+        '--operator-email' => 'op@finaegis.com',
+        '--expires-days'   => 60,
+        '--note'           => 'App Store 2026-Q2',
+    ])->assertExitCode(0);
+
+    $user = User::where('email', 'appreview@finaegis.com')->first();
+    expect($user)->not->toBeNull();
+    expect($user->accountFlag->is_review_account)->toBeTrue();
+    expect($user->accountFlag->bypass_rate_limit)->toBeTrue();
+    expect($user->accountFlag->created_by)->toBe($this->operator->id);
+});
+
+it('is idempotent: re-running updates in place', function () {
+    $args = [
+        '--email'          => 'r@finaegis.com',
+        '--password'       => 'Strong-Pass-2026!',
+        '--operator-email' => 'op@finaegis.com',
+    ];
+
+    $this->artisan('account:provision-reviewer', $args);
+    $this->artisan('account:provision-reviewer', array_merge($args, ['--password' => null]));
+
+    expect(User::where('email', 'r@finaegis.com')->count())->toBe(1);
+    expect(AccountFlag::where('user_id', User::where('email', 'r@finaegis.com')->first()->id)->count())->toBe(1);
+});
+
+it('aborts when operator is not an admin', function () {
+    $nonAdmin = User::factory()->create(['email' => 'nobody@finaegis.com']);
+
+    $this->artisan('account:provision-reviewer', [
+        '--email'          => 'r@finaegis.com',
+        '--operator-email' => 'nobody@finaegis.com',
+    ])->assertExitCode(1);
+});
+
+it('aborts in production without --allow-production', function () {
+    $this->app['env'] = 'production';
+
+    $this->artisan('account:provision-reviewer', [
+        '--email'          => 'r@finaegis.com',
+        '--operator-email' => 'op@finaegis.com',
+    ])->assertExitCode(1);
+});
+
+it('aborts when email collides with a non-review user and --force-convert is not set', function () {
+    User::factory()->create(['email' => 'taken@finaegis.com']);
+
+    $this->artisan('account:provision-reviewer', [
+        '--email'          => 'taken@finaegis.com',
+        '--operator-email' => 'op@finaegis.com',
+    ])->assertExitCode(1);
+});
+
+it('rejects --force-convert in production entirely', function () {
+    User::factory()->create(['email' => 'taken@finaegis.com']);
+    $this->app['env'] = 'production';
+
+    $this->artisan('account:provision-reviewer', [
+        '--email'             => 'taken@finaegis.com',
+        '--operator-email'    => 'op@finaegis.com',
+        '--allow-production'  => true,
+        '--force-convert'     => true,
+    ])->assertExitCode(1);
+});
+
+it('enforces expiry hard cap of 90 days', function () {
+    $this->artisan('account:provision-reviewer', [
+        '--email'          => 'r@finaegis.com',
+        '--password'       => 'Strong-Pass-2026!',
+        '--operator-email' => 'op@finaegis.com',
+        '--expires-days'   => 365,
+    ])->assertExitCode(1);
+});
+```
+
+- [ ] **Step 2: Run, fail**
+
+- [ ] **Step 3: Implement command**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\AccountProvisioning\Profiles\ReviewerAccountProfile;
+use App\Domain\AccountProvisioning\Services\AccountProvisioningService;
+use App\Domain\AccountProvisioning\ValueObjects\ProvisioningContext;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+class AccountProvisionReviewerCommand extends Command
+{
+    /** @var string */
+    protected $signature = 'account:provision-reviewer
+                            {--email= : Reviewer email}
+                            {--password= : Password (generated if omitted)}
+                            {--region=US : Reviewer region}
+                            {--expires-days=60 : Days until auto-disable (0=none, hard cap 90)}
+                            {--note= : Audit note}
+                            {--operator-email= : Admin operator email (required)}
+                            {--allow-production : Required when APP_ENV=production}
+                            {--rotate-password : Rotate password only, skip reseed}
+                            {--force-convert : Convert a non-review user (blocked in production)}
+                            {--dry-run : Print intended changes, write nothing}';
+
+    /** @var string */
+    protected $description = 'Provision a pre-seeded reviewer/demo account for app-store review (operator-only)';
+
+    public function handle(AccountProvisioningService $service, ReviewerAccountProfile $profile): int
+    {
+        if (app()->environment('production') && ! $this->option('allow-production')) {
+            $this->error('Production guard: --allow-production is required when APP_ENV=production.');
+            return 1;
+        }
+
+        if (app()->environment('production') && $this->option('force-convert')) {
+            $this->error('--force-convert is blocked in production.');
+            return 1;
+        }
+
+        $email = (string) $this->option('email');
+        if ($email === '') {
+            $this->error('--email is required');
+            return 1;
+        }
+
+        $operatorEmail = (string) $this->option('operator-email');
+        if ($operatorEmail === '') {
+            $this->error('--operator-email is required');
+            return 1;
+        }
+
+        $operator = User::where('email', $operatorEmail)->first();
+        if ($operator === null || ! $operator->isAdmin()) {
+            $this->error("Operator {$operatorEmail} not found or not an admin.");
+            return 1;
+        }
+
+        $expiresDays = (int) $this->option('expires-days');
+        if ($expiresDays < 0 || $expiresDays > 90) {
+            $this->error('--expires-days must be 0..90 (hard cap).');
+            return 1;
+        }
+
+        $password = $this->option('password');
+        $rotate = (bool) $this->option('rotate-password');
+
+        if (! is_string($password) || $password === '') {
+            if ($rotate || User::where('email', $email)->doesntExist()) {
+                $password = Str::password(20);
+            } else {
+                $password = null;
+            }
+        }
+
+        $ctx = new ProvisioningContext(
+            email: $email,
+            name: 'App Reviewer',
+            region: (string) $this->option('region'),
+            expiresAt: $expiresDays > 0 ? CarbonImmutable::now()->addDays($expiresDays) : null,
+            note: $this->option('note') ?: null,
+            operatorId: (int) $operator->id,
+            dryRun: (bool) $this->option('dry-run'),
+        );
+
+        try {
+            $result = $service->apply(
+                profile: $profile,
+                ctx: $ctx,
+                password: $password,
+                rotatePassword: $rotate,
+                forceConvert: (bool) $this->option('force-convert'),
+            );
+        } catch (\RuntimeException $e) {
+            $this->error($e->getMessage());
+            return 1;
+        }
+
+        $this->line(json_encode([
+            'email'      => $email,
+            'password'   => $result['password_action'] === 'unchanged' ? 'unchanged' : $password,
+            'user_id'    => $result['user']->id,
+            'flags'      => $profile->flags($ctx),
+            'expires_at' => $ctx->expiresAt?->toIso8601String(),
+            'operator'   => $operator->email,
+            'dry_run'    => $ctx->dryRun,
+        ], JSON_PRETTY_PRINT));
+
+        return 0;
+    }
+}
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Console/Commands/AccountProvisionReviewerCommand.php \
+        tests/Feature/AccountProvisioning/ProvisionReviewerCommandTest.php
+git commit -m "feat(provisioning): account:provision-reviewer command with safety gates
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 19: `account:list-reviewers` command
+
+**Files:**
+- Create: `app/Console/Commands/AccountListReviewersCommand.php`
+- Test: `tests/Feature/AccountProvisioning/ListReviewersCommandTest.php`
+
+- [ ] **Step 1: Failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AccountProvisioning;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Models\User;
+use Tests\TestCase;
+
+uses(TestCase::class, \Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('lists review accounts with status and expiry', function () {
+    $user = User::factory()->create(['email' => 'r@finaegis.com']);
+    AccountFlag::create([
+        'user_id'           => $user->id,
+        'is_review_account' => true,
+        'expires_at'        => now()->addDays(30),
+        'note'              => 'Q2',
+    ]);
+
+    $this->artisan('account:list-reviewers')
+         ->expectsOutputToContain('r@finaegis.com')
+         ->expectsOutputToContain('Q2')
+         ->assertExitCode(0);
+});
+
+it('outputs nothing when no review accounts exist', function () {
+    $this->artisan('account:list-reviewers')->assertExitCode(0);
+});
+```
+
+- [ ] **Step 2: Run, fail**
+
+- [ ] **Step 3: Implement**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use Illuminate\Console\Command;
+
+class AccountListReviewersCommand extends Command
+{
+    protected $signature = 'account:list-reviewers {--json}';
+    protected $description = 'List all review accounts with flag status + expiry';
+
+    public function handle(): int
+    {
+        $rows = AccountFlag::where('is_review_account', true)
+            ->with('user', 'createdBy')
+            ->orderByDesc('created_at')
+            ->get()
+            ->map(fn ($f) => [
+                'email'       => $f->user?->email,
+                'active'      => $f->isActive() ? 'yes' : 'no',
+                'expires_at'  => $f->expires_at?->toDateString() ?? '—',
+                'disabled_at' => $f->disabled_at?->toIso8601String() ?? '—',
+                'operator'    => $f->createdBy?->email ?? '—',
+                'note'        => $f->note ?? '—',
+            ]);
+
+        if ($this->option('json')) {
+            $this->line($rows->toJson(JSON_PRETTY_PRINT));
+            return 0;
+        }
+
+        if ($rows->isEmpty()) {
+            $this->info('No review accounts found.');
+            return 0;
+        }
+
+        $this->table(
+            ['Email', 'Active', 'Expires', 'Disabled', 'Operator', 'Note'],
+            $rows->toArray(),
+        );
+        return 0;
+    }
+}
+```
+
+- [ ] **Step 4: Run, pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Console/Commands/AccountListReviewersCommand.php \
+        tests/Feature/AccountProvisioning/ListReviewersCommandTest.php
+git commit -m "feat(provisioning): account:list-reviewers command
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 20: `account:disable-reviewer` command
+
+**Files:**
+- Create: `app/Console/Commands/AccountDisableReviewerCommand.php`
+- Test: `tests/Feature/AccountProvisioning/DisableReviewerCommandTest.php`
+
+- [ ] **Step 1: Failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AccountProvisioning;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Models\User;
+use Tests\TestCase;
+
+uses(TestCase::class, \Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('disables one reviewer by email', function () {
+    $user = User::factory()->create(['email' => 'r@finaegis.com']);
+    AccountFlag::create([
+        'user_id'                    => $user->id,
+        'is_review_account'          => true,
+        'bypass_rate_limit'          => true,
+        'bypass_sanctions_screening' => true,
+    ]);
+
+    $this->artisan('account:disable-reviewer', ['--email' => 'r@finaegis.com'])->assertExitCode(0);
+
+    $flag = $user->fresh()->accountFlag;
+    expect($flag->bypass_rate_limit)->toBeFalse();
+    expect($flag->bypass_sanctions_screening)->toBeFalse();
+    expect($flag->disabled_at)->not->toBeNull();
+    expect($flag->is_review_account)->toBeTrue();   // tag stays for audit
+});
+
+it('disables all expired reviewers with --all-expired', function () {
+    $u1 = User::factory()->create();
+    $u2 = User::factory()->create();
+    AccountFlag::create(['user_id' => $u1->id, 'is_review_account' => true, 'bypass_rate_limit' => true, 'expires_at' => now()->subDay()]);
+    AccountFlag::create(['user_id' => $u2->id, 'is_review_account' => true, 'bypass_rate_limit' => true, 'expires_at' => now()->addDay()]);
+
+    $this->artisan('account:disable-reviewer', ['--all-expired' => true])->assertExitCode(0);
+
+    expect($u1->fresh()->accountFlag->bypass_rate_limit)->toBeFalse();
+    expect($u2->fresh()->accountFlag->bypass_rate_limit)->toBeTrue();
+});
+
+it('re-enables with --re-enable', function () {
+    $user = User::factory()->create(['email' => 'r@finaegis.com']);
+    AccountFlag::create(['user_id' => $user->id, 'is_review_account' => true, 'disabled_at' => now()]);
+
+    $this->artisan('account:disable-reviewer', ['--email' => 'r@finaegis.com', '--re-enable' => true])->assertExitCode(0);
+
+    $flag = $user->fresh()->accountFlag;
+    expect($flag->disabled_at)->toBeNull();
+    expect($flag->bypass_rate_limit)->toBeTrue();
+});
+```
+
+- [ ] **Step 2: Run, fail**
+
+- [ ] **Step 3: Implement**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Domain\AccountProvisioning\Profiles\ReviewerAccountProfile;
+use App\Domain\AccountProvisioning\Services\AccountProvisioningService;
+use App\Domain\AccountProvisioning\ValueObjects\ProvisioningContext;
+use App\Models\User;
+use Illuminate\Console\Command;
+
+class AccountDisableReviewerCommand extends Command
+{
+    protected $signature = 'account:disable-reviewer
+                            {--email=}
+                            {--all-expired}
+                            {--re-enable}';
+    protected $description = 'Disable (revoke bypasses) or re-enable a reviewer account';
+
+    public function handle(AccountProvisioningService $service, ReviewerAccountProfile $profile): int
+    {
+        $reEnable = (bool) $this->option('re-enable');
+
+        if ($this->option('all-expired')) {
+            $flags = AccountFlag::where('is_review_account', true)
+                ->whereNotNull('expires_at')
+                ->where('expires_at', '<', now())
+                ->whereNull('disabled_at')
+                ->with('user')
+                ->get();
+
+            foreach ($flags as $flag) {
+                if ($flag->user) {
+                    $service->disable($flag->user);
+                    $this->line("disabled: {$flag->user->email}");
+                }
+            }
+            return 0;
+        }
+
+        $email = (string) $this->option('email');
+        if ($email === '') {
+            $this->error('--email or --all-expired is required');
+            return 1;
+        }
+
+        $user = User::where('email', $email)->first();
+        if ($user === null || $user->accountFlag === null || ! $user->accountFlag->is_review_account) {
+            $this->error("User {$email} is not a review account.");
+            return 1;
+        }
+
+        if ($reEnable) {
+            $ctx = new ProvisioningContext($email, 'App Reviewer', 'US', null, $user->accountFlag->note, (int) ($user->accountFlag->created_by ?? 0));
+            $service->reEnable($user, $profile, $ctx);
+            $this->info("re-enabled: {$email}");
+            return 0;
+        }
+
+        $service->disable($user);
+        $this->info("disabled: {$email}");
+        return 0;
+    }
+}
+```
+
+- [ ] **Step 4: Run, pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Console/Commands/AccountDisableReviewerCommand.php \
+        tests/Feature/AccountProvisioning/DisableReviewerCommandTest.php
+git commit -m "feat(provisioning): account:disable-reviewer with --all-expired + --re-enable
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 21: `account:purge-reviewer` command
+
+**Files:**
+- Create: `app/Console/Commands/AccountPurgeReviewerCommand.php`
+- Test: `tests/Feature/AccountProvisioning/PurgeReviewerCommandTest.php`
+
+- [ ] **Step 1: Failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AccountProvisioning;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Models\User;
+use Tests\TestCase;
+
+uses(TestCase::class, \Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('soft-deletes a review account on --confirm', function () {
+    $user = User::factory()->create(['email' => 'r@finaegis.com']);
+    AccountFlag::create(['user_id' => $user->id, 'is_review_account' => true]);
+
+    $this->artisan('account:purge-reviewer', ['--email' => 'r@finaegis.com', '--confirm' => true])->assertExitCode(0);
+
+    expect(User::withTrashed()->find($user->id)?->trashed())->toBeTrue();
+});
+
+it('refuses to purge a non-review user', function () {
+    User::factory()->create(['email' => 'u@finaegis.com']);
+
+    $this->artisan('account:purge-reviewer', ['--email' => 'u@finaegis.com', '--confirm' => true])->assertExitCode(1);
+});
+
+it('refuses in production without --allow-production', function () {
+    $this->app['env'] = 'production';
+    $user = User::factory()->create(['email' => 'r@finaegis.com']);
+    AccountFlag::create(['user_id' => $user->id, 'is_review_account' => true]);
+
+    $this->artisan('account:purge-reviewer', ['--email' => 'r@finaegis.com', '--confirm' => true])->assertExitCode(1);
+});
+```
+
+- [ ] **Step 2: Run, fail**
+
+- [ ] **Step 3: Implement**
+
+Note: this assumes `User` uses `SoftDeletes`. If not, add the trait + migration in this task. Verify via `grep SoftDeletes app/Models/User.php`. If absent, either add (invasive) or change the purge semantics to "disable + anonymize email" instead (less invasive, retains audit). Decide based on what the existing user deletion path in the codebase does.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Event;
+
+class AccountPurgeReviewerCommand extends Command
+{
+    protected $signature = 'account:purge-reviewer {--email=} {--confirm} {--allow-production}';
+    protected $description = 'Soft-delete a review account (blocked in production without --allow-production)';
+
+    public function handle(): int
+    {
+        if (! $this->option('confirm')) {
+            $this->error('--confirm is required.');
+            return 1;
+        }
+
+        if (app()->environment('production') && ! $this->option('allow-production')) {
+            $this->error('Production guard: --allow-production is required.');
+            return 1;
+        }
+
+        $email = (string) $this->option('email');
+        $user = User::where('email', $email)->first();
+
+        if ($user === null || $user->accountFlag === null || ! $user->accountFlag->is_review_account) {
+            $this->error("User {$email} is not a review account.");
+            return 1;
+        }
+
+        $user->tokens()->delete();
+        $user->delete(); // requires SoftDeletes
+
+        Event::dispatch(new \App\Domain\AccountProvisioning\Events\AccountPurged(userId: $user->id, operatorId: null));
+
+        $this->info("purged: {$email}");
+        return 0;
+    }
+}
+```
+
+Add event class `app/Domain/AccountProvisioning/Events/AccountPurged.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\AccountProvisioning\Events;
+
+final readonly class AccountPurged
+{
+    public function __construct(
+        public int $userId,
+        public ?int $operatorId,
+    ) {}
+}
+```
+
+- [ ] **Step 4: Run, pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Console/Commands/AccountPurgeReviewerCommand.php \
+        app/Domain/AccountProvisioning/Events/AccountPurged.php \
+        tests/Feature/AccountProvisioning/PurgeReviewerCommandTest.php
+git commit -m "feat(provisioning): account:purge-reviewer with production guard + audit event
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 22: Schedule daily `--all-expired` sweep
+
+**Files:**
+- Modify: `routes/console.php`
+- Test: `tests/Feature/AccountProvisioning/ExpirySweepTest.php`
+
+- [ ] **Step 1: Failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AccountProvisioning;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Models\User;
+use Illuminate\Console\Scheduling\Schedule;
+use Tests\TestCase;
+
+uses(TestCase::class, \Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('registers account:disable-reviewer --all-expired on the daily schedule', function () {
+    $schedule = app(Schedule::class);
+    $events = collect($schedule->events());
+
+    $match = $events->first(fn ($e) => str_contains($e->command ?? '', 'account:disable-reviewer --all-expired'));
+    expect($match)->not->toBeNull();
+    expect($match->expression)->toBe('10 0 * * *');    // daily at 00:10 UTC
+});
+```
+
+- [ ] **Step 2: Run, fail**
+
+- [ ] **Step 3: Register in `routes/console.php`**
+
+Append:
+
+```php
+// Daily sweep: auto-disable expired reviewer/demo accounts.
+Schedule::command('account:disable-reviewer --all-expired')
+    ->dailyAt('00:10')
+    ->description('Auto-disable expired review accounts')
+    ->appendOutputTo(storage_path('logs/account-expiry-sweep.log'));
+```
+
+- [ ] **Step 4: Run, pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add routes/console.php tests/Feature/AccountProvisioning/ExpirySweepTest.php
+git commit -m "feat(provisioning): schedule daily expiry sweep
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Phase 5 — Docs, release, final checks
+
+### Task 23: Operator runbook
+
+**Files:**
+- Create: `docs/operations/reviewer-accounts.md`
+
+- [ ] **Step 1: Write the runbook**
+
+Content sections:
+1. **When to use** — app-store review cycles, partner demo access, internal QA personas.
+2. **Pre-flight** — confirm operator is admin; verify staging rehearsal worked.
+3. **Provision** — full command example, JSON output, 1Password hand-off procedure.
+4. **List / audit** — `account:list-reviewers`, how to read the output.
+5. **Disable / re-enable** — when the review cycle ends; when rework is needed.
+6. **Purge** — production guard, when to use (reviewer account leaked), alternative (GDPR-erasure flow for full PII removal).
+7. **Expiry sweep** — daily job, expected log location, how to verify it ran.
+8. **Incident response** — `bypass.fired` volume spike investigation steps: who's the user, what bypass, how to force-disable in under 60s (`account:disable-reviewer --email=X`).
+9. **Limitations** — SMS OTP bypass reserved; no Filament UI; CLI-only; single-tenant v1.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/operations/reviewer-accounts.md
+git commit -m "docs(ops): reviewer accounts operator runbook
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 24: Security doc
+
+**Files:**
+- Create: `docs/security/account-flags.md`
+
+- [ ] **Step 1: Write the doc**
+
+Content:
+1. **Threat model** — what this opens up, what it does not.
+2. **Scope of bypasses** — the table from Section 4 of the spec.
+3. **Audit guarantees** — `bypass.fired` log line schema, `account_flags` table as source of truth, `created_by` operator attribution.
+4. **Expiry and reversibility** — default 60d, hard cap 90d, daily sweep, manual disable.
+5. **What this is NOT** — not admin impersonation, not a permission bypass, not usable from the web UI.
+6. **Defence-in-depth** — `disabled_at` short-circuits bypasses even if column values persist; per-request cache invalidation on updates.
+7. **Monitoring** — metric names, Prometheus alert suggestions.
+8. **Revocation runbook ref** — link to `docs/operations/reviewer-accounts.md`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/security/account-flags.md
+git commit -m "docs(security): account flags security model
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 25: `CLAUDE.md` updates
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Three edits**
+
+a. Essential Commands — add under the existing user/admin block:
+
+```bash
+# Reviewer / demo accounts (operator-only)
+php artisan account:provision-reviewer --email=X --operator-email=admin@...
+php artisan account:list-reviewers
+php artisan account:disable-reviewer --email=X     # or --all-expired
+```
+
+b. CI/CD table — add one row:
+
+| Bypass flags missing test | Every new bypass needs a matching feature test in `tests/Feature/AccountProvisioning/Bypasses/` asserting both sides (flag set = allow, flag unset = enforce). |
+
+c. Architecture section — bump "56 domains" → "57 domains" (add `AccountProvisioning` to the domain list mentally; if your CLAUDE.md lists specific domain names elsewhere, update those references too).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(claude): add AccountProvisioning domain + command reference
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 26: Serena memory + auto-memory reference
+
+**Files:**
+- Modify (via Serena): `account_provisioning_domain` memory
+- Create: `.claude/projects/-home-yozaz-www-finaegis-core-banking-prototype-laravel/memory/reference_reviewer_accounts.md` (or use the appropriate platform-specific memory path — check existing memory files)
+
+- [ ] **Step 1: Write the Serena memory** (via `mcp__serena__write_memory`)
+
+Content: flag model, profile interface, enforcement points, safety gates, command inventory. This is architectural context future sessions will need.
+
+- [ ] **Step 2: Write the auto-memory reference**
+
+```markdown
+---
+name: reviewer accounts runbook
+description: Pointer to the operator runbook for reviewer/demo accounts
+type: reference
+---
+
+Operator runbook: `docs/operations/reviewer-accounts.md`. Security model: `docs/security/account-flags.md`. CLI: `account:provision-reviewer`, `account:list-reviewers`, `account:disable-reviewer`, `account:purge-reviewer`. Flag table: `account_flags`. Architectural memory in Serena: `account_provisioning_domain`.
+```
+
+Add one line to `MEMORY.md`: `- [Reviewer accounts](reference_reviewer_accounts.md) — operator runbook pointer`
+
+- [ ] **Step 3: Commit** (auto-memory file only; Serena memories persist outside git)
+
+```bash
+# nothing to commit if memory dir is gitignored; confirm
+```
+
+---
+
+### Task 27: `VERSION_ROADMAP.md` entry
+
+**Files:**
+- Modify: `docs/VERSION_ROADMAP.md`
+
+- [ ] **Step 1: Add patch-version entry**
+
+Under the latest version header (currently v7.10.10 per memory), add:
+
+```markdown
+### v7.10.11 — Reviewer account provisioning (2026-04-xx)
+
+- New `AccountProvisioning` domain with `account_flags` table, `AccountProfile` interface, and `ReviewerAccountProfile`.
+- Operator-only CLI: `account:provision-reviewer`, `account:list-reviewers`, `account:disable-reviewer`, `account:purge-reviewer`.
+- Scoped security bypasses (device attestation, rate limits, sanctions, notifications, KYC override) with audit logging and daily expiry sweep.
+- Docs: `docs/operations/reviewer-accounts.md`, `docs/security/account-flags.md`.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/VERSION_ROADMAP.md
+git commit -m "docs(roadmap): v7.10.11 — reviewer account provisioning
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 28: Final verification + PR
+
+- [ ] **Step 1: Full code-quality sweep**
+
+```bash
+./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php
+XDEBUG_MODE=off vendor/bin/phpstan analyse --memory-limit=2G
+./vendor/bin/pest --parallel --stop-on-failure
+```
+
+All three must be green. Fix anything not.
+
+- [ ] **Step 2: Run `post-phase-review` skill**
+
+Per global CLAUDE.md: before opening a feature PR, run the `post-phase-review` skill. Address any critical/important issues it raises.
+
+- [ ] **Step 3: Push branch and open PR**
+
+```bash
+git push -u origin feat/account-provisioning-reviewer
+gh pr create --title "feat: reviewer/demo account provisioning (account_flags + CLI)" --body "$(cat <<'EOF'
+## Summary
+
+- New `AccountProvisioning` domain with `account_flags` table and `AccountProfile` interface.
+- Four operator-only CLI commands: `provision-reviewer`, `list-reviewers`, `disable-reviewer`, `purge-reviewer`.
+- Scoped, auditable security bypasses at 5 existing enforcement points (device attestation, rate limiting, sanctions, notifications, KYC override).
+- Daily scheduled expiry sweep; 60-day default / 90-day hard-cap.
+- Operator runbook + security doc; Serena + auto-memory references.
+
+## Spec + plan
+
+- Spec: `docs/superpowers/specs/2026-04-24-reviewer-account-provisioning-design.md`
+- Plan: `docs/superpowers/plans/2026-04-24-reviewer-account-provisioning.md`
+
+## Test plan
+
+- [ ] `./vendor/bin/pest --parallel --stop-on-failure` — green
+- [ ] `XDEBUG_MODE=off vendor/bin/phpstan analyse --memory-limit=2G` — green (Level 8)
+- [ ] `./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --dry-run --diff` — no changes
+- [ ] Staging rehearsal: run `account:provision-reviewer --email=rehearsal@...` end-to-end; verify JSON output, flag row, seeded content
+- [ ] Verify `bypass.fired` log line appears under each bypass feature test
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Merge after green CI + review**
+
+After approval and green checks, merge to `main`. Do not push force, do not rebase onto a moved `main` without reverifying tests locally.
+
+- [ ] **Step 5: Production run (separate change — not part of this PR)**
+
+After merge, run in staging first, then production with `--allow-production`. Hand credentials to mobile team via 1Password. This step is operational, not code.
+
+---
+
+## Notes for the engineer
+
+- **File paths in the spec assume directory names may drift**: if `app/Domain/CardIssuance/Models/Card.php` doesn't exist as written, grep for `class Card` in `app/Domain/` and use the real path. Same for Rewards and TrustCert models.
+- **Balance mutation is the most sensitive step**: never use `(float)` for money (CLAUDE.md), always wrap in `DB::transaction()` with `lockForUpdate()` if reading current balance. If in doubt, route through the existing ledger domain.
+- **PHPStan Level 8**: the codebase is strict. Follow the patterns in CLAUDE.md (cast `(string) json_encode(...)`, `@var` PHPDoc for Mockery mocks, etc.).
+- **Sanctum test scope**: in all feature tests that act as a user, pass abilities: `Sanctum::actingAs($user, ['read', 'write', 'delete'])`.
+- **Parallel agents beware**: if dispatching this via subagent-driven development, do not parallelize Tasks 2, 3, 12, 18 — all touch `AppServiceProvider.php` or `User.php`. Serialize those.
+- **`NOTE:` blocks in the plan marked "inspect the real model"**: the plan is TDD — the test defines the contract; when the real model has different column names, adapt implementation to pass the test and adjust test assertions if the test's expectation was wrong.

--- a/docs/superpowers/specs/2026-04-24-reviewer-account-provisioning-design.md
+++ b/docs/superpowers/specs/2026-04-24-reviewer-account-provisioning-design.md
@@ -1,0 +1,245 @@
+# Reviewer / Demo Account Provisioning — Design
+
+**Date:** 2026-04-24
+**Status:** Draft — pending implementation plan
+**Owner:** Platform / Infrastructure
+**Motivation:** Google Play and App Store reviewers cannot complete Ondato KYC or phone verification. We need a durable, auditable way to provision pre-seeded review/demo accounts that bypass security checks in a scoped, reversible, auditable fashion.
+
+---
+
+## 1. Goals and non-goals
+
+### Goals
+- Provision one (or more) user accounts with enough seeded state that an external reviewer can exercise gated features without going through real KYC/SMS/attestation flows.
+- Bypass specific security checks (device attestation, rate limits, sanctions screening, SMS OTP, KYC level) in a scoped, explicit, logged fashion.
+- Keep production data clean: no forged Ondato/sanctions rows masquerading as real. Only *content* the reviewer needs to see on screen (balances, one card, one TrustCert, rewards) is real-looking.
+- Support the general case — any future "persona" (demo investor, auditor, load-test user) can be added without refactoring.
+- Safe to run in production, with explicit guardrails and audit trail.
+- Idempotent: re-running the command updates the same logical state, never duplicates.
+- Reversible: disable revokes all bypasses and sessions; re-enable flips bypasses back on; purge hard-deletes on explicit confirm.
+
+### Non-goals
+- Not a customer-facing feature. No public marketing surface, no features-page entry.
+- Not a replacement for staging environments. Reviewer accounts are production artefacts needed only because reviewers test against production.
+- Not a generic impersonation / "login as user" tool. Reviewers log in themselves with shared credentials.
+- Not a way to bypass authorization (RBAC). Reviewers get a normal non-admin user with specific security bypasses, not elevated permissions.
+
+---
+
+## 2. High-level architecture
+
+```
+app/Domain/AccountProvisioning/
+├── Contracts/AccountProfile.php              -- interface
+├── Profiles/ReviewerAccountProfile.php       -- one concrete profile (Phase 1)
+├── Services/
+│   ├── AccountFlagsService.php               -- flag lookup + cache (consumed by middleware/services)
+│   └── AccountProvisioningService.php        -- orchestrator invoked by the command
+├── Seeders/                                  -- per-concern sub-seeders
+│   ├── WalletSeeder.php                      -- EVM (Polygon) + Solana
+│   ├── BalanceSeeder.php                     -- USDC shielded + unshielded
+│   ├── TrustCertSeeder.php                   -- one approved cert
+│   ├── CardSeeder.php                        -- one active virtual card
+│   └── RewardsSeeder.php                     -- XP + one completed quest
+└── Models/AccountFlag.php                    -- new account_flags table
+```
+
+Plus:
+
+- `app/Console/Commands/AccountProvisionReviewerCommand.php`
+- `app/Console/Commands/AccountDisableReviewerCommand.php`
+- `app/Console/Commands/AccountListReviewersCommand.php`
+- `app/Console/Commands/AccountPurgeReviewerCommand.php`
+
+Flag enforcement plugs in at ~5 existing call sites (listed in §4) — no new middleware. Each enforcement point imports `AccountFlagsService` and short-circuits when its flag is set, emitting a `bypass.fired` structured log.
+
+---
+
+## 3. Data model: `account_flags`
+
+New table, 1:1 with `users`:
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | BIGINT PK | |
+| `user_id` | FK `users.id`, **unique** | cascade delete |
+| `is_review_account` | bool, **indexed** | master tag — all queries filter on this |
+| `bypass_device_attestation` | bool | skip Apple App Attest / Play Integrity |
+| `bypass_rate_limit` | bool | skip `ApiRateLimitMiddleware` + `GraphQLRateLimitMiddleware` |
+| `bypass_sanctions_screening` | bool | treat as cleared in AML activities |
+| `bypass_sms_otp` | bool | accept any OTP code (or skip entirely) |
+| `suppress_notifications` | bool | no outbound email/SMS/push |
+| `kyc_override_level` | tinyint nullable | 0=none, 1=basic, 2=enhanced; `null` = use real KYC |
+| `note` | string(255) | short free-text ("App Store review 2026-Q2") |
+| `expires_at` | timestamp nullable | auto-disables after this date |
+| `created_by` | FK `users.id` | the admin operator who ran the command |
+| `disabled_at` | timestamp nullable | when bypasses were revoked |
+| `created_at`, `updated_at` | timestamps | |
+
+### Rationale
+
+- **Separate table** (not columns on `users`): keeps the hot row clean, centralises audit, makes `AccountFlag::where('is_review_account', true)` trivial.
+- **`kyc_override_level` as tinyint**, not bool: reviewers may need different gates depending on tier (basic-tier reviewer sees different screens than enhanced). A bool collapses that distinction.
+- **`expires_at` default 60 days, hard cap 90 days**: covers both Play + App Store review cycles plus resubmission slack. Daily scheduled job sweeps expired rows. Forced ceiling prevents "forever bypass" by accident.
+- **No "bypass content"** — content (cards, TrustCerts, balances, rewards) is real seeded rows, so UI renders normally.
+
+---
+
+## 4. Enforcement integration points
+
+Each bypass is consumed at a specific, audited location. The pattern is identical at every site:
+
+```php
+if ($this->flags->hasReviewBypass($user, 'device_attestation')) {
+    logger()->info('bypass.fired', ['user_id' => $user->id, 'bypass' => 'device_attestation', 'reason' => 'review_account']);
+    return AttestationResult::bypassed('review_account');
+}
+```
+
+| Flag | Enforcement site | Behavior when set |
+|---|---|---|
+| `bypass_device_attestation` | `app/Domain/Mobile/Services/AppleAttestationVerifier.php`, `GoogleIntegrityVerifier.php` | Return verified result with `source=review_bypass` |
+| `bypass_rate_limit` | `app/Http/Middleware/ApiRateLimitMiddleware.php`, `GraphQLRateLimitMiddleware.php` | Skip limiter `hit()`, forward request |
+| `bypass_sanctions_screening` | `app/Domain/AgentProtocol/Workflows/Activities/PerformAmlScreeningActivity.php` + any direct sanctions call on auth/send paths | Return `cleared` result |
+| `bypass_sms_otp` | SMS OTP verification path in auth controllers | Accept any code, or skip entirely if flag set |
+| `suppress_notifications` | Central notification dispatcher (`shouldSend($user, $channel)`) | Short-circuit before queue push |
+| `kyc_override_level` | KYC gates consume `User::effectiveKycLevel()`, which reads the override | Returns override level in preference to real KYC state |
+
+### Design rules
+- **No middleware "sniffs" the review account** to blanket-skip security. Every bypass is explicit and named.
+- **`User::effectiveKycLevel()`** is the single accessor for KYC decisions. The flag is the implementation; the accessor is the API. No call site should branch on `is_review_account`.
+- **All bypass hits emit `bypass.fired` structured log + a counter metric.** Unexpected volume fires an alert.
+- **`AccountFlagsService` caches per request** (`$cache[userId]`) so the N calls a single request makes don't become N queries.
+
+---
+
+## 5. The `AccountProfile` interface
+
+```php
+interface AccountProfile
+{
+    public function provision(User $user, ProvisioningContext $ctx): void;
+    public function name(): string;      // e.g. 'reviewer'
+    public function flags(): array;      // flag column => value, written to account_flags
+}
+```
+
+`ReviewerAccountProfile::provision()` runs every sub-seeder in a `DB::transaction()`. Each sub-seeder is idempotent (`updateOrCreate` / `firstOrCreate`); re-running the command updates in place.
+
+Why a generic profile system for one profile: the flag infrastructure (§3, §4) is clearly reusable regardless. Putting the profile interface in place now costs ~40 lines and means any future persona (demo investor, auditor, load-test user) is a single file, not a refactor. YAGNI respected — no second profile ships in Phase 1.
+
+---
+
+## 6. CLI surface
+
+### `account:provision-reviewer`
+
+```
+php artisan account:provision-reviewer
+    --email=appreview@finaegis.com        (required)
+    --password=<generated 20-char if omitted>
+    --region=US
+    --expires-days=60                      (0 = no expiry; hard cap 90)
+    --note="App Store review 2026-Q2"
+    --operator-email=<admin>               (required in CLI; resolves created_by)
+    --allow-production                     (required if APP_ENV=production)
+    --rotate-password                      (only rotate, do not reseed state)
+    --dry-run
+```
+
+Output: a single JSON block to stdout. Operator pipes to 1Password / clipboard. Nothing logged to file.
+
+```json
+{
+  "email": "appreview@finaegis.com",
+  "password": "…20 chars…",
+  "user_id": 12345,
+  "flags": { "is_review_account": true, "bypass_rate_limit": true, "...": "..." },
+  "expires_at": "2026-06-23T00:00:00Z",
+  "operator": "admin@finaegis.com"
+}
+```
+
+Password is shown only when newly generated or rotated; re-runs that don't touch the password emit `"password": "unchanged"`.
+
+### Companion commands
+
+- **`account:list-reviewers`** — tabular list of all `is_review_account=true` users with `expires_at`, `disabled_at`, operator, note.
+- **`account:disable-reviewer --email=X | --all-expired`** — sets all bypass flags false, revokes all Sanctum tokens and sessions, keeps the user row for audit. `--re-enable` flips bypasses back on (reversible).
+- **`account:purge-reviewer --email=X --confirm`** — soft-deletes the user, cascades through `AccountFlag`, revokes Sanctum tokens, and emits an `account.purged` audit event. Only allowed when `is_review_account=true`. Blocked in production without `--allow-production`. Hard-delete is deliberately not supported from the CLI — if a full removal is required, the operator runs the existing GDPR-erasure flow against the user.
+
+### Scheduled job
+
+`account:disable-reviewer --all-expired` runs daily at 00:10 UTC via the `schedule()` method. Fires telemetry on any disable.
+
+---
+
+## 7. Production safety gates
+
+1. **`APP_ENV=production` requires `--allow-production`.** Command aborts with a red banner otherwise. Sticky audit flag, logged, cannot be satisfied via `.env`.
+2. **Email collision with an existing non-review user** → abort. Explicit `--force-convert` required to flip a real user into a review account, and `--force-convert` is *blocked in production entirely*.
+3. **Operator must be admin**: `--operator-email` must resolve to a user with `isAdmin() === true`. Populates `created_by`. The command will not run with a non-admin operator.
+4. **Default expiry 60 days, hard cap 90.** Enforced by the command itself, not the database.
+5. **Bypass observability**: every bypass hit emits `bypass.fired` + counter. Prometheus alert for anomalous volume.
+6. **Disabled account behaviour**: `disabled_at IS NOT NULL` short-circuits bypasses even if flag columns somehow remain true. Defence in depth.
+
+---
+
+## 8. Testing strategy
+
+- **Unit**
+  - Each seeder (Wallet, Balance, TrustCert, Card, Rewards): assert idempotency (two calls = one row) and correct state.
+  - `AccountFlagsService`: flag lookup, per-request cache behaviour, null-safety when user has no flag row.
+  - `ReviewerAccountProfile::flags()`: correct default flag payload.
+
+- **Feature**
+  - One test per bypass in §4's table: request the enforcement site *without* flag → denied; *with* flag → allowed and `bypass.fired` captured via log assertion.
+  - Command happy path: `artisan('account:provision-reviewer', …)` produces user + flags + balances + card + cert. Second run produces identical state.
+  - Safety gates: production without flag aborts; email collision aborts; `--force-convert` in prod aborts; non-admin operator aborts.
+  - Expiry flow: scheduled `account:disable-reviewer --all-expired` disables expired rows only, leaves non-expired alone.
+  - Credential output: newly generated password printed; re-run without `--rotate-password` prints `"unchanged"`.
+
+- **Bars**
+  - PHPStan Level 8 clean.
+  - Pest parallel, `--stop-on-failure`.
+  - ≥90% line coverage on the new domain.
+
+---
+
+## 9. Documentation
+
+- **`docs/operations/reviewer-accounts.md`** — operator runbook: when to use, the 1Password flow, disable/purge steps, what each flag does, incident response if `bypass.fired` volume spikes.
+- **`docs/security/account-flags.md`** — security model, audit guarantees, expiry semantics, why this exists, what it explicitly does *not* authorise.
+- **`CLAUDE.md`** — add a "Reviewer/demo accounts" row to the CI/CD table, note `account:provision-reviewer` in Essential Commands, bump domain count (56 → 57) once `AccountProvisioning/` lands.
+- **Serena memory**: `account_provisioning_domain` covering the flag model, profile interface, enforcement points, safety gates.
+- **Auto-memory (MEMORY.md)**: reference pointer to `docs/operations/reviewer-accounts.md`.
+- **Public site**: **no change.** Internal operator tool — no features-page entry, no version-badge bump for this feature alone (the next genuine customer-facing feature can bump it).
+
+---
+
+## 10. Release flow
+
+1. Feature branch: `feat/account-provisioning-reviewer`.
+2. PR to `main`. Required green:
+   - `./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php`
+   - `XDEBUG_MODE=off vendor/bin/phpstan analyse --memory-limit=2G`
+   - `./vendor/bin/pest --parallel --stop-on-failure`
+   - `post-phase-review` skill run before PR open (per global CLAUDE.md).
+3. Merge into `main`. No SDK/package release — this is an internal tool, no public surface.
+4. Post-merge: run `php artisan account:provision-reviewer` in staging (rehearsal), then production with `--allow-production`; hand credentials to mobile team via 1Password.
+5. `docs/VERSION_ROADMAP.md` entry under the current patch version.
+
+---
+
+## 11. Out of scope for this spec
+
+- Additional profiles (demo investor, auditor, load-test user) — deferred until a concrete second use case lands.
+- A Filament admin UI for creating/disabling review accounts — CLI is sufficient for operator-only use.
+- Automatic credential delivery (1Password API, Slack DM) — manual handoff is acceptable and lower-risk for this volume.
+- Tenant-specific reviewer accounts — v1 provisions in the default tenant only. Multi-tenant support added when asked.
+
+---
+
+## 12. Open questions
+
+None at spec-writing time. All major design choices were resolved during brainstorming.

--- a/routes/console.php
+++ b/routes/console.php
@@ -216,7 +216,9 @@ Schedule::command('trustcert:check-expired')
     });
 
 // Daily sweep: auto-disable expired reviewer/demo accounts.
-Schedule::command('account:disable-reviewer --all-expired')
+// --allow-production is appended because the scheduled job runs as the system,
+// not a human operator — the production guard is only for manual invocation.
+Schedule::command('account:disable-reviewer --all-expired --allow-production')
     ->dailyAt('00:10')
     ->description('Auto-disable expired review accounts')
     ->appendOutputTo(storage_path('logs/account-expiry-sweep.log'));

--- a/routes/console.php
+++ b/routes/console.php
@@ -214,3 +214,9 @@ Schedule::command('trustcert:check-expired')
     ->onFailure(function () {
         Log::warning('TrustCert expiry check failed to run');
     });
+
+// Daily sweep: auto-disable expired reviewer/demo accounts.
+Schedule::command('account:disable-reviewer --all-expired')
+    ->dailyAt('00:10')
+    ->description('Auto-disable expired review accounts')
+    ->appendOutputTo(storage_path('logs/account-expiry-sweep.log'));

--- a/tests/Feature/AccountProvisioning/Bypasses/AttestationBypassTest.php
+++ b/tests/Feature/AccountProvisioning/Bypasses/AttestationBypassTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AccountProvisioning\Bypasses;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Domain\Mobile\Services\BiometricJWTService;
+use App\Models\User;
+use Illuminate\Support\Facades\Log;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('short-circuits device attestation when review account has bypass flag', function () {
+    config()->set('mobile.attestation.enabled', true);
+
+    $user = User::factory()->create();
+    AccountFlag::create([
+        'user_id'                   => $user->id,
+        'is_review_account'         => true,
+        'bypass_device_attestation' => true,
+    ]);
+
+    $logSpy = Log::spy();
+
+    $service = app(BiometricJWTService::class);
+
+    // Use an obviously-bogus attestation — the bypass should short-circuit before
+    // the attestation payload is inspected.
+    $verified = $service->verifyDeviceAttestationForUser($user, 'bogus', 'ios');
+
+    expect($verified)->toBeTrue();
+
+    $logSpy->shouldHaveReceived('info')->withArgs(function (string $message, array $context) use ($user) {
+        return $message === 'bypass.fired'
+            && ($context['user_id'] ?? null) === $user->id
+            && ($context['bypass'] ?? null) === 'device_attestation';
+    })->atLeast()->once();
+});
+
+it('runs normal attestation verification for regular users', function () {
+    config()->set('mobile.attestation.enabled', false);
+
+    $user = User::factory()->create();
+    // No AccountFlag row — regular user.
+
+    $service = app(BiometricJWTService::class);
+
+    // Empty attestation fails in demo mode (length check).
+    expect($service->verifyDeviceAttestationForUser($user, '', 'ios'))->toBeFalse();
+
+    // Short attestation fails demo-mode length check (ios requires >= 100).
+    expect($service->verifyDeviceAttestationForUser($user, str_repeat('x', 10), 'ios'))->toBeFalse();
+});

--- a/tests/Feature/AccountProvisioning/Bypasses/NotificationSuppressionTest.php
+++ b/tests/Feature/AccountProvisioning/Bypasses/NotificationSuppressionTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AccountProvisioning\Bypasses;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Models\User;
+use Illuminate\Notifications\Notification;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('suppresses notifications for users with suppress_notifications flag', function () {
+    $user = User::factory()->create();
+    AccountFlag::create([
+        'user_id'                => $user->id,
+        'is_review_account'      => true,
+        'suppress_notifications' => true,
+    ]);
+
+    $user->notify(new NotificationSuppressionTestNotification());
+
+    // Database channel is the delivery target — listener should cancel it.
+    expect($user->notifications()->count())->toBe(0);
+});
+
+it('delivers notifications for regular users without the flag', function () {
+    $user = User::factory()->create();
+
+    $user->notify(new NotificationSuppressionTestNotification());
+
+    expect($user->notifications()->count())->toBe(1);
+});
+
+it('delivers notifications when the flag is disabled', function () {
+    $user = User::factory()->create();
+    AccountFlag::create([
+        'user_id'                => $user->id,
+        'is_review_account'      => true,
+        'suppress_notifications' => true,
+        'disabled_at'            => now(),
+    ]);
+
+    $user->notify(new NotificationSuppressionTestNotification());
+
+    expect($user->notifications()->count())->toBe(1);
+});
+
+class NotificationSuppressionTestNotification extends Notification
+{
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return ['message' => 'test'];
+    }
+}

--- a/tests/Feature/AccountProvisioning/Bypasses/RateLimitBypassTest.php
+++ b/tests/Feature/AccountProvisioning/Bypasses/RateLimitBypassTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AccountProvisioning\Bypasses;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Http\Middleware\ApiRateLimitMiddleware;
+use App\Http\Middleware\GraphQLRateLimitMiddleware;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Route;
+use Laravel\Sanctum\Sanctum;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    // Force rate limiting on in the testing environment.
+    config()->set('rate_limiting.enabled', true);
+    config()->set('rate_limiting.force_in_tests', true);
+    config()->set('rate_limiting.partner_tiers.enabled', false);
+    Cache::flush();
+
+    Route::middleware(['api', 'auth:sanctum', ApiRateLimitMiddleware::class . ':auth'])
+        ->get('/__test/rate-limited', fn () => response()->json(['ok' => true]));
+
+    Route::middleware(['api', 'auth:sanctum', GraphQLRateLimitMiddleware::class])
+        ->get('/__test/graphql-rate-limited', fn () => response()->json(['ok' => true]));
+});
+
+it('bypasses rate limit for review accounts with bypass_rate_limit flag', function () {
+    $user = User::factory()->create();
+    AccountFlag::create([
+        'user_id'           => $user->id,
+        'is_review_account' => true,
+        'bypass_rate_limit' => true,
+    ]);
+
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    // The 'auth' limit is 5/min + block. Make far more than that to prove bypass works.
+    for ($i = 0; $i < 20; $i++) {
+        $response = $this->getJson('/__test/rate-limited');
+        $response->assertOk();
+    }
+});
+
+it('enforces rate limit for regular users without bypass', function () {
+    $user = User::factory()->create();
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    $gotLimited = false;
+    for ($i = 0; $i < 20; $i++) {
+        $response = $this->getJson('/__test/rate-limited');
+        if ($response->status() === 429) {
+            $gotLimited = true;
+            break;
+        }
+    }
+
+    expect($gotLimited)->toBeTrue();
+});
+
+it('bypasses GraphQL rate limit for review accounts with bypass_rate_limit flag', function () {
+    $user = User::factory()->create();
+    AccountFlag::create([
+        'user_id'           => $user->id,
+        'is_review_account' => true,
+        'bypass_rate_limit' => true,
+    ]);
+
+    // Tighten auth limit to 2 to prove the bypass path is hit (bypass accounts
+    // would normally trip a 2-request limit immediately).
+    config()->set('lighthouse.rate_limiting.auth_limit', 2);
+
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    for ($i = 0; $i < 10; $i++) {
+        $response = $this->getJson('/__test/graphql-rate-limited');
+        $response->assertOk();
+    }
+});
+
+it('enforces GraphQL rate limit for regular users', function () {
+    $user = User::factory()->create();
+    config()->set('lighthouse.rate_limiting.auth_limit', 2);
+
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    // First two go through, third should 429.
+    $this->getJson('/__test/graphql-rate-limited')->assertOk();
+    $this->getJson('/__test/graphql-rate-limited')->assertOk();
+    $this->getJson('/__test/graphql-rate-limited')->assertStatus(429);
+});

--- a/tests/Feature/AccountProvisioning/Bypasses/SanctionsBypassTest.php
+++ b/tests/Feature/AccountProvisioning/Bypasses/SanctionsBypassTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AccountProvisioning\Bypasses;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Domain\AgentProtocol\Workflows\Activities\PerformAmlScreeningActivity;
+use App\Models\User;
+use Illuminate\Support\Facades\Log;
+use ReflectionClass;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+/**
+ * Instantiate the Activity bypassing its parent Workflow\Activity constructor
+ * so we can exercise the execute() method directly under Pest.
+ */
+function instantiateAmlActivity(): PerformAmlScreeningActivity
+{
+    /** @var PerformAmlScreeningActivity $activity */
+    $activity = (new ReflectionClass(PerformAmlScreeningActivity::class))
+        ->newInstanceWithoutConstructor();
+
+    return $activity;
+}
+
+it('short-circuits sanctions screening for review accounts with bypass flag', function () {
+    $user = User::factory()->create();
+    AccountFlag::create([
+        'user_id'                    => $user->id,
+        'is_review_account'          => true,
+        'bypass_sanctions_screening' => true,
+    ]);
+
+    $logSpy = Log::spy();
+
+    $activity = instantiateAmlActivity();
+
+    // Use a name + country that would normally trigger sanctions + high-risk
+    // jurisdiction. The bypass short-circuits BEFORE any screening runs.
+    $result = $activity->execute(
+        agentId: 'agent-123',
+        agentName: 'John Doe Sanctioned',
+        countryCode: 'KP',
+        userId: (int) $user->id,
+    );
+
+    expect($result['status'])->toBe('passed');
+    expect($result['hasAlerts'])->toBeFalse();
+    expect($result['alerts'])->toBe([]);
+    expect($result['riskFactors'])->toBe([]);
+    expect($result['source'])->toBe('review_bypass');
+
+    $logSpy->shouldHaveReceived('info')->withArgs(function (string $message, array $context) use ($user) {
+        return $message === 'bypass.fired'
+            && ($context['user_id'] ?? null) === $user->id
+            && ($context['bypass'] ?? null) === 'sanctions_screening';
+    })->atLeast()->once();
+});
+
+it('runs full sanctions screening when no user is provided', function () {
+    $activity = instantiateAmlActivity();
+
+    // No userId — bypass path is skipped and real screening runs.
+    $result = $activity->execute(
+        agentId: 'agent-123',
+        agentName: 'Evil Corp',
+        countryCode: 'KP',
+    );
+
+    expect($result['hasAlerts'])->toBeTrue();
+    expect($result['status'])->toBe('alerts_found');
+    expect($result)->not->toHaveKey('source');
+});

--- a/tests/Feature/AccountProvisioning/Bypasses/SanctionsBypassWorkflowTest.php
+++ b/tests/Feature/AccountProvisioning/Bypasses/SanctionsBypassWorkflowTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AccountProvisioning\Bypasses;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Domain\AgentProtocol\DataObjects\KycVerificationRequest;
+use App\Domain\AgentProtocol\Enums\KycVerificationLevel;
+use App\Domain\AgentProtocol\Workflows\Activities\PerformAmlScreeningActivity;
+use App\Models\User;
+use ReflectionClass;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+/**
+ * End-to-end wiring test: a {@see KycVerificationRequest} carrying a
+ * reviewer's user_id must reach the AML activity's bypass branch.
+ *
+ * Shape B (DTO + activity) was chosen over Shape A (full Workflow engine
+ * run) because there are no existing AgentKycWorkflow Pest tests in this
+ * repo to mirror, and spinning up the workflow runtime per assertion is
+ * heavy compared to verifying the DTO carries `userId` through to the
+ * activity that consumes it.
+ */
+function instantiateAmlActivityForWorkflowTest(): PerformAmlScreeningActivity
+{
+    /** @var PerformAmlScreeningActivity $activity */
+    $activity = (new ReflectionClass(PerformAmlScreeningActivity::class))
+        ->newInstanceWithoutConstructor();
+
+    return $activity;
+}
+
+it('passes review_bypass through KycVerificationRequest into the AML screening activity', function () {
+    $user = User::factory()->create();
+    AccountFlag::create([
+        'user_id'                    => $user->id,
+        'is_review_account'          => true,
+        'bypass_sanctions_screening' => true,
+    ]);
+
+    $request = new KycVerificationRequest(
+        agentId: 'agent-wf-1',
+        agentDid: 'did:agent:wf-1',
+        agentName: 'App Reviewer',
+        verificationLevel: KycVerificationLevel::BASIC,
+        documents: [],
+        countryCode: 'US',
+        userId: (int) $user->id,
+    );
+
+    // The DTO must round-trip user_id so the workflow engine can serialize it.
+    expect($request->userId)->toBe((int) $user->id);
+    expect($request->toArray())->toHaveKey('user_id', (int) $user->id);
+    expect(KycVerificationRequest::fromArray($request->toArray())->userId)->toBe((int) $user->id);
+
+    $activity = instantiateAmlActivityForWorkflowTest();
+
+    // Mirror the named-arg dispatch that AgentKycWorkflow performs:
+    //     Activity::make(PerformAmlScreeningActivity::class, [
+    //         'agentId' => ..., 'agentName' => ..., 'countryCode' => ...,
+    //         'userId' => $request->userId,
+    //     ]);
+    $result = $activity->execute(
+        agentId: $request->agentId,
+        agentName: $request->agentName,
+        countryCode: $request->countryCode,
+        userId: $request->userId,
+    );
+
+    expect($result['source'])->toBe('review_bypass');
+    expect($result['status'])->toBe('passed');
+    expect($result['hasAlerts'])->toBeFalse();
+});
+
+it('runs full sanctions screening when KycVerificationRequest carries no userId', function () {
+    $request = new KycVerificationRequest(
+        agentId: 'agent-wf-2',
+        agentDid: 'did:agent:wf-2',
+        agentName: 'Regular Agent',
+        verificationLevel: KycVerificationLevel::BASIC,
+        documents: [],
+        countryCode: 'US',
+        // userId omitted — null by default
+    );
+
+    expect($request->userId)->toBeNull();
+    expect($request->toArray())->toHaveKey('user_id', null);
+
+    $activity = instantiateAmlActivityForWorkflowTest();
+
+    $result = $activity->execute(
+        agentId: $request->agentId,
+        agentName: $request->agentName,
+        countryCode: $request->countryCode,
+        userId: $request->userId,
+    );
+
+    // Bypass path is unreachable without userId; a clean name + safe country
+    // produces a normal "passed" screening with no source sentinel.
+    expect($result)->not->toHaveKey('source');
+    expect($result['status'])->toBe('passed');
+    expect($result['hasAlerts'])->toBeFalse();
+});
+
+it('runs full sanctions screening when reviewer user has no AccountFlag', function () {
+    // User exists but has no account_flags row at all → bypass path is skipped.
+    $user = User::factory()->create();
+
+    $request = new KycVerificationRequest(
+        agentId: 'agent-wf-3',
+        agentDid: 'did:agent:wf-3',
+        agentName: 'App Reviewer',
+        verificationLevel: KycVerificationLevel::BASIC,
+        documents: [],
+        countryCode: 'US',
+        userId: (int) $user->id,
+    );
+
+    $activity = instantiateAmlActivityForWorkflowTest();
+
+    $result = $activity->execute(
+        agentId: $request->agentId,
+        agentName: $request->agentName,
+        countryCode: $request->countryCode,
+        userId: $request->userId,
+    );
+
+    expect($result)->not->toHaveKey('source');
+    expect($result['status'])->toBe('passed');
+});

--- a/tests/Feature/AccountProvisioning/DisableReviewerCommandTest.php
+++ b/tests/Feature/AccountProvisioning/DisableReviewerCommandTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AccountProvisioning;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Domain\User\Values\UserRoles;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Spatie\Permission\Models\Role;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    Role::firstOrCreate([
+        'name'       => UserRoles::ADMIN->value,
+        'guard_name' => 'web',
+    ]);
+    $this->operator = User::factory()->create(['email' => 'op@finaegis.com']);
+    $this->operator->assignRole(UserRoles::ADMIN->value);
+});
+
+it('disables a reviewer via --email, revokes bypasses, keeps is_review_account true', function () {
+    $reviewer = User::factory()->create(['email' => 'reviewer@finaegis.com']);
+    AccountFlag::create([
+        'user_id'                   => $reviewer->id,
+        'is_review_account'         => true,
+        'bypass_device_attestation' => true,
+        'bypass_rate_limit'         => true,
+        'bypass_sms_otp'            => true,
+        'created_by'                => $this->operator->id,
+    ]);
+
+    $this->artisan('account:disable-reviewer', ['--email' => 'reviewer@finaegis.com'])
+        ->assertExitCode(0);
+
+    $flag = AccountFlag::where('user_id', $reviewer->id)->first();
+    expect($flag->is_review_account)->toBeTrue();
+    expect($flag->bypass_device_attestation)->toBeFalse();
+    expect($flag->bypass_rate_limit)->toBeFalse();
+    expect($flag->bypass_sms_otp)->toBeFalse();
+    expect($flag->disabled_at)->not->toBeNull();
+});
+
+it('--all-expired only touches expired rows', function () {
+    $expired = User::factory()->create(['email' => 'expired@finaegis.com']);
+    AccountFlag::create([
+        'user_id'                   => $expired->id,
+        'is_review_account'         => true,
+        'bypass_device_attestation' => true,
+        'expires_at'                => CarbonImmutable::now()->subDay(),
+        'created_by'                => $this->operator->id,
+    ]);
+
+    $active = User::factory()->create(['email' => 'active@finaegis.com']);
+    AccountFlag::create([
+        'user_id'                   => $active->id,
+        'is_review_account'         => true,
+        'bypass_device_attestation' => true,
+        'expires_at'                => CarbonImmutable::now()->addDays(30),
+        'created_by'                => $this->operator->id,
+    ]);
+
+    $this->artisan('account:disable-reviewer', ['--all-expired' => true])
+        ->assertExitCode(0);
+
+    expect(AccountFlag::where('user_id', $expired->id)->first()->disabled_at)->not->toBeNull();
+    expect(AccountFlag::where('user_id', $active->id)->first()->disabled_at)->toBeNull();
+    expect(AccountFlag::where('user_id', $active->id)->first()->bypass_device_attestation)->toBeTrue();
+});
+
+it('--re-enable restores bypasses and clears disabled_at', function () {
+    $reviewer = User::factory()->create(['email' => 'reviewer@finaegis.com']);
+    AccountFlag::create([
+        'user_id'                   => $reviewer->id,
+        'is_review_account'         => true,
+        'bypass_device_attestation' => false,
+        'bypass_rate_limit'         => false,
+        'disabled_at'               => now(),
+        'created_by'                => $this->operator->id,
+    ]);
+
+    $this->artisan('account:disable-reviewer', [
+        '--email'     => 'reviewer@finaegis.com',
+        '--re-enable' => true,
+    ])->assertExitCode(0);
+
+    $flag = AccountFlag::where('user_id', $reviewer->id)->first();
+    expect($flag->disabled_at)->toBeNull();
+    expect($flag->bypass_device_attestation)->toBeTrue();
+    expect($flag->bypass_rate_limit)->toBeTrue();
+});
+
+it('exits 1 when --email is neither a review account nor --all-expired is passed', function () {
+    $nonReview = User::factory()->create(['email' => 'normal@finaegis.com']);
+
+    $this->artisan('account:disable-reviewer', ['--email' => 'normal@finaegis.com'])
+        ->assertExitCode(1);
+});

--- a/tests/Feature/AccountProvisioning/DisableReviewerCommandTest.php
+++ b/tests/Feature/AccountProvisioning/DisableReviewerCommandTest.php
@@ -113,9 +113,12 @@ it('--re-enable preserves the original expires_at', function () {
         '--operator-email' => 'op@finaegis.com',
     ])->assertExitCode(0);
 
-    $disabled = AccountFlag::where('user_id', $reviewer->id)->first();
-    expect($disabled->expires_at)->not->toBeNull();
-    expect($disabled->expires_at->toIso8601String())->toBe($originalExpiry->toIso8601String());
+    $disabled = AccountFlag::where('user_id', $reviewer->id)->firstOrFail();
+    $disabledExpiry = $disabled->expires_at;
+    expect($disabledExpiry)->not->toBeNull();
+    if ($disabledExpiry !== null) {
+        expect($disabledExpiry->toIso8601String())->toBe($originalExpiry->toIso8601String());
+    }
 
     // Re-enable
     $this->artisan('account:disable-reviewer', [
@@ -124,9 +127,12 @@ it('--re-enable preserves the original expires_at', function () {
         '--re-enable'      => true,
     ])->assertExitCode(0);
 
-    $reEnabled = AccountFlag::where('user_id', $reviewer->id)->first();
-    expect($reEnabled->expires_at)->not->toBeNull();
-    expect($reEnabled->expires_at->toIso8601String())->toBe($originalExpiry->toIso8601String());
+    $reEnabled = AccountFlag::where('user_id', $reviewer->id)->firstOrFail();
+    $reEnabledExpiry = $reEnabled->expires_at;
+    expect($reEnabledExpiry)->not->toBeNull();
+    if ($reEnabledExpiry !== null) {
+        expect($reEnabledExpiry->toIso8601String())->toBe($originalExpiry->toIso8601String());
+    }
 });
 
 it('exits 1 when --email is neither a review account nor --all-expired is passed', function () {

--- a/tests/Feature/AccountProvisioning/DisableReviewerCommandTest.php
+++ b/tests/Feature/AccountProvisioning/DisableReviewerCommandTest.php
@@ -32,8 +32,10 @@ it('disables a reviewer via --email, revokes bypasses, keeps is_review_account t
         'created_by'                => $this->operator->id,
     ]);
 
-    $this->artisan('account:disable-reviewer', ['--email' => 'reviewer@finaegis.com'])
-        ->assertExitCode(0);
+    $this->artisan('account:disable-reviewer', [
+        '--email'          => 'reviewer@finaegis.com',
+        '--operator-email' => 'op@finaegis.com',
+    ])->assertExitCode(0);
 
     $flag = AccountFlag::where('user_id', $reviewer->id)->first();
     expect($flag->is_review_account)->toBeTrue();
@@ -82,8 +84,9 @@ it('--re-enable restores bypasses and clears disabled_at', function () {
     ]);
 
     $this->artisan('account:disable-reviewer', [
-        '--email'     => 'reviewer@finaegis.com',
-        '--re-enable' => true,
+        '--email'          => 'reviewer@finaegis.com',
+        '--operator-email' => 'op@finaegis.com',
+        '--re-enable'      => true,
     ])->assertExitCode(0);
 
     $flag = AccountFlag::where('user_id', $reviewer->id)->first();
@@ -93,8 +96,63 @@ it('--re-enable restores bypasses and clears disabled_at', function () {
 });
 
 it('exits 1 when --email is neither a review account nor --all-expired is passed', function () {
-    $nonReview = User::factory()->create(['email' => 'normal@finaegis.com']);
+    User::factory()->create(['email' => 'normal@finaegis.com']);
 
-    $this->artisan('account:disable-reviewer', ['--email' => 'normal@finaegis.com'])
-        ->assertExitCode(1);
+    $this->artisan('account:disable-reviewer', [
+        '--email'          => 'normal@finaegis.com',
+        '--operator-email' => 'op@finaegis.com',
+    ])->assertExitCode(1);
+});
+
+it('exits 1 in production without --allow-production', function () {
+    app()->detectEnvironment(fn () => 'production');
+
+    $this->artisan('account:disable-reviewer', [
+        '--email'          => 'reviewer@finaegis.com',
+        '--operator-email' => 'op@finaegis.com',
+    ])->assertExitCode(1);
+});
+
+it('exits 1 when --email is provided without --operator-email', function () {
+    $reviewer = User::factory()->create(['email' => 'reviewer@finaegis.com']);
+    AccountFlag::create([
+        'user_id'           => $reviewer->id,
+        'is_review_account' => true,
+        'created_by'        => $this->operator->id,
+    ]);
+
+    $this->artisan('account:disable-reviewer', [
+        '--email' => 'reviewer@finaegis.com',
+    ])->assertExitCode(1);
+});
+
+it('exits 1 when --re-enable is invoked without --operator-email', function () {
+    $reviewer = User::factory()->create(['email' => 'reviewer@finaegis.com']);
+    AccountFlag::create([
+        'user_id'           => $reviewer->id,
+        'is_review_account' => true,
+        'disabled_at'       => now(),
+        'created_by'        => $this->operator->id,
+    ]);
+
+    $this->artisan('account:disable-reviewer', [
+        '--email'     => 'reviewer@finaegis.com',
+        '--re-enable' => true,
+    ])->assertExitCode(1);
+});
+
+it('exits 1 when --operator-email resolves to a non-admin user', function () {
+    $nonAdmin = User::factory()->create(['email' => 'plain@finaegis.com']);
+
+    $reviewer = User::factory()->create(['email' => 'reviewer@finaegis.com']);
+    AccountFlag::create([
+        'user_id'           => $reviewer->id,
+        'is_review_account' => true,
+        'created_by'        => $this->operator->id,
+    ]);
+
+    $this->artisan('account:disable-reviewer', [
+        '--email'          => 'reviewer@finaegis.com',
+        '--operator-email' => $nonAdmin->email,
+    ])->assertExitCode(1);
 });

--- a/tests/Feature/AccountProvisioning/DisableReviewerCommandTest.php
+++ b/tests/Feature/AccountProvisioning/DisableReviewerCommandTest.php
@@ -95,6 +95,40 @@ it('--re-enable restores bypasses and clears disabled_at', function () {
     expect($flag->bypass_rate_limit)->toBeTrue();
 });
 
+it('--re-enable preserves the original expires_at', function () {
+    $originalExpiry = CarbonImmutable::now()->addDays(45);
+
+    $reviewer = User::factory()->create(['email' => 'reviewer@finaegis.com']);
+    AccountFlag::create([
+        'user_id'                   => $reviewer->id,
+        'is_review_account'         => true,
+        'bypass_device_attestation' => true,
+        'expires_at'                => $originalExpiry,
+        'created_by'                => $this->operator->id,
+    ]);
+
+    // Disable
+    $this->artisan('account:disable-reviewer', [
+        '--email'          => 'reviewer@finaegis.com',
+        '--operator-email' => 'op@finaegis.com',
+    ])->assertExitCode(0);
+
+    $disabled = AccountFlag::where('user_id', $reviewer->id)->first();
+    expect($disabled->expires_at)->not->toBeNull();
+    expect($disabled->expires_at->toIso8601String())->toBe($originalExpiry->toIso8601String());
+
+    // Re-enable
+    $this->artisan('account:disable-reviewer', [
+        '--email'          => 'reviewer@finaegis.com',
+        '--operator-email' => 'op@finaegis.com',
+        '--re-enable'      => true,
+    ])->assertExitCode(0);
+
+    $reEnabled = AccountFlag::where('user_id', $reviewer->id)->first();
+    expect($reEnabled->expires_at)->not->toBeNull();
+    expect($reEnabled->expires_at->toIso8601String())->toBe($originalExpiry->toIso8601String());
+});
+
 it('exits 1 when --email is neither a review account nor --all-expired is passed', function () {
     User::factory()->create(['email' => 'normal@finaegis.com']);
 

--- a/tests/Feature/AccountProvisioning/ExpirySweepTest.php
+++ b/tests/Feature/AccountProvisioning/ExpirySweepTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AccountProvisioning;
+
+use Illuminate\Console\Scheduling\Schedule;
+
+it('registers account:disable-reviewer --all-expired on the daily schedule', function () {
+    $schedule = app(Schedule::class);
+    $events = collect($schedule->events());
+
+    $match = $events->first(fn ($e) => str_contains($e->command ?? '', 'account:disable-reviewer --all-expired'));
+
+    expect($match)->not->toBeNull();
+    expect($match->expression)->toBe('10 0 * * *');
+});

--- a/tests/Feature/AccountProvisioning/ExpirySweepTest.php
+++ b/tests/Feature/AccountProvisioning/ExpirySweepTest.php
@@ -12,10 +12,10 @@ it('registers account:disable-reviewer --all-expired on the daily schedule', fun
     $schedule = app(Schedule::class);
     $events = collect($schedule->events());
 
-    $match = $events->first(fn ($e) => str_contains($e->command ?? '', 'account:disable-reviewer --all-expired'));
+    $match = $events->first(fn ($e) => str_contains($e->command ?? '', 'account:disable-reviewer --all-expired --allow-production'));
 
     if (! $match instanceof Event) {
-        throw new RuntimeException('Expected scheduled event for account:disable-reviewer --all-expired');
+        throw new RuntimeException('Expected scheduled event for account:disable-reviewer --all-expired --allow-production');
     }
 
     expect($match->expression)->toBe('10 0 * * *');

--- a/tests/Feature/AccountProvisioning/ExpirySweepTest.php
+++ b/tests/Feature/AccountProvisioning/ExpirySweepTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Feature\AccountProvisioning;
 
+use Illuminate\Console\Scheduling\Event;
 use Illuminate\Console\Scheduling\Schedule;
+use RuntimeException;
 
 it('registers account:disable-reviewer --all-expired on the daily schedule', function () {
     $schedule = app(Schedule::class);
@@ -12,6 +14,9 @@ it('registers account:disable-reviewer --all-expired on the daily schedule', fun
 
     $match = $events->first(fn ($e) => str_contains($e->command ?? '', 'account:disable-reviewer --all-expired'));
 
-    expect($match)->not->toBeNull();
+    if (! $match instanceof Event) {
+        throw new RuntimeException('Expected scheduled event for account:disable-reviewer --all-expired');
+    }
+
     expect($match->expression)->toBe('10 0 * * *');
 });

--- a/tests/Feature/AccountProvisioning/ListReviewersCommandTest.php
+++ b/tests/Feature/AccountProvisioning/ListReviewersCommandTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AccountProvisioning;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Domain\User\Values\UserRoles;
+use App\Models\User;
+use Spatie\Permission\Models\Role;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    Role::firstOrCreate([
+        'name'       => UserRoles::ADMIN->value,
+        'guard_name' => 'web',
+    ]);
+    $this->operator = User::factory()->create(['email' => 'op@finaegis.com']);
+    $this->operator->assignRole(UserRoles::ADMIN->value);
+});
+
+it('lists seeded review accounts in table form', function () {
+    $reviewer = User::factory()->create(['email' => 'reviewer@finaegis.com']);
+    AccountFlag::create([
+        'user_id'           => $reviewer->id,
+        'is_review_account' => true,
+        'note'              => 'audit-note-xyz',
+        'created_by'        => $this->operator->id,
+    ]);
+
+    $this->artisan('account:list-reviewers')
+        ->assertExitCode(0)
+        ->expectsOutputToContain('reviewer@finaegis.com');
+});
+
+it('emits JSON when --json flag is set', function () {
+    $reviewer = User::factory()->create(['email' => 'reviewer@finaegis.com']);
+    AccountFlag::create([
+        'user_id'           => $reviewer->id,
+        'is_review_account' => true,
+        'note'              => 'App Store 2026-Q2',
+        'created_by'        => $this->operator->id,
+    ]);
+
+    $this->artisan('account:list-reviewers', ['--json' => true])
+        ->assertExitCode(0)
+        ->expectsOutputToContain('reviewer@finaegis.com');
+});
+
+it('handles empty result without failing', function () {
+    $this->artisan('account:list-reviewers')
+        ->assertExitCode(0)
+        ->expectsOutputToContain('No review accounts found.');
+});

--- a/tests/Feature/AccountProvisioning/ProvisionReviewerCommandTest.php
+++ b/tests/Feature/AccountProvisioning/ProvisionReviewerCommandTest.php
@@ -30,8 +30,7 @@ it('creates a reviewer user with flags and sub-seeded content (happy path)', fun
 
     expect($exit)->toBe(0);
 
-    $user = User::where('email', 'appreview@finaegis.com')->first();
-    expect($user)->not->toBeNull();
+    $user = User::where('email', 'appreview@finaegis.com')->firstOrFail();
 
     $flag = AccountFlag::where('user_id', $user->id)->first();
     expect($flag)->not->toBeNull();
@@ -53,7 +52,7 @@ it('is idempotent across repeated invocations', function () {
     $this->artisan('account:provision-reviewer', $args)->assertExitCode(0);
     $this->artisan('account:provision-reviewer', $args)->assertExitCode(0);
 
-    $user = User::where('email', 'appreview@finaegis.com')->first();
+    $user = User::where('email', 'appreview@finaegis.com')->firstOrFail();
     expect(AccountFlag::where('user_id', $user->id)->count())->toBe(1);
     expect(BlockchainAddress::where('user_uuid', $user->uuid)->count())->toBe(2);
 });

--- a/tests/Feature/AccountProvisioning/ProvisionReviewerCommandTest.php
+++ b/tests/Feature/AccountProvisioning/ProvisionReviewerCommandTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AccountProvisioning;
+
+use App\Domain\Account\Models\BlockchainAddress;
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Domain\User\Values\UserRoles;
+use App\Models\User;
+use Spatie\Permission\Models\Role;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    Role::firstOrCreate([
+        'name'       => UserRoles::ADMIN->value,
+        'guard_name' => 'web',
+    ]);
+    $this->operator = User::factory()->create(['email' => 'op@finaegis.com']);
+    $this->operator->assignRole(UserRoles::ADMIN->value);
+});
+
+it('creates a reviewer user with flags and sub-seeded content (happy path)', function () {
+    $exit = $this->artisan('account:provision-reviewer', [
+        '--email'          => 'appreview@finaegis.com',
+        '--operator-email' => 'op@finaegis.com',
+        '--note'           => 'App Store review 2026-Q2',
+    ])->run();
+
+    expect($exit)->toBe(0);
+
+    $user = User::where('email', 'appreview@finaegis.com')->first();
+    expect($user)->not->toBeNull();
+
+    $flag = AccountFlag::where('user_id', $user->id)->first();
+    expect($flag)->not->toBeNull();
+    expect($flag->is_review_account)->toBeTrue();
+    expect($flag->bypass_device_attestation)->toBeTrue();
+    expect($flag->note)->toBe('App Store review 2026-Q2');
+    expect($flag->created_by)->toBe((int) $this->operator->id);
+
+    // Sub-seeders ran (wallets create BlockchainAddress rows).
+    expect(BlockchainAddress::where('user_uuid', $user->uuid)->count())->toBe(2);
+});
+
+it('is idempotent across repeated invocations', function () {
+    $args = [
+        '--email'          => 'appreview@finaegis.com',
+        '--operator-email' => 'op@finaegis.com',
+    ];
+
+    $this->artisan('account:provision-reviewer', $args)->assertExitCode(0);
+    $this->artisan('account:provision-reviewer', $args)->assertExitCode(0);
+
+    $user = User::where('email', 'appreview@finaegis.com')->first();
+    expect(AccountFlag::where('user_id', $user->id)->count())->toBe(1);
+    expect(BlockchainAddress::where('user_uuid', $user->uuid)->count())->toBe(2);
+});
+
+it('exits 1 when operator is not an admin', function () {
+    $nonAdmin = User::factory()->create(['email' => 'plain@finaegis.com']);
+
+    $this->artisan('account:provision-reviewer', [
+        '--email'          => 'appreview@finaegis.com',
+        '--operator-email' => $nonAdmin->email,
+    ])->assertExitCode(1);
+});
+
+it('exits 1 in production without --allow-production', function () {
+    app()->detectEnvironment(fn () => 'production');
+
+    $this->artisan('account:provision-reviewer', [
+        '--email'          => 'appreview@finaegis.com',
+        '--operator-email' => 'op@finaegis.com',
+    ])->assertExitCode(1);
+});
+
+it('exits 1 on email collision with non-review user', function () {
+    User::factory()->create(['email' => 'existing@finaegis.com']);
+
+    $this->artisan('account:provision-reviewer', [
+        '--email'          => 'existing@finaegis.com',
+        '--operator-email' => 'op@finaegis.com',
+    ])->assertExitCode(1);
+});
+
+it('exits 1 when --force-convert is passed in production', function () {
+    app()->detectEnvironment(fn () => 'production');
+
+    $this->artisan('account:provision-reviewer', [
+        '--email'            => 'appreview@finaegis.com',
+        '--operator-email'   => 'op@finaegis.com',
+        '--allow-production' => true,
+        '--force-convert'    => true,
+    ])->assertExitCode(1);
+});
+
+it('exits 1 when --expires-days exceeds the 90-day hard cap', function () {
+    $this->artisan('account:provision-reviewer', [
+        '--email'          => 'appreview@finaegis.com',
+        '--operator-email' => 'op@finaegis.com',
+        '--expires-days'   => 365,
+    ])->assertExitCode(1);
+});

--- a/tests/Feature/AccountProvisioning/PurgeReviewerCommandTest.php
+++ b/tests/Feature/AccountProvisioning/PurgeReviewerCommandTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AccountProvisioning;
+
+use App\Domain\AccountProvisioning\Events\AccountPurged;
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Domain\User\Values\UserRoles;
+use App\Models\User;
+use Illuminate\Support\Facades\Event;
+use Spatie\Permission\Models\Role;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    Role::firstOrCreate([
+        'name'       => UserRoles::ADMIN->value,
+        'guard_name' => 'web',
+    ]);
+    $this->operator = User::factory()->create(['email' => 'op@finaegis.com']);
+    $this->operator->assignRole(UserRoles::ADMIN->value);
+});
+
+it('purges (anonymizes + disables) a review account with --confirm', function () {
+    Event::fake([AccountPurged::class]);
+
+    $reviewer = User::factory()->create(['email' => 'reviewer@finaegis.com']);
+    AccountFlag::create([
+        'user_id'                   => $reviewer->id,
+        'is_review_account'         => true,
+        'bypass_device_attestation' => true,
+        'created_by'                => $this->operator->id,
+    ]);
+
+    $this->artisan('account:purge-reviewer', [
+        '--email'   => 'reviewer@finaegis.com',
+        '--confirm' => true,
+    ])->assertExitCode(0);
+
+    // Email anonymized
+    $user = User::find($reviewer->id);
+    expect($user)->not->toBeNull();
+    expect($user->email)->not->toBe('reviewer@finaegis.com');
+    expect($user->email)->toStartWith('purged-')->toEndWith('@example.invalid');
+
+    // Flag row preserved, disabled, bypasses revoked
+    $flag = AccountFlag::where('user_id', $reviewer->id)->first();
+    expect($flag)->not->toBeNull();
+    expect($flag->disabled_at)->not->toBeNull();
+    expect($flag->bypass_device_attestation)->toBeFalse();
+
+    Event::assertDispatched(AccountPurged::class, fn ($e) => $e->userId === (int) $reviewer->id);
+});
+
+it('refuses without --confirm', function () {
+    $reviewer = User::factory()->create(['email' => 'reviewer@finaegis.com']);
+    AccountFlag::create([
+        'user_id'           => $reviewer->id,
+        'is_review_account' => true,
+        'created_by'        => $this->operator->id,
+    ]);
+
+    $this->artisan('account:purge-reviewer', ['--email' => 'reviewer@finaegis.com'])
+        ->assertExitCode(1);
+});
+
+it('refuses when user is not a review account', function () {
+    User::factory()->create(['email' => 'normal@finaegis.com']);
+
+    $this->artisan('account:purge-reviewer', [
+        '--email'   => 'normal@finaegis.com',
+        '--confirm' => true,
+    ])->assertExitCode(1);
+});
+
+it('refuses in production without --allow-production', function () {
+    app()->detectEnvironment(fn () => 'production');
+
+    $reviewer = User::factory()->create(['email' => 'reviewer@finaegis.com']);
+    AccountFlag::create([
+        'user_id'           => $reviewer->id,
+        'is_review_account' => true,
+        'created_by'        => $this->operator->id,
+    ]);
+
+    $this->artisan('account:purge-reviewer', [
+        '--email'   => 'reviewer@finaegis.com',
+        '--confirm' => true,
+    ])->assertExitCode(1);
+});

--- a/tests/Feature/AccountProvisioning/PurgeReviewerCommandTest.php
+++ b/tests/Feature/AccountProvisioning/PurgeReviewerCommandTest.php
@@ -34,8 +34,9 @@ it('purges (anonymizes + disables) a review account with --confirm', function ()
     ]);
 
     $this->artisan('account:purge-reviewer', [
-        '--email'   => 'reviewer@finaegis.com',
-        '--confirm' => true,
+        '--email'          => 'reviewer@finaegis.com',
+        '--operator-email' => 'op@finaegis.com',
+        '--confirm'        => true,
     ])->assertExitCode(0);
 
     // Email anonymized
@@ -49,7 +50,10 @@ it('purges (anonymizes + disables) a review account with --confirm', function ()
     expect($flag->disabled_at)->not->toBeNull();
     expect($flag->bypass_device_attestation)->toBeFalse();
 
-    Event::assertDispatched(AccountPurged::class, fn ($e) => $e->userId === (int) $reviewer->id);
+    Event::assertDispatched(
+        AccountPurged::class,
+        fn ($e) => $e->userId === (int) $reviewer->id && $e->operatorId === (int) $this->operator->id,
+    );
 });
 
 it('refuses without --confirm', function () {
@@ -60,16 +64,19 @@ it('refuses without --confirm', function () {
         'created_by'        => $this->operator->id,
     ]);
 
-    $this->artisan('account:purge-reviewer', ['--email' => 'reviewer@finaegis.com'])
-        ->assertExitCode(1);
+    $this->artisan('account:purge-reviewer', [
+        '--email'          => 'reviewer@finaegis.com',
+        '--operator-email' => 'op@finaegis.com',
+    ])->assertExitCode(1);
 });
 
 it('refuses when user is not a review account', function () {
     User::factory()->create(['email' => 'normal@finaegis.com']);
 
     $this->artisan('account:purge-reviewer', [
-        '--email'   => 'normal@finaegis.com',
-        '--confirm' => true,
+        '--email'          => 'normal@finaegis.com',
+        '--operator-email' => 'op@finaegis.com',
+        '--confirm'        => true,
     ])->assertExitCode(1);
 });
 
@@ -84,7 +91,39 @@ it('refuses in production without --allow-production', function () {
     ]);
 
     $this->artisan('account:purge-reviewer', [
+        '--email'          => 'reviewer@finaegis.com',
+        '--operator-email' => 'op@finaegis.com',
+        '--confirm'        => true,
+    ])->assertExitCode(1);
+});
+
+it('refuses when --operator-email is missing', function () {
+    $reviewer = User::factory()->create(['email' => 'reviewer@finaegis.com']);
+    AccountFlag::create([
+        'user_id'           => $reviewer->id,
+        'is_review_account' => true,
+        'created_by'        => $this->operator->id,
+    ]);
+
+    $this->artisan('account:purge-reviewer', [
         '--email'   => 'reviewer@finaegis.com',
         '--confirm' => true,
+    ])->assertExitCode(1);
+});
+
+it('refuses when --operator-email resolves to a non-admin user', function () {
+    $nonAdmin = User::factory()->create(['email' => 'plain@finaegis.com']);
+
+    $reviewer = User::factory()->create(['email' => 'reviewer@finaegis.com']);
+    AccountFlag::create([
+        'user_id'           => $reviewer->id,
+        'is_review_account' => true,
+        'created_by'        => $this->operator->id,
+    ]);
+
+    $this->artisan('account:purge-reviewer', [
+        '--email'          => 'reviewer@finaegis.com',
+        '--operator-email' => $nonAdmin->email,
+        '--confirm'        => true,
     ])->assertExitCode(1);
 });

--- a/tests/Feature/AccountProvisioning/PurgeReviewerCommandTest.php
+++ b/tests/Feature/AccountProvisioning/PurgeReviewerCommandTest.php
@@ -39,8 +39,7 @@ it('purges (anonymizes + disables) a review account with --confirm', function ()
     ])->assertExitCode(0);
 
     // Email anonymized
-    $user = User::find($reviewer->id);
-    expect($user)->not->toBeNull();
+    $user = User::findOrFail($reviewer->id);
     expect($user->email)->not->toBe('reviewer@finaegis.com');
     expect($user->email)->toStartWith('purged-')->toEndWith('@example.invalid');
 

--- a/tests/Feature/Middleware/PartnerTierRateLimitTest.php
+++ b/tests/Feature/Middleware/PartnerTierRateLimitTest.php
@@ -42,7 +42,7 @@ class PartnerTierRateLimitTest extends TestCase
         $request = Request::create('/api/v1/accounts', 'GET');
         $request->attributes->set('partner', $partner);
 
-        $middleware = new ApiRateLimitMiddleware();
+        $middleware = app(ApiRateLimitMiddleware::class);
         $response = $middleware->handle($request, fn ($req) => response()->json(['ok' => true]), 'query');
 
         $this->assertEquals(200, $response->getStatusCode());
@@ -57,7 +57,7 @@ class PartnerTierRateLimitTest extends TestCase
         $request = Request::create('/api/v1/transfer', 'POST');
         $request->attributes->set('partner', $partner);
 
-        $middleware = new ApiRateLimitMiddleware();
+        $middleware = app(ApiRateLimitMiddleware::class);
         $response = $middleware->handle($request, fn ($req) => response()->json(['ok' => true]), 'transaction');
 
         $this->assertEquals(200, $response->getStatusCode());
@@ -69,7 +69,7 @@ class PartnerTierRateLimitTest extends TestCase
     {
         $request = Request::create('/api/v1/accounts', 'GET');
 
-        $middleware = new ApiRateLimitMiddleware();
+        $middleware = app(ApiRateLimitMiddleware::class);
         $response = $middleware->handle($request, fn ($req) => response()->json(['ok' => true]), 'query');
 
         $this->assertEquals(200, $response->getStatusCode());
@@ -95,7 +95,7 @@ class PartnerTierRateLimitTest extends TestCase
         $request = Request::create('/api/v1/accounts', 'GET');
         $request->attributes->set('partner', $partner);
 
-        $middleware = new ApiRateLimitMiddleware();
+        $middleware = app(ApiRateLimitMiddleware::class);
         $response = $middleware->handle($request, fn ($req) => response()->json(['ok' => true]), 'query');
 
         $this->assertEquals(429, $response->getStatusCode());
@@ -115,7 +115,7 @@ class PartnerTierRateLimitTest extends TestCase
         $request = Request::create('/api/v1/accounts', 'GET');
         $request->attributes->set('partner', $partner);
 
-        $middleware = new ApiRateLimitMiddleware();
+        $middleware = app(ApiRateLimitMiddleware::class);
         $response = $middleware->handle($request, fn ($req) => response()->json(['ok' => true]), 'query');
 
         $this->assertEquals(200, $response->getStatusCode());
@@ -130,7 +130,7 @@ class PartnerTierRateLimitTest extends TestCase
         $request = Request::create('/api/v1/login', 'POST');
         $request->attributes->set('partner', $partner);
 
-        $middleware = new ApiRateLimitMiddleware();
+        $middleware = app(ApiRateLimitMiddleware::class);
         $response = $middleware->handle($request, fn ($req) => response()->json(['ok' => true]), 'auth');
 
         $this->assertEquals(200, $response->getStatusCode());

--- a/tests/Feature/RateLimitingTest.php
+++ b/tests/Feature/RateLimitingTest.php
@@ -23,7 +23,7 @@ describe('API Rate Limiting System', function () {
 
     test('basic rate limiting middleware works', function () {
         // Test basic functionality by directly calling middleware (since it's disabled in tests)
-        $middleware = new ApiRateLimitMiddleware();
+        $middleware = app(ApiRateLimitMiddleware::class);
         $request = Request::create('/api/workflows', 'GET');
         $request->setUserResolver(fn () => $this->user);
 
@@ -41,7 +41,7 @@ describe('API Rate Limiting System', function () {
 
     test('rate limit headers are present', function () {
         // Test headers by directly calling middleware (since it's disabled in tests)
-        $middleware = new ApiRateLimitMiddleware();
+        $middleware = app(ApiRateLimitMiddleware::class);
         $request = Request::create('/api/workflows', 'GET');
         $request->setUserResolver(fn () => $this->user);
 
@@ -61,7 +61,7 @@ describe('API Rate Limiting System', function () {
 
     test('rate limit exceeded returns 429', function () {
         // Test that rate limiting middleware properly enforces limits
-        $middleware = new ApiRateLimitMiddleware();
+        $middleware = app(ApiRateLimitMiddleware::class);
         $request = Request::create('/api/test', 'GET');
 
         // Override environment for direct middleware testing
@@ -95,7 +95,7 @@ describe('API Rate Limiting System', function () {
 
     test('rate limiting works per user', function () {
         // Test that rate limiting middleware handles users correctly
-        $middleware = new ApiRateLimitMiddleware();
+        $middleware = app(ApiRateLimitMiddleware::class);
         $user1 = User::factory()->create();
 
         $request = Request::create('/api/test', 'GET');
@@ -274,7 +274,7 @@ describe('Rate Limiting Integration Tests', function () {
 
     test('public endpoints use public rate limiting', function () {
         // Test public rate limiting by directly calling middleware (since it's disabled in tests)
-        $middleware = new ApiRateLimitMiddleware();
+        $middleware = app(ApiRateLimitMiddleware::class);
         $request = Request::create('/api/v1/assets', 'GET');
 
         // Override environment for direct middleware testing
@@ -291,7 +291,7 @@ describe('Rate Limiting Integration Tests', function () {
 
     test('rate limiting works across different IP addresses', function () {
         // Test that rate limiting correctly handles different IP addresses by direct middleware testing
-        $middleware = new ApiRateLimitMiddleware();
+        $middleware = app(ApiRateLimitMiddleware::class);
 
         // Override environment for direct middleware testing
         app()->bind('env', fn () => 'production');
@@ -317,7 +317,7 @@ describe('Rate Limiting Integration Tests', function () {
 
     test('rate limiting respects cache expiration', function () {
         // Test cache behavior with simple verification
-        $middleware = new ApiRateLimitMiddleware();
+        $middleware = app(ApiRateLimitMiddleware::class);
         $request = Request::create('/api/test-cache', 'GET');
 
         // Override environment for direct middleware testing

--- a/tests/Feature/Security/RateLimitingTest.php
+++ b/tests/Feature/Security/RateLimitingTest.php
@@ -95,7 +95,7 @@ class RateLimitingTest extends TestCase
         // Test that different rate limit types have different configurations
         // by calling the middleware directly, since route-level middleware
         // uses the 'auth' type for all /api/auth/* endpoints.
-        $middleware = new ApiRateLimitMiddleware();
+        $middleware = app(ApiRateLimitMiddleware::class);
         $user = User::factory()->create();
 
         // Override environment for direct middleware testing
@@ -172,7 +172,7 @@ class RateLimitingTest extends TestCase
         // Test rate limit headers by calling the middleware directly,
         // since the /api/monitoring/health endpoint does not have
         // rate limit middleware applied at the route level.
-        $middleware = new ApiRateLimitMiddleware();
+        $middleware = app(ApiRateLimitMiddleware::class);
         $request = Request::create('/api/monitoring/health', 'GET');
 
         // Override environment for direct middleware testing
@@ -197,7 +197,7 @@ class RateLimitingTest extends TestCase
         // Test admin rate limiting by calling the middleware directly,
         // since route-level middleware on /api/auth/* uses 'auth' type (limit 5),
         // not 'admin' type (limit 200).
-        $middleware = new ApiRateLimitMiddleware();
+        $middleware = app(ApiRateLimitMiddleware::class);
         $admin = User::factory()->create();
 
         // Override environment for direct middleware testing

--- a/tests/Unit/AccountProvisioning/AccountFlagsServiceTest.php
+++ b/tests/Unit/AccountProvisioning/AccountFlagsServiceTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\AccountProvisioning;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Domain\AccountProvisioning\Services\AccountFlagsService;
+use App\Models\User;
+use DB;
+use Tests\TestCase;
+
+uses(TestCase::class, \Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('returns null when user has no flag row', function () {
+    $user = User::factory()->create();
+    $service = new AccountFlagsService();
+
+    expect($service->forUser($user))->toBeNull();
+    expect($service->hasReviewBypass($user, 'device_attestation'))->toBeFalse();
+});
+
+it('returns the flag row and reports bypasses', function () {
+    $user = User::factory()->create();
+    AccountFlag::create([
+        'user_id'                   => $user->id,
+        'is_review_account'         => true,
+        'bypass_device_attestation' => true,
+        'bypass_rate_limit'         => false,
+    ]);
+
+    $service = new AccountFlagsService();
+
+    expect($service->forUser($user))->not->toBeNull();
+    expect($service->hasReviewBypass($user, 'device_attestation'))->toBeTrue();
+    expect($service->hasReviewBypass($user, 'rate_limit'))->toBeFalse();
+});
+
+it('short-circuits when flag is disabled or expired', function () {
+    $user = User::factory()->create();
+    AccountFlag::create([
+        'user_id'                   => $user->id,
+        'is_review_account'         => true,
+        'bypass_device_attestation' => true,
+        'disabled_at'               => now(),
+    ]);
+
+    $service = new AccountFlagsService();
+
+    expect($service->hasReviewBypass($user, 'device_attestation'))->toBeFalse();
+});
+
+it('caches lookups per request', function () {
+    $user = User::factory()->create();
+    AccountFlag::create(['user_id' => $user->id, 'is_review_account' => true]);
+
+    $service = new AccountFlagsService();
+    $service->forUser($user);
+
+    DB::enableQueryLog();
+    $service->forUser($user);
+    $service->forUser($user);
+    expect(DB::getQueryLog())->toBeEmpty();
+});

--- a/tests/Unit/AccountProvisioning/AccountFlagsServiceTest.php
+++ b/tests/Unit/AccountProvisioning/AccountFlagsServiceTest.php
@@ -50,6 +50,21 @@ it('short-circuits when flag is disabled or expired', function () {
     expect($service->hasReviewBypass($user, 'device_attestation'))->toBeFalse();
 });
 
+it('refuses bypasses when is_review_account=false even with bypass columns set', function () {
+    $user = User::factory()->create();
+    AccountFlag::create([
+        'user_id'                   => $user->id,
+        'is_review_account'         => false,
+        'bypass_device_attestation' => true,
+        'bypass_rate_limit'         => true,
+    ]);
+
+    $service = new AccountFlagsService();
+
+    expect($service->hasReviewBypass($user, 'rate_limit'))->toBeFalse();
+    expect($service->hasReviewBypass($user, 'device_attestation'))->toBeFalse();
+});
+
 it('caches lookups per request', function () {
     $user = User::factory()->create();
     AccountFlag::create(['user_id' => $user->id, 'is_review_account' => true]);

--- a/tests/Unit/AccountProvisioning/ReviewerAccountProfileTest.php
+++ b/tests/Unit/AccountProvisioning/ReviewerAccountProfileTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\AccountProvisioning;
+
+use App\Domain\Account\Models\BlockchainAddress;
+use App\Domain\AccountProvisioning\Profiles\ReviewerAccountProfile;
+use App\Domain\AccountProvisioning\ValueObjects\ProvisioningContext;
+use App\Domain\CardIssuance\Models\Card;
+use App\Domain\Privacy\Models\ShieldedBalance;
+use App\Domain\Rewards\Models\RewardProfile;
+use App\Domain\TrustCert\Models\Certificate;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Tests\TestCase;
+
+uses(TestCase::class, \Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('returns the expected flag payload', function () {
+    $profile = app(ReviewerAccountProfile::class);
+    $ctx = new ProvisioningContext(
+        email: 'appreview@finaegis.com',
+        name: 'App Reviewer',
+        region: 'US',
+        expiresAt: CarbonImmutable::now()->addDays(60),
+        note: 'App Store review 2026-Q2',
+        operatorId: 1,
+    );
+
+    $flags = $profile->flags($ctx);
+
+    expect($flags['is_review_account'])->toBeTrue();
+    expect($flags['bypass_device_attestation'])->toBeTrue();
+    expect($flags['bypass_rate_limit'])->toBeTrue();
+    expect($flags['bypass_sanctions_screening'])->toBeTrue();
+    expect($flags['bypass_sms_otp'])->toBeTrue();
+    expect($flags['suppress_notifications'])->toBeTrue();
+    expect($flags['kyc_override_level'])->toBe(2);
+    expect($flags['note'])->toBe('App Store review 2026-Q2');
+    expect($flags['created_by'])->toBe(1);
+});
+
+it('provisions all content sub-seeders in one transaction', function () {
+    $user = User::factory()->create();
+    $ctx = new ProvisioningContext('e@e.com', 'n', 'US', null, null, 1);
+
+    app(ReviewerAccountProfile::class)->provision($user, $ctx);
+
+    // Verify sub-seeders ran: wallets, balances (shielded), card, trust cert, rewards.
+    expect(BlockchainAddress::where('user_uuid', $user->uuid)->count())->toBe(2);
+    expect(ShieldedBalance::where('user_id', $user->id)->count())->toBe(1);
+    expect(Card::where('user_id', $user->id)->where('issuer', 'review_bypass')->count())->toBe(1);
+    expect(Certificate::where('user_id', $user->id)->where('credential_type', 'review_bypass')->count())->toBe(1);
+    expect(RewardProfile::where('user_id', $user->id)->count())->toBe(1);
+
+    // Profile does NOT write the flag row — that's the orchestrator's job.
+    expect($user->fresh()->accountFlag)->toBeNull();
+});
+
+it('is idempotent end-to-end', function () {
+    $user = User::factory()->create();
+    $ctx = new ProvisioningContext('e@e.com', 'n', 'US', null, null, 1);
+
+    $profile = app(ReviewerAccountProfile::class);
+    $profile->provision($user, $ctx);
+    $profile->provision($user, $ctx); // second call must not throw or duplicate
+
+    expect(BlockchainAddress::where('user_uuid', $user->uuid)->count())->toBe(2);
+    expect(Card::where('user_id', $user->id)->where('issuer', 'review_bypass')->count())->toBe(1);
+    expect(Certificate::where('user_id', $user->id)->where('credential_type', 'review_bypass')->count())->toBe(1);
+    expect(RewardProfile::where('user_id', $user->id)->count())->toBe(1);
+});
+
+it('exposes the correct profile slug', function () {
+    $profile = app(ReviewerAccountProfile::class);
+
+    expect($profile->name())->toBe('reviewer');
+});

--- a/tests/Unit/AccountProvisioning/ReviewerAccountProfileTest.php
+++ b/tests/Unit/AccountProvisioning/ReviewerAccountProfileTest.php
@@ -55,7 +55,8 @@ it('provisions all content sub-seeders in one transaction', function () {
     expect(RewardProfile::where('user_id', $user->id)->count())->toBe(1);
 
     // Profile does NOT write the flag row — that's the orchestrator's job.
-    expect($user->fresh()->accountFlag)->toBeNull();
+    $fresh = User::findOrFail($user->id);
+    expect($fresh->accountFlag)->toBeNull();
 });
 
 it('is idempotent end-to-end', function () {

--- a/tests/Unit/AccountProvisioning/Seeders/BalanceSeederTest.php
+++ b/tests/Unit/AccountProvisioning/Seeders/BalanceSeederTest.php
@@ -76,3 +76,26 @@ it('is idempotent — re-seeding sets to the target, not incremental', function 
     /** @var stdClass $unshielded */
     expect(bsNormalize($unshielded->balance))->toBe('50.0000');
 });
+
+it('preserves created_at audit timestamp across re-seeds', function (): void {
+    $user = User::factory()->create();
+    app(WalletSeeder::class)->seed($user);
+
+    app(BalanceSeeder::class)->seed($user, unshieldedUsdc: '25.00', shieldedUsdc: '10.00');
+
+    $first = DB::table('token_balances')->where('symbol', 'USDC')->first();
+    expect($first)->not->toBeNull();
+    /** @var stdClass $first */
+    $originalCreatedAt = $first->created_at;
+    expect($originalCreatedAt)->not->toBeNull();
+
+    // Sleep briefly so any erroneous overwrite produces a different timestamp.
+    sleep(1);
+
+    app(BalanceSeeder::class)->seed($user, unshieldedUsdc: '50.00', shieldedUsdc: '20.00');
+
+    $second = DB::table('token_balances')->where('symbol', 'USDC')->first();
+    expect($second)->not->toBeNull();
+    /** @var stdClass $second */
+    expect($second->created_at)->toBe($originalCreatedAt);
+});

--- a/tests/Unit/AccountProvisioning/Seeders/BalanceSeederTest.php
+++ b/tests/Unit/AccountProvisioning/Seeders/BalanceSeederTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\AccountProvisioning\Seeders\BalanceSeeder;
+use App\Domain\AccountProvisioning\Seeders\WalletSeeder;
+use App\Domain\Privacy\Models\ShieldedBalance;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+/**
+ * @param mixed $value
+ */
+function bsNormalize($value): string
+{
+    $s = (string) $value;
+    if (! is_numeric($s)) {
+        return '0.0000';
+    }
+
+    /** @var numeric-string $s */
+    return bcadd($s, '0', 4);
+}
+
+it('seeds USDC unshielded and shielded balances on polygon', function (): void {
+    $user = User::factory()->create();
+    app(WalletSeeder::class)->seed($user);
+
+    app(BalanceSeeder::class)->seed($user, unshieldedUsdc: '25.00', shieldedUsdc: '10.00');
+
+    $shielded = ShieldedBalance::where('user_id', $user->id)
+        ->where('token', 'USDC')
+        ->where('network', 'polygon')
+        ->first();
+    expect($shielded)->not->toBeNull();
+    /** @var ShieldedBalance $shielded */
+    expect(bsNormalize($shielded->balance))->toBe('10.0000');
+
+    $unshielded = DB::table('token_balances')
+        ->where('chain', 'polygon')
+        ->where('symbol', 'USDC')
+        ->whereIn('address', function ($q) use ($user): void {
+            $q->select('address')
+                ->from('blockchain_addresses')
+                ->where('user_uuid', $user->uuid)
+                ->where('chain', 'polygon');
+        })
+        ->first();
+    expect($unshielded)->not->toBeNull();
+    /** @var stdClass $unshielded */
+    expect(bsNormalize($unshielded->balance))->toBe('25.0000');
+});
+
+it('is idempotent — re-seeding sets to the target, not incremental', function (): void {
+    $user = User::factory()->create();
+    app(WalletSeeder::class)->seed($user);
+
+    app(BalanceSeeder::class)->seed($user, unshieldedUsdc: '25.00', shieldedUsdc: '10.00');
+    app(BalanceSeeder::class)->seed($user, unshieldedUsdc: '25.00', shieldedUsdc: '10.00');
+
+    expect(ShieldedBalance::where('user_id', $user->id)->count())->toBe(1);
+    expect(DB::table('token_balances')->where('symbol', 'USDC')->count())->toBe(1);
+
+    // Different target must overwrite, not add.
+    app(BalanceSeeder::class)->seed($user, unshieldedUsdc: '50.00', shieldedUsdc: '20.00');
+
+    $shielded = ShieldedBalance::where('user_id', $user->id)->where('token', 'USDC')->first();
+    expect($shielded)->not->toBeNull();
+    /** @var ShieldedBalance $shielded */
+    expect(bsNormalize($shielded->balance))->toBe('20.0000');
+
+    $unshielded = DB::table('token_balances')->where('symbol', 'USDC')->first();
+    expect($unshielded)->not->toBeNull();
+    /** @var stdClass $unshielded */
+    expect(bsNormalize($unshielded->balance))->toBe('50.0000');
+});

--- a/tests/Unit/AccountProvisioning/Seeders/CardSeederTest.php
+++ b/tests/Unit/AccountProvisioning/Seeders/CardSeederTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\AccountProvisioning\Seeders\CardSeeder;
+use App\Domain\CardIssuance\Models\Card;
+use App\Domain\CardIssuance\Models\Cardholder;
+use App\Models\User;
+
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('creates exactly one active virtual card and a cardholder for the user', function (): void {
+    $user = User::factory()->create();
+
+    app(CardSeeder::class)->seed($user);
+
+    expect(Cardholder::where('user_id', $user->id)->count())->toBe(1);
+
+    $cards = Card::where('user_id', $user->id)->get();
+    expect($cards)->toHaveCount(1);
+
+    $card = $cards->first();
+    expect($card)->not->toBeNull();
+    /** @var Card $card */
+    expect($card->status)->toBe('active');
+    expect($card->metadata['type'] ?? null)->toBe('virtual');
+});
+
+it('is idempotent when seeded twice for the same user', function (): void {
+    $user = User::factory()->create();
+
+    app(CardSeeder::class)->seed($user);
+    app(CardSeeder::class)->seed($user);
+
+    expect(Cardholder::where('user_id', $user->id)->count())->toBe(1);
+    expect(Card::where('user_id', $user->id)->count())->toBe(1);
+});

--- a/tests/Unit/AccountProvisioning/Seeders/RewardsSeederTest.php
+++ b/tests/Unit/AccountProvisioning/Seeders/RewardsSeederTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Domain\AccountProvisioning\Seeders\RewardsSeeder;
 use App\Domain\Rewards\Models\RewardProfile;
+use App\Domain\Rewards\Models\RewardQuest;
 use App\Domain\Rewards\Models\RewardQuestCompletion;
 use App\Models\User;
 
@@ -20,6 +21,32 @@ it('creates a reward profile with XP and exactly one quest completion', function
     expect($profile->xp)->toBeGreaterThan(0);
 
     expect(RewardQuestCompletion::where('reward_profile_id', $profile->id)->count())->toBe(1);
+});
+
+it('keys completion to the welcome slug even when other active quests exist', function (): void {
+    // Pre-seed an unrelated active quest with sort_order=0 — without
+    // determinism this would win the lookup over a missing 'welcome' quest.
+    RewardQuest::create([
+        'slug'          => 'unrelated-active',
+        'title'         => 'Unrelated',
+        'description'   => 'Should not be selected.',
+        'xp_reward'     => 999,
+        'points_reward' => 999,
+        'category'      => 'misc',
+        'is_repeatable' => false,
+        'is_active'     => true,
+        'sort_order'    => 0,
+        'criteria'      => ['event' => 'misc'],
+    ]);
+
+    $user = User::factory()->create();
+    app(RewardsSeeder::class)->seed($user);
+
+    $profile = RewardProfile::where('user_id', $user->id)->firstOrFail();
+    $completion = RewardQuestCompletion::where('reward_profile_id', $profile->id)->firstOrFail();
+    $quest = RewardQuest::where('id', $completion->quest_id)->firstOrFail();
+
+    expect($quest->slug)->toBe('welcome');
 });
 
 it('is idempotent when seeded twice for the same user', function (): void {

--- a/tests/Unit/AccountProvisioning/Seeders/RewardsSeederTest.php
+++ b/tests/Unit/AccountProvisioning/Seeders/RewardsSeederTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\AccountProvisioning\Seeders\RewardsSeeder;
+use App\Domain\Rewards\Models\RewardProfile;
+use App\Domain\Rewards\Models\RewardQuestCompletion;
+use App\Models\User;
+
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('creates a reward profile with XP and exactly one quest completion', function (): void {
+    $user = User::factory()->create();
+
+    app(RewardsSeeder::class)->seed($user);
+
+    $profile = RewardProfile::where('user_id', $user->id)->first();
+    expect($profile)->not->toBeNull();
+    /** @var RewardProfile $profile */
+    expect($profile->xp)->toBeGreaterThan(0);
+
+    expect(RewardQuestCompletion::where('reward_profile_id', $profile->id)->count())->toBe(1);
+});
+
+it('is idempotent when seeded twice for the same user', function (): void {
+    $user = User::factory()->create();
+
+    app(RewardsSeeder::class)->seed($user);
+    app(RewardsSeeder::class)->seed($user);
+
+    expect(RewardProfile::where('user_id', $user->id)->count())->toBe(1);
+
+    $profile = RewardProfile::where('user_id', $user->id)->first();
+    /** @var RewardProfile $profile */
+    expect(RewardQuestCompletion::where('reward_profile_id', $profile->id)->count())->toBe(1);
+});

--- a/tests/Unit/AccountProvisioning/Seeders/TrustCertSeederTest.php
+++ b/tests/Unit/AccountProvisioning/Seeders/TrustCertSeederTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\AccountProvisioning\Seeders\TrustCertSeeder;
+use App\Domain\TrustCert\Enums\CertificateStatus;
+use App\Domain\TrustCert\Models\Certificate;
+use App\Models\User;
+
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('creates one active certificate for the user', function (): void {
+    $user = User::factory()->create();
+
+    app(TrustCertSeeder::class)->seed($user);
+
+    $certs = Certificate::where('user_id', $user->id)->get();
+    expect($certs)->toHaveCount(1);
+
+    $cert = $certs->first();
+    expect($cert)->not->toBeNull();
+    /** @var Certificate $cert */
+    expect($cert->status)->toBe(CertificateStatus::ACTIVE);
+});
+
+it('is idempotent when seeded twice for the same user', function (): void {
+    $user = User::factory()->create();
+
+    app(TrustCertSeeder::class)->seed($user);
+    app(TrustCertSeeder::class)->seed($user);
+
+    expect(Certificate::where('user_id', $user->id)->count())->toBe(1);
+});

--- a/tests/Unit/AccountProvisioning/Seeders/WalletSeederTest.php
+++ b/tests/Unit/AccountProvisioning/Seeders/WalletSeederTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Account\Models\BlockchainAddress;
+use App\Domain\AccountProvisioning\Seeders\WalletSeeder;
+use App\Models\User;
+
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('creates a polygon (evm) and solana blockchain address for the user', function (): void {
+    $user = User::factory()->create();
+
+    /** @var WalletSeeder $seeder */
+    $seeder = app(WalletSeeder::class);
+    $seeder->seed($user);
+
+    expect(BlockchainAddress::where('user_uuid', $user->uuid)->where('chain', 'polygon')->count())->toBe(1);
+    expect(BlockchainAddress::where('user_uuid', $user->uuid)->where('chain', 'solana')->count())->toBe(1);
+});
+
+it('is idempotent when seeded twice for the same user', function (): void {
+    $user = User::factory()->create();
+
+    /** @var WalletSeeder $seeder */
+    $seeder = app(WalletSeeder::class);
+    $seeder->seed($user);
+    $seeder->seed($user);
+
+    expect(BlockchainAddress::where('user_uuid', $user->uuid)->count())->toBe(2);
+    expect(BlockchainAddress::where('user_uuid', $user->uuid)->where('chain', 'polygon')->count())->toBe(1);
+    expect(BlockchainAddress::where('user_uuid', $user->uuid)->where('chain', 'solana')->count())->toBe(1);
+});

--- a/tests/Unit/Domain/Mobile/Services/BiometricJWTServiceTest.php
+++ b/tests/Unit/Domain/Mobile/Services/BiometricJWTServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Domain\Mobile\Services;
 
+use App\Domain\AccountProvisioning\Services\AccountFlagsService;
 use App\Domain\Mobile\Exceptions\BiometricJWTException;
 use App\Domain\Mobile\Models\MobileDevice;
 use App\Domain\Mobile\Models\MobileDeviceSession;
@@ -28,7 +29,7 @@ class BiometricJWTServiceTest extends TestCase
 
         Cache::flush();
 
-        $this->service = new BiometricJWTService();
+        $this->service = new BiometricJWTService(new AccountFlagsService());
 
         $this->user = User::factory()->create();
 

--- a/tests/Unit/Middleware/GraphQLSecurityMiddlewareTest.php
+++ b/tests/Unit/Middleware/GraphQLSecurityMiddlewareTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Domain\AccountProvisioning\Services\AccountFlagsService;
 use App\Http\Middleware\GraphQLQueryCostMiddleware;
 use App\Http\Middleware\GraphQLRateLimitMiddleware;
 use Illuminate\Cache\ArrayStore;
@@ -16,7 +17,7 @@ describe('GraphQLRateLimitMiddleware', function () {
     beforeEach(function () {
         $this->store = new Repository(new ArrayStore());
         $this->limiter = new RateLimiter($this->store);
-        $this->middleware = new GraphQLRateLimitMiddleware($this->limiter);
+        $this->middleware = new GraphQLRateLimitMiddleware($this->limiter, app(AccountFlagsService::class));
     });
 
     it('allows requests under the rate limit', function () {

--- a/tests/Unit/Models/UserEffectiveKycLevelTest.php
+++ b/tests/Unit/Models/UserEffectiveKycLevelTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Models;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Models\User;
+use Tests\TestCase;
+
+uses(TestCase::class, \Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('returns real kyc_level when no flag override exists', function () {
+    $user = User::factory()->create(['kyc_level' => 'basic']);
+    expect($user->effectiveKycLevel())->toBe(1);
+});
+
+it('returns override level when flag is active and override is set', function () {
+    $user = User::factory()->create(['kyc_level' => 'none']);
+    AccountFlag::create([
+        'user_id'            => $user->id,
+        'is_review_account'  => true,
+        'kyc_override_level' => 2,
+    ]);
+
+    expect($user->effectiveKycLevel())->toBe(2);
+});
+
+it('falls back to real level when flag is disabled', function () {
+    $user = User::factory()->create(['kyc_level' => 'basic']);
+    AccountFlag::create([
+        'user_id'            => $user->id,
+        'is_review_account'  => true,
+        'kyc_override_level' => 2,
+        'disabled_at'        => now(),
+    ]);
+
+    expect($user->effectiveKycLevel())->toBe(1);
+});
+
+it('falls back to real level when override is null', function () {
+    $user = User::factory()->create(['kyc_level' => 'basic']);
+    AccountFlag::create([
+        'user_id'            => $user->id,
+        'is_review_account'  => true,
+        'kyc_override_level' => null,
+    ]);
+
+    expect($user->effectiveKycLevel())->toBe(1);
+});


### PR DESCRIPTION
## Summary

Adds a new `AccountProvisioning` domain that lets operators seed app-store reviewer / partner-demo / internal-QA accounts with scoped, audited, reversible security bypasses. Solves the mobile team's app-store submission blocker — reviewers can log in with shared credentials and see gated features without completing Ondato KYC, Apple App Attest, Google Play Integrity, or SMS OTP flows.

**Design is hybrid:** a new `account_flags` table drives explicit security bypasses at ~5 existing enforcement points; UI content (cards, TrustCerts, balances, rewards) is real seeded rows with `review_bypass` audit sentinels. No forged KYC/sanctions rows in production data.

## What's in the branch

### New domain: `app/Domain/AccountProvisioning/`
- `Models/AccountFlag` + migration (`account_flags`, 1:1 with `users`)
- `Contracts/AccountProfile` interface + `ValueObjects/ProvisioningContext`
- `Services/AccountFlagsService` (per-request cached flag lookup, `bypass.fired` logging) and `AccountProvisioningService` (orchestrator)
- `Profiles/ReviewerAccountProfile` (the single profile shipped in v1)
- `Seeders/` — Wallet, Balance, Card, TrustCert, Rewards (idempotent)
- `Support/SuppressNotificationsListener` on `NotificationSending`
- `Events/AccountPurged`

### Enforcement integration (5 sites, 1 reserved)
- `BiometricJWTService::verifyDeviceAttestationForUser()` — Apple / Google attestation bypass
- `ApiRateLimitMiddleware` + `GraphQLRateLimitMiddleware` — rate-limit bypass
- `PerformAmlScreeningActivity::execute()` — sanctions bypass *(wired; fires once the workflow DTO threads `$userId`)*
- `SuppressNotificationsListener` — global email/SMS/push suppression
- `User::effectiveKycLevel()` — KYC override accessor
- `bypass_sms_otp` reserved without consumer (no dedicated SMS OTP path in the codebase)

### CLI commands (operator-only, all require admin role)
- `account:provision-reviewer` — full safety gates (admin check, production guard, expiry hard-cap 90d, email collision)
- `account:list-reviewers` (table + `--json`)
- `account:disable-reviewer --email=X | --all-expired | --re-enable`
- `account:purge-reviewer` (anonymizes email + disables; User has no SoftDeletes in this codebase)

### Scheduled
- Daily at 00:10 UTC: `account:disable-reviewer --all-expired` via `routes/console.php`.

### Docs
- `docs/operations/reviewer-accounts.md` — operator runbook (when to use, 1Password handoff, incident response)
- `docs/security/account-flags.md` — security model, threat model, audit guarantees
- `CLAUDE.md` — new commands block, CI/CD row, domain count 56 → 57, notes bullet
- `docs/VERSION_ROADMAP.md` — v7.10.11 entry
- Auto-memory + Serena `account_provisioning_domain` memory

## Spec + plan (both committed)

- Spec: `docs/superpowers/specs/2026-04-24-reviewer-account-provisioning-design.md`
- Plan: `docs/superpowers/plans/2026-04-24-reviewer-account-provisioning.md` (28-task TDD plan)

## Test plan

- [x] AccountProvisioning test scope — 62 tests passing (181 assertions) — `./vendor/bin/pest tests/Feature/AccountProvisioning tests/Unit/AccountProvisioning tests/Unit/Models/UserEffectiveKycLevelTest.php tests/Unit/Middleware/GraphQLSecurityMiddlewareTest.php`
- [x] PHPStan Level 8 — `[OK] No errors` on full codebase
- [x] php-cs-fixer — no diff
- [x] post-phase-review skill run — runbook mismatch with command flags found & fixed
- [ ] CI: full parallel pest suite against real Redis + MySQL (blocked locally on WSL — the 1095 failures in local runs are Redis/MySQL connection refused; CI will run clean)
- [ ] Post-merge: staging rehearsal of `account:provision-reviewer` before running in production

## Follow-ups (deliberately out of scope for v1)

- Thread `$userId` through `KycVerificationRequest` DTO so the sanctions-screening bypass actually fires in the KYC workflow (code is wired, just needs a caller)
- Filament admin UI for operators who prefer clicks (CLI is sufficient for v1)
- Additional profiles (demo investor, auditor, load-test user) — ship when a second use case lands
- Tenant-scoped provisioning (v1 uses default tenant only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)