### PR TITLE
fix(console,mcp): register domain commands; skip ramp tools when no provider

### DIFF
--- a/app/Domain/Basket/Console/Commands/ShowBasketPerformanceCommand.php
+++ b/app/Domain/Basket/Console/Commands/ShowBasketPerformanceCommand.php
@@ -33,7 +33,7 @@ class ShowBasketPerformanceCommand extends Command
         /** @var BasketAsset|null $basket */
         $basket = null;
         $basketCode = $this->argument('basket') ?? config('baskets.primary_code', 'GCU');
-        $period = $this->option('period');
+        $period = (string) ($this->option('period') ?? '30d');
         $detailed = $this->option('detailed');
 
         // Find the basket

--- a/app/Filament/Admin/Resources/ApiKeyResource.php
+++ b/app/Filament/Admin/Resources/ApiKeyResource.php
@@ -30,7 +30,9 @@ class ApiKeyResource extends Resource
 
     public static function getNavigationBadge(): ?string
     {
-        return static::getModel()::where('is_active', true)->count() ?: null;
+        $count = static::getModel()::where('is_active', true)->count();
+
+        return $count > 0 ? (string) $count : null;
     }
 
     public static function form(Form $form): Form

--- a/app/Filament/Admin/Resources/CgoNotificationResource.php
+++ b/app/Filament/Admin/Resources/CgoNotificationResource.php
@@ -89,7 +89,9 @@ class CgoNotificationResource extends Resource
 
     public static function getNavigationBadge(): ?string
     {
-        return static::getModel()::count();
+        $count = static::getModel()::count();
+
+        return $count > 0 ? (string) $count : null;
     }
 
     public static function getPages(): array

--- a/app/Filament/Admin/Resources/GcuVotingProposalResource.php
+++ b/app/Filament/Admin/Resources/GcuVotingProposalResource.php
@@ -29,7 +29,9 @@ class GcuVotingProposalResource extends Resource
 
     public static function getNavigationBadge(): ?string
     {
-        return static::getModel()::where('status', 'active')->count() ?: null;
+        $count = static::getModel()::where('status', 'active')->count();
+
+        return $count > 0 ? (string) $count : null;
     }
 
     public static function form(Form $form): Form

--- a/app/Filament/Admin/Resources/SubscriberResource.php
+++ b/app/Filament/Admin/Resources/SubscriberResource.php
@@ -287,7 +287,9 @@ class SubscriberResource extends Resource
 
     public static function getNavigationBadge(): ?string
     {
-        return static::getModel()::where('status', Subscriber::STATUS_ACTIVE)->count();
+        $count = static::getModel()::where('status', Subscriber::STATUS_ACTIVE)->count();
+
+        return $count > 0 ? (string) $count : null;
     }
 
     public static function getNavigationBadgeColor(): ?string

--- a/app/Filament/Resources/CgoInvestmentResource.php
+++ b/app/Filament/Resources/CgoInvestmentResource.php
@@ -33,7 +33,7 @@ class CgoInvestmentResource extends Resource
     {
         $pending = static::getModel()::where('status', 'pending')->count();
 
-        return $pending > 0 ? $pending : null;
+        return $pending > 0 ? (string) $pending : null;
     }
 
     public static function getNavigationBadgeColor(): ?string

--- a/app/Filament/Resources/CgoRefundResource.php
+++ b/app/Filament/Resources/CgoRefundResource.php
@@ -403,7 +403,9 @@ class CgoRefundResource extends Resource
 
     public static function getNavigationBadge(): ?string
     {
-        return static::getModel()::where('status', 'pending')->count();
+        $count = static::getModel()::where('status', 'pending')->count();
+
+        return $count > 0 ? (string) $count : null;
     }
 
     public static function getNavigationBadgeColor(): ?string

--- a/app/Filament/Resources/ContactSubmissionResource.php
+++ b/app/Filament/Resources/ContactSubmissionResource.php
@@ -23,7 +23,9 @@ class ContactSubmissionResource extends Resource
 
     public static function getNavigationBadge(): ?string
     {
-        return static::getModel()::where('status', 'pending')->count() ?: null;
+        $count = static::getModel()::where('status', 'pending')->count();
+
+        return $count > 0 ? (string) $count : null;
     }
 
     public static function getNavigationBadgeColor(): ?string

--- a/app/Providers/MCPToolServiceProvider.php
+++ b/app/Providers/MCPToolServiceProvider.php
@@ -122,8 +122,19 @@ class MCPToolServiceProvider extends ServiceProvider
         }
 
         $registry = $this->app->make(ToolRegistry::class);
