### PR TITLE
feat(@finaegis/mcp): file token-store fallback when OS keychain unavailable

### DIFF
--- a/packages/finaegis-mcp-stdio/README.md
+++ b/packages/finaegis-mcp-stdio/README.md
@@ -20,7 +20,9 @@ Add to `claude_desktop_config.json`:
 }
 ```
 
-First launch opens a browser for OAuth consent. The token is stored in your OS keychain. Subsequent launches are silent.
+First launch opens a browser for OAuth consent. The token is stored in your OS keychain (macOS Keychain, Windows Credential Manager, or Linux libsecret/gnome-keyring). Subsequent launches are silent.
+
+If the OS keychain is unavailable — common on **WSL2, Docker, Alpine, and headless Linux** — the relay automatically falls back to a file at `$XDG_CONFIG_HOME/finaegis-mcp/tokens.json` with permissions `0600` (read/write for the owning user only). The file is plain JSON, not encrypted at rest. A one-line warning is printed to stderr the first time this happens.
 
 ## Environment overrides
 
@@ -28,9 +30,11 @@ First launch opens a browser for OAuth consent. The token is stored in your OS k
 |---|---|
 | `MCP_SERVER_URL` | `https://mcp.zelta.app/mcp` |
 | `MCP_AUTH_SERVER` | `https://zelta.app` |
-| `MCP_TOKEN_PATH` | OS keychain via `keytar` |
+| `MCP_OAUTH_NO_BROWSER` | unset — set to `1` to print the auth URL instead of opening a browser |
+| `FINAEGIS_MCP_TOKEN_STORE` | auto — set to `file` to force the file store, or `keychain` to require the OS keychain (errors if missing) |
 
 ## Troubleshooting
 
 - **Browser does not open** — set `MCP_OAUTH_NO_BROWSER=1` and follow the URL printed to stderr.
-- **Token expired** — delete the keychain entry: `npx @finaegis/mcp --logout`.
+- **Token expired** — log out and re-auth: `npx @finaegis/mcp --logout`.
+- **`libsecret-1.so.0: cannot open shared object file`** — the keychain backend can't load. The relay handles this automatically and falls back to the file store; you can also force it with `FINAEGIS_MCP_TOKEN_STORE=file`.

--- a/packages/finaegis-mcp-stdio/package-lock.json
+++ b/packages/finaegis-mcp-stdio/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "@finaegis/mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@finaegis/mcp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "keytar": "^7.9.0",
         "open": "^10.1.0",
         "undici": "^6.21.0"
       },
