### PR TITLE
feat: multi-connection test infrastructure

### DIFF
--- a/.github/workflows/03-test-suite.yml
+++ b/.github/workflows/03-test-suite.yml
@@ -412,7 +412,99 @@ jobs:
           DB_USERNAME: root
           DB_PASSWORD: root
         run: php -d memory_limit=2G ./vendor/bin/pest --testsuite=Integration --configuration=phpunit.ci-optimized.xml --exclude-group=slow
-        
+
+  multi-connection-tests:
+    name: Multi-Connection Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: testing
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ env.PHP_VERSION }}
+          extensions: mbstring, dom, fileinfo, mysql, redis, opcache, pcntl, gd, imagick, bcmath, intl, zip, soap, gmp
+          tools: composer:v2
+          coverage: none
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer Dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ${{ steps.composer-cache.outputs.dir }}
+            vendor
+          key: ${{ runner.os }}-multiconn-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-multiconn-composer-
+
+      - name: Setup Environment
+        run: cp .env.testing .env
+
+      - name: Install Dependencies
+        run: |
+          for i in 1 2 3; do
+            if composer install --prefer-dist --no-progress --optimize-autoloader; then
+              break
+            fi
+            sleep 5
+            composer clear-cache
+          done
+
+      - name: Prepare Laravel Application
+        run: |
+          echo "DB_CONNECTION=mysql" >> .env
+          echo "DB_HOST=127.0.0.1" >> .env
+          echo "DB_PORT=3306" >> .env
+          echo "DB_DATABASE=testing" >> .env
+          echo "DB_USERNAME=root" >> .env
+          echo "DB_PASSWORD=root" >> .env
+
+          php artisan key:generate
+          php artisan config:clear
+          php artisan migrate --force
+
+      - name: Run Multi-Connection Tests
+        env:
+          DB_CONNECTION: mysql
+          DB_HOST: 127.0.0.1
+          DB_PORT: 3306
+          DB_DATABASE: testing
+          DB_USERNAME: root
+          DB_PASSWORD: root
+          CI: true
+        run: php -d memory_limit=2G ./vendor/bin/pest --testsuite=MultiConnection
+
   behat-tests:
     name: Behat Tests
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ namespace App\Domain\Exchange\Services;
 | Helius API key | Must be query param `?api-key=` — does NOT support Authorization header |
 | Webhook metadata | Whitelist fields via `array_intersect_key()` — never store raw `$tx` payload |
 | Bypass flag missing test | Every new bypass flag in `account_flags` needs a matching feature test in `tests/Feature/AccountProvisioning/Bypasses/` asserting both sides (flag set = allow, flag unset = enforce) |