+        $rampUnavailable = $this->isRampDisabledInProduction();
 
         foreach ($this->tools as $toolClass) {
+            // Ramp tools depend on a real provider; in prod the mock provider
+            // throws on construction. Skip registration silently rather than
+            // logging "Failed to register" warnings on every request boot.
+            if ($rampUnavailable && (
+                $toolClass === RampStartTool::class
+                || $toolClass === RampStatusTool::class
+            )) {
+                continue;
+            }
+
             try {
                 $tool = $this->app->make($toolClass);
                 $registry->register($tool);
@@ -134,5 +145,16 @@ class MCPToolServiceProvider extends ServiceProvider
                 ]);
             }
         }
+    }
+
+    /**
+     * True when Ramp tools cannot be instantiated under the current config.
+     * The mock provider is the default and refuses to load in production, so
+     * we treat that as "no real provider configured" and skip the tools.
+     */
+    private function isRampDisabledInProduction(): bool
+    {
+        return $this->app->environment('production')
+            && config('ramp.default_provider') === 'mock';
     }
 }

--- a/app/Providers/MCPToolServiceProvider.php
+++ b/app/Providers/MCPToolServiceProvider.php
@@ -128,10 +128,8 @@ class MCPToolServiceProvider extends ServiceProvider
             // Ramp tools depend on a real provider; in prod the mock provider
             // throws on construction. Skip registration silently rather than
             // logging "Failed to register" warnings on every request boot.
-            if ($rampUnavailable && (
-                $toolClass === RampStartTool::class
-                || $toolClass === RampStatusTool::class
-            )) {
+            $isRampTool = $toolClass === RampStartTool::class || $toolClass === RampStatusTool::class;
+            if ($rampUnavailable && $isRampTool) {
                 continue;
             }
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,17 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\View;
 
+// Auto-discover Artisan commands from every domain's Console/Commands directory.
+// Without this, classes like banks:check-alerts and liquidity:update-market-making
+// are defined but never registered — the scheduler then logs "namespace not found"
+// every minute. Laravel's default discovery only scans app/Console/Commands.
+$domainCommandPaths = [];
+foreach (glob(__DIR__ . '/../app/Domain/*/Console/Commands', GLOB_ONLYDIR) ?: [] as $path) {
+    $domainCommandPaths[] = $path;
+}
+
 return Application::configure(basePath: dirname(__DIR__))
+    ->withCommands($domainCommandPaths)
     ->withRouting(
         using: function () {
             $host = request()->getHost();


### PR DESCRIPTION
## Two prod log-spam fixes

### 1. Scheduled commands missing
\`\`\`
production.ERROR: Scheduled command [...artisan banks:check-alerts] failed with exit code [1]
production.ERROR: There are no commands defined in the \"banks\" namespace.
production.ERROR: Scheduled command [...artisan liquidity:update-market-making] failed with exit code [1]
production.ERROR: There are no commands defined in the \"liquidity\" namespace.
\`\`\`

19 domain commands under \`app/Domain/*/Console/Commands/\` were never auto-registered with Artisan — Laravel's default discovery only scans \`app/Console/Commands/\`. The \`routes/console.php\` schedule references them, so every cron tick logs the namespace error. Register them via \`->withCommands(...)\` in \`bootstrap/app.php\` by globbing the domain command directories.

### 2. Ramp tools failing every request
\`\`\`
production.WARNING: Failed to register MCP tool: App\\Domain\\MCP\\Tools\\Ramp\\RampStartTool
{\"error\":\"Mock ramp provider must not be used in production.\"}
\`\`\`

The mock \`RampProvider\` correctly refuses construction in production. \`MCPToolServiceProvider::boot\` then logs a warning per request. Until we have a real ramp provider, skip Ramp tool registration when \`ramp.default_provider === 'mock'\` and \`app()->environment('production')\`. Other tools keep their warn-and-continue path.

## Test plan
- [x] PHPStan + php-cs-fixer clean
- [x] \`glob('app/Domain/*/Console/Commands')\` finds 10 directories with 19 commands total
- [ ] Deploy → \`sudo -u www-data php artisan list | grep -E '^(banks|liquidity):' \` lists the previously-missing commands
- [ ] Deploy → wait one minute → no new \"namespace not found\" or \"Failed to register MCP tool\" lines in laravel.log

🤖 Generated with [Claude Code](https://claude.com/claude-code)