### PR TITLE
fix(wallet): register payment_intent rate-limit config + clarify amount unit contract

### DIFF
--- a/app/Http/Controllers/Api/Wallet/MobileWalletController.php
+++ b/app/Http/Controllers/Api/Wallet/MobileWalletController.php
@@ -546,13 +546,20 @@ class MobileWalletController extends Controller
         path: '/api/v1/wallet/transactions/send',
         operationId: 'walletSend',
         summary: 'Send a transaction',
-        description: 'Creates a payment intent and auto-submits it to send tokens to a recipient address.',
+        description: 'Creates a payment intent and auto-submits it to send tokens to a recipient address. ' .
+            'Amounts are in DECIMAL MAJOR UNITS — e.g. "1" or "1.5" for 1.5 USDC. ' .
+            'Do NOT pre-convert to atomic / on-chain integer units (e.g. "1500000" for 1.5 USDC at 6dp).',
         tags: ['Mobile Wallet'],
         security: [['sanctum' => []]],
         requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(required: ['to', 'token', 'amount', 'network'], properties: [
         new OA\Property(property: 'to', type: 'string', example: '0x1234...abcd', description: 'Recipient address'),
         new OA\Property(property: 'token', type: 'string', enum: ['USDC', 'USDT', 'WETH', 'WBTC'], example: 'USDC', description: 'Token symbol'),
-        new OA\Property(property: 'amount', type: 'string', example: '100.00', description: 'Amount to send'),
+        new OA\Property(
+            property: 'amount',
+            type: 'string',
+            example: '1.50',
+            description: 'Amount in decimal major units (NOT atomic). For 1 USDC send "1" or "1.00", not "1000000".',
+        ),
         new OA\Property(property: 'network', type: 'string', example: 'polygon', description: 'Target network'),
         ]))
     )]

--- a/app/Http/Middleware/TransactionRateLimitMiddleware.php
+++ b/app/Http/Middleware/TransactionRateLimitMiddleware.php
@@ -63,6 +63,28 @@ class TransactionRateLimitMiddleware
             'daily_window'      => 86400,
             'progressive_delay' => false,
         ],
