### PR TITLE
fix: multi-connection test bootstrap bugs (uuid + transaction leak)

### DIFF
--- a/tests/MultiConnection/Framework/ConnectionTopologyTest.php
+++ b/tests/MultiConnection/Framework/ConnectionTopologyTest.php
@@ -7,6 +7,7 @@ namespace Tests\MultiConnection\Framework;
 use App\Domain\CardIssuance\Models\Cardholder;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 it('routes User writes to the default connection', function () {
     $user = new User();
@@ -30,21 +31,24 @@ it('does not see uncommitted writes from another connection', function () {
 
     DB::connection()->beginTransaction();
 
-    DB::connection()->table('users')->insert([
-        'name'              => 'Topology Test',
-        'email'             => $email,
-        'password'          => 'irrelevant',
-        'email_verified_at' => now(),
-        'created_at'        => now(),
-        'updated_at'        => now(),
-    ]);
+    try {
+        DB::connection()->table('users')->insert([
+            'uuid'              => (string) Str::uuid(),
+            'name'              => 'Topology Test',
+            'email'             => $email,
+            'password'          => 'irrelevant',
+            'email_verified_at' => now(),
+            'created_at'        => now(),
+            'updated_at'        => now(),
+        ]);
 
-    // Same connection (same session) sees it.
-    $sameConn = DB::connection()->table('users')->where('email', $email)->exists();
-    // Different connection (different session) does NOT see it.
-    $tenantConn = DB::connection('tenant')->table('users')->where('email', $email)->exists();
-
-    DB::connection()->rollBack();
+        // Same connection (same session) sees it.
+        $sameConn = DB::connection()->table('users')->where('email', $email)->exists();
+        // Different connection (different session) does NOT see it.
+        $tenantConn = DB::connection('tenant')->table('users')->where('email', $email)->exists();
+    } finally {
+        DB::connection()->rollBack();
+    }
 
     expect($sameConn)->toBeTrue();
     expect($tenantConn)->toBeFalse();

--- a/tests/MultiConnection/MultiConnectionTestCase.php
+++ b/tests/MultiConnection/MultiConnectionTestCase.php
@@ -52,9 +52,22 @@ abstract class MultiConnectionTestCase extends BaseTestCase
     protected function tearDown(): void
     {
         if (Config::get('database.force_real_tenant_connection') === true) {
+            // A failing test may leave a transaction open on either connection.
+            // Open transactions hold metadata locks that block TRUNCATE for
+            // 10s+, cascading the failure into every subsequent test's setUp.
+            $this->rollBackOpenTransactions();
             $this->truncateAllConnections();
         }
 
         parent::tearDown();
+    }
+
+    private function rollBackOpenTransactions(): void
+    {
+        foreach ([(string) Config::get('database.default'), 'tenant'] as $connection) {
+            while (DB::connection($connection)->transactionLevel() > 0) {
+                DB::connection($connection)->rollBack();
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Two bugs in the multi-connection test infrastructure surfaced when CI ran against real MySQL on main. PRs #962 and #963 both auto-merged before their CI completed (because the new \`Multi-Connection Tests\` check is not in the required-checks list — see PR #962 review for that note), so the bugs are currently in main.

## Bug 1: missing uuid column in raw INSERT

\`ConnectionTopologyTest\`'s test 4 ("does not see uncommitted writes from another connection") does a raw \`DB::connection()->table('users')->insert([...])\` to test cross-connection visibility. My plan's INSERT didn't include the \`uuid\` column. The users table has a non-nullable \`uuid\` column (added in migration \`2024_08_21_203644_add_uuid_to_users_table\`), so MySQL rejects with:

\`\`\`
SQLSTATE[HY000]: General error: 1364 Field 'uuid' doesn't have a default value
\`\`\`

**Fix:** add \`'uuid' => (string) Str::uuid()\` to the insert. Also wrap the insert + reads in \`try/finally\` so \`rollBack()\` always runs, even if an assertion fails between begin and rollback.

## Bug 2: transaction leak cascading the failure

When test 4 threw (Bug 1), the default connection's transaction was left open in error state. Teardown's \`TRUNCATE TABLE users\` then timed out at 10s because the open transaction held a metadata lock:

\`\`\`
Execution aborted after 10 seconds (SQL: truncate table \`users\`)
\`\`\`

That timeout cascaded into every subsequent test's \`setUp\` truncate, so all 6 tests failed even though only one had the actual bug.

**Fix:** defensive \`rollBackOpenTransactions()\` in \`MultiConnectionTestCase::tearDown\` before the truncate, on both default and tenant connections. Walks each connection's \`transactionLevel()\` down to zero. Prevents any future failed test from poisoning the rest of the suite.

## Test plan

- [ ] CI \`Multi-Connection Tests\` check passes (6/6 instead of 6/6 fail)
- [ ] All other CI checks remain green
- [ ] PHPStan Level 8 clean

## Followup (already noted)

- \`Multi-Connection Tests\` needs to be added to required checks for the \`main\` branch protection rule, otherwise auto-merge keeps firing before this job completes. Settings → Branches → main → "Require status checks to pass before merging" → add \`Test Suite / Multi-Connection Tests\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)