### PR TITLE
feat(@finaegis/mcp): --login flag + always-print authorization URL

### DIFF
--- a/packages/finaegis-mcp-stdio/README.md
+++ b/packages/finaegis-mcp-stdio/README.md
@@ -2,15 +2,23 @@
 
 Connect Claude Desktop, Cursor, or Continue.dev to **Zelta** via the Model Context Protocol.
 
-## Install
+## First-time login
 
 ```bash
-npx -y @finaegis/mcp
+npx -y @finaegis/mcp --login
+```
+
+This prints an authorization URL to the terminal and (where possible) opens it in your browser. After you complete consent, the token is persisted and the wrapper exits. You can re-run `--login` at any time to refresh credentials.
+
+On Linux without `libsecret` (WSL2, Docker, Alpine, headless servers), set `NPM_CONFIG_OMIT=optional` to skip installing the native `keytar` dependency:
+
+```bash
+NPM_CONFIG_OMIT=optional npx -y @finaegis/mcp@0.1.2 --login
 ```
 
 ## Configure (Claude Desktop)
 
-Add to `claude_desktop_config.json`:
+Once logged in, add to `claude_desktop_config.json`:
 
 ```json
 {
@@ -20,7 +28,21 @@ Add to `claude_desktop_config.json`:
 }
 ```
 
-First launch opens a browser for OAuth consent. The token is stored in your OS keychain (macOS Keychain, Windows Credential Manager, or Linux libsecret/gnome-keyring). Subsequent launches are silent.
+On Linux without `libsecret`, include the env var:
+
+```json
+{
+  "mcpServers": {
+    "zelta": {
+      "command": "npx",
+      "args": ["-y", "@finaegis/mcp"],
+      "env": { "NPM_CONFIG_OMIT": "optional" }
+    }
+  }
+}
+```
+
+Tokens are stored in your OS keychain (macOS Keychain, Windows Credential Manager, or Linux libsecret/gnome-keyring) when available. Subsequent launches are silent.
 
 If the OS keychain is unavailable — common on **WSL2, Docker, Alpine, and headless Linux** — the relay automatically falls back to a file at `$XDG_CONFIG_HOME/finaegis-mcp/tokens.json` with permissions `0600` (read/write for the owning user only). The file is plain JSON, not encrypted at rest. A one-line warning is printed to stderr the first time this happens.
 

--- a/packages/finaegis-mcp-stdio/package-lock.json
+++ b/packages/finaegis-mcp-stdio/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@finaegis/mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@finaegis/mcp",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/finaegis-mcp-stdio/package.json
+++ b/packages/finaegis-mcp-stdio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finaegis/mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Stdio-to-remote relay for the Zelta MCP server. Lets stdio-only MCP clients (Claude Desktop, Cursor, Continue.dev) connect to https://mcp.zelta.app/mcp.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/finaegis-mcp-stdio/src/index.ts
+++ b/packages/finaegis-mcp-stdio/src/index.ts
@@ -9,7 +9,19 @@ async function main(): Promise<void> {
 
   if (process.argv.includes('--logout')) {
     await helper.logout();
-    process.stderr.write('Logged out — keychain entry deleted.\n');
+    process.stderr.write('Logged out — credentials deleted.\n');
+
+    return;
+  }
+
+  if (process.argv.includes('--login')) {
+    // Drive the OAuth flow standalone, without waiting for an MCP client to
+    // hand us a stdio request. Useful for first-time setup verification on
+    // WSL2/headless boxes where the user wants to confirm auth works before
+    // wiring the relay into Claude Desktop or another client.
+    process.stderr.write(`Logging in to ${cfg.authServer} for ${cfg.serverUrl}...\n`);
+    await helper.getAccessToken();
+    process.stderr.write('Logged in. You can now configure your MCP client to use this relay.\n');
 
     return;
   }

--- a/packages/finaegis-mcp-stdio/src/oauth-helper.ts
+++ b/packages/finaegis-mcp-stdio/src/oauth-helper.ts
@@ -127,17 +127,20 @@ export class OAuthHelper {
     }).toString();
 
     // Start the loopback server BEFORE opening the browser so we don't race
-    // a fast-clicking user against the bind. open() can throw on headless
-    // systems; if it does, fall back to printing the URL.
+    // a fast-clicking user against the bind.
     const codePromise = this.waitForCode(state);
 
-    if (this.cfg.oauthNoBrowser) {
-      process.stderr.write(`Open this URL to authorize:\n  ${authUrl}\n`);
-    } else {
+    // Always print the URL — on WSL2, Docker, and bare SSH sessions, open()
+    // can return without throwing while no browser actually launches, leaving
+    // the user staring at a silent terminal. Printing first makes the URL
+    // available regardless of what the browser-open call does.
+    process.stderr.write(`Open this URL to authorize:\n  ${authUrl}\n`);
+
+    if (!this.cfg.oauthNoBrowser) {
       try {
         await open(authUrl);
       } catch {
-        process.stderr.write(`Could not open browser. Open this URL manually:\n  ${authUrl}\n`);
+        // Browser open failed — the URL is already printed above.
       }
     }
 


### PR DESCRIPTION
## Summary

`v0.1.1` relay sits idle in interactive terminals because OAuth only fires when an MCP client sends a stdio request needing auth. WSL2/headless users had no way to verify auth before configuring Claude Desktop, and silent \`open()\` failures left them staring at a hung terminal with no link.

## What changed

- **`--login` flag**: \`npx -y @finaegis/mcp@0.1.2 --login\` drives the OAuth flow standalone — prints the URL, opens browser when possible, captures callback, persists token, exits.
- **Always print the auth URL to stderr** (not only on browser-open failure). \`open()\` returns without throwing on WSL2 even when no browser launches, so the previous "only print on failure" path silently failed.
- README: front-and-center "First-time login" section with the \`NPM_CONFIG_OMIT=optional\` workaround for the keytar prebuild-install hang on Linux without libsecret.

## Test plan

- [x] \`npm run build\` clean.
- [x] \`npm test\` 10/10 (existing 4 + 6 file-store cases from #984 still pass).
- [x] Smoke: \`node dist/index.js --login\` from a fresh pack/install reaches the DCR endpoint (uncovered an unrelated 419 server-side CSRF bug — separate PR).
- [ ] After merge + tag, \`npx -y @finaegis/mcp@0.1.2 --login\` on WSL2 prints the auth URL to stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)