### PR TITLE
fix(test): isolate DemoHsmProviderTest from parallel cache contamination

### DIFF
--- a/tests/Unit/Domain/KeyManagement/HSM/DemoHsmProviderTest.php
+++ b/tests/Unit/Domain/KeyManagement/HSM/DemoHsmProviderTest.php
@@ -9,6 +9,10 @@ uses(Tests\TestCase::class);
 
 describe('DemoHsmProvider', function () {
     beforeEach(function () {
+        // Per-process in-memory cache so parallel runs can't wipe each other's
+        // stored secrets (Cache::flush below + writes in the provider share
+        // the default driver across processes otherwise).
+        config()->set('cache.default', 'array');
         Cache::flush();
         $this->provider = new DemoHsmProvider();
     });


### PR DESCRIPTION
## Summary

Hit on PR #982. Same root cause as `BackpressureHandlerTest` (#981): the `beforeEach` calls `Cache::flush()` against the shared default cache driver, and Pest's `--parallel 2` lets a second worker wipe stored secrets while another test is mid-assertion.

\`\`\`
✗ DemoHsmProvider > storage > it deletes secrets
  Failed asserting that false is true.
\`\`\`

\`\`\`php
$deleted = $this->provider->delete($secretId);  // false — key already
                                                // wiped by another worker
\`\`\`

## Fix

One line per project pattern (CLAUDE.md): set `cache.default` to `array` so the provider's writes and `flush()` stay process-local.

\`\`\`php
config()->set('cache.default', 'array');
\`\`\`

9/9 pass locally.

## Note: systemic issue

Grep'd `tests/Unit/` for `Cache::flush()` — **49 files use it, only 6 already have the array guard**. The other 43 are at-risk for the same flake. A scheduled cleanup PR will sweep them all in one go (we can't sweep them inline without scope-creeping the MCP launch).

## Test plan

- [x] `./vendor/bin/pest tests/Unit/Domain/KeyManagement/HSM/DemoHsmProviderTest.php` — 9/9 pass.
- [ ] CI on this PR — Unit Tests parallel run goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)