### PR TITLE
fix(oauth): drop+recreate client_id columns (MariaDB cast rejection)

### DIFF
--- a/database/migrations/2026_04_29_000001_oauth_client_id_uuid_columns.php
+++ b/database/migrations/2026_04_29_000001_oauth_client_id_uuid_columns.php
@@ -15,36 +15,41 @@ use Illuminate\Support\Facades\Schema;
  * during the OAuth authorization-code grant. There are no in-flight rows to
  * preserve — OAuth was functionally inert prior to v13 (see the recreation
  * comment in 2026_04_28_000004).
+ *
+ * MariaDB rejects a direct ->change() from bigint unsigned to uuid
+ * ("Cannot cast 'bigint unsigned' as 'uuid'"), so we drop and recreate the
+ * column. None of the three columns carry an index in the original schema.
  */
 return new class () extends Migration {
+    /** @var list<string> */
+    private array $tables = [
+        'oauth_auth_codes',
+        'oauth_access_tokens',
+        'oauth_personal_access_clients',
+    ];
+
     public function up(): void
     {
-        Schema::table('oauth_auth_codes', function (Blueprint $table) {
-            $table->uuid('client_id')->change();
-        });
-
-        Schema::table('oauth_access_tokens', function (Blueprint $table) {
-            $table->uuid('client_id')->change();
-        });
-
-        Schema::table('oauth_personal_access_clients', function (Blueprint $table) {
-            $table->uuid('client_id')->change();
-        });
+        foreach ($this->tables as $name) {
+            Schema::table($name, function (Blueprint $table) {
+                $table->dropColumn('client_id');
+            });
+            Schema::table($name, function (Blueprint $table) {
+                $table->uuid('client_id')->after('id');
+            });
+        }
     }
 
     public function down(): void
     {
-        Schema::table('oauth_auth_codes', function (Blueprint $table) {
-            $table->unsignedBigInteger('client_id')->change();
-        });
-
-        Schema::table('oauth_access_tokens', function (Blueprint $table) {
-            $table->unsignedBigInteger('client_id')->change();
-        });
-
-        Schema::table('oauth_personal_access_clients', function (Blueprint $table) {
-            $table->unsignedBigInteger('client_id')->change();
-        });
+        foreach ($this->tables as $name) {
+            Schema::table($name, function (Blueprint $table) {
+                $table->dropColumn('client_id');
+            });
+            Schema::table($name, function (Blueprint $table) {
+                $table->unsignedBigInteger('client_id')->after('id');
+            });
+        }
     }
 
     public function getConnection(): ?string


### PR DESCRIPTION
## What broke
\`migrate\` on prod after #991 failed mid-DDL:
\`\`\`
SQLSTATE[HY000]: General error: 4078 Cannot cast 'bigint unsigned' as 'uuid'
in assignment of zelta.oauth_auth_codes.client_id
\`\`\`
MariaDB doesn't support implicit cast from \`bigint unsigned\` to its native \`uuid\` type.

## Fix
Drop the old \`client_id\` column and add it back as \`uuid\` in the same migration. None of the three Passport tables (\`oauth_auth_codes\`, \`oauth_access_tokens\`, \`oauth_personal_access_clients\`) carry an index on \`client_id\` in the original schema, so the drop is safe. No production data to preserve.

The previous migration's record never made it into the \`migrations\` table (DDL erred), so this corrected version will run on the next deploy under the same filename.

## Test plan
- [x] PHPStan + php-cs-fixer clean
- [ ] Deploy → \`php artisan migrate --force\` succeeds
- [ ] Retry \`npx -y @finaegis/mcp@0.1.5 --login\` → OAuth approve completes 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)