### PR TITLE
fix(wallet): Helius sync — send api-key as query param, propagate failures

### DIFF
--- a/app/Domain/Wallet/Services/HeliusWebhookSyncService.php
+++ b/app/Domain/Wallet/Services/HeliusWebhookSyncService.php
@@ -103,6 +103,8 @@ class HeliusWebhookSyncService
 
     /**
      * Sync all Solana addresses from the database to Helius.
+     *
+     * Returns the count of addresses pushed on success, 0 on failure.
      */
     public function syncAllAddresses(): int
     {
@@ -123,7 +125,9 @@ class HeliusWebhookSyncService
             ->values()
             ->all();
 
-        $this->updateWebhookAddresses($webhookId, $apiKey, $addresses);
+        if (! $this->updateWebhookAddresses($webhookId, $apiKey, $addresses)) {
+            return 0;
+        }
 
         Log::info('Helius: Synced all Solana addresses', ['count' => count($addresses)]);
 
@@ -161,6 +165,10 @@ class HeliusWebhookSyncService
     /**
      * Update the webhook with a new address list.
      *
+     * Helius requires `api-key` as a query parameter — it does not accept the
+     * key in the JSON body or in an Authorization header. Sending it in the
+     * body (Laravel's default for Http::put) fails with 401 missing api key.
+     *
      * @param array<string> $addresses
      */
     private function updateWebhookAddresses(string $webhookId, string $apiKey, array $addresses): bool
@@ -168,9 +176,9 @@ class HeliusWebhookSyncService
         $uniqueAddresses = array_values(array_unique($addresses));
 
         $response = Http::timeout(15)
+            ->withQueryParameters(['api-key' => $apiKey])
             ->put("https://api.helius.xyz/v0/webhooks/{$webhookId}", [
                 'accountAddresses' => $uniqueAddresses,
-                'api-key'          => $apiKey,
             ]);
 
         if (! $response->successful()) {

--- a/tests/Feature/Domain/Wallet/HeliusWebhookSyncServiceTest.php
+++ b/tests/Feature/Domain/Wallet/HeliusWebhookSyncServiceTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Account\Models\BlockchainAddress;
+use App\Domain\Wallet\Services\HeliusWebhookSyncService;
+use App\Models\User;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Tests\Traits\CreatesSolanaTestTables;
+
+uses(CreatesSolanaTestTables::class);
+
+beforeEach(function (): void {
+    config([
+        'cache.default'              => 'array',
+        'services.helius.webhook_id' => 'test-webhook-id',
+        'services.helius.api_key'    => 'test-api-key',
+    ]);
+
+    $this->createSolanaTestTables();
+});
+
+afterEach(function (): void {
+    $this->dropSolanaTestTables();
+});
+
+it('sends api-key as a query parameter on the PUT request, not in the body', function (): void {
+    $user = User::factory()->create();
+    BlockchainAddress::create([
+        'user_uuid'  => $user->uuid,
+        'chain'      => 'solana',
+        'address'    => '9UYjpLnTu78B5kqNoKgghLTcRKsUUZNRGUfxEZiwpR7L',
+        'public_key' => '9UYjpLnTu78B5kqNoKgghLTcRKsUUZNRGUfxEZiwpR7L',
+        'is_active'  => true,
+    ]);
+
+    Http::fake([
+        'https://api.helius.xyz/v0/webhooks/test-webhook-id*' => Http::response([
+            'webhookID'        => 'test-webhook-id',
+            'accountAddresses' => ['9UYjpLnTu78B5kqNoKgghLTcRKsUUZNRGUfxEZiwpR7L'],
+        ], 200),
+    ]);
+
+    $count = (new HeliusWebhookSyncService())->syncAllAddresses();
+
+    expect($count)->toBe(1);
+
+    Http::assertSent(function (Request $request): bool {
+        if ($request->method() !== 'PUT') {
+            return false;
+        }
+
+        // api-key MUST be in the URL query string
+        if (! str_contains($request->url(), 'api-key=test-api-key')) {
+            return false;
+        }
+
+        // and MUST NOT leak into the JSON body
+        $body = $request->data();
+
+        return ! array_key_exists('api-key', $body)
+            && isset($body['accountAddresses'])
+            && in_array('9UYjpLnTu78B5kqNoKgghLTcRKsUUZNRGUfxEZiwpR7L', $body['accountAddresses'], true);
+    });
+});
+
+it('returns 0 when the upstream Helius PUT fails', function (): void {
+    $user = User::factory()->create();
+    BlockchainAddress::create([
+        'user_uuid'  => $user->uuid,
+        'chain'      => 'solana',
+        'address'    => '9UYjpLnTu78B5kqNoKgghLTcRKsUUZNRGUfxEZiwpR7L',
+        'public_key' => '9UYjpLnTu78B5kqNoKgghLTcRKsUUZNRGUfxEZiwpR7L',
+        'is_active'  => true,
+    ]);
+
+    Http::fake([
+        'https://api.helius.xyz/v0/webhooks/test-webhook-id*' => Http::response([
+            'jsonrpc' => '2.0',
+            'error'   => ['code' => -32401, 'message' => 'missing api key'],
+        ], 401),
+    ]);
+
+    $count = (new HeliusWebhookSyncService())->syncAllAddresses();
+
+    expect($count)->toBe(0);
+});


### PR DESCRIPTION
## Summary

**Production hotfix.** Two bugs in \`HeliusWebhookSyncService\` combined to silence every Solana receive notification and Activity feed entry since **2026-04-04** (~27 days).

1. **api-key sent in PUT body instead of query string.** \`Http::put(\$url, \$data)\` sends \`\$data\` as JSON body, but Helius requires \`api-key\` as a query param. Every PUT to \`PUT /v0/webhooks/{id}\` was returning \`401 missing api key\`. CLAUDE.md already documents this constraint — the bug just predated the note.
   - Fix: \`withQueryParameters(['api-key' => \$apiKey])\` on the PUT.
2. **\`syncAllAddresses()\` ignored upstream failures** and reported \`count(db_addresses)\` unconditionally. \`php artisan solana:sync\` therefore logged \"Synced 4\" while Helius's webhook config still had only 1 stale address, with no error surfaced.
   - Fix: return 0 when the PUT fails so the artisan command reports failure.

## Production evidence

\`\`\`
[2026-05-01 08:06:20] production.ERROR: Helius: Failed to update webhook addresses
{\"status\":401,\"body\":\"{\\\"jsonrpc\\\":\\\"2.0\\\",\\\"error\\\":{\\\"code\\\":-32401,\\\"message\\\":\\\"missing api key\\\"}}\",\"count\":4}
\`\`\`

Helius webhook config GET (before fix):
\`\`\`json
{ \"accountAddresses_count\": 1, \"has_yozaz\": false, \"authHeader_set\": true }
\`\`\`

The single stale address belongs to user_id=4 (registered before the regression) and is the source of the recent \`Helius webhook secret verification failed\` log lines — Helius is calling that one address with a now-rotated authHeader.

## Why this happened

The \`BlockchainAddressObserver::created()\` auto-sync path also goes through this method, so every new Solana address since the bug landed never reached Helius — they sat in our DB \`is_active=true\` while Helius didn't know they existed. There's no reconciliation loop catching the drift between \`SELECT count(*) FROM blockchain_addresses WHERE chain='solana'\` and Helius's \`accountAddresses\` length. Worth scheduling \`solana:sync\` on cron + alerting on count drift as a follow-up.

## Test plan

- [x] \`./vendor/bin/pest tests/Feature/Domain/Wallet/HeliusWebhookSyncServiceTest.php\` — 2 passed (3 assertions)
  - asserts PUT carries \`api-key\` in URL query, never in body
  - asserts \`syncAllAddresses\` returns 0 when upstream rejects with 401
- [x] PHPStan clean
- [x] php-cs-fixer clean
- [ ] **After merge + deploy:** re-run \`sudo -u www-data php /srv/zelta/artisan solana:sync\` on prod; verify \`accountAddresses_count: 4\` and \`has_yozaz: true\` via Helius API.
- [ ] Send 1 USDC to the user's Solana address; confirm new row in \`blockchain_address_transactions\` and \`activity_feed_items\` within ~10s.

## Follow-up (separate PRs)
- Pusher \`cURL error 35: SSL routines::packet length too long\` from April 4 (broadcasts queue) — recurs once webhook flow is unblocked.
- 30+ \`Job requires tenant context\` failures in mobile queue from April 1 (unrelated, but visible in failed_jobs).
- Schedule \`solana:sync\` on cron + alert on Helius/DB address count drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)