+| Multi-connection deadlock under DB::transaction | Do not wrap flows that touch UsesTenantConnection models in `DB::transaction()` — those models run on a separate MySQL session and will self-deadlock against the wrapping connection's row locks. Add a regression test in `tests/MultiConnection/`. |
 
 ```bash
 gh pr checks <PR_NUMBER>              # Check PR status
@@ -132,5 +133,6 @@ Packagist sources the three PHP packages from **split-mirror repos**, not the mo
 - Webhook controllers: Helius handles Solana, Alchemy handles EVM — both send FCM push via `PushNotificationService`
 - Alchemy webhook signing keys: stored in `webhook_endpoints` table (managed by `AlchemyWebhookManager`), not env vars
 - Test tables: use `Tests\Traits\CreatesSolanaTestTables` trait for in-memory SQLite schema in webhook/wallet tests
+- Multi-connection tests: `tests/MultiConnection/` — runs against real MySQL with `database.force_real_tenant_connection=true` so models with `UsesTenantConnection` use a separate MySQL session. Required check on PRs. See `docs/superpowers/specs/2026-04-26-multi-connection-test-infrastructure-design.md`.
 - Parallel agent merges: always check for duplicate `use` imports after merging agent branches
 - Reviewer accounts: operator-only tool for app-store review submissions — see `docs/operations/reviewer-accounts.md`. Bypasses are scoped via `account_flags` table; the daily sweep runs at 00:10 UTC via `routes/console.php`.

--- a/app/Domain/Shared/Traits/UsesTenantConnection.php
+++ b/app/Domain/Shared/Traits/UsesTenantConnection.php
@@ -62,6 +62,7 @@ trait UsesTenantConnection
      */
     protected function shouldUseDefaultConnection(): bool
     {
+        // Strict === true: only programmatic boolean overrides count, never env strings.
         if (Config::get('database.force_real_tenant_connection') === true) {
             return false;
         }

--- a/app/Domain/Shared/Traits/UsesTenantConnection.php
+++ b/app/Domain/Shared/Traits/UsesTenantConnection.php
@@ -55,19 +55,17 @@ trait UsesTenantConnection
     /**
      * Determine if the model should use the default connection instead of tenant.
      *
-     * This returns true when APP_ENV is 'testing'. In testing environments,
-     * using a separate 'tenant' connection causes issues:
-     *
-     * - SQLite in-memory: Each connection has isolated database
-     * - MySQL: Separate connections can cause lock wait timeouts with transactions
-     *
-     * In production, stancl/tenancy properly configures the tenant connection
-     * to point to tenant-specific databases.
+     * Returns true when APP_ENV is 'testing'. The
+     * `database.force_real_tenant_connection` config flag overrides the
+     * carve-out — set it to true in test base classes that need the production
+     * multi-session topology (see tests/MultiConnection/).
      */
     protected function shouldUseDefaultConnection(): bool
     {
-        // In testing environment, always use the default connection
-        // to avoid isolation issues with separate database connections
+        if (Config::get('database.force_real_tenant_connection') === true) {
+            return false;
+        }
+
         return Config::get('app.env') === 'testing';
     }
 }

--- a/config/database.php
+++ b/config/database.php
@@ -275,6 +275,12 @@ return [
 
     ],
 
+    // Multi-connection test escape hatch. The UsesTenantConnection trait
+    // checks this with === true, so only test base classes setting a
+    // literal boolean override the testing-mode connection collapse.
+    // Never bind to env() — env strings would not satisfy === true.
+    'force_real_tenant_connection' => false,
+
     /*
     |--------------------------------------------------------------------------
     | Migration Repository Table

--- a/docs/superpowers/plans/2026-04-26-multi-connection-test-infrastructure.md
+++ b/docs/superpowers/plans/2026-04-26-multi-connection-test-infrastructure.md
@@ -1,0 +1,893 @@
+# Multi-Connection Test Infrastructure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a `tests/MultiConnection/` test category that runs against real MySQL with the `UsesTenantConnection` testing carve-out disabled, so tests exercise the production multi-session topology and catch the class of bug PR #960 fixed.
+
+**Architecture:** Add a config-driven escape hatch to the `UsesTenantConnection` trait. Build a `MultiConnectionTestCase` base class that flips the flag, purges PDO instances on both connections, and truncates non-system tables between tests. Two trait helpers handle MySQL availability skip and table truncation. Wire into a new CI job and required check.
+
+**Tech Stack:** PHP 8.4, Laravel 12, Pest 3, MySQL 8 (CI), MariaDB 10.11+ (prod). Spec: `docs/superpowers/specs/2026-04-26-multi-connection-test-infrastructure-design.md`.
+
+**Branch:** `feat/multi-connection-test-infrastructure` (already created)
+
+---
+
+## File Structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `app/Domain/Shared/Traits/UsesTenantConnection.php` | Modify | Add config-driven escape hatch (one extra `if` in `shouldUseDefaultConnection`) |
+| `tests/Unit/Shared/UsesTenantConnectionTraitTest.php` | Create | Unit-test the new escape hatch flag (no DB required) |
+| `tests/MultiConnection/Concerns/SkipsWithoutMySQL.php` | Create | Trait: `markTestSkipped` if MySQL not available |
+| `tests/MultiConnection/Concerns/TruncatesAllConnections.php` | Create | Trait: truncate non-system tables on default + tenant connections |
+| `tests/MultiConnection/MultiConnectionTestCase.php` | Create | Base class: flip flag, purge PDO, truncate, skip-if-no-MySQL |
+| `tests/MultiConnection/Framework/ConnectionTopologyTest.php` | Create | Self-check: confirms tenant ≠ default at the PDO level |
+| `tests/MultiConnection/AccountProvisioning/AccountProvisioningServiceMultiConnectionTest.php` | Create | Tier 1 regression — `apply()` does not deadlock under real multi-session |
+| `phpunit.xml` | Modify | Add `<testsuite name="MultiConnection">` |
+| `tests/Pest.php` | Modify | Bind base class to `MultiConnection` directory |
+| `.github/workflows/03-test-suite.yml` | Modify | Add `multi-connection-tests` job |
+| `CLAUDE.md` | Modify | One-line pointer to the new test category |
+
+---
+
+## Task 1: Add config-driven escape hatch to UsesTenantConnection trait
+
+**Files:**
+- Modify: `app/Domain/Shared/Traits/UsesTenantConnection.php`
+- Test: `tests/Unit/Shared/UsesTenantConnectionTraitTest.php`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/Unit/Shared/UsesTenantConnectionTraitTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Shared;
+
+use App\Domain\Shared\Traits\UsesTenantConnection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Config;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+beforeEach(function () {
+    $this->model = new class () extends Model {
+        use UsesTenantConnection;
+    };
+});
+
+it('returns null (default connection) when running under testing env without override', function () {
+    Config::set('app.env', 'testing');
+    Config::set('database.force_real_tenant_connection', false);
+
+    expect($this->model->getConnectionName())->toBeNull();
+});
+
+it('returns "tenant" when force_real_tenant_connection is true even under testing', function () {
+    Config::set('app.env', 'testing');
+    Config::set('database.force_real_tenant_connection', true);
+
+    expect($this->model->getConnectionName())->toBe('tenant');
+});
+
+it('returns "tenant" when env is not testing regardless of override flag', function () {
+    Config::set('app.env', 'production');
+    Config::set('database.force_real_tenant_connection', false);
+
+    expect($this->model->getConnectionName())->toBe('tenant');
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./vendor/bin/pest tests/Unit/Shared/UsesTenantConnectionTraitTest.php`
+Expected: 1 fail (second test — flag is currently ignored, returns null when env=testing).
+
+- [ ] **Step 3: Implement the escape hatch**
+
+Edit `app/Domain/Shared/Traits/UsesTenantConnection.php` — replace the `shouldUseDefaultConnection` method:
+
+```php
+    /**
+     * Determine if the model should use the default connection instead of tenant.
+     *
+     * Returns true when APP_ENV is 'testing'. The
+     * `database.force_real_tenant_connection` config flag overrides the
+     * carve-out — set it to true in test base classes that need the production
+     * multi-session topology (see tests/MultiConnection/).
+     */
+    protected function shouldUseDefaultConnection(): bool
+    {
+        if (Config::get('database.force_real_tenant_connection') === true) {
+            return false;
+        }
+
+        return Config::get('app.env') === 'testing';
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./vendor/bin/pest tests/Unit/Shared/UsesTenantConnectionTraitTest.php`
+Expected: 3 pass.
+
+- [ ] **Step 5: Run PHPStan + cs-fixer**
+
+Run: `./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php app/Domain/Shared/Traits/UsesTenantConnection.php tests/Unit/Shared/UsesTenantConnectionTraitTest.php`
+Run: `XDEBUG_MODE=off vendor/bin/phpstan analyse app/Domain/Shared/Traits/UsesTenantConnection.php tests/Unit/Shared/UsesTenantConnectionTraitTest.php --memory-limit=2G`
+Expected: zero errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/Domain/Shared/Traits/UsesTenantConnection.php tests/Unit/Shared/UsesTenantConnectionTraitTest.php
+git commit -m "feat: add force_real_tenant_connection escape hatch to UsesTenantConnection
+
+Default off — preserves existing test-mode collapse. Set to true in test
+base classes that need real multi-session topology (production parity).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Add MultiConnection testsuite to phpunit.xml + Pest.php
+
+**Files:**
+- Modify: `phpunit.xml`
+- Modify: `tests/Pest.php`
+- Create: `tests/MultiConnection/.gitkeep` (placeholder, removed in Task 5 when first real file lands)
+
+- [ ] **Step 1: Add testsuite entry to `phpunit.xml`**
+
+Edit `phpunit.xml` — locate the `<testsuites>` block and add a new entry after the `Security` testsuite:
+
+```xml
+        <testsuite name="Security">
+            <directory>tests/Security</directory>
+        </testsuite>
+        <testsuite name="MultiConnection">
+            <directory>tests/MultiConnection</directory>
+        </testsuite>
+    </testsuites>
+```
+
+- [ ] **Step 2: Verify Pest discovers the testsuite**
+
+Create the directory:
+
+```bash
+mkdir -p tests/MultiConnection
+touch tests/MultiConnection/.gitkeep
+```
+
+Run: `./vendor/bin/pest --testsuite=MultiConnection --list-tests`
+Expected: zero tests listed (no test files yet), no error about unknown testsuite.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add phpunit.xml tests/MultiConnection/.gitkeep
+git commit -m "test: register MultiConnection testsuite in phpunit.xml
+
+Empty directory placeholder. Tests land in subsequent commits.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Create SkipsWithoutMySQL concern
+
+**Files:**
+- Create: `tests/MultiConnection/Concerns/SkipsWithoutMySQL.php`
+
+This trait does not need its own dedicated unit test — its behavior is exercised in Task 6's framework self-check (which would fail at setup time on machines without MySQL if the skip didn't fire correctly).
+
+- [ ] **Step 1: Create the trait**
+
+Create `tests/MultiConnection/Concerns/SkipsWithoutMySQL.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\MultiConnection\Concerns;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+trait SkipsWithoutMySQL
+{
+    /**
+     * Skip the test if MySQL is not the configured default driver or not reachable.
+     *
+     * Multi-connection tests need real MySQL because they assert behavior
+     * specific to InnoDB row-level locks and independent MySQL sessions.
+     * On dev machines without MySQL (e.g., WSL), tests skip gracefully so
+     * `pest --parallel` stays green. CI is the source of truth.
+     */
+    protected function skipIfMySQLUnavailable(): void
+    {
+        $driver = Config::get('database.connections.' . Config::get('database.default') . '.driver');
+
+        if (! in_array($driver, ['mysql', 'mariadb'], true)) {
+            $this->markTestSkipped(
+                "Multi-connection tests require MySQL/MariaDB; default driver is '{$driver}'."
+            );
+        }
+
+        try {
+            DB::connection()->getPdo();
+        } catch (Throwable $e) {
+            $this->markTestSkipped('MySQL not reachable: ' . $e->getMessage());
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run cs-fixer + PHPStan**
+
+Run: `./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php tests/MultiConnection/Concerns/SkipsWithoutMySQL.php`
+Run: `XDEBUG_MODE=off vendor/bin/phpstan analyse tests/MultiConnection/Concerns/SkipsWithoutMySQL.php --memory-limit=2G`
+Expected: zero errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/MultiConnection/Concerns/SkipsWithoutMySQL.php
+git commit -m "test: add SkipsWithoutMySQL concern for multi-connection tests
+
+Marks tests skipped when default driver isn't MySQL/MariaDB or
+when the connection is unreachable. Keeps local dev workflow on
+WSL/SQLite green; CI runs everything.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Create TruncatesAllConnections concern
+
+**Files:**
+- Create: `tests/MultiConnection/Concerns/TruncatesAllConnections.php`
+
+Strategy: list **preserved** tables (much shorter and more stable than listing every table to truncate). Truncate everything else on both connections. Foreign key checks toggled around the truncation.
+
+- [ ] **Step 1: Create the trait**
+
+Create `tests/MultiConnection/Concerns/TruncatesAllConnections.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\MultiConnection\Concerns;
+
+use Illuminate\Support\Facades\DB;
+
+trait TruncatesAllConnections
+{
+    /**
+     * Tables preserved across tests in this suite.
+     *
+     * - migrations: required for schema state
+     * - permission/role tables: created once via createRoles() pattern; truncating
+     *   them forces every test to re-seed roles, which is wasteful
+     */
+    private const PRESERVED_TABLES = [
+        'migrations',
+        'roles',
+        'permissions',
+        'model_has_roles',
+        'model_has_permissions',
+        'role_has_permissions',
+    ];
+
+    /**
+     * Truncate every non-preserved table on both default and tenant connections.
+     *
+     * MultiConnection tests cannot use RefreshDatabase (which wraps the default
+     * connection in a single transaction the tenant connection cannot see).
+     * We truncate instead, and since both connections target the same physical
+     * database, we only need to truncate once via the default connection.
+     * The two connections still see the same on-disk state because they share
+     * the same DB.
+     */
+    protected function truncateAllConnections(): void
+    {
+        $tables = $this->resolveTablesToTruncate();
+
+        DB::connection()->statement('SET FOREIGN_KEY_CHECKS=0');
+
+        try {
+            foreach ($tables as $table) {
+                DB::connection()->table($table)->truncate();
+            }
+        } finally {
+            DB::connection()->statement('SET FOREIGN_KEY_CHECKS=1');
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function resolveTablesToTruncate(): array
+    {
+        $all = array_map(
+            fn (array $row) => array_values((array) $row)[0],
+            DB::connection()->select('SHOW TABLES')
+        );
+
+        return array_values(array_filter(
+            $all,
+            fn (string $table) => ! in_array($table, self::PRESERVED_TABLES, true)
+        ));
+    }
+}
+```
+
+- [ ] **Step 2: Run cs-fixer + PHPStan**
+
+Run: `./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php tests/MultiConnection/Concerns/TruncatesAllConnections.php`
+Run: `XDEBUG_MODE=off vendor/bin/phpstan analyse tests/MultiConnection/Concerns/TruncatesAllConnections.php --memory-limit=2G`
+Expected: zero errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/MultiConnection/Concerns/TruncatesAllConnections.php
+git commit -m "test: add TruncatesAllConnections concern for multi-connection tests
+
+Truncates every non-preserved table after each test. Preserves
+migrations + Spatie role/permission tables to avoid re-seeding cost.
+Toggles FK checks around the truncation.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Create MultiConnectionTestCase base class
+
+**Files:**
+- Create: `tests/MultiConnection/MultiConnectionTestCase.php`
+- Modify: `tests/Pest.php` (bind base class to MultiConnection directory)
+- Delete: `tests/MultiConnection/.gitkeep`
+
+- [ ] **Step 1: Create the base class**
+
+Create `tests/MultiConnection/MultiConnectionTestCase.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\MultiConnection;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Tests\CreatesApplication;
+use Tests\MultiConnection\Concerns\SkipsWithoutMySQL;
+use Tests\MultiConnection\Concerns\TruncatesAllConnections;
+
+/**
+ * Base class for tests that exercise the production multi-session topology.
+ *
+ * Production runs models with `UsesTenantConnection` on a separate MySQL
+ * session from the default connection. The standard `Tests\TestCase` collapses
+ * those connections to a single session under APP_ENV=testing — which masks
+ * an entire class of multi-session bugs (see PR #960).
+ *
+ * This base class:
+ *   1. Skips the test if MySQL is not reachable (local dev safety).
+ *   2. Sets `database.force_real_tenant_connection = true` so the
+ *      UsesTenantConnection trait stops collapsing.
+ *   3. Purges both PDO instances so the two connections are independent
+ *      MySQL sessions for the lifetime of the test.
+ *   4. Truncates non-preserved tables before and after each test (we cannot
+ *      use RefreshDatabase — its single-connection transaction is exactly
+ *      what we are trying to test against).
+ */
+abstract class MultiConnectionTestCase extends BaseTestCase
+{
+    use CreatesApplication;
+    use SkipsWithoutMySQL;
+    use TruncatesAllConnections;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->skipIfMySQLUnavailable();
+
+        Config::set('database.force_real_tenant_connection', true);
+
+        DB::purge(Config::get('database.default'));
+        DB::purge('tenant');
+
+        $this->truncateAllConnections();
+    }
+
+    protected function tearDown(): void
+    {
+        if (Config::get('database.force_real_tenant_connection') === true) {
+            $this->truncateAllConnections();
+        }
+
+        parent::tearDown();
+    }
+}
+```
+
+- [ ] **Step 2: Bind base class to MultiConnection directory in Pest.php**
+
+Edit `tests/Pest.php` — add this line after the existing `uses(TestCase::class)->in(...)` calls (around line 23):
+
+```php
+uses(TestCase::class)->in('Feature');
+uses(TestCase::class)->in('Domain');
+uses(TestCase::class)->in('Console');
+uses(\Tests\MultiConnection\MultiConnectionTestCase::class)->in('MultiConnection');
+```
+
+- [ ] **Step 3: Remove the placeholder**
+
+```bash
+git rm tests/MultiConnection/.gitkeep
+```
+
+- [ ] **Step 4: Run cs-fixer + PHPStan**
+
+Run: `./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php tests/MultiConnection/MultiConnectionTestCase.php tests/Pest.php`
+Run: `XDEBUG_MODE=off vendor/bin/phpstan analyse tests/MultiConnection/MultiConnectionTestCase.php --memory-limit=2G`
+Expected: zero errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/MultiConnection/MultiConnectionTestCase.php tests/Pest.php
+git rm tests/MultiConnection/.gitkeep
+git commit -m "test: add MultiConnectionTestCase base class
+
+Forces real tenant connection (separate MySQL session), purges PDO
+instances, truncates between tests. Bound to tests/MultiConnection/
+via Pest.php uses() binding.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Topology self-check test
+
+**Files:**
+- Create: `tests/MultiConnection/Framework/ConnectionTopologyTest.php`
+
+This is the framework's smoke test. If it ever breaks, every other test in this suite is silently neutered — so it is the most important test in the suite.
+
+- [ ] **Step 1: Create the self-check test**
+
+Create `tests/MultiConnection/Framework/ConnectionTopologyTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\MultiConnection\Framework;
+
+use App\Domain\CardIssuance\Models\Cardholder;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+it('routes User writes to the default connection', function () {
+    $user = new User();
+    expect($user->getConnectionName())->toBeNull();
+});
+
+it('routes Cardholder writes to the tenant connection', function () {
+    $cardholder = new Cardholder();
+    expect($cardholder->getConnectionName())->toBe('tenant');
+});
+
+it('uses distinct PDO instances on default and tenant connections', function () {
+    $defaultPdo = DB::connection()->getPdo();
+    $tenantPdo = DB::connection('tenant')->getPdo();
+
+    expect($defaultPdo)->not->toBe($tenantPdo);
+});
+
+it('does not see uncommitted writes from another connection', function () {
+    $email = 'topology-' . uniqid() . '@example.invalid';
+
+    DB::connection()->beginTransaction();
+
+    DB::connection()->table('users')->insert([
+        'name'              => 'Topology Test',
+        'email'             => $email,
+        'password'          => 'irrelevant',
+        'email_verified_at' => now(),
+        'created_at'        => now(),
+        'updated_at'        => now(),
+    ]);
+
+    // Same connection (same session) sees it.
+    $sameConn = DB::connection()->table('users')->where('email', $email)->exists();
+    // Different connection (different session) does NOT see it.
+    $tenantConn = DB::connection('tenant')->table('users')->where('email', $email)->exists();
+
+    DB::connection()->rollBack();
+
+    expect($sameConn)->toBeTrue();
+    expect($tenantConn)->toBeFalse();
+});
+```
+
+- [ ] **Step 2: Run the self-check**
+
+Prerequisite: MySQL must be reachable. If running locally without MySQL, all four tests will skip — that is correct behavior.
+
+If MySQL is available, run:
+
+```bash
+DB_CONNECTION=mysql DB_HOST=127.0.0.1 DB_DATABASE=testing DB_USERNAME=root DB_PASSWORD=root \
+  ./vendor/bin/pest --testsuite=MultiConnection
+```
+
+Expected: 4 pass (or 4 skip on machines without MySQL).
+
+- [ ] **Step 3: Run cs-fixer + PHPStan**
+
+Run: `./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php tests/MultiConnection/Framework/ConnectionTopologyTest.php`
+Run: `XDEBUG_MODE=off vendor/bin/phpstan analyse tests/MultiConnection/Framework/ConnectionTopologyTest.php --memory-limit=2G`
+Expected: zero errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/MultiConnection/Framework/ConnectionTopologyTest.php
+git commit -m "test: add ConnectionTopology self-check for MultiConnection suite
+
+Asserts the four invariants the framework depends on:
+  1. User writes route to default connection
+  2. Cardholder writes route to tenant connection
+  3. PDO instances are distinct (separate MySQL sessions)
+  4. Uncommitted writes are session-isolated
+
+Without these, every other test in the suite is silently neutered.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: AccountProvisioningServiceMultiConnectionTest
+
+**Files:**
+- Create: `tests/MultiConnection/AccountProvisioning/AccountProvisioningServiceMultiConnectionTest.php`
+
+Tier 1 regression — exercises `apply()` with a real reviewer profile end-to-end under multi-session topology. Confirms PR #960's fix holds; if anyone re-introduces a wrapping `DB::transaction`, this test will deadlock and timeout, surfacing the regression.
+
+- [ ] **Step 1: Create the regression test**
+
+Create `tests/MultiConnection/AccountProvisioning/AccountProvisioningServiceMultiConnectionTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\MultiConnection\AccountProvisioning;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Domain\AccountProvisioning\Profiles\ReviewerAccountProfile;
+use App\Domain\AccountProvisioning\Services\AccountProvisioningService;
+use App\Domain\AccountProvisioning\ValueObjects\ProvisioningContext;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+it('completes apply() without deadlock under real multi-session topology', function () {
+    $profile = app(ReviewerAccountProfile::class);
+
+    $ctx = new ProvisioningContext(
+        email: 'multiconn-' . uniqid() . '@example.invalid',
+        name: 'Multi-Connection Test',
+        region: 'US',
+        expiresAt: now()->addDays(60)->toImmutable(),
+        note: 'multi-connection regression',
+        operatorId: 1,
+    );
+
+    // If apply() ever re-introduces a wrapping DB::transaction, this call
+    // deadlocks on the cardholders FK lookup and times out at innodb_lock_wait_timeout.
+    $result = app(AccountProvisioningService::class)->apply(
+        profile: $profile,
+        ctx: $ctx,
+        password: 'Strong-Pass-2026!',
+        rotatePassword: false,
+        forceConvert: false,
+    );
+
+    expect($result['password_action'])->toBe('created');
+    expect($result['user'])->toBeInstanceOf(User::class);
+});
+
+it('persists AccountFlag and routes Cardholder write to the tenant connection', function () {
+    $profile = app(ReviewerAccountProfile::class);
+
+    $ctx = new ProvisioningContext(
+        email: 'multiconn-flag-' . uniqid() . '@example.invalid',
+        name: 'Flag Routing Test',
+        region: 'US',
+        expiresAt: now()->addDays(60)->toImmutable(),
+        note: 'flag and tenant routing',
+        operatorId: 1,
+    );
+
+    $result = app(AccountProvisioningService::class)->apply(
+        profile: $profile,
+        ctx: $ctx,
+        password: 'Strong-Pass-2026!',
+        rotatePassword: false,
+        forceConvert: false,
+    );
+
+    $userId = $result['user']->id;
+
+    // AccountFlag persisted on default connection.
+    $flagOnDefault = DB::connection()->table('account_flags')->where('user_id', $userId)->exists();
+    expect($flagOnDefault)->toBeTrue();
+
+    $flag = AccountFlag::where('user_id', $userId)->first();
+    expect($flag)->not->toBeNull();
+    expect($flag->is_review_account)->toBeTrue();
+
+    // Cardholder persisted on tenant connection (proves multi-session write completed).
+    $cardholderOnTenant = DB::connection('tenant')->table('cardholders')->where('user_id', $userId)->exists();
+    expect($cardholderOnTenant)->toBeTrue();
+});
+```
+
+- [ ] **Step 2: Run the test against MySQL**
+
+If MySQL is available locally:
+
+```bash
+DB_CONNECTION=mysql DB_HOST=127.0.0.1 DB_DATABASE=testing DB_USERNAME=root DB_PASSWORD=root \
+  ./vendor/bin/pest --testsuite=MultiConnection
+```
+
+Expected: 6 pass (4 from Task 6 + 2 from this task), or 6 skip without MySQL.
+
+If a deadlock or timeout fires here, **stop** and check whether `AccountProvisioningService::apply()` has been wrapped in a `DB::transaction` again — that would be exactly the regression this test catches.
+
+- [ ] **Step 3: Run cs-fixer + PHPStan**
+
+Run: `./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php tests/MultiConnection/AccountProvisioning/AccountProvisioningServiceMultiConnectionTest.php`
+Run: `XDEBUG_MODE=off vendor/bin/phpstan analyse tests/MultiConnection/AccountProvisioning/AccountProvisioningServiceMultiConnectionTest.php --memory-limit=2G`
+Expected: zero errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/MultiConnection/AccountProvisioning/AccountProvisioningServiceMultiConnectionTest.php
+git commit -m "test: add multi-connection regression test for AccountProvisioningService
+
+Exercises apply() with the reviewer profile under real two-MySQL-session
+topology. If a wrapping DB::transaction is reintroduced (the bug PR #960
+fixed), this test deadlocks on the cardholders insert and times out at
+innodb_lock_wait_timeout — surfacing the regression in CI.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Add Multi-Connection Tests CI job
+
+**Files:**
+- Modify: `.github/workflows/03-test-suite.yml`
+
+- [ ] **Step 1: Add the job to the workflow file**
+
+Edit `.github/workflows/03-test-suite.yml` — add this job after the existing `integration-tests:` job (around line 414, before `behat-tests:`):
+
+```yaml
+  multi-connection-tests:
+    name: Multi-Connection Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: testing
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ env.PHP_VERSION }}
+          extensions: mbstring, dom, fileinfo, mysql, redis, opcache, pcntl, gd, imagick, bcmath, intl, zip, soap, gmp
+          tools: composer:v2
+          coverage: none
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer Dependencies
+        uses: actions/cache@v5
+        with:
+          path: |
+            ${{ steps.composer-cache.outputs.dir }}
+            vendor
+          key: ${{ runner.os }}-multiconn-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-multiconn-composer-
+
+      - name: Setup Environment
+        run: cp .env.testing .env
+
+      - name: Install Dependencies
+        run: |
+          for i in 1 2 3; do
+            if composer install --prefer-dist --no-progress --optimize-autoloader; then
+              break
+            fi
+            sleep 5
+            composer clear-cache
+          done
+
+      - name: Prepare Laravel Application
+        run: |
+          echo "DB_CONNECTION=mysql" >> .env
+          echo "DB_HOST=127.0.0.1" >> .env
+          echo "DB_PORT=3306" >> .env
+          echo "DB_DATABASE=testing" >> .env
+          echo "DB_USERNAME=root" >> .env
+          echo "DB_PASSWORD=root" >> .env
+
+          php artisan key:generate
+          php artisan config:clear
+          php artisan migrate --force
+
+      - name: Run Multi-Connection Tests
+        env:
+          DB_CONNECTION: mysql
+          DB_HOST: 127.0.0.1
+          DB_PORT: 3306
+          DB_DATABASE: testing
+          DB_USERNAME: root
+          DB_PASSWORD: root
+          CI: true
+        run: php -d memory_limit=2G ./vendor/bin/pest --testsuite=MultiConnection
+```
+
+- [ ] **Step 2: Verify YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/03-test-suite.yml'))"`
+Expected: no output (valid YAML).
+
+- [ ] **Step 3: Commit and push**
+
+```bash
+git add .github/workflows/03-test-suite.yml
+git commit -m "ci: add multi-connection tests job to test suite pipeline
+
+Runs tests/MultiConnection/ against real MySQL on every PR.
+Mirrors the integration-tests job structure, ~15 min timeout.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+git push -u origin feat/multi-connection-test-infrastructure
+```
+
+- [ ] **Step 4: Verify CI passes**
+
+Run: `gh run list --branch feat/multi-connection-test-infrastructure --limit 5`
+
+Wait for the `Multi-Connection Tests` check to complete. Expected: PASS, with 6 tests run (4 framework + 2 regression).
+
+If FAIL, run: `gh run view <RUN_ID> --log-failed` and triage.
+
+---
+
+## Task 9: Update CLAUDE.md with reference
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Add a one-line pointer to the "Notes" bullet list**
+
+Edit `CLAUDE.md` — locate the "Notes" section (the long bullet list near the bottom) and add this line near the other test-related entries (after the "Test tables: use `Tests\Traits\CreatesSolanaTestTables`..." line):
+
+```markdown
+- Multi-connection tests: `tests/MultiConnection/` — runs against real MySQL with `database.force_real_tenant_connection=true` so models with `UsesTenantConnection` use a separate MySQL session. Required check on PRs. See `docs/superpowers/specs/2026-04-26-multi-connection-test-infrastructure-design.md`.
+```
+
+- [ ] **Step 2: Add a CI/CD table row**
+
+In the "CI/CD" section's `| Issue | Fix |` table, add this row near the other multi-connection / DB rows:
+
+```markdown
+| Multi-connection deadlock under DB::transaction | Do not wrap flows that touch UsesTenantConnection models in `DB::transaction()` — those models run on a separate MySQL session and will self-deadlock against the wrapping connection's row locks. Add a regression test in `tests/MultiConnection/`. |
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: reference multi-connection test category in CLAUDE.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification
+
+- [ ] **Push and confirm all CI checks pass**
+
+```bash
+git push
+gh pr create --title "feat: multi-connection test infrastructure" --body "$(cat <<'EOF'
+## Summary
+- New \`tests/MultiConnection/\` test category that exercises the production multi-MySQL-session topology
+- Catches the class of bug PR #960 fixed (wrapping \`DB::transaction\` deadlocking against tenant-connection writes)
+- Adds config-driven escape hatch on \`UsesTenantConnection\` so the test base class can disable the testing carve-out
+
+## Test plan
+- [ ] CI \`Multi-Connection Tests\` check passes
+- [ ] All other CI checks remain green (no regression to existing suites)
+- [ ] \`./vendor/bin/pest tests/Unit/Shared/UsesTenantConnectionTraitTest.php\` passes
+- [ ] Locally without MySQL: \`./vendor/bin/pest --testsuite=MultiConnection\` skips all tests gracefully
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected:
+- New CI job `Multi-Connection Tests` runs and passes
+- All other checks pass
+- 6 multi-connection tests pass
+
+- [ ] **Mark TaskCreate #36 complete and merge**
+
+After all checks green and review approval:
+
+```bash
+gh pr merge --squash --auto
+```

--- a/docs/superpowers/specs/2026-04-26-multi-connection-test-infrastructure-design.md
+++ b/docs/superpowers/specs/2026-04-26-multi-connection-test-infrastructure-design.md
@@ -1,0 +1,221 @@
+# Multi-Connection Test Infrastructure — Design
+
+**Status:** approved (pending implementation)
+**Author:** Marijus Planciunas
+**Date:** 2026-04-26
+**Related:** PR #960 (the production bug this prevents recurring)
+
+## Goal
+
+Build test infrastructure that catches multi-connection (multi-MySQL-session) failure modes — the class of bugs that production hit on 2026-04-26 (`Lock wait timeout exceeded` on a `cardholders` insert from `AccountProvisioningService::apply()`).
+
+## Why this is needed
+
+The `App\Domain\Shared\Traits\UsesTenantConnection` trait deliberately collapses the `tenant` connection to the default connection whenever `APP_ENV === 'testing'`. The trait's own docblock names the failure mode it is hiding:
+
+```php
+// MySQL: Separate connections can cause lock wait timeouts with transactions
+```
+
+This collapse is the reason the deadlock never appeared in CI:
+
+- **Production topology:** `users` → default connection (one MySQL session). `cardholders`, `cards` → `tenant` connection (separate MySQL session, even when pointed at the same physical database).
+- **Test topology (today):** `users`, `cardholders`, `cards` → all default connection. Single session. Same in-process transaction. No way to deadlock against yourself across sessions.
+
+The bug shipped because every test ran a topology that does not exist in production. CI already has MySQL available for Feature/Integration jobs — the gap is structural, not infrastructural.
+
+## Non-goals
+
+- Changing the production tenant topology.
+- Removing the `UsesTenantConnection` testing carve-out for the existing test suite — that has hundreds of dependent tests; an audit is out of scope here.
+- Comprehensive coverage across all ~20 `UsesTenantConnection` models in v1. Framework first, breadth later.
+
+## Design
+
+### Component overview
+
+```
+tests/
+  MultiConnection/                       # new testsuite
+    MultiConnectionTestCase.php          # base class (forces real tenant connection + truncation)
+    Concerns/
+      TruncatesAllConnections.php        # cleanup trait
+      SkipsWithoutMySQL.php              # local-dev skip
+    AccountProvisioning/
+      AccountProvisioningServiceMultiConnectionTest.php   # tier 1 regression
+    Framework/
+      ConnectionTopologyTest.php         # self-check: confirms tenant ≠ default
+```
+
+### 1. Trait escape hatch
+
+Add one config-driven branch to `UsesTenantConnection::shouldUseDefaultConnection()`:
+
+```php
+protected function shouldUseDefaultConnection(): bool
+{
+    if (Config::get('database.force_real_tenant_connection') === true) {
+        return false;
+    }
+    return Config::get('app.env') === 'testing';
+}
+```
+
+Default: `false`. The base class flips it on in `setUp`. Laravel resets `config()` between tests, so no manual cleanup is needed.
+
+This is intentionally one extra `if` — discoverable in a grep, easy to delete if we ever fully remove the carve-out.
+
+### 2. Base class: `MultiConnectionTestCase`
+
+Responsibilities:
+
+1. **Hard-require MySQL.** If `DB_CONNECTION !== 'mysql'` (or the connection is unreachable), `markTestSkipped` with a clear reason — preserves local dev workflow on machines without MySQL.
+2. **Set `database.force_real_tenant_connection = true`** so the trait stops collapsing. The existing `tenant` connection in `config/database.php` already points at the same env-driven host/database as `mysql`, so no additional config rewriting is needed — separate PDO instances on the same DB is exactly the production topology.
+3. **Force fresh PDO instances** with `DB::purge('mysql')` and `DB::purge('tenant')` so the two connections are independent MySQL sessions for the lifetime of the test.
+4. **Truncate all touched tables** between tests instead of `RefreshDatabase`. `RefreshDatabase` wraps the default connection in a transaction that the tenant connection cannot see — wrong tool for this job.
+
+Sketch:
+
+```php
+abstract class MultiConnectionTestCase extends BaseTestCase
+{
+    use CreatesApplication;
+    use TruncatesAllConnections;
+    use SkipsWithoutMySQL;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->skipIfMySQLUnavailable();
+
+        Config::set('database.force_real_tenant_connection', true);
+
+        // Force fresh PDO instances so the two connections are separate sessions.
+        DB::purge('mysql');
+        DB::purge('tenant');
+
+        $this->truncateAllConnections();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->truncateAllConnections();
+        parent::tearDown();
+    }
+}
+```
+
+### 3. `TruncatesAllConnections` cleanup
+
+Why truncation, not transactions:
+
+| Strategy | Cross-session FK visibility | Speed | Verdict |
+|---|---|---|---|
+| `RefreshDatabase` (one transaction on default) | Broken — tenant can't see uncommitted users | Fast | Wrong: collapses the topology we're trying to test |
+| Per-connection transactions | Broken — same reason | Fast | Wrong, same problem |
+| `migrate:fresh` per test | OK | 5–15s/test | Too slow |
+| **Truncation per test** | **OK — both connections see committed writes during test** | **~50–200ms/test** | **Chosen** |
+
+Implementation:
+
+- One-time bootstrap: `migrate:fresh` runs once per test process (Pest fixture/`beforeAll`).
+- Per-test cleanup: `TRUNCATE` only the tables that the test actually touched, plus a known set of "always touched" tables (users, account_flags, cardholders, cards, etc.).
+- `SET FOREIGN_KEY_CHECKS=0` around truncation — required because we're truncating across FK boundaries.
+- Roles/permissions tables (`spatie/laravel-permission`) excluded from truncation so `createRoles()` from the existing `TestCase` pattern can be called once per process.
+
+Open implementation detail (resolved during build): exact list of "always truncate" tables. Start with the union of tables hit by Tier 1+2 tests, document and grow.
+
+### 4. CI integration
+
+New job in `.github/workflows/03-test-suite.yml`, modeled on the existing `integration-tests` job:
+
+```yaml
+multi-connection-tests:
+  name: Multi-Connection Tests
+  runs-on: ubuntu-latest
+  timeout-minutes: 15
+  services:
+    mysql: { image: mysql:8.0, ... }
+    redis: { image: redis:7-alpine, ... }
+  steps:
+    - ... (standard setup) ...
+    - name: Run Multi-Connection Tests
+      env:
+        DB_CONNECTION: mysql
+        DB_HOST: 127.0.0.1
+        ...
+      run: php -d memory_limit=2G ./vendor/bin/pest --testsuite=MultiConnection
+```
+
+- Required check on PRs (branch protection rule, separate from existing checks).
+- New testsuite added to `phpunit.xml`:
+  ```xml
+  <testsuite name="MultiConnection">
+      <directory>tests/MultiConnection</directory>
+  </testsuite>
+  ```
+
+### 5. Local dev
+
+`SkipsWithoutMySQL`:
+
+```php
+protected function skipIfMySQLUnavailable(): void
+{
+    if (Config::get('database.default') !== 'mysql') {
+        $this->markTestSkipped('Multi-connection tests require MySQL.');
+    }
+    try {
+        DB::connection('mysql')->getPdo();
+    } catch (\Throwable $e) {
+        $this->markTestSkipped('MySQL not reachable: ' . $e->getMessage());
+    }
+}
+```
+
+`pest --parallel` on a machine without MySQL stays green by skipping. CI is the source of truth.
+
+## Initial test coverage (v1)
+
+### Tier 1 — must ship
+
+1. **`Framework/ConnectionTopologyTest`** — self-check. Asserts that inside the base class:
+   - `User::create()` writes via the default connection.
+   - `Cardholder::create()` writes via the `tenant` connection.
+   - The two connections have distinct PDO instances (`!==`).
+   - A row inserted on default but not committed is visible to the default connection (same session) but invisible to the tenant connection (different session).
+
+   Without this, a future regression that re-collapses the connections silently neuters every other test in the suite.
+
+2. **`AccountProvisioning/AccountProvisioningServiceMultiConnectionTest`** — exercises `apply()` with the real reviewer profile end-to-end. Confirms the no-wrapping-transaction fix works under realistic multi-session topology. Pair this with a "guarded regression" test: re-introduce a wrapping `DB::transaction` via reflection or a test-only subclass and assert it deadlocks (proves the test would catch the regression).
+
+### Tier 2 — ship if ≤30 min wiring
+
+3. A direct card-issuance flow test (without going through `AccountProvisioningService`) — covers the same multi-connection write pattern via a different entry point. Skip if it requires significant scaffolding.
+
+### Tier 3 — defer
+
+Lending, AgentProtocol, Performance flows. Add as bugs surface or as part of those domains' own work. The framework makes it cheap to add later.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| The "always truncate" table list drifts as new models are added | Document in `MultiConnectionTestCase` docblock; add a CI lint step that warns when a new `UsesTenantConnection` model lacks coverage (deferred to follow-up) |
+| Truncation cost grows with more tests | Acceptable up to ~50 tests in this suite. Beyond that, switch to per-test ephemeral DBs |
+| The trait escape hatch gets misused outside `tests/MultiConnection/` | Keep the config key documented; its only legitimate caller is `MultiConnectionTestCase::setUp` |
+| Self-check test ironically passes when broken | The self-check explicitly asserts PDO instance inequality (`!==`), which is the bypass-resistant invariant — collapse and you fail this test |
+
+## Decisions log
+
+- **Test class scope**: B (new test category) — chosen over A (single regression test) and C (suite-wide promotion). Surgical, doesn't blow up existing tests.
+- **Isolation strategy**: #3 truncation — chosen over migrations (slow), per-connection transactions (defeats the purpose), and ephemeral DBs (overkill).
+- **Trait override mechanism**: A (config flag) — chosen over a static trait flag (footgun: requires manual reset).
+- **Coverage scope**: Tier 1 + Tier 2 if cheap.
+- **CI placement**: B (new dedicated job, required check) — chosen over reusing Integration (pollution risk) and slow-tests (PRs would slip through).
+- **Local dev**: graceful skip when MySQL unreachable.
+
+## Implementation handoff
+
+Implementation plan to be drafted via `superpowers:writing-plans` next.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -28,6 +28,9 @@
         <testsuite name="Security">
             <directory>tests/Security</directory>
         </testsuite>
+        <testsuite name="MultiConnection">
+            <directory>tests/MultiConnection</directory>
+        </testsuite>
     </testsuites>
     <source>
         <include>

--- a/tests/MultiConnection/AccountProvisioning/AccountProvisioningServiceMultiConnectionTest.php
+++ b/tests/MultiConnection/AccountProvisioning/AccountProvisioningServiceMultiConnectionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\MultiConnection\AccountProvisioning;
+
+use App\Domain\AccountProvisioning\Models\AccountFlag;
+use App\Domain\AccountProvisioning\Profiles\ReviewerAccountProfile;
+use App\Domain\AccountProvisioning\Services\AccountProvisioningService;
+use App\Domain\AccountProvisioning\ValueObjects\ProvisioningContext;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+it('completes apply() without deadlock under real multi-session topology', function () {
+    $profile = app(ReviewerAccountProfile::class);
+
+    $ctx = new ProvisioningContext(
+        email: 'multiconn-' . uniqid() . '@example.invalid',
+        name: 'Multi-Connection Test',
+        region: 'US',
+        expiresAt: now()->addDays(60)->toImmutable(),
+        note: 'multi-connection regression',
+        operatorId: 1,
+    );
+
+    // If apply() ever re-introduces a wrapping DB::transaction, this call
+    // deadlocks on the cardholders FK lookup and times out at innodb_lock_wait_timeout.
+    $result = app(AccountProvisioningService::class)->apply(
+        profile: $profile,
+        ctx: $ctx,
+        password: 'Strong-Pass-2026!',
+        rotatePassword: false,
+        forceConvert: false,
+    );
+
+    expect($result['password_action'])->toBe('created');
+    expect($result['user'])->toBeInstanceOf(User::class);
+});
+
+it('persists AccountFlag and routes Cardholder write to the tenant connection', function () {
+    $profile = app(ReviewerAccountProfile::class);
+
+    $ctx = new ProvisioningContext(
+        email: 'multiconn-flag-' . uniqid() . '@example.invalid',
+        name: 'Flag Routing Test',
+        region: 'US',
+        expiresAt: now()->addDays(60)->toImmutable(),
+        note: 'flag and tenant routing',
+        operatorId: 1,
+    );
+
+    $result = app(AccountProvisioningService::class)->apply(
+        profile: $profile,
+        ctx: $ctx,
+        password: 'Strong-Pass-2026!',
+        rotatePassword: false,
+        forceConvert: false,
+    );
+
+    $userId = $result['user']->id;
+
+    // AccountFlag persisted on default connection.
+    $flagOnDefault = DB::connection()->table('account_flags')->where('user_id', $userId)->exists();
+    expect($flagOnDefault)->toBeTrue();
+
+    $flag = AccountFlag::where('user_id', $userId)->first();
+    expect($flag)->not->toBeNull();
+    expect($flag->is_review_account)->toBeTrue();
+
+    // Cardholder persisted on tenant connection (proves multi-session write completed).
+    $cardholderOnTenant = DB::connection('tenant')->table('cardholders')->where('user_id', $userId)->exists();
+    expect($cardholderOnTenant)->toBeTrue();
+});

--- a/tests/MultiConnection/Concerns/SkipsWithoutMySQL.php
+++ b/tests/MultiConnection/Concerns/SkipsWithoutMySQL.php
@@ -20,6 +20,10 @@ trait SkipsWithoutMySQL
      */
     protected function skipIfMySQLUnavailable(): void
     {
+        if (! Config::has('database.connections.tenant')) {
+            $this->markTestSkipped('Multi-connection tests require a "tenant" connection in database config.');
+        }
+
         $driver = Config::get('database.connections.' . Config::get('database.default') . '.driver');
 
         if (! in_array($driver, ['mysql', 'mariadb'], true)) {

--- a/tests/MultiConnection/Concerns/SkipsWithoutMySQL.php
+++ b/tests/MultiConnection/Concerns/SkipsWithoutMySQL.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\MultiConnection\Concerns;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+trait SkipsWithoutMySQL
+{
+    /**
+     * Skip the test if MySQL is not the configured default driver or not reachable.
+     *
+     * Multi-connection tests need real MySQL because they assert behavior
+     * specific to InnoDB row-level locks and independent MySQL sessions.
+     * On dev machines without MySQL (e.g., WSL), tests skip gracefully so
+     * `pest --parallel` stays green. CI is the source of truth.
+     */
+    protected function skipIfMySQLUnavailable(): void
+    {
+        $driver = Config::get('database.connections.' . Config::get('database.default') . '.driver');
+
+        if (! in_array($driver, ['mysql', 'mariadb'], true)) {
+            $this->markTestSkipped(
+                "Multi-connection tests require MySQL/MariaDB; default driver is '{$driver}'."
+            );
+        }
+
+        try {
+            DB::connection()->getPdo();
+        } catch (Throwable $e) {
+            $this->markTestSkipped('MySQL not reachable: ' . $e->getMessage());
+        }
+    }
+}

--- a/tests/MultiConnection/Concerns/TruncatesAllConnections.php
+++ b/tests/MultiConnection/Concerns/TruncatesAllConnections.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\MultiConnection\Concerns;
+
+use Illuminate\Support\Facades\DB;
+
+trait TruncatesAllConnections
+{
+    /**
+     * Tables preserved across tests in this suite.
+     *
+     * - migrations: required for schema state
+     * - permission/role tables: created once via createRoles() pattern; truncating
+     *   them forces every test to re-seed roles, which is wasteful
+     */
+    private const PRESERVED_TABLES = [
+        'migrations',
+        'roles',
+        'permissions',
+        'model_has_roles',
+        'model_has_permissions',
+        'role_has_permissions',
+    ];
+
+    /**
+     * Truncate every non-preserved table on both default and tenant connections.
+     *
+     * MultiConnection tests cannot use RefreshDatabase (which wraps the default
+     * connection in a single transaction the tenant connection cannot see).
+     * We truncate instead, and since both connections target the same physical
+     * database, we only need to truncate once via the default connection.
+     * The two connections still see the same on-disk state because they share
+     * the same DB.
+     */
+    protected function truncateAllConnections(): void
+    {
+        $tables = $this->resolveTablesToTruncate();
+
+        DB::connection()->statement('SET FOREIGN_KEY_CHECKS=0');
+
+        try {
+            foreach ($tables as $table) {
+                DB::connection()->table($table)->truncate();
+            }
+        } finally {
+            DB::connection()->statement('SET FOREIGN_KEY_CHECKS=1');
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function resolveTablesToTruncate(): array
+    {
+        $all = array_map(
+            fn (array $row) => array_values((array) $row)[0],
+            DB::connection()->select('SHOW TABLES')
+        );
+
+        return array_values(array_filter(
+            $all,
+            fn (string $table) => ! in_array($table, self::PRESERVED_TABLES, true)
+        ));
+    }
+}

--- a/tests/MultiConnection/Framework/ConnectionTopologyTest.php
+++ b/tests/MultiConnection/Framework/ConnectionTopologyTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\MultiConnection\Framework;
+
+use App\Domain\CardIssuance\Models\Cardholder;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+it('routes User writes to the default connection', function () {
+    $user = new User();
+    expect($user->getConnectionName())->toBeNull();
+});
+
+it('routes Cardholder writes to the tenant connection', function () {
+    $cardholder = new Cardholder();
+    expect($cardholder->getConnectionName())->toBe('tenant');
+});
+
+it('uses distinct PDO instances on default and tenant connections', function () {
+    $defaultPdo = DB::connection()->getPdo();
+    $tenantPdo = DB::connection('tenant')->getPdo();
+
+    expect($defaultPdo)->not->toBe($tenantPdo);
+});
+
+it('does not see uncommitted writes from another connection', function () {
+    $email = 'topology-' . uniqid() . '@example.invalid';
+
+    DB::connection()->beginTransaction();
+
+    DB::connection()->table('users')->insert([
+        'name'              => 'Topology Test',
+        'email'             => $email,
+        'password'          => 'irrelevant',
+        'email_verified_at' => now(),
+        'created_at'        => now(),
+        'updated_at'        => now(),
+    ]);
+
+    // Same connection (same session) sees it.
+    $sameConn = DB::connection()->table('users')->where('email', $email)->exists();
+    // Different connection (different session) does NOT see it.
+    $tenantConn = DB::connection('tenant')->table('users')->where('email', $email)->exists();
+
+    DB::connection()->rollBack();
+
+    expect($sameConn)->toBeTrue();
+    expect($tenantConn)->toBeFalse();
+});

--- a/tests/MultiConnection/MultiConnectionTestCase.php
+++ b/tests/MultiConnection/MultiConnectionTestCase.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\MultiConnection;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Tests\CreatesApplication;
+use Tests\MultiConnection\Concerns\SkipsWithoutMySQL;
+use Tests\MultiConnection\Concerns\TruncatesAllConnections;
+
+/**
+ * Base class for tests that exercise the production multi-session topology.
+ *
+ * Production runs models with `UsesTenantConnection` on a separate MySQL
+ * session from the default connection. The standard `Tests\TestCase` collapses
+ * those connections to a single session under APP_ENV=testing — which masks
+ * an entire class of multi-session bugs (see PR #960).
+ *
+ * This base class:
+ *   1. Skips the test if MySQL is not reachable (local dev safety).
+ *   2. Sets `database.force_real_tenant_connection = true` so the
+ *      UsesTenantConnection trait stops collapsing.
+ *   3. Purges both PDO instances so the two connections are independent
+ *      MySQL sessions for the lifetime of the test.
+ *   4. Truncates non-preserved tables before and after each test (we cannot
+ *      use RefreshDatabase — its single-connection transaction is exactly
+ *      what we are trying to test against).
+ */
+abstract class MultiConnectionTestCase extends BaseTestCase
+{
+    use CreatesApplication;
+    use SkipsWithoutMySQL;
+    use TruncatesAllConnections;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->skipIfMySQLUnavailable();
+
+        Config::set('database.force_real_tenant_connection', true);
+
+        DB::purge((string) Config::get('database.default'));
+        DB::purge('tenant');
+
+        $this->truncateAllConnections();
+    }
+
+    protected function tearDown(): void
+    {
+        if (Config::get('database.force_real_tenant_connection') === true) {
+            $this->truncateAllConnections();
+        }
+
+        parent::tearDown();
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -21,6 +21,7 @@ use Tests\TestCase;
 uses(TestCase::class)->in('Feature');
 uses(TestCase::class)->in('Domain');
 uses(TestCase::class)->in('Console');
+uses(Tests\MultiConnection\MultiConnectionTestCase::class)->in('MultiConnection');
 
 // Use InteractsWithFilament trait for Filament tests
 uses(Tests\Traits\InteractsWithFilament::class)->in('Feature/Filament');

--- a/tests/Unit/Shared/UsesTenantConnectionTraitTest.php
+++ b/tests/Unit/Shared/UsesTenantConnectionTraitTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Shared;
+
+use App\Domain\Shared\Traits\UsesTenantConnection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Config;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+beforeEach(function () {
+    $this->model = new class () extends Model {
+        use UsesTenantConnection;
+    };
+});
+
+it('returns null (default connection) when running under testing env without override', function () {
+    Config::set('app.env', 'testing');
+    Config::set('database.force_real_tenant_connection', false);
+
+    expect($this->model->getConnectionName())->toBeNull();
+});
+
+it('returns "tenant" when force_real_tenant_connection is true even under testing', function () {
+    Config::set('app.env', 'testing');
+    Config::set('database.force_real_tenant_connection', true);
+
+    expect($this->model->getConnectionName())->toBe('tenant');
+});
+
+it('returns "tenant" when env is not testing regardless of override flag', function () {
+    Config::set('app.env', 'production');
+    Config::set('database.force_real_tenant_connection', false);
+
+    expect($this->model->getConnectionName())->toBe('tenant');
+});


### PR DESCRIPTION
## Summary

New `tests/MultiConnection/` test category that catches multi-MySQL-session bugs — the class of bug PR #960 fixed. Production runs `UsesTenantConnection` models on a separate MySQL session, but the trait deliberately collapses to the default connection under `APP_ENV=testing`, hiding multi-session deadlocks. This branch adds infrastructure to disable that collapse for a dedicated test suite.

**Spec:** \`docs/superpowers/specs/2026-04-26-multi-connection-test-infrastructure-design.md\`
**Plan:** \`docs/superpowers/plans/2026-04-26-multi-connection-test-infrastructure.md\`

## What lands

- **Trait escape hatch:** \`database.force_real_tenant_connection\` config flag on \`UsesTenantConnection\`. Defaults to \`false\` (existing behavior). Strict \`=== true\` check — only programmatic boolean overrides count, never env strings.
- **Test base class:** \`Tests\\MultiConnection\\MultiConnectionTestCase\` — flips the flag, purges PDO instances on both connections, truncates non-preserved tables between tests. Skips gracefully if MySQL unavailable (local dev safety).
- **Concerns:** \`SkipsWithoutMySQL\` and \`TruncatesAllConnections\` traits.
- **Tests:**
  - \`tests/MultiConnection/Framework/ConnectionTopologyTest.php\` — 4 self-check assertions: User routes to default, Cardholder routes to tenant, PDO instances are distinct, uncommitted writes are session-isolated. If the topology silently re-collapses, this test fails first.
  - \`tests/MultiConnection/AccountProvisioning/AccountProvisioningServiceMultiConnectionTest.php\` — Tier 1 regression: \`apply()\` completes without deadlock; AccountFlag persists on default, Cardholder persists on tenant.
- **CI job:** new \`Multi-Connection Tests\` job in \`03-test-suite.yml\` runs \`--testsuite=MultiConnection\` against MySQL 8.0 on every PR.
- **Docs:** \`CLAUDE.md\` updated with pointer + CI/CD pitfall row.

## Test plan

- [ ] CI \`Multi-Connection Tests\` check passes (6 tests pass under MySQL).
- [ ] All other CI checks remain green — escape hatch defaults to false, no existing test should change behavior.
- [ ] Local \`./vendor/bin/pest --testsuite=MultiConnection\` skips gracefully on machines without MySQL (e.g., WSL).
- [ ] PHPStan Level 8 clean across all new files.

## Known follow-ups (from final code review)

Captured for future work, not blocking this PR:

1. **Guarded regression test** (spec called for it, plan dropped it): re-introduce a wrapping \`DB::transaction\` via a test-only subclass and assert it deadlocks — would prove the regression catcher itself works. The topology self-check (Tests 2 and 3) covers most of this concern, but not the apply()-specific path.
2. **\`config:cache\` vs \`config:clear\` in CI**: the new job uses \`config:clear\` while \`integration-tests\` uses \`config:cache\`. Current behavior is correct (process-level env overrides), but \`config:cache\` is the safer pattern.
3. **MariaDB driver vs MySQL 8.0 service**: \`tenant\` connection is configured with \`driver=mariadb\` but CI service is \`mysql:8.0\`. Wire-protocol compatible but worth verifying. Switch CI to \`mariadb:10.11\` if any issues arise.
4. **\`operatorId: 1\` fragility in regression test**: works because of TRUNCATE + auto-increment behavior. Better long-term to create an explicit operator user with a real id.
5. **50s timeout on regression catch**: if \`apply()\` deadlocks, CI takes \`innodb_lock_wait_timeout\` (default 50s) to fail. Could lower for faster feedback.

## Background

PR #960 fixed a production deadlock where \`AccountProvisioningService::apply()\` was wrapped in \`DB::transaction()\`. That held a row-level lock on the just-created \`users\` row in the default-connection session. The Cardholder seeder (tenant connection — separate MySQL session) tried to do an FK lookup against that locked row and self-deadlocked. The bug shipped because tests collapsed both connections to a single session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)