### PR TITLE
docs(web): refresh website content for v7.11.0 (MCP launch)

### DIFF
--- a/resources/views/about.blade.php
+++ b/resources/views/about.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'About ' . config('brand.name', 'Zelta') . ' — Open Source Core Banking Infrastructure',
-        'description' => 'Learn about Zelta, the open-source core banking platform — 57 modules covering payments, lending, compliance, DeFi, and a public MCP server for AI agents. Apache-2.0, built with Laravel.',
+        'description' => 'Learn about Zelta, the open-source core banking platform — 59 modules covering payments, lending, compliance, DeFi, and a public MCP server for AI agents. Apache-2.0, built with Laravel.',
         'keywords' => config('brand.name', 'Zelta') . ' about, open source banking, core banking platform, GCU, ISO 20022, PSD2, open banking, Interledger, microfinance, event sourcing, CQRS, Laravel banking, DDD, fintech infrastructure',
     ])
 
@@ -33,7 +33,7 @@
                 @include('partials.breadcrumb', ['items' => [['name' => 'About', 'url' => url('/about')]]])
                 <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">About <span class="text-gradient">{{ config('brand.name', 'Zelta') }}</span></h1>
                 <p class="text-lg text-slate-400 max-w-2xl mx-auto">
-                    Open-source core banking infrastructure built with Laravel — 57 domain modules covering everything from democratic currency governance to AI agent commerce.
+                    Open-source core banking infrastructure built with Laravel — 59 domain modules covering everything from democratic currency governance to AI agent commerce.
                 </p>
             </div>
         </div>
@@ -47,7 +47,7 @@
                 <div class="animate-on-scroll">
                     <h2 class="font-display text-3xl lg:text-4xl font-bold text-slate-900 mb-6">What Is {{ config('brand.name', 'Zelta') }}?</h2>
                     <p class="text-lg text-slate-600 mb-4 leading-relaxed">
-                        {{ config('brand.name', 'Zelta') }} is a core banking platform built with Laravel, implementing event sourcing, CQRS, domain-driven design, and AI agent integration across 57 bounded contexts.
+                        {{ config('brand.name', 'Zelta') }} is a core banking platform built with Laravel, implementing event sourcing, CQRS, domain-driven design, and AI agent integration across 59 bounded contexts.
                     </p>
                     <p class="text-lg text-slate-600 mb-6 leading-relaxed">
                         At its heart is the <strong>Global Currency Unit (GCU)</strong>&mdash;a democratically governed basket currency where users vote on composition from six global reserve assets.
@@ -210,7 +210,7 @@
                 <div class="card-feature">
                     <h4 class="font-display text-base font-bold text-slate-900 mb-2">For Founders</h4>
                     <p class="text-sm text-slate-500 mb-3">
-                        Build your fintech product on battle-tested infrastructure. 57 domain modules, Apache-2.0 licensed, ready to customize.
+                        Build your fintech product on battle-tested infrastructure. 59 domain modules, Apache-2.0 licensed, ready to customize.
                     </p>
                     <a href="{{ route('developers') }}" class="text-sm text-blue-600 font-semibold hover:text-blue-700 transition">
                         View Documentation &rarr;

--- a/resources/views/changelog.blade.php
+++ b/resources/views/changelog.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'Changelog | ' . config('brand.name', 'Zelta'),
-        'description' => 'Release history for the Zelta core banking platform. Track every feature shipped, bug fixed, and improvement made — v7.0 through v7.10.8.',
+        'description' => 'Release history for the Zelta core banking platform. Track every feature shipped, bug fixed, and improvement made — v7.0 through v7.11.0.',
         'keywords' => 'changelog, release notes, updates, ' . config('brand.name', 'Zelta') . ', version history, core banking',
     ])
 