@@ -24,6 +23,9 @@
       },
       "engines": {
         "node": ">=20"
+      },
+      "optionalDependencies": {
+        "keytar": "^7.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1030,13 +1032,15 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -1086,6 +1090,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -1185,7 +1190,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/content-disposition": {
       "version": "1.1.0",
@@ -1280,6 +1286,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -1305,6 +1312,7 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -1363,6 +1371,7 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -1401,6 +1410,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -1532,6 +1542,7 @@
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "license": "(MIT OR WTFPL)",
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -1672,7 +1683,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1739,7 +1751,8 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -1840,7 +1853,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -1852,7 +1866,8 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
@@ -1959,6 +1974,7 @@
       "integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "node-addon-api": "^4.3.0",
         "prebuild-install": "^7.0.1"
@@ -2041,6 +2057,7 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -2053,6 +2070,7 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "license": "MIT",
+      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2061,7 +2079,8 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -2092,7 +2111,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -2108,6 +2128,7 @@
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
       "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -2119,7 +2140,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
       "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -2277,6 +2299,7 @@
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
       "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -2316,6 +2339,7 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -2365,6 +2389,7 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -2380,6 +2405,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -2489,7 +2515,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -2502,6 +2529,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
+      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2678,7 +2706,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
@@ -2699,6 +2728,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -2743,6 +2773,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -2752,6 +2783,7 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2761,6 +2793,7 @@
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
       "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -2773,6 +2806,7 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -2842,6 +2876,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -2906,7 +2941,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/packages/finaegis-mcp-stdio/package.json
+++ b/packages/finaegis-mcp-stdio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finaegis/mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Stdio-to-remote relay for the Zelta MCP server. Lets stdio-only MCP clients (Claude Desktop, Cursor, Continue.dev) connect to https://mcp.zelta.app/mcp.",
   "license": "Apache-2.0",
   "type": "module",
@@ -29,9 +29,11 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "keytar": "^7.9.0",
     "open": "^10.1.0",
     "undici": "^6.21.0"
+  },
+  "optionalDependencies": {
+    "keytar": "^7.9.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/finaegis-mcp-stdio/src/oauth-helper.ts
+++ b/packages/finaegis-mcp-stdio/src/oauth-helper.ts
@@ -1,9 +1,9 @@
 import { createServer, IncomingMessage, ServerResponse } from 'node:http';
 import { randomBytes, createHash } from 'node:crypto';
 import { fetch } from 'undici';
-import keytar from 'keytar';
 import open from 'open';
 import { RelayConfig } from './config.js';
+import { getTokenStore } from './token-store.js';
 
 interface TokenSet {
   access_token: string;
@@ -65,12 +65,14 @@ export class OAuthHelper {
   }
 
   async logout(): Promise<void> {
-    await keytar.deletePassword(this.cfg.keychainService, this.cfg.keychainAccount);
-    await keytar.deletePassword(this.cfg.keychainService, this.cfg.keychainAccount + '.dcr');
+    const store = await getTokenStore();
+    await store.delete(this.cfg.keychainService, this.cfg.keychainAccount);
+    await store.delete(this.cfg.keychainService, this.cfg.keychainAccount + '.dcr');
   }
 
   private async readToken(): Promise<TokenSet | null> {
-    const raw = await keytar.getPassword(this.cfg.keychainService, this.cfg.keychainAccount);
+    const store = await getTokenStore();
+    const raw = await store.get(this.cfg.keychainService, this.cfg.keychainAccount);
     if (!raw) return null;
     try {
       return JSON.parse(raw) as TokenSet;
@@ -80,7 +82,8 @@ export class OAuthHelper {
   }
 
   private async writeToken(t: TokenSet): Promise<void> {
-    await keytar.setPassword(this.cfg.keychainService, this.cfg.keychainAccount, JSON.stringify(t));
+    const store = await getTokenStore();
+    await store.set(this.cfg.keychainService, this.cfg.keychainAccount, JSON.stringify(t));
   }
 
   private async refresh(refreshToken: string): Promise<TokenSet | null> {
@@ -225,7 +228,8 @@ export class OAuthHelper {
    * under a separate account.
    */
   private async dcrIfNeeded(): Promise<ClientCreds> {
-    const stored = await keytar.getPassword(this.cfg.keychainService, this.cfg.keychainAccount + '.dcr');
+    const store = await getTokenStore();
+    const stored = await store.get(this.cfg.keychainService, this.cfg.keychainAccount + '.dcr');
     if (stored) {
       try {
         return JSON.parse(stored) as ClientCreds;
@@ -247,7 +251,7 @@ export class OAuthHelper {
       throw new Error(`DCR failed: ${res.status} ${await res.text()}`);
     }
     const data = (await res.json()) as ClientCreds;
-    await keytar.setPassword(this.cfg.keychainService, this.cfg.keychainAccount + '.dcr', JSON.stringify(data));
+    await store.set(this.cfg.keychainService, this.cfg.keychainAccount + '.dcr', JSON.stringify(data));
     return data;
   }
 }

--- a/packages/finaegis-mcp-stdio/src/token-store.ts
+++ b/packages/finaegis-mcp-stdio/src/token-store.ts
@@ -1,0 +1,140 @@
+import { promises as fs } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+// Mirrors the keytar surface we actually use, so the rest of the wrapper
+// doesn't have to know which backend is in play.
+export interface TokenStore {
+  get(service: string, account: string): Promise<string | null>;
+  set(service: string, account: string, value: string): Promise<void>;
+  delete(service: string, account: string): Promise<void>;
+  readonly kind: 'keychain' | 'file';
+}
+
+let cached: TokenStore | undefined;
+
+export async function getTokenStore(): Promise<TokenStore> {
+  if (cached) return cached;
+
+  const force = process.env.FINAEGIS_MCP_TOKEN_STORE;
+  if (force === 'file') {
+    cached = createFileStore();
+    return cached;
+  }
+  if (force === 'keychain') {
+    cached = await tryKeychainOrThrow();
+    return cached;
+  }
+
+  // Default: prefer the OS keychain, fall back to a file if it's not viable
+  // (libsecret missing on WSL2 / Alpine / Docker, no D-Bus session, etc.).
+  const keychain = await tryKeychain();
+  if (keychain) {
+    cached = keychain;
+    return cached;
+  }
+
+  const fallback = createFileStore();
+  process.stderr.write(
+    `[@finaegis/mcp] OS keychain unavailable; falling back to file store at ${fallback.path}.\n` +
+      `[@finaegis/mcp] Set FINAEGIS_MCP_TOKEN_STORE=keychain to require the keychain (will error if missing).\n`,
+  );
+  cached = fallback;
+  return cached;
+}
+
+async function tryKeychain(): Promise<TokenStore | null> {
+  try {
+    return await loadKeychainStore();
+  } catch {
+    return null;
+  }
+}
+
+async function tryKeychainOrThrow(): Promise<TokenStore> {
+  return loadKeychainStore();
+}
+
+interface KeytarLike {
+  getPassword(service: string, account: string): Promise<string | null>;
+  setPassword(service: string, account: string, value: string): Promise<void>;
+  deletePassword(service: string, account: string): Promise<boolean>;
+  findCredentials(service: string): Promise<{ account: string; password: string }[]>;
+}
+
+async function loadKeychainStore(): Promise<TokenStore> {
+  // Dynamic import so a missing libsecret / D-Bus session surfaces as a
+  // catchable error here instead of crashing module load.
+  const mod = (await import('keytar')) as { default?: KeytarLike } & KeytarLike;
+  const keytar: KeytarLike = mod.default ?? mod;
+  // Round-trip a no-op call so libsecret/D-Bus problems surface here, not on
+  // the first real getPassword later.
+  await keytar.findCredentials('finaegis-mcp.healthcheck');
+  return {
+    kind: 'keychain',
+    get: (service, account) => keytar.getPassword(service, account),
+    set: (service, account, value) => keytar.setPassword(service, account, value),
+    delete: async (service, account) => {
+      await keytar.deletePassword(service, account);
+    },
+  };
+}
+
+interface FileStore extends TokenStore {
+  readonly path: string;
+}
+
+function createFileStore(): FileStore {
+  const baseDir = configBaseDir();
+  const dir = path.join(baseDir, 'finaegis-mcp');
+  const file = path.join(dir, 'tokens.json');
+
+  const read = async (): Promise<Record<string, string>> => {
+    try {
+      const raw = await fs.readFile(file, 'utf8');
+      return JSON.parse(raw) as Record<string, string>;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return {};
+      throw err;
+    }
+  };
+
+  const write = async (data: Record<string, string>): Promise<void> => {
+    await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+    const tmp = `${file}.tmp`;
+    await fs.writeFile(tmp, JSON.stringify(data, null, 2), { mode: 0o600 });
+    await fs.rename(tmp, file);
+  };
+
+  const key = (service: string, account: string): string => `${service}::${account}`;
+
+  return {
+    kind: 'file',
+    path: file,
+    async get(service, account) {
+      const data = await read();
+      return data[key(service, account)] ?? null;
+    },
+    async set(service, account, value) {
+      const data = await read();
+      data[key(service, account)] = value;
+      await write(data);
+    },
+    async delete(service, account) {
+      const data = await read();
+      delete data[key(service, account)];
+      await write(data);
+    },
+  };
+}
+
+function configBaseDir(): string {
+  if (process.env.XDG_CONFIG_HOME) return process.env.XDG_CONFIG_HOME;
+  if (process.platform === 'win32' && process.env.APPDATA) return process.env.APPDATA;
+  return path.join(homedir(), '.config');
+}
+
+// Test hook so config tests can reset between cases.
+export function _resetTokenStoreForTesting(): void {
+  cached = undefined;
+}

--- a/packages/finaegis-mcp-stdio/test/token-store.test.ts
+++ b/packages/finaegis-mcp-stdio/test/token-store.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { getTokenStore, _resetTokenStoreForTesting } from '../src/token-store.js';
+
+describe('token-store file backend', () => {
+  let dir: string;
+  const originalConfigHome = process.env.XDG_CONFIG_HOME;
+  const originalForce = process.env.FINAEGIS_MCP_TOKEN_STORE;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(tmpdir(), 'finaegis-mcp-test-'));
+    process.env.XDG_CONFIG_HOME = dir;
+    process.env.FINAEGIS_MCP_TOKEN_STORE = 'file';
+    _resetTokenStoreForTesting();
+  });
+
+  afterEach(async () => {
+    process.env.XDG_CONFIG_HOME = originalConfigHome;
+    process.env.FINAEGIS_MCP_TOKEN_STORE = originalForce;
+    _resetTokenStoreForTesting();
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('returns null when no entry exists', async () => {
+    const store = await getTokenStore();
+    expect(store.kind).toBe('file');
+    expect(await store.get('svc', 'acct')).toBeNull();
+  });
+
+  it('round-trips a value', async () => {
+    const store = await getTokenStore();
+    await store.set('svc', 'acct', 'hello');
+    expect(await store.get('svc', 'acct')).toBe('hello');
+  });
+
+  it('keeps separate accounts independent', async () => {
+    const store = await getTokenStore();
+    await store.set('svc', 'a', 'one');
+    await store.set('svc', 'b', 'two');
+    expect(await store.get('svc', 'a')).toBe('one');
+    expect(await store.get('svc', 'b')).toBe('two');
+  });
+
+  it('delete removes the entry', async () => {
+    const store = await getTokenStore();
+    await store.set('svc', 'acct', 'hello');
+    await store.delete('svc', 'acct');
+    expect(await store.get('svc', 'acct')).toBeNull();
+  });
+
+  it('persists across calls (re-reads file)', async () => {
+    const first = await getTokenStore();
+    await first.set('svc', 'acct', 'persisted');
+    _resetTokenStoreForTesting();
+
+    const second = await getTokenStore();
+    expect(await second.get('svc', 'acct')).toBe('persisted');
+  });
+
+  it('writes file with 0600 mode', async () => {
+    if (process.platform === 'win32') return; // Windows has no POSIX modes.
+
+    const store = await getTokenStore();
+    await store.set('svc', 'acct', 'whatever');
+    const file = path.join(dir, 'finaegis-mcp', 'tokens.json');
+    const stat = await fs.stat(file);
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+});


### PR DESCRIPTION
## Summary

`v0.1.0` crashes immediately on **WSL2, Alpine, Docker, headless Linux, and any environment without libsecret + a running D-Bus secret service**:

\`\`\`
Error: libsecret-1.so.0: cannot open shared object file: No such file or directory
    at Object..node (node:internal/modules/cjs/loader:1864:18)
    at Object.<anonymous> (.../keytar/lib/keytar.js:1:14)
\`\`\`

`keytar` was imported eagerly at the top of `oauth-helper.ts`, so the `require()` itself blew up before any code ran. Found while running `npx -y @finaegis/mcp` for the manual smoke test.

## What changed

**New `TokenStore` abstraction (`src/token-store.ts`)** with two backends:

- **keychain** — lazy-loads `keytar` via dynamic `import()` inside try/catch. A no-op `findCredentials()` healthcheck surfaces `libsecret`/D-Bus errors at the abstraction boundary instead of letting them propagate to the first real `getPassword` call.
- **file** — writes JSON to `$XDG_CONFIG_HOME/finaegis-mcp/tokens.json` (or `%APPDATA%/finaegis-mcp/tokens.json` on Windows). Atomic write via temp + rename. Mode `0600` on the file, `0700` on the directory.

Detection runs once on first `getTokenStore()` call and is cached for the rest of the process. Default behavior:

1. Try keychain. If it loads cleanly, use it.
2. Otherwise fall back to file, with a one-line stderr warning naming the file path and the override env var.

Override:

| `FINAEGIS_MCP_TOKEN_STORE` | Behavior |
|---|---|
| unset (default) | Auto-detect: keychain if available, else file. |
| `file` | Force file backend; never touch keytar. |
| `keychain` | Require keychain; throw if unavailable. |

**`keytar` moved to `optionalDependencies`** so `npm install` on minimal Linux containers succeeds even when prebuild download / native build fails.

## Why this design

- File store is plain JSON with `0600` perms — _not_ encrypted at rest. README is explicit about this. Token has a 30-day server-side TTL so blast radius is bounded; this matches the model used by `kubectl`, `gcloud`, and `gh` CLI for their tokens.
- Keychain stays default to preserve the encryption-at-rest property for the platforms where it works.
- Lazy import + healthcheck means a misconfigured Linux box doesn't even pay the cost of loading the native binary in the failure case — the dynamic import either succeeds quickly or fails before any state is held.

## Test plan

- [x] `npm test` — 10/10 pass (4 existing + 6 new file-backend tests including `0600` mode check).
- [x] `npm run build` — clean.
- [x] Manual smoke: `FINAEGIS_MCP_TOKEN_STORE=file node -e ...` returns `kind: 'file'`. Default (no env var) on this WSL2 box auto-falls-back to file with the expected stderr warning.
- [ ] After merge + `mcp-v0.1.1` tag, `npx -y @finaegis/mcp@0.1.1` on WSL2 should reach the OAuth browser flow instead of crashing on keytar.

## Follow-up

Once `0.1.1` lands and the human smoke test passes, deprecate `0.1.0` on npm with `npm deprecate @finaegis/mcp@0.1.0 "Crashes on Linux without libsecret; upgrade to 0.1.1+"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)