### PR TITLE
fix(test): isolate BackpressureHandlerTest from parallel cache contamination

### DIFF
--- a/tests/Unit/Domain/Shared/EventSourcing/BackpressureHandlerTest.php
+++ b/tests/Unit/Domain/Shared/EventSourcing/BackpressureHandlerTest.php
@@ -18,6 +18,11 @@ class BackpressureHandlerTest extends TestCase
     {
         parent::setUp();
 
+        // Per-process in-memory cache so parallel runs can't wipe each other's
+        // pause keys (Cache::flush below + writes in the handler share the
+        // default driver across processes otherwise).
+        config()->set('cache.default', 'array');
+
         config()->set('event-streaming.prefix', 'test:events');
         config()->set('event-streaming.consumer_group', 'test-consumers');
         config()->set('event-streaming.backpressure.warning_threshold', 1000);


### PR DESCRIPTION
## Summary

- BackpressureHandlerTest's `setUp()` calls `Cache::flush()` against the default cache driver. CI runs Pest with `--parallel 2`, so two test processes share that driver. When process B flushes the cache mid-execution of process A, process A's just-written `event-streaming:paused:account` key disappears, and the next `Cache::has(...)` returns false.
- This caused the `Failed asserting that false is true` failure on PR #980 (and intermittently elsewhere — see context).

## What it does

Adds one line to `setUp()`:

```php
config()->set('cache.default', 'array');
```

The `array` driver is per-process in-memory, so writes and `flush()` calls in this test stay local to whichever Pest worker is running it. Two parallel workers can no longer step on each other.

## Why this fix

Matches the existing project pattern (CLAUDE.md memory): _"Parallel cache tests: Use `config(['cache.default' => 'array'])` to avoid cross-process interference"_. Same fix has been applied to other parallel-flaky tests in this repo before.

## Context — recent Unit Tests flakes

- PR #978 (PHPCS code-style change): different flake (`AiLlmUsage::it_calculates_provider_statistics`, `2 !== 3`)
- PR #979 (Phase 5 docs): same `AiLlmUsage` flake — retry-only-failed cleared it
- PR #980 (this workflow PR): **the one this PR fixes** — `BackpressureHandlerTest > pause consumer stores pause info`

The `AiLlmUsage` flake is a separate root cause (database, not cache) and isn't fixed here. If it surfaces again, that's the next investigation.

## Test plan

- [x] `./vendor/bin/pest tests/Unit/Domain/Shared/EventSourcing/BackpressureHandlerTest.php` — 14/14 pass, 51 assertions, single-process locally.
- [ ] CI on this PR — full Unit Tests parallel run goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)