@@ -43,6 +43,22 @@
 
             @php
                 $releases = [
+                    [
+                        'version' => 'v7.11.0',
+                        'date' => 'April 30, 2026',
+                        'label' => 'Public MCP Server + Brand Polish',
+                        'label_color' => 'indigo',
+                        'badge_color' => 'bg-indigo-100 text-indigo-700 border-indigo-200',
+                        'dot_color' => 'bg-indigo-500',
+                        'items' => [
+                            'Public MCP server — <code>https://mcp.zelta.app/mcp</code> serves a 12-tool catalog (accounts, payments, exchange, baskets, mcp ramp) over OAuth 2.1 with RFC 7591 dynamic client registration and RFC 9728 protected resource metadata. Designed for Claude Desktop, Cursor, and any spec-compliant AI agent. Spec: <code>docs/superpowers/specs/2026-04-27-mcp-server-design.md</code>.',
+                            '<code>@finaegis/mcp</code> npm wrapper — published stdio bridge for MCP clients that don\'t speak HTTP+SSE directly. Styled OAuth callback pages, file-based token storage by default (no keytar dependency), and a published <code>FinAegis/mcp</code> mirror for clean install.',
+                            'Brand polish on auth surfaces — login page, application logo, and footer no longer hard-code "FinAegis"; production deployments now read <code>config(\'brand.name\')</code> end-to-end. Open-source / Apache-2.0 marketing copy is gated to demo environments.',
+                            'Admin panel hardening — non-admin users hitting <code>/admin</code> now redirect to <code>/dashboard</code> with a flash error instead of a bare 403. Filament widgets gain module-aware visibility (<code>WidgetRespectsModuleVisibility</code> trait), matching the existing resource gating; production deployments can scope the dashboard via <code>ADMIN_MODULES</code>.',
+                            'Production env hygiene — <code>SHOW_PROMO_PAGES=false</code> and <code>ADMIN_MODULES</code> guidance now ship in <code>.env.production.example</code> and <code>.env.zelta.example</code> so customer-facing deployments derived from these templates pick the right scope by default.',
+                            'Auto-discovery for domain console commands — <code>app/Domain/*/Console/Commands/</code> now register automatically via <code>bootstrap/app.php</code>, fixing intermittent "namespace not found" errors during scheduled runs. Ramp tools skip self-registration when only the mock provider is configured.',
+                        ],
+                    ],
                     [
                         'version' => 'v7.10.8',
                         'date' => 'April 19, 2026',

--- a/resources/views/developers/index.blade.php
+++ b/resources/views/developers/index.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'Developer Docs — REST, GraphQL & CLI Reference | ' . config('brand.name', 'Zelta'),
-        'description' => config('brand.name', 'Zelta') . ' developer docs: 1,400+ REST and GraphQL API routes, SDKs, CLI tools, and WebSocket integrations across 56 banking modules. Get started in minutes.',
+        'description' => config('brand.name', 'Zelta') . ' developer docs: 1,400+ REST and GraphQL API routes, public MCP server, SDKs, CLI tools, and WebSocket integrations across 59 banking modules. Get started in minutes.',
         'keywords' => config('brand.name', 'Zelta') . ', developer, API, documentation, SDK, CLI, REST API, GraphQL, WebSocket, Laravel, banking API, open source, integration',
     ])
 @endsection
@@ -137,7 +137,7 @@
                 <div class="text-center">
                     <div class="inline-flex items-center px-4 py-2 bg-white/10 backdrop-blur-sm rounded-full text-sm mb-6">
                         <span class="w-2 h-2 bg-green-400 rounded-full mr-2 animate-pulse"></span>
-                        <span>v7.10.8 Documentation — 57 Domains, 1,400+ Routes, GraphQL + REST + x402</span>
+                        <span>v7.11.0 Documentation — 59 Domains, 1,400+ Routes, GraphQL + REST + MCP + x402</span>
                     </div>
                     <h1 class="text-5xl md:text-7xl font-bold mb-6 bg-clip-text text-transparent bg-gradient-to-r from-white to-blue-200">
                         Build with 1,400+ API Routes
@@ -177,8 +177,8 @@
                     <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                     </svg>
