### PR TITLE
fix: skip empty tables in MultiConnection truncate (CI 10s timeout)

### DIFF
--- a/tests/MultiConnection/Concerns/TruncatesAllConnections.php
+++ b/tests/MultiConnection/Concerns/TruncatesAllConnections.php
@@ -25,18 +25,27 @@ trait TruncatesAllConnections
     ];
 
     /**
-     * Truncate every non-preserved table on both default and tenant connections.
+     * Truncate every non-preserved, non-empty table on both default and tenant
+     * connections.
      *
      * MultiConnection tests cannot use RefreshDatabase (which wraps the default
      * connection in a single transaction the tenant connection cannot see).
      * We truncate instead, and since both connections target the same physical
      * database, we only need to truncate once via the default connection.
-     * The two connections still see the same on-disk state because they share
-     * the same DB.
+     *
+     * We only TRUNCATE tables that have rows. Empty tables are no-ops anyway,
+     * and the project has 200+ tables — issuing TRUNCATE on each of them every
+     * test setUp/tearDown serializes through MySQL's redo log writer and trips
+     * the per-statement timeout. Skipping empties keeps the cleanup proportional
+     * to what each test actually wrote.
      */
     protected function truncateAllConnections(): void
     {
         $tables = $this->resolveTablesToTruncate();
+
+        if ($tables === []) {
+            return;
+        }
 
         DB::connection()->statement('SET FOREIGN_KEY_CHECKS=0');
 
@@ -59,9 +68,14 @@ trait TruncatesAllConnections
             DB::connection()->select('SHOW TABLES')
         );
 
-        return array_values(array_filter(
+        $candidates = array_filter(
             $all,
             fn (string $table) => ! in_array($table, self::PRESERVED_TABLES, true)
+        );
+
+        return array_values(array_filter(
+            $candidates,
+            fn (string $table) => DB::connection()->table($table)->limit(1)->exists()
         ));
     }
 }


### PR DESCRIPTION
## Summary

Third fast-follow on the multi-connection test infrastructure. PR #964 fixed two bootstrap bugs but a third surfaced when CI ran: the truncate loop iterates ~200 tables per test setUp + tearDown, and MySQL aborts individual TRUNCATEs after 10s once the redo log writer falls behind.

## Failure

Each of the 4 DB-touching tests failed at a different table:

\`\`\`
truncate table wallet_addresses          → aborted after 10s
truncate table visa_cli_spending_limits  → aborted after 10s
truncate table votes                      → aborted after 10s
truncate table users                      → aborted after 10s
\`\`\`

The 2 no-DB topology tests (\`getConnectionName()\` checks) still passed.

## Root cause

This codebase has 200+ tables. \`TruncatesAllConnections::resolveTablesToTruncate()\` returned every non-preserved table, and the trait then issued \`TRUNCATE TABLE\` on each. MySQL serializes TRUNCATE through the redo log writer; once enough TRUNCATEs queue up, the per-statement timeout fires. The vast majority of tables were empty (no test data) — the work was wasted.

## Fix

Filter truncate candidates by \`exists()\` first. Only TRUNCATE tables that actually have rows.

\`\`\`php
return array_values(array_filter(
    \$candidates,
    fn (string \$table) => DB::connection()->table(\$table)->limit(1)->exists()
));
\`\`\`

After this:
- **First test in suite**: every table is empty post-migration → zero truncates → setUp is fast.
- **Subsequent tests**: only the tables the previous test wrote to (users, account_flags, cardholders, cards, wallets, balances, …) need clearing. Proportional to test work, not schema size.

Also added an early return when the candidate list is empty, so we don't pay the FK-checks toggle cost for nothing.

## Test plan

- [ ] CI \`Multi-Connection Tests\` passes — all 6 tests run.
- [ ] PHPStan Level 8 clean (verified locally).

## Outstanding (still on the user's plate)

- Required-checks list on \`main\` branch protection: add \`Test Suite / Multi-Connection Tests\`. Three PRs in a row (#962, #963, #964) auto-merged before this job completed because it's not a required check. https://github.com/FinAegis/core-banking-prototype-laravel/settings/branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)