### PR TITLE
fix(oauth): widen client_id columns to UUID for Passport v13

### DIFF
--- a/database/migrations/2026_04_29_000001_oauth_client_id_uuid_columns.php
+++ b/database/migrations/2026_04_29_000001_oauth_client_id_uuid_columns.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Widens the client_id foreign-key columns to UUID to match the
+ * oauth_clients.id type adopted in 2026_04_28_000004 (Passport v13).
+ *
+ * Without this, MariaDB silently coerces UUIDs like "019ddaae-8521-..." into
+ * a leading-digit integer and emits "Data truncated for column 'client_id'"
+ * during the OAuth authorization-code grant. There are no in-flight rows to
+ * preserve — OAuth was functionally inert prior to v13 (see the recreation
+ * comment in 2026_04_28_000004).
+ */
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('oauth_auth_codes', function (Blueprint $table) {
+            $table->uuid('client_id')->change();
+        });
+
+        Schema::table('oauth_access_tokens', function (Blueprint $table) {
+            $table->uuid('client_id')->change();
+        });
+
+        Schema::table('oauth_personal_access_clients', function (Blueprint $table) {
+            $table->uuid('client_id')->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('oauth_auth_codes', function (Blueprint $table) {
+            $table->unsignedBigInteger('client_id')->change();
+        });
+
+        Schema::table('oauth_access_tokens', function (Blueprint $table) {
+            $table->unsignedBigInteger('client_id')->change();
+        });
+
+        Schema::table('oauth_personal_access_clients', function (Blueprint $table) {
+            $table->unsignedBigInteger('client_id')->change();
+        });
+    }
+
+    public function getConnection(): ?string
+    {
+        return $this->connection ?? config('passport.connection');
+    }
+};

--- a/tests/Feature/MCP/OAuthAuthCodeSchemaTest.php
+++ b/tests/Feature/MCP/OAuthAuthCodeSchemaTest.php
@@ -34,7 +34,7 @@ it('round-trips a UUID client_id through oauth_auth_codes without truncation', f
 
     $row = DB::table('oauth_auth_codes')->first();
     expect($row)->not->toBeNull();
-    /** @var \stdClass $row */
+    /** @var stdClass $row */
     expect($row->client_id)->toBe($uuid);
 
     DB::table('oauth_auth_codes')->where('id', str_repeat('a', 80))->delete();

--- a/tests/Feature/MCP/OAuthAuthCodeSchemaTest.php
+++ b/tests/Feature/MCP/OAuthAuthCodeSchemaTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+it('stores client_id as a UUID-compatible column on oauth_auth_codes', function () {
+    $type = Schema::getColumnType('oauth_auth_codes', 'client_id');
+    expect($type)->toBe('varchar');
+});
+
+it('stores client_id as a UUID-compatible column on oauth_access_tokens', function () {
+    $type = Schema::getColumnType('oauth_access_tokens', 'client_id');
+    expect($type)->toBe('varchar');
+});
+
+it('stores client_id as a UUID-compatible column on oauth_personal_access_clients', function () {
+    $type = Schema::getColumnType('oauth_personal_access_clients', 'client_id');
+    expect($type)->toBe('varchar');
+});
+
+it('round-trips a UUID client_id through oauth_auth_codes without truncation', function () {
+    $uuid = '019ddaae-8521-7126-97be-8a2120715a7b';
+
+    DB::table('oauth_auth_codes')->insert([
+        'id'         => str_repeat('a', 80),
+        'user_id'    => 1,
+        'client_id'  => $uuid,
+        'scopes'     => '[]',
+        'revoked'    => 0,
+        'expires_at' => now()->addMinutes(10),
+    ]);
+
+    $row = DB::table('oauth_auth_codes')->first();
+    expect($row)->not->toBeNull();
+    /** @var \stdClass $row */
+    expect($row->client_id)->toBe($uuid);
+
+    DB::table('oauth_auth_codes')->where('id', str_repeat('a', 80))->delete();
+});


### PR DESCRIPTION
## Root cause
The Passport v13 migration (2026_04_28_000004) recreated \`oauth_clients.id\` as a UUID but didn't touch the foreign-keying \`client_id\` columns on the related tables. They stayed as \`unsignedBigInteger\` from the original 2024 schema.

When DCR issued a UUID client_id and the user approved consent, MariaDB silently coerced the UUID into a leading-digit integer and emitted \`Data truncated for column 'client_id'\`. The OAuth approve endpoint 500'd, blocking \`@finaegis/mcp\` login.

\`\`\`
SQLSTATE[01000]: Warning: 1265 Data truncated for column 'client_id' at row 1
SQL: insert into oauth_auth_codes (..., client_id, ...) values (..., 019ddaae-8521-7126-97be-8a2120715a7b, ...)
\`\`\`

## Fix
Change \`client_id\` to \`uuid\` on:
- \`oauth_auth_codes\`
- \`oauth_access_tokens\`
- \`oauth_personal_access_clients\`

No data migration needed — OAuth was functionally inert before the v13 schema (per the comment in 2026_04_28_000004).

## Test plan
- [x] PHPStan + php-cs-fixer clean
- [x] Regression test: column type assertions + UUID round-trip without truncation
- [ ] Deploy migration, retry \`npx -y @finaegis/mcp@0.1.5 --login\`, OAuth approve completes 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)