### PR TITLE
fix: TruncatesAllConnections row type (multi-connection tests broken on main)

### DIFF
--- a/tests/MultiConnection/Concerns/TruncatesAllConnections.php
+++ b/tests/MultiConnection/Concerns/TruncatesAllConnections.php
@@ -55,7 +55,7 @@ trait TruncatesAllConnections
     private function resolveTablesToTruncate(): array
     {
         $all = array_map(
-            fn (array $row) => array_values((array) $row)[0],
+            fn (object $row) => array_values((array) $row)[0],
             DB::connection()->select('SHOW TABLES')
         );
 


### PR DESCRIPTION
## Summary
Fast-follow fix for PR #962. The multi-connection test infrastructure shipped with a type bug in \`TruncatesAllConnections::resolveTablesToTruncate()\` — \`DB::select('SHOW TABLES')\` returns \`array<int, stdClass>\`, but the closure was typed \`array \$row\`, so PHP rejects the stdClass at the type hint before the \`(array) \$row\` cast inside can run.

PHPStan didn't catch this because static analysis doesn't see the runtime shape of \`select()\` results. Locally everything skipped (no MySQL on WSL). The bug only surfaced when the new CI job ran against real MySQL — all 6 multi-connection tests failed with:

\`\`\`
Argument #1 (\$row) must be of type array, stdClass given
at tests/MultiConnection/Concerns/TruncatesAllConnections.php:58
\`\`\`

PR #962 auto-merged before that CI run completed, so main is currently carrying the bug.

## Fix
One-character change: \`fn (array \$row)\` → \`fn (object \$row)\`. Already on the (now-merged) feat branch as commit 1a200be1; cherry-picked here.

## Test plan
- [ ] CI \`Multi-Connection Tests\` check passes (6/6 tests run instead of 6/6 fail)
- [ ] All other CI checks remain green
- [ ] PHPStan Level 8 still clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)