### PR TITLE
fix(@finaegis/mcp): add repository/homepage/bugs to package.json

### DIFF
--- a/packages/finaegis-mcp-stdio/package.json
+++ b/packages/finaegis-mcp-stdio/package.json
@@ -9,6 +9,15 @@
   },
   "main": "./dist/index.js",
   "files": ["dist", "README.md"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FinAegis/core-banking-prototype-laravel.git",
+    "directory": "packages/finaegis-mcp-stdio"
+  },
+  "homepage": "https://finaegis.org/features/mcp",
+  "bugs": {
+    "url": "https://github.com/FinAegis/core-banking-prototype-laravel/issues"
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w",


### PR DESCRIPTION
## Summary

The `mcp-v0.1.0` publish failed with:

\`\`\`
npm error 422 ... package.json: "repository.url" is "", expected to match
"https://github.com/FinAegis/core-banking-prototype-laravel" from provenance
\`\`\`

Sigstore provenance signs the GitHub Actions build origin and refuses to publish unless `package.json` declares the same source repo. Adding the canonical pointer (matching `cli-release.yml`'s generated form), plus `homepage` and `bugs`.

Nothing reached npm — the 422 is pre-upload — so the version stays at `0.1.0`. After this merges, the next steps are:

1. Delete the old `mcp-v0.1.0` tag (local + remote).
2. Re-tag at the new HEAD.
3. Both workflows fire again. (Note: the mirror split also failed on the first run with `403 Permission to FinAegis/mcp.git denied to YOzaz` — `MIRROR_PAT` needs `FinAegis/mcp` added to its repository allowlist. Tracked separately.)

## Test plan

- [x] `package.json` is valid JSON, formatting matches the surrounding file.
- [ ] CI green on this PR (no functional code paths touched).
- [ ] After merge + retag, npm registry shows `@finaegis/mcp@0.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)