-                    <span class="font-medium">v7.10.8 Released:</span>
-                    <span class="ml-2">Public SDK distribution — CLI, JS/TS, Python, and PHP SDKs now install from npm, PyPI, and Packagist in one command. 57 DDD domains, 1,400+ API routes, GraphQL (45 domains), ISO 20022, ISO 8583, x402 Protocol.</span>
+                    <span class="font-medium">v7.11.0 Released:</span>
+                    <span class="ml-2">Public MCP server at <code class="code-font">mcp.zelta.app</code> — 12 OAuth-protected banking tools for Claude Desktop, Cursor, and any spec-compliant AI agent. <code class="code-font">@finaegis/mcp</code> on npm. 59 DDD domains, 1,400+ API routes, GraphQL (45 domains), ISO 20022, ISO 8583, x402 Protocol.</span>
                 </div>
             </div>
         </section>

--- a/resources/views/features/agent-protocol.blade.php
+++ b/resources/views/features/agent-protocol.blade.php
@@ -38,7 +38,7 @@
                 ]])
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-cyan-400 rounded-full mr-2"></span>
-                    v7.10.8 &middot; Autonomous Agent Commerce
+                    v7.11.0 &middot; Autonomous Agent Commerce
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">
                     Agent Protocol

--- a/resources/views/features/ai-framework.blade.php
+++ b/resources/views/features/ai-framework.blade.php
@@ -38,7 +38,7 @@
                 ]])
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.10.8 &middot; Multi-Agent Intelligence
+                    v7.11.0 &middot; Multi-Agent Intelligence
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">
                     AI Framework

--- a/resources/views/features/machine-payments.blade.php
+++ b/resources/views/features/machine-payments.blade.php
@@ -34,7 +34,7 @@
                 </div>
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.10.8 &middot; Multi-Rail Payments
+                    v7.11.0 &middot; Multi-Rail Payments
                 </div>
                 <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
                     Machine Payments Protocol

--- a/resources/views/features/x402-protocol.blade.php
+++ b/resources/views/features/x402-protocol.blade.php
@@ -36,7 +36,7 @@
                 </div>
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.10.8 &middot; Production Ready
+                    v7.11.0 &middot; Production Ready
                 </div>
                 <h1 class="font-display text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">x402 Protocol</h1>
                 <p class="text-lg text-slate-400 max-w-3xl mx-auto mb-8">

--- a/resources/views/partials/public-nav.blade.php
+++ b/resources/views/partials/public-nav.blade.php
@@ -37,7 +37,7 @@
                                     </div>
                                     <div>
                                         <div class="text-sm font-medium text-slate-200">All Features</div>
-                                        <div class="text-xs text-slate-500">57 domain modules</div>
+                                        <div class="text-xs text-slate-500">59 domain modules</div>
                                     </div>
                                 </a>
                                 <a href="{{ route('gcu') }}" class="dropdown-link {{ request()->routeIs('gcu*') ? 'dropdown-link-active' : '' }}">

--- a/resources/views/platform/index.blade.php
+++ b/resources/views/platform/index.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => config('brand.name', 'Zelta') . ' Platform - Open Banking for Developers',
-        'description' => 'Zelta Platform: open-source core banking with 56 DDD domains, ISO 20022, PSD2, multi-rail payments, and cross-chain DeFi. Apache-2.0 licensed, built for developers.',
+        'description' => 'Zelta Platform: open-source core banking with 59 DDD domains, ISO 20022, PSD2, multi-rail payments, cross-chain DeFi, and a public MCP server. Apache-2.0 licensed, built for developers.',
         'keywords' => config('brand.name', 'Zelta') . ' platform, banking infrastructure, open source banking, developer API, ISO 20022, PSD2, payment rails, Interledger, microfinance, ledger, Apache-2.0 license, core banking API, fintech development, DDD, event sourcing',
     ])
 
@@ -177,7 +177,7 @@
                                 <div class="text-sm text-gray-500">License</div>
                             </div>
                             <div>
-                                <div class="text-2xl font-bold text-blue-400 code-font">56</div>
+                                <div class="text-2xl font-bold text-blue-400 code-font">59</div>
                                 <div class="text-sm text-gray-500">Domains</div>
                             </div>
                             <div>
@@ -390,7 +390,7 @@
 
                 <!-- Available Modules -->
                 <div class="text-center py-12">
