### PR TITLE
fix(wallet): Helius sync — whitelist allowed PUT fields

### DIFF
--- a/app/Domain/Wallet/Services/HeliusWebhookSyncService.php
+++ b/app/Domain/Wallet/Services/HeliusWebhookSyncService.php
@@ -30,6 +30,24 @@ class HeliusWebhookSyncService
 
     private const LOCK_TIMEOUT = 15;
 
+    /**
+     * Fields Helius accepts on PUT /v0/webhooks/{id}.
+     *
+     * The GET response includes server-managed fields (`webhookID`, `project`,
+     * `wallet`, `lastEnabledAt`, etc.) that Helius rejects with 400 on PUT.
+     * We whitelist instead of blacklist so future-added server fields don't
+     * silently break sync.
+     */
+    private const PUT_ALLOWED_FIELDS = [
+        'webhookURL',
+        'transactionTypes',
+        'accountAddresses',
+        'webhookType',
+        'authHeader',
+        'txnStatus',
+        'encoding',
+    ];
+
     /** @var array<string> Solana system/program addresses that must never be monitored */
     private const RESERVED_ADDRESSES = [
         '11111111111111111111111111111111',
@@ -195,10 +213,11 @@ class HeliusWebhookSyncService
 
         /** @var array<string, mixed> $config */
         $config = (array) $current->json();
-        $config['accountAddresses'] = $uniqueAddresses;
 
-        // Strip server-managed fields that Helius rejects on PUT.
-        unset($config['webhookID'], $config['project']);
+        // Helius rejects unknown/server-managed fields on PUT. Whitelist only
+        // the fields documented as accepted, plus our updated address list.
+        $config = array_intersect_key($config, array_flip(self::PUT_ALLOWED_FIELDS));
+        $config['accountAddresses'] = $uniqueAddresses;
 
         $response = Http::timeout(15)
             ->withQueryParameters(['api-key' => $apiKey])

--- a/tests/Feature/Domain/Wallet/HeliusWebhookSyncServiceTest.php
+++ b/tests/Feature/Domain/Wallet/HeliusWebhookSyncServiceTest.php
@@ -35,8 +35,12 @@ afterEach(function (): void {
 function heliusWebhookConfig(): array
 {
     return [
-        'webhookID'        => 'test-webhook-id',
-        'wallet'           => 'project-wallet',
+        // Server-managed fields the GET returns but PUT rejects:
+        'webhookID'     => 'test-webhook-id',
+        'wallet'        => 'project-wallet',
+        'lastEnabledAt' => '2026-04-01T00:00:00Z',
+        'project'       => 'zelta-prod',
+        // PUT-allowed fields:
         'webhookURL'       => 'https://zelta.app/api/webhooks/helius/solana',
         'transactionTypes' => ['ANY'],
         'accountAddresses' => ['existing-address-from-helius'],
@@ -109,8 +113,11 @@ it('replays webhookURL, transactionTypes, webhookType and authHeader on PUT', fu
             && ($body['transactionTypes'] ?? null) === ['ANY']
             && ($body['webhookType'] ?? null) === 'enhanced'
             && ($body['authHeader'] ?? null) === 'shared-secret'
-            // server-managed fields must be stripped
-            && ! array_key_exists('webhookID', $body);
+            // server-managed fields the GET returns but PUT rejects must be stripped
+            && ! array_key_exists('webhookID', $body)
+            && ! array_key_exists('wallet', $body)
+            && ! array_key_exists('lastEnabledAt', $body)
+            && ! array_key_exists('project', $body);
     });
 });
 


### PR DESCRIPTION
## Summary

Third fix in the Helius sync chain (#1003 → #1004 → this). After GET-then-PUT was working, prod returned another 400:

\`\`\`
"message": ["property wallet should not exist",
            "property lastEnabledAt should not exist"],
"statusCode": 400
\`\`\`

\`#1004\` stripped \`webhookID\` and \`project\` on a hunch, but Helius's GET response actually carries more server-managed fields (\`wallet\`, \`lastEnabledAt\`, and likely more they'll add later). Whack-a-mole isn't a strategy.

## Fix

Switch from blacklist → whitelist. Only the documented PUT fields go through:

\`\`\`php
private const PUT_ALLOWED_FIELDS = [
    'webhookURL', 'transactionTypes', 'accountAddresses',
    'webhookType', 'authHeader', 'txnStatus', 'encoding',
];
\`\`\`

Future server-managed fields Helius adds to the GET response can no longer break sync.

## Test plan

- [x] 4 tests passing. The regression test now asserts \`webhookID\`, \`wallet\`, \`lastEnabledAt\`, \`project\` are all stripped from the PUT body.
- [x] PHPStan clean
- [x] php-cs-fixer clean
- [ ] **After merge + deploy:** \`solana:sync\` then verify \`{count: 4, has_yozaz: true}\` via Helius API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)