### PR TITLE
feat(admin): module-aware widget visibility

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -109,6 +109,11 @@ BRAND_LEGAL_JURISDICTION=
 BRAND_GITHUB_URL=
 GOOGLE_ANALYTICS_ID=
 
+# Hide open-source marketing pages (/about, /pricing, /security, etc.) when
+# this deployment is a customer-facing product rather than the FinAegis demo.
+# FinAegis demo site (finaegis.org): leave true. Customer/Zelta install: false.
+SHOW_PROMO_PAGES=false
+
 # Admin panel — visible module groups (comma-separated). Empty = show all
 # (FinAegis full platform). For Zelta-style restricted view, use:
 # ADMIN_MODULES="System,Mobile,Relayer,TrustCert,Banking,AI Agents,Commerce,Mobile Payments,Privacy,Fraud Detection,Key Management"

--- a/.env.production.example
+++ b/.env.production.example
@@ -109,6 +109,11 @@ BRAND_LEGAL_JURISDICTION=
 BRAND_GITHUB_URL=
 GOOGLE_ANALYTICS_ID=
 
+# Admin panel — visible module groups (comma-separated). Empty = show all
+# (FinAegis full platform). For Zelta-style restricted view, use:
+# ADMIN_MODULES="System,Mobile,Relayer,TrustCert,Banking,AI Agents,Commerce,Mobile Payments,Privacy,Fraud Detection,Key Management"
+ADMIN_MODULES=
+
 # =============================================================================
 # SECURITY
 # =============================================================================

--- a/.env.zelta.example
+++ b/.env.zelta.example
@@ -43,6 +43,10 @@ BRAND_GITHUB_URL=
 BRAND_TAGLINE="Pay with Stablecoins. Stay Private."
 GOOGLE_ANALYTICS_ID=
 
+# Admin panel — visible module groups (comma-separated). Empty = show all.
+# Zelta production hides domains that are not part of the mobile wallet scope.
+ADMIN_MODULES="System,Mobile,Relayer,TrustCert,Banking,AI Agents,Commerce,Mobile Payments,Privacy,Fraud Detection,Key Management"
+
 # =============================================================================
 # DEMO MODE — ALL DISABLED FOR PRODUCTION
 # =============================================================================

--- a/.env.zelta.example
+++ b/.env.zelta.example
@@ -43,6 +43,10 @@ BRAND_GITHUB_URL=
 BRAND_TAGLINE="Pay with Stablecoins. Stay Private."
 GOOGLE_ANALYTICS_ID=
 
