### PR TITLE
ci: add mcp-release.yml to publish @finaegis/mcp on mcp-v* tag

### DIFF
--- a/.github/workflows/mcp-release.yml
+++ b/.github/workflows/mcp-release.yml
@@ -1,0 +1,65 @@
+name: FinAegis MCP Stdio Wrapper Release
+
+on:
+  push:
+    tags:
+      - 'mcp-v*'
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish @finaegis/mcp to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # sigstore provenance
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+          cache-dependency-path: packages/finaegis-mcp-stdio/package-lock.json
+
+      - name: Verify tag matches package.json version
+        working-directory: packages/finaegis-mcp-stdio
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          TAG_VERSION="${REF#refs/tags/mcp-v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag mcp-v${TAG_VERSION} does not match package.json version ${PKG_VERSION}"
+            exit 1
+          fi
+          echo "Publishing version ${TAG_VERSION}"
+
+      - name: Install dependencies (skip native builds)
+        working-directory: packages/finaegis-mcp-stdio
+        run: npm ci --ignore-scripts
+
+      - name: Build
+        working-directory: packages/finaegis-mcp-stdio
+        run: npm run build
+
+      - name: Publish to npm (with provenance)
+        working-directory: packages/finaegis-mcp-stdio
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Summary
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          VERSION="${REF#refs/tags/mcp-v}"
+          {
+            echo "## @finaegis/mcp v${VERSION} Published"
+            echo ""
+            echo "Install: \`npx -y @finaegis/mcp@${VERSION}\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/mcp-release.yml` so that `git push origin mcp-v*` actually publishes `@finaegis/mcp` to npm.
- Without this, the existing `monorepo-split.yml` only mirrors the package source into `FinAegis/mcp` — nothing ever calls `npm publish`. The plan assumed the publish workflow lived "in the mirror," but the established pattern (e.g. `cli-release.yml`) is to keep release workflows in this monorepo where `NPM_TOKEN` already lives.

## What it does

On a `mcp-v*` tag push:
1. Checks out the repo and sets up Node 20 with the npm registry.
2. **Version guard** — fails fast if `package.json` version doesn't match the tag (`mcp-v0.1.0` ↔ `0.1.0`).
3. `npm ci --ignore-scripts` — skips `keytar`'s native build on the runner. Publishing only needs to run `tsc`; end users get the prebuilt binary via `prebuild-install` when they actually install the package.
4. `npm run build` (tsc).
5. `npm publish --access public --provenance` — sigstore provenance via `id-token: write`.

Uses `env: REF: \${{ github.ref }}` indirection in the two `run:` steps that read the tag, per the workflow-injection guide.

## After this merges

I still need to:
- `gh repo create FinAegis/mcp --public` so `monorepo-split.yml` has a destination.
- `git tag mcp-v0.1.0 && git push origin mcp-v0.1.0` — both workflows then fire (split mirrors source, mcp-release publishes to npm).

## Test plan

- [x] Workflow file lints (YAML valid, no shell issues, env-var indirection used).
- [ ] CI on this PR passes (only static checks run on a non-tag push — the publish job won't fire here).
- [ ] After merge + tag, verify `https://www.npmjs.com/package/@finaegis/mcp` shows `0.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)