+        // Mobile wallet payment intent submissions (P2P sends, merchant payments).
+        // Count-based only: amount is in token-native units that vary per token
+        // (USDC=6dp, SOL=9dp, ETH=18dp, fiat=2dp). Without a spot-price oracle in
+        // this layer, a single fiat-cents amount cap cannot be applied correctly
+        // — see app/Domain/MobilePayment/Services/PaymentIntentService.php for
+        // per-intent business validation. Do NOT add amount_limit here.
+        'payment_intent' => [
+            'limit'             => 30,    // 30 payment intents per hour
+            'window'            => 3600,
+            'daily_limit'       => 200,   // 200 payment intents per day
+            'daily_window'      => 86400,
+            'progressive_delay' => false,
+        ],
+        // Relayer-backed smart account operations (gasless EVM transactions).
+        // Count-based only for the same reason as payment_intent.
+        'relayer' => [
+            'limit'             => 30,
+            'window'            => 3600,
+            'daily_limit'       => 200,
+            'daily_window'      => 86400,
+            'progressive_delay' => false,
+        ],
     ];
 
     /**
@@ -81,6 +103,11 @@ class TransactionRateLimitMiddleware
         }
 
         // Get transaction rate limit configuration
+        if (! isset(self::TRANSACTION_LIMITS[$transactionType])) {
+            Log::warning('Transaction rate limit: unknown transaction type, falling back to transfer', [
+                'transaction_type' => $transactionType,
+            ]);
+        }
         $config = self::TRANSACTION_LIMITS[$transactionType] ?? self::TRANSACTION_LIMITS['transfer'];
 
         $userId = $request->user()?->id;
@@ -220,7 +247,13 @@ class TransactionRateLimitMiddleware
                     'retry_after'   => $retryAfter,
                     'limit_type'    => 'hourly_amount',
                     'limit_details' => [
+                        // All limit values are integers in minor units (e.g. cents
+                        // for USD/EUR-denominated routes). The middleware multiplies
+                        // a major-unit decimal request amount (e.g. "1.50" → 150) by
+                        // 100 — see extractAmount(). Clients can use limit_unit to
+                        // disambiguate when surfacing this to users.
                         'limit'            => $config['amount_limit'],
+                        'limit_unit'       => 'minor_units_x100',
                         'current_amount'   => $currentAmount,
                         'requested_amount' => $amount,
                         'remaining_amount' => max(0, $config['amount_limit'] - $currentAmount),

--- a/tests/Feature/Http/Middleware/TransactionRateLimitMiddlewareTest.php
+++ b/tests/Feature/Http/Middleware/TransactionRateLimitMiddlewareTest.php
@@ -40,6 +40,11 @@ class TransactionRateLimitMiddlewareTest extends TestCase
             ->post('/test-transfer', function () {
                 return response()->json(['message' => 'transfer successful']);
             });
+
+        Route::middleware(['auth:sanctum', 'transaction.rate_limit:payment_intent'])
+            ->post('/test-payment-intent', function () {
+                return response()->json(['message' => 'payment_intent successful']);
+            });
     }
 
     #[Test]
@@ -270,5 +275,54 @@ class TransactionRateLimitMiddlewareTest extends TestCase
         $response = $this->postJson('/test-transfer', ['amount' => 10]);
         $response->assertStatus(429)
             ->assertJsonStructure(['security_notice']);
+    }
+
+    #[Test]
+    public function test_payment_intent_route_does_not_enforce_amount_limit(): void
+    {
+        // Crypto sends carry token amounts whose USD value is unknown to this
+        // middleware. Without a spot-price oracle, a fiat-cents amount cap can
+        // only produce false positives — see the comment on the payment_intent
+        // entry in TRANSACTION_LIMITS.
+        Sanctum::actingAs($this->user, ['read', 'write', 'delete']);
+
+        // An amount that would massively exceed transfer's $2000 cap should
+        // pass on payment_intent because amount_limit is intentionally absent.
+        $response = $this->postJson('/test-payment-intent', ['amount' => 1_000_000]);
+
+        $response->assertStatus(200)
+            ->assertJson(['message' => 'payment_intent successful']);
+    }
+
+    #[Test]
+    public function test_payment_intent_count_limit_still_applies(): void
+    {
+        Sanctum::actingAs($this->user, ['read', 'write', 'delete']);
+
+        // payment_intent allows 30 per hour
+        for ($i = 0; $i < 30; $i++) {
+            $this->postJson('/test-payment-intent', ['amount' => '1'])->assertStatus(200);
+        }
+
+        $response = $this->postJson('/test-payment-intent', ['amount' => '1']);
+        $response->assertStatus(429)
+            ->assertJsonPath('limit_type', 'hourly_count');
+    }
+
+    #[Test]
+    public function test_amount_limit_response_includes_unit_metadata(): void
+    {
+        // When the legacy fiat amount cap is enforced, the 429 response must
+        // declare its unit so clients can interpret limit/requested_amount
+        // unambiguously.
+        Sanctum::actingAs($this->user, ['read', 'write', 'delete']);
+
+        $response = $this->postJson('/test-deposit', ['amount' => 1500]); // exceeds $1000/hr cap
+
+        $response->assertStatus(429)
+            ->assertJsonPath('limit_type', 'hourly_amount')
+            ->assertJsonPath('limit_details.limit_unit', 'minor_units_x100')
+            ->assertJsonPath('limit_details.limit', 100000)
+            ->assertJsonPath('limit_details.requested_amount', 150000); // 1500 * 100
     }
 }


### PR DESCRIPTION
## Summary

The \`POST /api/v1/wallet/transactions/send\` route mounts \`transaction.rate_limit:payment_intent\`, but \`TransactionRateLimitMiddleware\` had no \`payment_intent\` entry in its \`TRANSACTION_LIMITS\` map. The lookup silently fell back to \`transfer\`'s fiat-cents amount cap (\$2000/hour). Same issue with \`relayer\` on the create-account route.

Mobile dev's repro:

\`\`\`
amount="1000000"  (intending 1 USDC × 10⁶ atomic, the SPL convention)
→ middleware: (int)(1_000_000 * 100) = 100_000_000
→ 429: requested_amount=100_000_000, limit=200_000
\`\`\`

The 100× discrepancy is the middleware's \`* 100\` (decimal-major → cents) fiat conversion applied to a crypto send.

## Root cause

Even with the unit contract clarified, applying a fiat-cents amount cap to crypto sends is **unenforceable** — the middleware has no token-decimals or spot-price awareness, so it can't translate atomic or major-unit token amounts to USD. The correct boundary for amount-based limits on crypto flows is \`PaymentIntentService\` and downstream business validation, not this transport-layer middleware.

## Fix

1. **Register explicit \`payment_intent\` + \`relayer\` configs**. Count-based limits only (30/hour, 200/day). NO \`amount_limit\`. The inline comment documents why so future devs don't add one reflexively.
2. **Fail loudly on unknown transaction types**. Middleware still falls back to \`transfer\` defensively, but now logs a warning so the gap is visible in observability.
3. **Add \`limit_unit: 'minor_units_x100'\`** to the 429 amount-limit response. Clients (mobile, dashboards) can disambiguate when amount limits *are* applied on legacy fiat routes.
4. **OpenAPI annotation on \`/wallet/transactions/send\`** now states explicitly that amount is in DECIMAL MAJOR UNITS, with a counter-example calling out the atomic-units mistake.

## Mobile-facing contract (paste to mobile dev)

> Amount on \`POST /api/v1/wallet/transactions/send\` is **decimal major units**, not atomic. Send \`\"1\"\` or \`\"1.50\"\` for 1.5 USDC. Do NOT pre-convert to atomic / on-chain integer units (e.g. \`\"1500000\"\`).
>
> The \`payment_intent\` route now has count-based limits only (30/hour, 200/day). Amount-based caps were removed because the middleware can't translate token amounts to USD without a price oracle — per-intent business validation lives in \`PaymentIntentService\` instead.
>
> When you DO get a 429 from amount-limited routes (deposit, withdraw, fiat-transfer), \`limit_details.limit_unit\` is now in the response. Current value is \`\"minor_units_x100\"\` (i.e. cents — multiply your decimal request by 100 to compare). Surface that to the user verbatim if you need to.

## Test plan

- [x] 15 tests passing in \`TransactionRateLimitMiddlewareTest\` (12 existing + 3 new)
  - \`payment_intent\` route accepts amount=1_000_000 that would 429 on \`transfer\`
  - \`payment_intent\` count limit (30/hour) still triggers \`hourly_count\` 429
  - amount-limit 429 carries \`limit_unit\` and documented \`* 100\` scaling
- [x] PHPStan clean
- [x] php-cs-fixer clean
- [ ] Manual verification on prod (after merge): mobile sends \`amount=\"1\"\` for 1 USDC → 200 (not 429).

🤖 Generated with [Claude Code](https://claude.com/claude-code)