+# Hide /about, /pricing, /security and other open-source marketing pages.
+# Zelta production serves the app landing page at root and routes promo paths to /.
+SHOW_PROMO_PAGES=false
+
 # Admin panel — visible module groups (comma-separated). Empty = show all.
 # Zelta production hides domains that are not part of the mobile wallet scope.
 ADMIN_MODULES="System,Mobile,Relayer,TrustCert,Banking,AI Agents,Commerce,Mobile Payments,Privacy,Fraud Detection,Key Management"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,16 @@ Required repo secrets for release workflows: `NPM_TOKEN` (must be npm **Automati
 
 Packagist sources the three PHP packages from **split-mirror repos**, not the monorepo — Packagist only reads root `composer.json`. The `monorepo-split.yml` workflow auto-pushes `packages/zelta-sdk/`, `packages/zelta-cli/`, `sdks/php/`, and `packages/finaegis-mcp-stdio/` into their respective mirrors on every `main` push and release tag (via `splitsh/lite`). Mirror tags use a stripped prefix: `sdk-v1.0.1` → mirror tag `v1.0.1`.
 
+## Admin Panel — Brand & Module Visibility
+
+- Brand fallback in `AdminPanelProvider` is `Zelta` (production); demo deployments override with `BRAND_NAME`
+- Auth pages read `config('brand.name')` — never hardcode "FinAegis" in `authentication-card-logo.blade.php` or `application-logo.blade.php`
+- Footer "open-source" tagline only renders in demo mode or when `SHOW_PROMO_PAGES=true`
+- Non-admin users hitting `/admin` redirect to `/dashboard` with a flash error via `App\Filament\Http\Middleware\RedirectNonAdmins` (replaces Filament's bundled `Authenticate` so non-admins don't get a bare 403)
+- Resources gate by nav group via `App\Filament\Admin\Traits\RespectsModuleVisibility` (already on every Resource)
+- Widgets gate by `$adminModule` (matching a nav group) via `App\Filament\Admin\Traits\WidgetRespectsModuleVisibility` — set on every widget under `app/Filament/Admin/Widgets/`. Widgets with their own `canView()` AND the module check via `static::adminModuleAllowsView()`
+- Production envs default `SHOW_PROMO_PAGES=false`; Zelta also pins `ADMIN_MODULES` to the mobile-wallet scope in `.env.zelta.example`
+
 ## MCP Server (v7.11.0+)
 
 - Public endpoint: `https://mcp.zelta.app/mcp` (subdomain handled in `bootstrap/app.php`)

--- a/app/Filament/Admin/Traits/WidgetRespectsModuleVisibility.php
+++ b/app/Filament/Admin/Traits/WidgetRespectsModuleVisibility.php
@@ -65,7 +65,13 @@ trait WidgetRespectsModuleVisibility
 
         try {
             $reflection = new ReflectionProperty(static::class, 'adminModule');
-            $reflection->setAccessible(true);
+
+            // Bail loudly if a consumer ever declares $adminModule as a non-static
+            // property — the rest of the trait assumes class-level visibility.
+            if (! $reflection->isStatic()) {
+                return null;
+            }
+
             $value = $reflection->getValue();
         } catch (ReflectionException) {
             return null;

--- a/app/Filament/Admin/Traits/WidgetRespectsModuleVisibility.php
+++ b/app/Filament/Admin/Traits/WidgetRespectsModuleVisibility.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Filament\Admin\Traits;
 
+use ReflectionException;
+use ReflectionProperty;
+
 /**
  * Provides a module-visibility check for Filament widgets.
  *
@@ -61,10 +64,10 @@ trait WidgetRespectsModuleVisibility
         }
 
         try {
-            $reflection = new \ReflectionProperty(static::class, 'adminModule');
+            $reflection = new ReflectionProperty(static::class, 'adminModule');
             $reflection->setAccessible(true);
             $value = $reflection->getValue();
-        } catch (\ReflectionException) {
+        } catch (ReflectionException) {
             return null;
         }
 

--- a/app/Filament/Admin/Traits/WidgetRespectsModuleVisibility.php
+++ b/app/Filament/Admin/Traits/WidgetRespectsModuleVisibility.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Traits;
+
+/**
+ * Provides a module-visibility check for Filament widgets.
+ *
+ * Widgets opt in by adding `use WidgetRespectsModuleVisibility;` and declaring
+ * `protected static ?string $adminModule = 'Banking';` (matching one of the
+ * navigation groups listed in ADMIN_MODULES).
+ *
+ * Widgets without their own canView() can use the default canView() implemented
+ * here. Widgets that need additional permission/context checks should define
+ * their own canView() and AND it with `static::adminModuleAllowsView()`.
+ *
+ * When ADMIN_MODULES is unset, all widgets remain visible (full platform).
+ * When set, only widgets whose $adminModule is in the allowed list render.
+ */
+trait WidgetRespectsModuleVisibility
+{
+    public static function canView(): bool
+    {
+        return static::adminModuleAllowsView();
+    }
+
+    /**
+     * Returns true when the widget's module is currently allowed in ADMIN_MODULES.
+     */
+    protected static function adminModuleAllowsView(): bool
+    {
+        /** @var array<string>|null $allowedModules */
+        $allowedModules = config('brand.admin_modules');
+
+        // null = show all (full platform mode)
+        if ($allowedModules === null) {
+            return true;
+        }
+
+        $module = static::resolveAdminModule();
+
+        // Widgets without an explicit module declaration are hidden when
+        // ADMIN_MODULES is set — same convention as resources without a group.
+        if ($module === null || $module === '') {
+            return false;
+        }
+
+        return in_array($module, $allowedModules, true);
+    }
+
+    /**
+     * Reads the consuming class's $adminModule static property via reflection
+     * so the trait does not have to declare the property itself (which would
+     * conflict with consumer-side property defaults at composition time).
+     */
+    protected static function resolveAdminModule(): ?string
+    {
+        if (! property_exists(static::class, 'adminModule')) {
+            return null;
+        }
+
+        try {
+            $reflection = new \ReflectionProperty(static::class, 'adminModule');
+            $reflection->setAccessible(true);
+            $value = $reflection->getValue();
+        } catch (\ReflectionException) {
+            return null;
+        }
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+}

--- a/app/Filament/Admin/Widgets/AggregateHealthWidget.php
+++ b/app/Filament/Admin/Widgets/AggregateHealthWidget.php
@@ -5,12 +5,17 @@ declare(strict_types=1);
 namespace App\Filament\Admin\Widgets;
 
 use App\Domain\Monitoring\Services\EventStoreService;
+use App\Filament\Admin\Traits\WidgetRespectsModuleVisibility;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 use Illuminate\Support\Facades\Cache;
 
 class AggregateHealthWidget extends BaseWidget
 {
+    use WidgetRespectsModuleVisibility;
+
+    protected static ?string $adminModule = 'System';
+
     protected static ?string $pollingInterval = '60s';
 
     protected static ?int $sort = 3;

--- a/app/Filament/Admin/Widgets/BankAllocationWidget.php
+++ b/app/Filament/Admin/Widgets/BankAllocationWidget.php
@@ -2,12 +2,17 @@
 
 namespace App\Filament\Admin\Widgets;
 
+use App\Filament\Admin\Traits\WidgetRespectsModuleVisibility;
 use App\Models\UserBankPreference;
 use Filament\Widgets\Widget;
 use Illuminate\Support\Number;
 
 class BankAllocationWidget extends Widget
 {
+    use WidgetRespectsModuleVisibility;
+
+    protected static ?string $adminModule = 'Banking';
+
     protected static string $view = 'filament.admin.widgets.bank-allocation-widget';
 
     protected int|string|array $columnSpan = 'full';

--- a/app/Filament/Admin/Widgets/BankHealthMonitorWidget.php
+++ b/app/Filament/Admin/Widgets/BankHealthMonitorWidget.php
@@ -5,10 +5,15 @@ declare(strict_types=1);
 namespace App\Filament\Admin\Widgets;
 
 use App\Domain\Custodian\Services\CustodianHealthMonitor;
+use App\Filament\Admin\Traits\WidgetRespectsModuleVisibility;
 use Filament\Widgets\Widget;
 
 class BankHealthMonitorWidget extends Widget
 {
+    use WidgetRespectsModuleVisibility;
+
+    protected static ?string $adminModule = 'Banking';
+
     protected static string $view = 'filament.admin.widgets.bank-health-monitor-widget';
 
     protected int|string|array $columnSpan = 'full';

--- a/app/Filament/Admin/Widgets/BankOperationsDashboard.php
+++ b/app/Filament/Admin/Widgets/BankOperationsDashboard.php
@@ -8,11 +8,16 @@ use App\Domain\Account\Models\Transfer;
 use App\Domain\Custodian\Models\CustodianAccount;
 use App\Domain\Custodian\Services\CustodianHealthMonitor;
 use App\Domain\Custodian\Services\DailyReconciliationService;
+use App\Filament\Admin\Traits\WidgetRespectsModuleVisibility;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 
 class BankOperationsDashboard extends BaseWidget
 {
+    use WidgetRespectsModuleVisibility;
+
+    protected static ?string $adminModule = 'Banking';
+
     protected static ?int $sort = 1;
 
     protected function getStats(): array

--- a/app/Filament/Admin/Widgets/BasketPerformanceChart.php
+++ b/app/Filament/Admin/Widgets/BasketPerformanceChart.php
@@ -3,12 +3,17 @@
 namespace App\Filament\Admin\Widgets;
 
 use App\Domain\Basket\Models\BasketAsset;
+use App\Filament\Admin\Traits\WidgetRespectsModuleVisibility;
 use Filament\Widgets\ChartWidget;
 use Filament\Widgets\Concerns\InteractsWithPageFilters;
 
 class BasketPerformanceChart extends ChartWidget
 {
+    use WidgetRespectsModuleVisibility;
+
     use InteractsWithPageFilters;
+
+    protected static ?string $adminModule = 'System';
 
     protected static ?string $heading = 'Basket Performance';
 
@@ -146,6 +151,10 @@ class BasketPerformanceChart extends ChartWidget
 
     public static function canView(): bool
     {
+        if (! static::adminModuleAllowsView()) {
+            return false;
+        }
+
         return auth()->user()?->can('view_basket_performance') ?? true;
     }
 }

--- a/app/Filament/Admin/Widgets/BasketPerformanceStats.php
+++ b/app/Filament/Admin/Widgets/BasketPerformanceStats.php
@@ -4,12 +4,17 @@ namespace App\Filament\Admin\Widgets;
 
 use App\Domain\Basket\Models\BasketAsset;
 use App\Domain\Basket\Services\BasketPerformanceService;
+use App\Filament\Admin\Traits\WidgetRespectsModuleVisibility;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 use Illuminate\Support\Facades\Cache;
 
 class BasketPerformanceStats extends BaseWidget
 {
+    use WidgetRespectsModuleVisibility;
+
+    protected static ?string $adminModule = 'System';
+
     protected static ?string $pollingInterval = '60s';
 
     protected static ?int $sort = 2;
@@ -125,6 +130,10 @@ class BasketPerformanceStats extends BaseWidget
 
     public static function canView(): bool
     {
+        if (! static::adminModuleAllowsView()) {
+            return false;
+        }
+
         return auth()->user()?->can('view_basket_performance') ?? true;
     }
 }

--- a/app/Filament/Admin/Widgets/DomainHealthWidget.php
+++ b/app/Filament/Admin/Widgets/DomainHealthWidget.php
@@ -5,12 +5,17 @@ declare(strict_types=1);
 namespace App\Filament\Admin\Widgets;
 
 use App\Domain\Monitoring\Services\EventStoreHealthCheck;
+use App\Filament\Admin\Traits\WidgetRespectsModuleVisibility;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 use Illuminate\Support\Facades\Cache;
 
 class DomainHealthWidget extends BaseWidget
 {
+    use WidgetRespectsModuleVisibility;
+
+    protected static ?string $adminModule = 'System';
+
     protected static ?string $pollingInterval = '60s';
 
     protected static ?int $sort = 5;

--- a/app/Filament/Admin/Widgets/EventStoreStatsWidget.php
+++ b/app/Filament/Admin/Widgets/EventStoreStatsWidget.php
@@ -5,12 +5,17 @@ declare(strict_types=1);
 namespace App\Filament\Admin\Widgets;
 
 use App\Domain\Monitoring\Services\EventStoreService;
+use App\Filament\Admin\Traits\WidgetRespectsModuleVisibility;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 use Illuminate\Support\Facades\Cache;
 
 class EventStoreStatsWidget extends BaseWidget
 {
+    use WidgetRespectsModuleVisibility;
+
+    protected static ?string $adminModule = 'System';
+
     protected static ?string $pollingInterval = '30s';
 
     protected static ?int $sort = 1;

--- a/app/Filament/Admin/Widgets/EventStoreThroughputWidget.php
+++ b/app/Filament/Admin/Widgets/EventStoreThroughputWidget.php
@@ -5,11 +5,16 @@ declare(strict_types=1);
 namespace App\Filament\Admin\Widgets;
 
 use App\Domain\Monitoring\Services\EventStoreService;
+use App\Filament\Admin\Traits\WidgetRespectsModuleVisibility;
 use Filament\Widgets\ChartWidget;
 use Illuminate\Support\Facades\Cache;
 
 class EventStoreThroughputWidget extends ChartWidget
 {
+    use WidgetRespectsModuleVisibility;
+
+    protected static ?string $adminModule = 'System';
+
     protected static ?string $heading = 'Event Throughput (Events/Minute)';
 
     protected static ?string $pollingInterval = '10s';

--- a/app/Filament/Admin/Widgets/GCUBasketWidget.php
+++ b/app/Filament/Admin/Widgets/GCUBasketWidget.php
@@ -8,6 +8,10 @@ class GCUBasketWidget extends PrimaryBasketWidget
 
     public static function canView(): bool
     {
+        if (! static::adminModuleAllowsView()) {
+            return false;
+        }
+
         // Only show if GCU is configured as the primary basket
         return config('baskets.primary_code') === 'GCU';
     }

--- a/app/Filament/Admin/Widgets/ModuleHealthWidget.php
+++ b/app/Filament/Admin/Widgets/ModuleHealthWidget.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Admin\Widgets;
 
+use App\Filament\Admin\Traits\WidgetRespectsModuleVisibility;
 use App\Infrastructure\Domain\DomainManager;
 use App\Infrastructure\Domain\Enums\DomainStatus;
 use App\Infrastructure\Domain\Enums\DomainType;
@@ -14,6 +15,10 @@ use Illuminate\Support\Facades\File;
 
 class ModuleHealthWidget extends BaseWidget
 {
+    use WidgetRespectsModuleVisibility;
+
+    protected static ?string $adminModule = 'System';
+
     protected static ?string $pollingInterval = '60s';
 
     protected static ?int $sort = 3;

--- a/app/Filament/Admin/Widgets/MultiBankDistributionWidget.php
+++ b/app/Filament/Admin/Widgets/MultiBankDistributionWidget.php
@@ -2,11 +2,16 @@
 
 namespace App\Filament\Admin\Widgets;
 
+use App\Filament\Admin\Traits\WidgetRespectsModuleVisibility;
 use App\Models\UserBankPreference;
 use Filament\Widgets\Widget;
 
 class MultiBankDistributionWidget extends Widget
 {
+    use WidgetRespectsModuleVisibility;
+
+    protected static ?string $adminModule = 'Banking';
+
     protected static string $view = 'filament.admin.widgets.multi-bank-distribution-widget';
 
     protected int|string|array $columnSpan = 'full';
@@ -18,6 +23,10 @@ class MultiBankDistributionWidget extends Widget
      */
     public static function canView(): bool
     {
+        if (! static::adminModuleAllowsView()) {
+            return false;
+        }
+
         // Show this widget when GCU is enabled or when there are bank preferences
         return config('app.gcu_enabled', false) || UserBankPreference::exists();
     }

--- a/app/Filament/Admin/Widgets/PrimaryBasketWidget.php
+++ b/app/Filament/Admin/Widgets/PrimaryBasketWidget.php
@@ -3,10 +3,15 @@
 namespace App\Filament\Admin\Widgets;
 
 use App\Domain\Basket\Models\BasketAsset;
+use App\Filament\Admin\Traits\WidgetRespectsModuleVisibility;
 use Filament\Widgets\Widget;
 
 class PrimaryBasketWidget extends Widget
 {
+    use WidgetRespectsModuleVisibility;
+
+    protected static ?string $adminModule = 'System';
+
     protected static string $view = 'filament.admin.widgets.primary-basket-widget';
 
     protected int|string|array $columnSpan = 'full';

--- a/app/Filament/Admin/Widgets/SystemMetricsWidget.php
+++ b/app/Filament/Admin/Widgets/SystemMetricsWidget.php
@@ -4,12 +4,17 @@ declare(strict_types=1);
 
 namespace App\Filament\Admin\Widgets;
 
+use App\Filament\Admin\Traits\WidgetRespectsModuleVisibility;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 use Illuminate\Support\Facades\Cache;
 
 class SystemMetricsWidget extends BaseWidget
 {
+    use WidgetRespectsModuleVisibility;
+
+    protected static ?string $adminModule = 'System';
+
     protected static ?string $pollingInterval = '10s';
 
     protected static ?int $sort = 4;

--- a/app/Filament/Admin/Widgets/TenantSelectorWidget.php
+++ b/app/Filament/Admin/Widgets/TenantSelectorWidget.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Admin\Widgets;
 
+use App\Filament\Admin\Traits\WidgetRespectsModuleVisibility;
 use App\Models\Tenant;
 use Filament\Widgets\Widget;
 use Illuminate\Contracts\View\View;
@@ -16,6 +17,10 @@ use Illuminate\Contracts\View\View;
  */
 class TenantSelectorWidget extends Widget
 {
+    use WidgetRespectsModuleVisibility;
+
+    protected static ?string $adminModule = 'System';
+
     protected static string $view = 'filament.admin.widgets.tenant-selector-widget';
 
     protected int|string|array $columnSpan = 'full';
@@ -109,6 +114,10 @@ class TenantSelectorWidget extends Widget
      */
     public static function canView(): bool
     {
+        if (! static::adminModuleAllowsView()) {
+            return false;
+        }
+
         // Only show if tenancy is configured
         return class_exists(\Stancl\Tenancy\Tenancy::class);
     }

--- a/tests/Filament/Admin/Traits/Fixtures/FixtureBankingWidget.php
+++ b/tests/Filament/Admin/Traits/Fixtures/FixtureBankingWidget.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Filament\Admin\Traits\Fixtures;
+
+use App\Filament\Admin\Traits\WidgetRespectsModuleVisibility;
+use Filament\Widgets\Widget;
+
+class FixtureBankingWidget extends Widget
+{
+    use WidgetRespectsModuleVisibility;
+
+    protected static ?string $adminModule = 'Banking';
+
+    protected static string $view = 'welcome';
+}

--- a/tests/Filament/Admin/Traits/Fixtures/FixtureSystemWidget.php
+++ b/tests/Filament/Admin/Traits/Fixtures/FixtureSystemWidget.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Filament\Admin\Traits\Fixtures;
+
+use App\Filament\Admin\Traits\WidgetRespectsModuleVisibility;
+use Filament\Widgets\Widget;
+
+class FixtureSystemWidget extends Widget
+{
+    use WidgetRespectsModuleVisibility;
+
+    protected static ?string $adminModule = 'System';
+
+    protected static string $view = 'welcome';
+}

--- a/tests/Filament/Admin/Traits/Fixtures/FixtureUngroupedWidget.php
+++ b/tests/Filament/Admin/Traits/Fixtures/FixtureUngroupedWidget.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Filament\Admin\Traits\Fixtures;
+
+use App\Filament\Admin\Traits\WidgetRespectsModuleVisibility;
+use Filament\Widgets\Widget;
+
+class FixtureUngroupedWidget extends Widget
+{
+    use WidgetRespectsModuleVisibility;
+
+    protected static string $view = 'welcome';
+}

--- a/tests/Filament/Admin/Traits/WidgetRespectsModuleVisibilityTest.php
+++ b/tests/Filament/Admin/Traits/WidgetRespectsModuleVisibilityTest.php
@@ -2,35 +2,11 @@
 
 declare(strict_types=1);
 
-use App\Filament\Admin\Traits\WidgetRespectsModuleVisibility;
-use Filament\Widgets\Widget;
+use Tests\Filament\Admin\Traits\Fixtures\FixtureBankingWidget;
+use Tests\Filament\Admin\Traits\Fixtures\FixtureSystemWidget;
+use Tests\Filament\Admin\Traits\Fixtures\FixtureUngroupedWidget;
 
 uses(Tests\TestCase::class);
-
-class FixtureBankingWidget extends Widget
-{
-    use WidgetRespectsModuleVisibility;
-
-    protected static ?string $adminModule = 'Banking';
-
-    protected static string $view = 'welcome';
-}
-
-class FixtureSystemWidget extends Widget
-{
-    use WidgetRespectsModuleVisibility;
-
-    protected static ?string $adminModule = 'System';
-
-    protected static string $view = 'welcome';
-}
-
-class FixtureUngroupedWidget extends Widget
-{
-    use WidgetRespectsModuleVisibility;
-
-    protected static string $view = 'welcome';
-}
 
 describe('WidgetRespectsModuleVisibility', function () {
     it('shows all widgets when ADMIN_MODULES is unset', function () {

--- a/tests/Filament/Admin/Traits/WidgetRespectsModuleVisibilityTest.php
+++ b/tests/Filament/Admin/Traits/WidgetRespectsModuleVisibilityTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Admin\Traits\WidgetRespectsModuleVisibility;
+use Filament\Widgets\Widget;
+
+uses(Tests\TestCase::class);
+
+class FixtureBankingWidget extends Widget
+{
+    use WidgetRespectsModuleVisibility;
+
+    protected static ?string $adminModule = 'Banking';
+
+    protected static string $view = 'welcome';
+}
+
+class FixtureSystemWidget extends Widget
+{
+    use WidgetRespectsModuleVisibility;
+
+    protected static ?string $adminModule = 'System';
+
+    protected static string $view = 'welcome';
+}
+
+class FixtureUngroupedWidget extends Widget
+{
+    use WidgetRespectsModuleVisibility;
+
+    protected static string $view = 'welcome';
+}
+
+describe('WidgetRespectsModuleVisibility', function () {
+    it('shows all widgets when ADMIN_MODULES is unset', function () {
+        config(['brand.admin_modules' => null]);
+
+        expect(FixtureBankingWidget::canView())->toBeTrue();
+        expect(FixtureSystemWidget::canView())->toBeTrue();
+        expect(FixtureUngroupedWidget::canView())->toBeTrue();
+    });
+
+    it('shows only widgets whose module is in the allowed list', function () {
+        config(['brand.admin_modules' => ['Banking']]);
+
+        expect(FixtureBankingWidget::canView())->toBeTrue();
+        expect(FixtureSystemWidget::canView())->toBeFalse();
+    });
+
+    it('hides ungrouped widgets when ADMIN_MODULES is set', function () {
+        config(['brand.admin_modules' => ['Banking', 'System']]);
+
+        expect(FixtureUngroupedWidget::canView())->toBeFalse();
+    });
+
+    it('matches module names exactly (case-sensitive)', function () {
+        config(['brand.admin_modules' => ['banking']]);
+
+        expect(FixtureBankingWidget::canView())->toBeFalse();
+    });
+});


### PR DESCRIPTION
## Summary
- Resources have respected `ADMIN_MODULES` via `RespectsModuleVisibility` for a while; widgets did not. In Zelta production (`ADMIN_MODULES=System,Mobile,...`), widgets for hidden domains still rendered on the dashboard.
- Adds a parallel `WidgetRespectsModuleVisibility` trait that gates each widget by a static `$adminModule` mapped onto a Filament navigation group.
- Five widgets that already had a custom `canView()` (permission / feature-flag checks) now AND the module check with their existing logic so neither check is dropped.
- Adds `ADMIN_MODULES` guidance to `.env.production.example` and `.env.zelta.example` so production deployments pick the right scope.

## Widget assignments
- **Banking**: `BankAllocationWidget`, `BankHealthMonitorWidget`, `BankOperationsDashboard`, `MultiBankDistributionWidget`
- **System**: `AggregateHealthWidget`, `BasketPerformanceChart`, `BasketPerformanceStats`, `DomainHealthWidget`, `EventStoreStatsWidget`, `EventStoreThroughputWidget`, `GCUBasketWidget`, `ModuleHealthWidget`, `PrimaryBasketWidget`, `SystemMetricsWidget`, `TenantSelectorWidget`

## Test plan
- [ ] Set `ADMIN_MODULES="System"` in `.env`, log in as admin, verify Banking widgets are hidden from the dashboard.
- [ ] Unset `ADMIN_MODULES`, verify all widgets render.
- [ ] Set `ADMIN_MODULES="Banking,System"` (Zelta scope), verify both widget groups render.
- [ ] Confirm `BasketPerformanceChart`/`BasketPerformanceStats` still respect the existing `view_basket_performance` permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)