### PR TITLE
fix(@finaegis/mcp): use generic client_name + npm client_uri (v0.1.3)

### DIFF
--- a/packages/finaegis-mcp-stdio/package-lock.json
+++ b/packages/finaegis-mcp-stdio/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@finaegis/mcp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@finaegis/mcp",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/finaegis-mcp-stdio/package.json
+++ b/packages/finaegis-mcp-stdio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finaegis/mcp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Stdio-to-remote relay for the Zelta MCP server. Lets stdio-only MCP clients (Claude Desktop, Cursor, Continue.dev) connect to https://mcp.zelta.app/mcp.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/finaegis-mcp-stdio/src/oauth-helper.ts
+++ b/packages/finaegis-mcp-stdio/src/oauth-helper.ts
@@ -244,8 +244,13 @@ export class OAuthHelper {
     const res = await fetch(`${this.cfg.authServer}/oauth/register`, {
       method:  'POST',
       headers: { 'Content-Type': 'application/json' },
+      // RFC 7591 client metadata. client_name is what the user sees on the
+      // consent screen — kept generic so the AS's brand-impersonation
+      // blocklist accepts us. Brand identity is conveyed through client_uri,
+      // which the consent template can render as a verification link.
       body:    JSON.stringify({
-        client_name:   '@finaegis/mcp (stdio)',
+        client_name:   'MCP Stdio Relay',
+        client_uri:    'https://www.npmjs.com/package/@finaegis/mcp',
         redirect_uris: [REDIRECT_URI],
         grant_types:   ['authorization_code', 'refresh_token'],
       }),


### PR DESCRIPTION
## Summary

\`v0.1.2\` DCR fails with 400:

\`\`\`
invalid_client_metadata: client_name contains reserved keyword 'finaegis' —
use a name that doesn't impersonate a known brand
\`\`\`

The wrapper sent \`client_name: '@finaegis/mcp (stdio)'\`. The auth server's blocklist (\`MCP_DCR_RESERVED_NAMES\` in \`config/mcp.php\`) blocks any name containing \`finaegis\`, \`zelta\`, \`anthropic\`, \`stripe\`, etc. — a deliberate defense against future 3rd-party MCP clients impersonating official software on the consent screen.

The blocklist is correct as a security boundary; we just need the first-party wrapper not to trip it.

## Fix

| Field | Before | After |
|---|---|---|
| \`client_name\` | \`@finaegis/mcp (stdio)\` | \`MCP Stdio Relay\` |
| \`client_uri\` | _(not sent)\` | \`https://www.npmjs.com/package/@finaegis/mcp\` |

Brand identity now travels through \`client_uri\` (RFC 7591 §2 — "URL of the home page of the client"). The consent template can render it as a clickable verification link so users can confirm the package is the official one.

This is the standard pattern: \`gh\`, \`gcloud\`, \`aws\`, \`stripe-cli\` all use generic descriptors on their consent screens with brand identity in the URL.

## Test plan

- [x] \`npm test\` 10/10 pass.
- [x] \`npm run build\` clean.
- [ ] After merge + tag, \`npx -y @finaegis/mcp@0.1.3 --login\` on WSL2 reaches the OAuth browser flow without a 400 from DCR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)