### PR TITLE
fix(@finaegis/mcp): hide keytar from tsc resolution (v0.1.5)

### DIFF
--- a/packages/finaegis-mcp-stdio/package-lock.json
+++ b/packages/finaegis-mcp-stdio/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@finaegis/mcp",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@finaegis/mcp",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/finaegis-mcp-stdio/package.json
+++ b/packages/finaegis-mcp-stdio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finaegis/mcp",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Stdio-to-remote relay for the Zelta MCP server. Lets stdio-only MCP clients (Claude Desktop, Cursor, Continue.dev) connect to https://mcp.zelta.app/mcp.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/finaegis-mcp-stdio/src/token-store.ts
+++ b/packages/finaegis-mcp-stdio/src/token-store.ts
@@ -43,7 +43,13 @@ async function loadKeychainStore(): Promise<TokenStore> {
   // backend can `npm i -g keytar` and set FINAEGIS_MCP_TOKEN_STORE=keychain.
   let mod: { default?: KeytarLike } & KeytarLike;
   try {
-    mod = (await import('keytar')) as { default?: KeytarLike } & KeytarLike;
+    // keytar is intentionally not declared as a (optional)Dependency from
+    // 0.1.4 onward — its native build hangs `npx` installs on common
+    // environments. Users opt in by `npm i -g keytar`. The dynamic specifier
+    // hides the import from TS resolution, which would otherwise fail in CI
+    // where keytar isn't in node_modules at build time.
+    const specifier = 'keytar';
+    mod = (await import(specifier)) as { default?: KeytarLike } & KeytarLike;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ERR_MODULE_NOT_FOUND' || (err as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND') {
       throw new Error(


### PR DESCRIPTION
## Summary
v0.1.4's CI publish failed: \`tsc\` couldn't resolve \`keytar\` because we removed it from \`package.json\` but the source still had a static \`await import('keytar')\`. Hide the specifier behind a string variable so TS skips resolution. Runtime path unchanged.

## Why this slipped through
Locally the build passed because my \`node_modules\` still had keytar from before the removal. \`npm ci\` on a fresh runner exposes the issue.

## Test plan
- [x] \`rm -rf node_modules && npm ci && npm run build && npm test\` — clean, 10/10 pass with no keytar present
- [ ] Tag \`mcp-v0.1.5\` after merge → publish workflow succeeds → \`npx -y @finaegis/mcp@0.1.5 --login\` resolves on WSL2

🤖 Generated with [Claude Code](https://claude.com/claude-code)