-                    <h2 class="text-3xl font-bold text-slate-900 mb-4">56 Domain Modules</h2>
+                    <h2 class="text-3xl font-bold text-slate-900 mb-4">59 Domain Modules</h2>
                     <p class="text-lg text-slate-600 mb-8 max-w-2xl mx-auto">
                         From ISO 20022 messaging to microfinance lending — every banking capability in one codebase.
                     </p>

--- a/resources/views/pricing.blade.php
+++ b/resources/views/pricing.blade.php
@@ -58,7 +58,7 @@
                         <ul class="space-y-3 mb-8 text-sm text-slate-600">
                             <li class="list-check">Full source code access</li>
                             <li class="list-check">Apache-2.0 License</li>
-                            <li class="list-check">All 57 domain modules</li>
+                            <li class="list-check">All 59 domain modules</li>
                             <li class="list-check">ISO 20022, Open Banking, Payment Rails</li>
                             <li class="list-check">Ledger, Microfinance, Interledger</li>
                             <li class="list-check">Community support</li>

--- a/resources/views/support/faq.blade.php
+++ b/resources/views/support/faq.blade.php
@@ -13,7 +13,7 @@
     $faqData = [
         [
             'question' => 'What is the current status of ' . config('brand.name', 'Zelta') . '?',
-            'answer' => config('brand.name', 'Zelta') . ' v7.10.8 is a fully-featured open-source core banking platform with 56 domain modules. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
+            'answer' => config('brand.name', 'Zelta') . ' v7.11.0 is a fully-featured open-source core banking platform with 59 domain modules, including a public OAuth-protected MCP server for AI agents. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
         ],
         [
             'question' => 'Can I use real money on the platform?',
@@ -21,7 +21,7 @@
         ],
         [
             'question' => 'How do I get started?',
-            'answer' => 'Register for a free account to explore the sandbox, or clone the repository from GitHub to self-host. You can explore all 56 domain modules, test the APIs, and provide feedback through our support channels.'
+            'answer' => 'Register for a free account to explore the sandbox, or clone the repository from GitHub to self-host. You can explore all 59 domain modules, test the APIs, and provide feedback through our support channels.'
         ],
         [
             'question' => 'What is the Global Currency Unit (GCU)?',
@@ -127,10 +127,10 @@
                     </button>
                     <div class="faq-answer px-6 py-4 bg-white rounded-b-lg">
                         <p class="text-slate-500">
-                            {{ config('brand.name', 'Zelta') }} is a fully-featured open-source core banking platform at v7.10.8. The sandbox environment lets you:
+                            {{ config('brand.name', 'Zelta') }} is a fully-featured open-source core banking platform at v7.11.0. The sandbox environment lets you:
                         </p>
                         <ul class="list-disc list-inside mt-2 text-slate-500 space-y-1">
-                            <li>Explore 56 domain modules including DeFi, cross-chain, privacy, and rewards</li>
+                            <li>Explore 59 domain modules including DeFi, cross-chain, privacy, MCP, and rewards</li>
                             <li>Test 1,400+ API routes and a 45-domain GraphQL API</li>
                             <li>Try KYC/AML compliance flows, card issuing, and mobile payments</li>
                             <li>All transactions use test data &mdash; no real funds are involved</li>
@@ -340,7 +340,7 @@
                             We have an exciting roadmap ahead:
                         </p>
                         <ul class="list-disc list-inside mt-2 text-slate-500 space-y-1">
-                            <li><strong>Delivered:</strong> 56 domain modules, 1,400+ API routes, GraphQL (45 domains), event sourcing</li>
+                            <li><strong>Delivered:</strong> 59 domain modules, 1,400+ API routes, GraphQL (45 domains), public MCP server, event sourcing</li>
                             <li><strong>Delivered:</strong> Mobile app backend, passkey auth, card issuing, KYC/AML</li>
                             <li><strong>Delivered:</strong> Cross-chain bridges, DeFi connectors, X402 micropayments</li>
                             <li><strong>Delivered:</strong> GCU voting system, production bank integrations</li>

--- a/resources/views/support/guides.blade.php
+++ b/resources/views/support/guides.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'Support Guides - ' . config('brand.name', 'Zelta'),
-        'description' => config('brand.name', 'Zelta') . ' platform guides and documentation. Learn how to use, deploy, and contribute to our open-source core banking platform with 56 domain modules.',
+        'description' => config('brand.name', 'Zelta') . ' platform guides and documentation. Learn how to use, deploy, and contribute to our open-source core banking platform with 59 domain modules.',
         'keywords' => config('brand.name', 'Zelta') . ' guides, documentation, tutorials, open source banking, core banking platform',
     ])
 @endsection

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => config('brand.name', 'Zelta') . ' - Open Source Core Banking Infrastructure',
-        'description' => 'Open-source core banking platform with 57 modules: payments, lending, compliance, and DeFi. ISO 20022, PSD2, ACH, SEPA. Apache-2.0 licensed, built with Laravel.',
+        'description' => 'Open-source core banking platform with 59 modules: payments, lending, compliance, DeFi, and a public MCP server for AI agents. ISO 20022, PSD2, ACH, SEPA. Apache-2.0 licensed, built with Laravel.',
         'keywords' => config('brand.name', 'Zelta') . ', open source banking, core banking infrastructure, GCU, ISO 20022, PSD2, open banking, ACH, SEPA, Interledger, microfinance, event sourcing, DeFi, RegTech, banking API, Laravel fintech',
     ])
 
