### PR TITLE
fix(mcp): exempt /oauth/register from CSRF (RFC 7591)

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -866,6 +866,11 @@ Route::get('/.well-known/oauth-authorization-server', App\Domain\MCP\Discovery\A
     ->middleware(['throttle:mcp.discovery'])
     ->name('mcp.discovery.authorization-server');
 
+// RFC 7591 DCR is by design unauthenticated and called by external clients
+// that have no Laravel session, so they cannot carry a CSRF token. Inheriting
+// the `web` group's VerifyCsrfToken middleware (because this route lives in
+// routes/web.php) returns 419 to every legitimate request. Strip CSRF here.
 Route::post('/oauth/register', App\Domain\MCP\Auth\DynamicClientRegistrationController::class)
     ->middleware(['api', 'throttle:5,1'])
+    ->withoutMiddleware([App\Http\Middleware\VerifyCsrfToken::class])
     ->name('mcp.oauth.register');

--- a/tests/Feature/MCP/DcrRegistrationTest.php
+++ b/tests/Feature/MCP/DcrRegistrationTest.php
@@ -27,3 +27,12 @@ it('registers a DCR client and returns credentials', function () {
         'registration_method' => 'dcr',
     ]);
 });
+
+it('excludes VerifyCsrfToken from the DCR route (RFC 7591 — clients have no session)', function () {
+    $route = collect(Illuminate\Support\Facades\Route::getRoutes()->getRoutes())
+        ->firstWhere(fn ($r) => $r->getName() === 'mcp.oauth.register');
+
+    expect($route)->not->toBeNull();
+    expect($route->excludedMiddleware())
+        ->toContain(App\Http\Middleware\VerifyCsrfToken::class);
+});

--- a/tests/Feature/MCP/DcrRegistrationTest.php
+++ b/tests/Feature/MCP/DcrRegistrationTest.php
@@ -32,7 +32,8 @@ it('excludes VerifyCsrfToken from the DCR route (RFC 7591 — clients have no se
     $route = collect(Illuminate\Support\Facades\Route::getRoutes()->getRoutes())
         ->firstWhere(fn ($r) => $r->getName() === 'mcp.oauth.register');
 
-    expect($route)->not->toBeNull();
+    expect($route)->toBeInstanceOf(Illuminate\Routing\Route::class);
+    /** @var Illuminate\Routing\Route $route */
     expect($route->excludedMiddleware())
         ->toContain(App\Http\Middleware\VerifyCsrfToken::class);
 });


### PR DESCRIPTION
## Summary

The DCR endpoint at \`/oauth/register\` is registered in \`routes/web.php\`, which means it inherits the \`web\` middleware group — including \`VerifyCsrfToken\`. Real clients per RFC 7591 don't carry a Laravel session and have no CSRF token to send, so every production POST returned **419 Page Expired**.

Existing \`DcrRegistrationTest\` passed because Pest's \`postJson()\` helper doesn't actually exercise CSRF — that's how this slipped past CI to production.

Surfaced when I ran the new \`--login\` flag (PR #985) against the deployed auth server:

\`\`\`
fatal: Error: DCR failed: 419 ... <title>Page Expired</title>
\`\`\`

## Fix

\`\`\`php
Route::post('/oauth/register', App\Domain\MCP\Auth\DynamicClientRegistrationController::class)
    ->middleware(['api', 'throttle:5,1'])
    ->withoutMiddleware([App\Http\Middleware\VerifyCsrfToken::class])  // <-- added
    ->name('mcp.oauth.register');
\`\`\`

\`->middleware(['api', ...])\` adds API middleware on top but does **not** remove the \`web\` group — so the explicit \`->withoutMiddleware()\` is necessary.

## Regression test

Adds a route-definition assertion that fails fast if the exclusion is dropped:

\`\`\`php
expect($route->excludedMiddleware())
    ->toContain(\App\Http\Middleware\VerifyCsrfToken::class);
\`\`\`

This catches the regression at the route-config layer (where postJson() can't), so a future change moving the route around can't silently re-introduce 419s.

## Test plan

- [x] \`./vendor/bin/pest tests/Feature/MCP/DcrRegistrationTest.php\` — 2/2 pass (existing happy path + new exclusion check).
- [x] \`./vendor/bin/php-cs-fixer fix\` clean.
- [ ] After merge + redeploy, \`npx -y @finaegis/mcp@0.1.2 --login\` from a fresh client gets past DCR.

## Why this is the right fix (vs alternatives)

- **Move route to \`routes/api.php\`** would prefix the URL with \`/api/\` (or require overriding the prefix), breaking the discovery metadata that already advertises \`/oauth/register\`.
- **Add to global \`VerifyCsrfToken\` exclusion list** would split this configuration across two files and make the route's middleware behavior less obvious.
- **Route-level \`->withoutMiddleware()\`** keeps the middleware decision colocated with the route definition and is explicit about the security choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)