### PR TITLE
fix(ci): make deploy release-notes step idempotent

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -563,14 +563,37 @@ jobs:
         with:
           script: |
             const tag = context.ref.replace('refs/tags/', '');
-            const release = await github.rest.repos.createRelease({
+            try {
+              await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag,
+              });
+              core.info(`Release for tag ${tag} already exists; skipping creation.`);
+              return;
+            } catch (err) {
+              if (err.status !== 404) throw err;
+            }
+            const tags = await github.rest.repos.listTags({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+            });
+            const versionTags = tags.data
+              .map(t => t.name)
+              .filter(name => name.startsWith('v') && name !== tag);
+            const previousTag = versionTags[0] ?? '';
+            const compareUrl = previousTag
+              ? `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/compare/${previousTag}...${tag}`
+              : `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/releases/tag/${tag}`;
+            await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
               tag_name: tag,
               name: `Release ${tag}`,
-              body: `## What's Changed\n\nFull changelog: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/compare/...${tag}`,
+              body: `## What's Changed\n\nFull changelog: ${compareUrl}`,
               draft: false,
-              prerelease: false
+              prerelease: false,
             });
 
   deployment-summary:


### PR DESCRIPTION
## Summary

- Short-circuit the **Create Release Notes** step in `deploy.yml` if a release for the pushed tag already exists, instead of letting `createRelease` hard-fail with `422 already_exists`.
- Compute the previous version tag and build a real compare URL (`compare/<prev>...<tag>`); fall back to the release page when there is no prior tag. Previously the body always read `compare/...vX.Y.Z` (empty `from`).

## Why

The v7.11.0 tag-deploy workflow ([run 25173660981](https://github.com/FinAegis/core-banking-prototype-laravel/actions/runs/25173660981)) failed at this step because the release had already been published manually with curated notes:

```
Validation Failed: {"resource":"Release","code":"already_exists","field":"tag_name"}
```

The deployment itself succeeded — only the post-deploy auto-stub-release step failed. Future tag pushes shouldn't fail just because a real human (or another step) created the release first.

## Test plan

- [ ] Workflow YAML lints clean (push will trigger validation).
- [ ] Next tag push that *does* have a pre-existing release: step logs `Release for tag ... already exists; skipping creation.` and succeeds.
- [ ] Next tag push that has *no* pre-existing release: step creates one with a working `compare/<prev>...<tag>` URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)