@@ -32,7 +32,7 @@
                     <svg class="w-4 h-4 text-fa-teal" fill="currentColor" viewBox="0 0 20 20">
                         <path fill-rule="evenodd" d="M12.316 3.051a1 1 0 01.633 1.265l-4 12a1 1 0 11-1.898-.632l4-12a1 1 0 011.265-.633zM5.707 6.293a1 1 0 010 1.414L3.414 10l2.293 2.293a1 1 0 11-1.414 1.414l-3-3a1 1 0 010-1.414l3-3a1 1 0 011.414 0zm8.586 0a1 1 0 011.414 0l3 3a1 1 0 010 1.414l-3 3a1 1 0 11-1.414-1.414L16.586 10l-2.293-2.293a1 1 0 010-1.414z" clip-rule="evenodd"/>
                     </svg>
-                    Open Source &middot; Apache-2.0 Licensed &middot; 57 Domains
+                    Open Source &middot; Apache-2.0 Licensed &middot; 59 Domains
                 </div>
 
                 <!-- MCP-compatible badge -->
@@ -49,7 +49,7 @@
 
                 <!-- Subheading -->
                 <p class="text-lg sm:text-xl text-slate-400 max-w-2xl mx-auto mb-10 leading-relaxed animate-fade-in-up" style="animation-delay: 0.15s">
-                    Ship compliant banking products in weeks, not years. 57 production-ready modules cover payments, lending, compliance, and cross-border transfers — so you build features, not infrastructure.
+                    Ship compliant banking products in weeks, not years. 59 production-ready modules cover payments, lending, compliance, and cross-border transfers — so you build features, not infrastructure.
                 </p>
 
                 <!-- CTA Buttons -->
@@ -201,7 +201,7 @@
 
             <div class="text-center mt-12 animate-on-scroll">
                 <a href="{{ route('features') }}" class="btn-primary !bg-slate-900 hover:!bg-slate-800 !rounded-lg group">
-                    See All 57 Domains
+                    See All 59 Domains
                     <svg class="w-4 h-4 ml-2 transition-transform group-hover:translate-x-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path></svg>
                 </a>
             </div>


### PR DESCRIPTION
## Summary
- Update domain count 56/57 → 59 across welcome, about, platform, pricing, support guides, FAQ, and the public nav.
- Bump version badge from v7.10.8 → v7.11.0 on the developers landing page.
- Add a v7.11.0 changelog entry describing the public MCP server launch, brand polish on auth surfaces, admin redirect for non-admins, and the SHOW_PROMO_PAGES + ADMIN_MODULES env defaults that ship with this release.

## Test plan
- [ ] Visit /welcome, /about, /platform, /pricing, /support/faq — verify "59 domain modules" / "59 Domains" copy renders consistently.
- [ ] Visit /developers — verify v7.11.0 release banner, MCP mention, 59 Domains.
- [ ] Visit /changelog — verify v7.11.0 entry sits at the top and links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)