### PR TITLE
chore: file pre-flag-flip TODO on attestation challenge handshake

### DIFF
--- a/app/Domain/Mobile/Services/BiometricJWTService.php
+++ b/app/Domain/Mobile/Services/BiometricJWTService.php
@@ -243,6 +243,28 @@ class BiometricJWTService implements BiometricJWTServiceInterface
      *
      * When MOBILE_ATTESTATION_ENABLED=true, delegates to the platform-specific
      * verifier. Falls back to demo mode (length check) when disabled.
+     *
+     * MUST FIX BEFORE FLIPPING MOBILE_ATTESTATION_ENABLED=true:
+     *   The iOS branch passes empty string as challenge to AppleAttestationVerifier.
+     *   AppleAttestationVerifier::verify() then looks for SHA-256("") inside the
+     *   attestation, which won't match anything mobile sends. iOS verification
+     *   will always fail until this is wired up.
+     *
+     *   The mobile client sends the challenge alongside the attestation
+     *   (32-byte random hex per call as of 2026-04-26). To fix:
+     *     1. Add `device_challenge` to LoginController / RegisterController /
+     *        MobileController / PasskeyController validation rules.
+     *     2. Plumb it through verifyDeviceAttestationForUser() →
+     *        verifyDeviceAttestation() (new $challenge param) →
+     *        AppleAttestationVerifier::verify($attestation, $challenge).
+     *     3. For Android, pass the challenge as the nonce to Play Integrity's
+     *        decrypt request inside GoogleIntegrityVerifier (currently no
+     *        challenge handling at all).
+     *
+     *   Coordinate with the mobile team before flipping — see the conversation
+     *   thread on PR #321 (FinAegis/finaegis-mobile) and the App Attest /
+     *   Play Integrity handshake design notes the mobile dev shared on
+     *   2026-04-26.
      */
     public function verifyDeviceAttestation(string $attestation, string $deviceType): bool
     {
@@ -253,6 +275,7 @@ class BiometricJWTService implements BiometricJWTServiceInterface
         // Production attestation when enabled
         if (config('mobile.attestation.enabled', false)) {
             return match ($deviceType) {
+                // FIXME: empty challenge — see method docblock; must wire mobile-supplied challenge before flag flip.
                 'ios'     => app(AppleAttestationVerifier::class)->verify($attestation, ''),
                 'android' => app(GoogleIntegrityVerifier::class)->verify($attestation),
                 default   => false,

--- a/config/mobile.php
+++ b/config/mobile.php
@@ -132,7 +132,15 @@ return [
     */
 
     'attestation' => [
-        // Enable device attestation verification
+        // Enable device attestation verification.
+        //
+        // DO NOT FLIP TO TRUE WITHOUT FIRST WIRING THE MOBILE-SUPPLIED CHALLENGE.
+        // BiometricJWTService::verifyDeviceAttestation() currently passes empty
+        // string as challenge to AppleAttestationVerifier — iOS will always fail
+        // verification until controllers accept and plumb the device_challenge
+        // field through to the verifiers. See the FIXME at
+        // app/Domain/Mobile/Services/BiometricJWTService.php and coordinate with
+        // the mobile team before changing this default.
         'enabled' => env('MOBILE_ATTESTATION_ENABLED', false),
 
         // Apple App Attest settings


### PR DESCRIPTION
## Summary
Files the BiometricJWTService challenge bug surfaced during the mobile attestation thread (FinAegis/finaegis-mobile PR #321). When \`MOBILE_ATTESTATION_ENABLED\` is eventually flipped to \`true\`:
- iOS verification will always fail because BiometricJWTService passes \`''\` as challenge to AppleAttestationVerifier, and the verifier looks for SHA-256("") inside the attestation
- Android's GoogleIntegrityVerifier currently has no challenge handling at all

Mobile already sends a 32-byte random hex challenge alongside the attestation. Backend just doesn't extract or use it.

## Why now
This is a "must fix before flag flip" item. Documenting it in code (rather than a Linear ticket or memory note) means anyone toggling the flag in the future hits the warning at exactly the right moment. Two strategically placed comments:
- \`config/mobile.php\` — warning above the flag itself, so anyone editing \`MOBILE_ATTESTATION_ENABLED\` sees it
- \`BiometricJWTService.php\` — full method docblock explaining what's broken + the 3-step fix path, plus a one-line FIXME at the actual bug site

No functional changes. No tests added (nothing to test — the call site is dead code while the flag is off).

## Test plan
- [x] PHPStan clean (verified locally)
- [ ] CI green
- [ ] Reviewer can read both comments and follow the fix path without needing context from this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)