### PR TITLE
fix(admin): redirect non-admins to /dashboard instead of 403

### DIFF
--- a/app/Filament/Http/Middleware/RedirectNonAdmins.php
+++ b/app/Filament/Http/Middleware/RedirectNonAdmins.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Http\Middleware;
+
+use Filament\Facades\Filament;
+use Filament\Http\Middleware\Authenticate as FilamentAuthenticate;
+use Filament\Models\Contracts\FilamentUser;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Drop-in replacement for Filament's bundled Authenticate middleware that
+ * redirects authenticated users without admin access to /dashboard instead
+ * of returning a bare 403. Unauthenticated users follow the standard
+ * redirect-to-login flow inherited from the framework.
+ */
+class RedirectNonAdmins extends FilamentAuthenticate
+{
+    /**
+     * @param  array<string>  $guards
+     */
+    protected function authenticate($request, array $guards): void
+    {
+        $guard = Filament::auth();
+
+        if (! $guard->check()) {
+            $this->unauthenticated($request, $guards);
+        }
+
+        $this->auth->shouldUse(Filament::getAuthGuard());
+
+        /** @var Model $user */
+        $user = $guard->user();
+        $panel = Filament::getCurrentPanel();
+
+        if ($panel === null) {
+            return;
+        }
+
+        $canAccess = $user instanceof FilamentUser
+            ? $user->canAccessPanel($panel)
+            : config('app.env') === 'local';
+
+        if (! $canAccess) {
+            // Bail out via a thrown HttpResponseException so the redirect
+            // takes effect immediately and the rest of the middleware
+            // pipeline doesn't run on a half-authorised request.
+            throw new \Illuminate\Http\Exceptions\HttpResponseException(
+                $this->buildRedirect($request)
+            );
+        }
+    }
+
+    private function buildRedirect(Request $request): RedirectResponse
+    {
+        $message = 'Your account does not have admin access. You\'ve been redirected to your dashboard.';
+
+        return redirect()
+            ->route('dashboard')
+            ->with('error', $message);
+    }
+}

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -3,7 +3,7 @@
 namespace App\Providers\Filament;
 
 use App\Filament\Admin\Pages\Dashboard;
-use Filament\Http\Middleware\Authenticate;
+use App\Filament\Http\Middleware\RedirectNonAdmins;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
@@ -65,7 +65,7 @@ class AdminPanelProvider extends PanelProvider
             )
             ->authMiddleware(
                 [
-                    Authenticate::class,
+                    RedirectNonAdmins::class,
                 ]
             );
     }


### PR DESCRIPTION
## Summary
- Authenticated users without admin access who hit `/admin` previously saw a bare 403 from Filament's bundled `Authenticate` middleware.
- They now land on `/dashboard` with a friendly flash message explaining their account does not have admin access.
- Implemented as a drop-in subclass (`RedirectNonAdmins`) of `Filament\Http\Middleware\Authenticate`, so guests still get the standard redirect-to-login flow — only the access-denied branch is intercepted.

## Test plan
- [ ] Log in as a non-admin user, then visit `/admin` — verify redirect to `/dashboard` with the flash error.
- [ ] Log in as an admin user, then visit `/admin` — verify normal panel access (no redirect).
- [ ] Log out and visit `/admin` — verify standard redirect to `/admin/login`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)