### PR TITLE
fix(security): auto-inject GA hosts into CSP when brand.ga_id is set

### DIFF
--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -107,6 +107,20 @@ class SecurityHeaders
         $apiEndpoint = config('security.csp.api_endpoint', '');
         $wsEndpoint = config('security.csp.ws_endpoint', '');
 
+        // Auto-inject GA-required hosts whenever a GA tag is configured. Operators
+        // shouldn't need to keep CSP_SCRIPT_SOURCES manually in sync with brand.ga_id
+        // — and forgetting to do so silently breaks pageview tracking on prod.
+        if (config('brand.ga_id')) {
+            $scriptSources = $this->mergeUnique($scriptSources, ['https://www.googletagmanager.com']);
+            $connectSources = $this->mergeUnique($connectSources, [
+                'https://www.google-analytics.com',
+                'https://*.google-analytics.com',
+                'https://www.googletagmanager.com',
+                'https://stats.g.doubleclick.net',
+                'https://*.doubleclick.net',
+            ]);
+        }
+
         // Build production policies (unsafe-eval only for admin panel / Alpine.js)
         $evalDirective = $needsUnsafeEval ? "'unsafe-eval' " : '';
         $policies = [
@@ -159,6 +173,26 @@ class SecurityHeaders
         }
 
         return implode('; ', $policies);
+    }
+
+    /**
+     * Merge two CSP source lists into a deduplicated, trimmed result.
+     *
+     * @param  list<string>  $existing
+     * @param  list<string>  $additions
+     * @return list<string>
+     */
+    private function mergeUnique(array $existing, array $additions): array
+    {
+        $merged = [];
+        foreach ([...$existing, ...$additions] as $value) {
+            $value = trim($value);
+            if ($value !== '' && ! in_array($value, $merged, true)) {
+                $merged[] = $value;
+            }
+        }
+
+        return $merged;
     }
 
     /**

--- a/tests/Feature/Security/CspGaAutoInjectTest.php
+++ b/tests/Feature/Security/CspGaAutoInjectTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+it('auto-injects googletagmanager into script-src when brand.ga_id is set', function () {
+    config(['brand.ga_id' => 'G-TESTID12345']);
+
+    $response = $this->get('/');
+    $csp = (string) $response->headers->get('Content-Security-Policy');
+
+    expect($csp)->toContain('https://www.googletagmanager.com');
+});
+
+it('auto-injects google-analytics + doubleclick hosts into connect-src when brand.ga_id is set', function () {
+    config(['brand.ga_id' => 'G-TESTID12345']);
+
+    $response = $this->get('/');
+    $csp = (string) $response->headers->get('Content-Security-Policy');
+
+    expect($csp)->toContain('https://www.google-analytics.com');
+    expect($csp)->toContain('https://stats.g.doubleclick.net');
+});
+
+it('does not inject GA hosts when brand.ga_id is empty', function () {
+    config(['brand.ga_id' => '']);
+    config(['security.csp.script_sources' => '']);
+    config(['security.csp.connect_sources' => '']);
+
+    $response = $this->get('/');
+    $csp = (string) $response->headers->get('Content-Security-Policy');
+
+    expect($csp)->not->toContain('googletagmanager');
+    expect($csp)->not->toContain('google-analytics');
+});


### PR DESCRIPTION
## What broke
Browser console on zelta.app:
\`\`\`
Loading the script 'https://www.googletagmanager.com/gtag/js?id=G-...' violates
the following Content Security Policy directive: \"script-src 'self' 'unsafe-inline'\".
The action has been blocked.
\`\`\`

## Root cause
\`CSP_SCRIPT_SOURCES\` env var on prod was not in sync with \`GOOGLE_ANALYTICS_ID\` — the GA tag was rendered into the page (because \`brand.ga_id\` is set) but the matching \`googletagmanager.com\` host was missing from \`script-src\`.

## Fix
Treat the two configs as one decision: when \`brand.ga_id\` is non-empty, automatically append the GA-required hosts to \`script-src\` and \`connect-src\`. Operators no longer have to remember to keep two separate env vars in sync.

## Test plan
- [x] PHPStan + php-cs-fixer clean
- [x] Regression: GA hosts present in CSP when \`brand.ga_id\` set; absent when empty
- [ ] Deploy → reload zelta.app → no GA CSP error in console → pageview registers in GA real-time

🤖 Generated with [Claude Code](https://claude.com/claude-code)