### PR TITLE
fix(wallet): Helius sync — replay full webhook config on PUT

### DIFF
--- a/app/Domain/Wallet/Services/HeliusWebhookSyncService.php
+++ b/app/Domain/Wallet/Services/HeliusWebhookSyncService.php
@@ -165,9 +165,14 @@ class HeliusWebhookSyncService
     /**
      * Update the webhook with a new address list.
      *
-     * Helius requires `api-key` as a query parameter — it does not accept the
-     * key in the JSON body or in an Authorization header. Sending it in the
-     * body (Laravel's default for Http::put) fails with 401 missing api key.
+     * Helius's PUT /v0/webhooks/{id} replaces the entire webhook config — it
+     * does NOT support partial updates. Sending only accountAddresses fails
+     * with 400 ("Webhook URL is required", "Transaction types must be an
+     * array", etc.). So we GET the current config, swap accountAddresses,
+     * and PUT the whole object back.
+     *
+     * Helius requires `api-key` as a query parameter — it does not accept
+     * the key in the JSON body or in an Authorization header.
      *
      * @param array<string> $addresses
      */
@@ -175,11 +180,29 @@ class HeliusWebhookSyncService
     {
         $uniqueAddresses = array_values(array_unique($addresses));
 
+        $current = Http::timeout(15)
+            ->withQueryParameters(['api-key' => $apiKey])
+            ->get("https://api.helius.xyz/v0/webhooks/{$webhookId}");
+
+        if (! $current->successful()) {
+            Log::error('Helius: Failed to fetch current webhook config for update', [
+                'status' => $current->status(),
+                'body'   => $current->body(),
+            ]);
+
+            return false;
+        }
+
+        /** @var array<string, mixed> $config */
+        $config = (array) $current->json();
+        $config['accountAddresses'] = $uniqueAddresses;
+
+        // Strip server-managed fields that Helius rejects on PUT.
+        unset($config['webhookID'], $config['project']);
+
         $response = Http::timeout(15)
             ->withQueryParameters(['api-key' => $apiKey])
-            ->put("https://api.helius.xyz/v0/webhooks/{$webhookId}", [
-                'accountAddresses' => $uniqueAddresses,
-            ]);
+            ->put("https://api.helius.xyz/v0/webhooks/{$webhookId}", $config);
 
         if (! $response->successful()) {
             Log::error('Helius: Failed to update webhook addresses', [

--- a/tests/Feature/Domain/Wallet/HeliusWebhookSyncServiceTest.php
+++ b/tests/Feature/Domain/Wallet/HeliusWebhookSyncServiceTest.php
@@ -25,6 +25,26 @@ afterEach(function (): void {
     $this->dropSolanaTestTables();
 });
 
+/**
+ * Realistic Helius `GET /v0/webhooks/{id}` response. The PUT must replay
+ * webhookURL / transactionTypes / webhookType / authHeader back to Helius
+ * or it 400s with "Webhook URL is required" etc.
+ *
+ * @return array<string, mixed>
+ */
+function heliusWebhookConfig(): array
+{
+    return [
+        'webhookID'        => 'test-webhook-id',
+        'wallet'           => 'project-wallet',
+        'webhookURL'       => 'https://zelta.app/api/webhooks/helius/solana',
+        'transactionTypes' => ['ANY'],
+        'accountAddresses' => ['existing-address-from-helius'],
+        'webhookType'      => 'enhanced',
+        'authHeader'       => 'shared-secret',
+    ];
+}
+
 it('sends api-key as a query parameter on the PUT request, not in the body', function (): void {
     $user = User::factory()->create();
     BlockchainAddress::create([
@@ -36,10 +56,7 @@ it('sends api-key as a query parameter on the PUT request, not in the body', fun
     ]);
 
     Http::fake([
-        'https://api.helius.xyz/v0/webhooks/test-webhook-id*' => Http::response([
-            'webhookID'        => 'test-webhook-id',
-            'accountAddresses' => ['9UYjpLnTu78B5kqNoKgghLTcRKsUUZNRGUfxEZiwpR7L'],
-        ], 200),
+        'https://api.helius.xyz/v0/webhooks/test-webhook-id*' => Http::response(heliusWebhookConfig(), 200),
     ]);
 
     $count = (new HeliusWebhookSyncService())->syncAllAddresses();
@@ -65,7 +82,60 @@ it('sends api-key as a query parameter on the PUT request, not in the body', fun
     });
 });
 
+it('replays webhookURL, transactionTypes, webhookType and authHeader on PUT', function (): void {
+    $user = User::factory()->create();
+    BlockchainAddress::create([
+        'user_uuid'  => $user->uuid,
+        'chain'      => 'solana',
+        'address'    => '9UYjpLnTu78B5kqNoKgghLTcRKsUUZNRGUfxEZiwpR7L',
+        'public_key' => '9UYjpLnTu78B5kqNoKgghLTcRKsUUZNRGUfxEZiwpR7L',
+        'is_active'  => true,
+    ]);
+
+    Http::fake([
+        'https://api.helius.xyz/v0/webhooks/test-webhook-id*' => Http::response(heliusWebhookConfig(), 200),
+    ]);
+
+    (new HeliusWebhookSyncService())->syncAllAddresses();
+
+    Http::assertSent(function (Request $request): bool {
+        if ($request->method() !== 'PUT') {
+            return false;
+        }
+
+        $body = $request->data();
+
+        return ($body['webhookURL'] ?? null) === 'https://zelta.app/api/webhooks/helius/solana'
+            && ($body['transactionTypes'] ?? null) === ['ANY']
+            && ($body['webhookType'] ?? null) === 'enhanced'
+            && ($body['authHeader'] ?? null) === 'shared-secret'
+            // server-managed fields must be stripped
+            && ! array_key_exists('webhookID', $body);
+    });
+});
+
 it('returns 0 when the upstream Helius PUT fails', function (): void {
+    $user = User::factory()->create();
+    BlockchainAddress::create([
+        'user_uuid'  => $user->uuid,
+        'chain'      => 'solana',
+        'address'    => '9UYjpLnTu78B5kqNoKgghLTcRKsUUZNRGUfxEZiwpR7L',
+        'public_key' => '9UYjpLnTu78B5kqNoKgghLTcRKsUUZNRGUfxEZiwpR7L',
+        'is_active'  => true,
+    ]);
+
+    Http::fake([
+        'https://api.helius.xyz/v0/webhooks/test-webhook-id*' => Http::sequence()
+            ->push(heliusWebhookConfig(), 200)        // GET succeeds
+            ->push(['error' => 'Bad Request'], 400),  // PUT rejects
+    ]);
+
+    $count = (new HeliusWebhookSyncService())->syncAllAddresses();
+
+    expect($count)->toBe(0);
+});
+
+it('returns 0 when the upstream Helius GET fails', function (): void {
     $user = User::factory()->create();
     BlockchainAddress::create([
         'user_uuid'  => $user->uuid,


### PR DESCRIPTION
## Summary

Follow-up to #1003. After fixing the api-key transport, the next request to Helius surfaced a second issue: **`PUT /v0/webhooks/{id}` replaces the entire webhook configuration** — partial updates aren't supported. Sending only `accountAddresses` returns 400:

\`\`\`
"message": ["Webhook URL is required",
            "Webhook type is required",
            "At least one transaction type is required",
            "Each transaction type must be a valid TransactionType",
            ...],
"statusCode": 400
\`\`\`

So our previous code could never have worked end-to-end even with the api-key transport correct. The brief April 3-4 window of working webhooks predates this code path.

## Fix

\`updateWebhookAddresses()\` now:
1. GETs the current webhook config from Helius
2. Swaps in our new \`accountAddresses\` list
3. Strips server-managed fields Helius rejects on PUT (\`webhookID\`, \`project\`)
4. PUTs the full merged config back

\`Cache::lock\` in \`addAddress\`/\`removeAddress\` already serializes concurrent updates within the app, so this GET-then-PUT pattern is race-safe for our writers.

## Test plan

- [x] 4 passing tests, including two new regressions:
  - replays \`webhookURL\` / \`transactionTypes\` / \`webhookType\` / \`authHeader\` on PUT and strips \`webhookID\`
  - returns 0 when the upstream GET fails (not just PUT)
- [x] PHPStan clean
- [x] php-cs-fixer clean
- [ ] **After merge + deploy** on prod:
  \`\`\`bash
  sudo -u www-data php /srv/zelta/artisan solana:sync
  curl -sS \"https://api.helius.xyz/v0/webhooks/\$ID?api-key=\$KEY\" | jq '{count: (.accountAddresses|length)}'
  \`\`\`
  Expected: \`{ count: 4 }\` and \`has_yozaz: true\`. Then send 1 USDC and watch \`storage/logs/laravel.log\` for \"Helius: Solana transaction stored\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)