### PR TITLE
feat: add /legal/delete-account public page for Play Store

### DIFF
--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -113,6 +113,12 @@ class SitemapController extends Controller
                 'changefreq' => 'monthly',
                 'priority'   => '0.5',
             ],
+            [
+                'url'        => $baseUrl . '/legal/delete-account',
+                'lastmod'    => $now,
+                'changefreq' => 'monthly',
+                'priority'   => '0.5',
+            ],
         ];
 
         // Promo/marketing pages — only when SHOW_PROMO_PAGES=true (e.g. finaegis.org)

--- a/resources/views/legal/delete-account.blade.php
+++ b/resources/views/legal/delete-account.blade.php
@@ -1,0 +1,65 @@
+<x-guest-layout>
+    @section('title', 'Delete Your Account — Zelta')
+    @section('description', 'How to delete your Zelta account, what data is deleted, and what records FinAegis retains under financial-services law.')
+
+    <div class="bg-white">
+        <!-- Header -->
+        <div class="bg-gray-50 border-b">
+            <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+                <h1 class="text-4xl font-bold text-gray-900">Delete Your Account</h1>
+                <p class="mt-4 text-lg text-gray-600">App: <strong>Zelta</strong> &middot; Developer: <strong>FinAegis</strong></p>
+                <p class="mt-2 text-sm text-gray-500">Last updated: {{ \Carbon\Carbon::parse('2026-04-26')->format('F j, Y') }}</p>
+            </div>
+        </div>
+
+        <!-- Content -->
+        <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+            <div class="prose prose-lg max-w-none">
+
+                <p>You can request deletion of your Zelta account and associated data at any time. There are two ways to do it.</p>
+
+                <h2>Option 1 &mdash; Delete in the app (fastest)</h2>
+                <ol>
+                    <li>Open the Zelta app and sign in.</li>
+                    <li>Go to <strong>Profile &rarr; Settings &rarr; Security &amp; Privacy</strong>.</li>
+                    <li>Tap <strong>Delete Account</strong>.</li>
+                    <li>Confirm with your password.</li>
+                </ol>
+                <p>Your account is queued for deletion immediately and your sessions are terminated.</p>
+
+                <h2>Option 2 &mdash; Delete by email</h2>
+                <p>If you cannot access the app, email <a href="mailto:support@zelta.app?subject=Delete%20my%20account">support@zelta.app</a> from the email address on your Zelta account, with the subject line <strong>"Delete my account"</strong>. We will verify your identity and process the request within 30 days.</p>
+                <p>If that email address is no longer accessible, contact us from any address and include enough information for us to verify your identity (full legal name, date of birth, last four digits of any linked card, approximate date of last activity). We may request additional verification before proceeding.</p>
+
+                <h2>What gets deleted</h2>
+                <ul>
+                    <li>Profile information (name, email, phone, avatar)</li>
+                    <li>Wallet preferences and saved recipients</li>
+                    <li>Device shards and passkey credentials</li>
+                    <li>In-app activity (notifications, rewards XP, dismissed banners)</li>
+                    <li>Push notification tokens</li>
+                    <li>Linked virtual cards (deactivated immediately)</li>
+                </ul>
+
+                <h2>What is retained, and for how long</h2>
+                <p>FinAegis operates as a regulated financial-services provider. Some records must be retained after account closure to comply with anti-money-laundering, sanctions, tax, and consumer-protection law. Specific retention periods depend on the jurisdiction in which your account was held; the figures below reflect the typical range.</p>
+
+                <ul>
+                    <li><strong>KYC and identity-verification records</strong> &mdash; 5&ndash;10 years after account closure (EU AMLD; UK MLR 2017; equivalent regimes elsewhere).</li>
+                    <li><strong>Transaction history and on-chain references</strong> &mdash; 5&ndash;10 years.</li>
+                    <li><strong>Compliance, sanctions-screening, and fraud-investigation records</strong> &mdash; up to 10 years where required by financial regulators.</li>
+                    <li><strong>Records subject to an active legal hold or law-enforcement request</strong> &mdash; for the duration of the hold.</li>
+                </ul>
+
+                <p>After the applicable retention period expires, the residual records are deleted or fully anonymized.</p>
+
+                <h2>On-chain transactions</h2>
+                <p>Transactions recorded on public blockchains (Ethereum, Polygon, Base, Arbitrum, BSC, Solana, and other supported networks) cannot be deleted by us. They are part of immutable public ledgers and remain visible after account deletion. We can only remove the link between your identity and those addresses from our own systems.</p>
+
+                <h2>Questions?</h2>
+                <p>Email <a href="mailto:support@zelta.app">support@zelta.app</a> or visit our <a href="{{ route('legal.privacy') }}">Privacy Policy</a> for more detail on how we handle your data.</p>
+
+            </div>
+        </div>
+    </div>
+</x-guest-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -251,6 +251,10 @@ Route::get('/legal/cookies', function () {
     return view('legal.cookies');
 })->name('legal.cookies');
 
+Route::get('/legal/delete-account', function () {
+    return view('legal.delete-account');
+})->name('legal.delete-account');
+
 // Apple App Site Association — enables passkey AutoFill + Universal Links on iOS 16+
 Route::get('/.well-known/apple-app-site-association', function () {
     return response()->json([


### PR DESCRIPTION
## Summary
- New public page at `/legal/delete-account` — required by Google Play's app submission process for apps that store user accounts.
- Page identifies the app (**Zelta**) and developer (**FinAegis**), describes both deletion paths (in-app flow + email fallback), lists deleted vs. retained data, and explains AML/CTF retention obligations.
- Added to dynamic sitemap (`SitemapController`), so search engines + Play Store crawlers can find it.

## Why now
Mobile team is blocked on Google Play submission — Google's review checks scrape a public URL (not an in-app flow), so the existing in-app delete flow at `app/flows/settings/security-privacy.tsx` was insufficient. This shipping unblocks submission.

## Notes
- Retention numbers stated as ranges (5–10 years) reflect the typical jurisdictional spread (UK MLR 2017 = 5y, EU AMLD = 5y national-extendable, etc.) rather than committing to a single figure that could conflict with the actual regulator-of-record. Verify with compliance before locking exact numbers.
- "Developer: FinAegis" is hardcoded in the view (matches Play Store registration), not config-driven — Zelta is the app brand, FinAegis is the legal entity per Play Store metadata.
- No footer-link wiring in this PR — Play Store scrapes the URL directly; footer additions across `support/*.blade.php` and `sub-products/index.blade.php` can come in a follow-up if SEO discoverability becomes a concern.

## Test plan
- [ ] Page renders at `/legal/delete-account` (verified locally — HTTP 200, content correct: App: Zelta · Developer: FinAegis).
- [ ] Sitemap entry added to `SitemapController::getPublicRoutes()` (verified inline in code; runtime regen on deploy).
- [ ] CI green (no DB or test impact — view + route + sitemap entry only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)