### PR TITLE
fix(security): relax CSP form-action on /oauth/* for loopback redirects

### DIFF
--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -61,6 +61,26 @@ class SecurityHeaders
      */
     private function getContentSecurityPolicy(Request $request): string
     {
+        // OAuth authorization endpoints: the consent form posts to /oauth/authorize
+        // and the server then 302s to the client's registered redirect_uri. Modern
+        // browsers apply form-action to the entire redirect chain, so a strict
+        // 'self' policy blocks the loopback redirect that RFC 8252 native apps
+        // (Claude Desktop, Cursor, etc. via @finaegis/mcp) rely on. We trust
+        // Passport's own redirect_uri validation against oauth_clients here.
+        if ($request->is('oauth/*')) {
+            return implode('; ', [
+                "default-src 'self'",
+                "script-src 'self' 'unsafe-inline'",
+                "style-src 'self' 'unsafe-inline' https://fonts.bunny.net",
+                "img-src 'self' data: blob: https:",
+                "font-src 'self' https://fonts.bunny.net",
+                "connect-src 'self'",
+                "form-action 'self' http://127.0.0.1:* http://[::1]:* https:",
+                "base-uri 'self'",
+                "frame-ancestors 'none'",
+            ]);
+        }
+
         // Swagger UI requires relaxed CSP (CDN assets + unsafe-eval for JSON rendering)
         if ($request->is('api/documentation*') || $request->is('docs*')) {
             return implode('; ', [

--- a/tests/Feature/MCP/OAuthCspFormActionTest.php
+++ b/tests/Feature/MCP/OAuthCspFormActionTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+it('allows loopback redirect_uris in form-action CSP for OAuth pages', function () {
+    $response = $this->get('/oauth/authorize?response_type=code&client_id=x&redirect_uri=http%3A%2F%2F127.0.0.1%3A53682%2Fcallback');
+
+    $csp = (string) $response->headers->get('Content-Security-Policy');
+
+    expect($csp)->toContain('form-action');
+    expect($csp)->toContain('http://127.0.0.1:*');
+    expect($csp)->toContain('http://[::1]:*');
+    expect($csp)->toContain('https:');
+});
+
+it('keeps strict form-action on non-OAuth pages', function () {
+    $response = $this->get('/');
+
+    $csp = (string) $response->headers->get('Content-Security-Policy');
+
+    expect($csp)->toContain("form-action 'self'");
+    expect($csp)->not->toContain('http://127.0.0.1:*');
+});


### PR DESCRIPTION
## What broke
The OAuth consent flow silently fails after clicking Approve. Browser console shows:

\`\`\`
Sending form data to 'https://zelta.app/oauth/authorize' violates the
following Content Security Policy directive: \"form-action 'self'\".
The request has been blocked.
\`\`\`

## Root cause
Modern browsers apply \`form-action\` to the **entire redirect chain** after a form POST, not just the immediate action URL. After POST \`/oauth/authorize\`, Passport 302s to the client's registered \`redirect_uri\` — for RFC 8252 native apps (Claude Desktop, Cursor, Continue.dev via \`@finaegis/mcp\`) that's \`http://127.0.0.1:53682/callback\`, which doesn't match \`'self'\` and gets blocked. Chrome's error message points at the original POST URL, which made this hard to spot — the actual block is on the loopback redirect.

## Fix
Relax \`form-action\` on \`/oauth/*\` paths only:
- \`'self'\` (existing)
- \`http://127.0.0.1:*\` and \`http://[::1]:*\` (RFC 8252 loopback)
- \`https:\` (any HTTPS redirect_uri for hosted clients)

Other CSP directives (\`script-src\`, \`object-src\`, etc.) stay strict on these paths. Non-OAuth pages keep the global strict policy untouched.

This is not an OAuth security regression — Passport independently validates \`redirect_uri\` against the client's registered \`oauth_clients.redirect_uris\` row before issuing the 302.

## Test plan
- [x] PHPStan + php-cs-fixer clean
- [x] Regression test: \`/oauth/*\` allows loopback + https in form-action; \`/\` still strict
- [ ] Deploy → \`npx -y @finaegis/mcp@0.1.5 --login\` → Approve → 302 to \`http://127.0.0.1:53682/callback\` succeeds → wrapper prints "Logged in"

🤖 Generated with [Claude Code](https://claude.com/claude-code)