### PR TITLE
fix(broadcasting): cluster-mode Pusher config — drop scheme/encrypted/curl_options

### DIFF
--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -36,20 +36,26 @@ return [
             'key'     => env('PUSHER_APP_KEY'),
             'secret'  => env('PUSHER_APP_SECRET'),
             'app_id'  => env('PUSHER_APP_ID'),
-            'options' => array_filter([
-                'cluster' => env('PUSHER_APP_CLUSTER', 'eu'),
-                'useTLS'  => env('PUSHER_SCHEME', 'https') === 'https',
-                // Only set host/port for self-hosted Soketi.
-                // For Pusher cloud, leave PUSHER_HOST unset so the SDK resolves via cluster.
-                'host'         => env('PUSHER_HOST') ?: null,
-                'port'         => env('PUSHER_HOST') ? (int) env('PUSHER_PORT', 6001) : null,
-                'scheme'       => env('PUSHER_SCHEME', 'https'),
-                'encrypted'    => env('PUSHER_SCHEME', 'https') === 'https',
-                'curl_options' => [
-                    CURLOPT_SSL_VERIFYHOST => env('PUSHER_SCHEME', 'https') === 'https' ? 2 : 0,
-                    CURLOPT_SSL_VERIFYPEER => env('PUSHER_SCHEME', 'https') === 'https',
+            'options' => env('PUSHER_HOST')
+                // Self-hosted Soketi (or compatible). Need explicit host/port/scheme.
+                ? [
+                    'cluster' => env('PUSHER_APP_CLUSTER', 'mt1'),
+                    'host'    => env('PUSHER_HOST'),
+                    'port'    => (int) env('PUSHER_PORT', 6001),
+                    'scheme'  => env('PUSHER_SCHEME', 'http'),
+                    'useTLS'  => env('PUSHER_SCHEME', 'http') === 'https',
+                ]
+                // Pusher cloud. Just cluster + useTLS — the SDK resolves
+                // api-{cluster}.pusher.com:443 internally. Passing scheme,
+                // encrypted, host, or port alongside this triggers a
+                // longstanding bug in pusher/pusher-php-server 7.x where the
+                // SDK builds the URL with port 80 but does a TLS handshake,
+                // surfacing as "cURL error 35: SSL routines::packet length
+                // too long" on every broadcast.
+                : [
+                    'cluster' => env('PUSHER_APP_CLUSTER', 'eu'),
+                    'useTLS'  => true,
                 ],
-            ], fn ($v) => $v !== null),
             'client_options' => [
                 // Guzzle client options for webhook callbacks
             ],

--- a/tests/Unit/Config/BroadcastingPusherConfigTest.php
+++ b/tests/Unit/Config/BroadcastingPusherConfigTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Config;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression tests for the Pusher broadcasting config shape.
+ *
+ * The pusher/pusher-php-server 7.x SDK has a longstanding bug where
+ * passing `scheme` / `encrypted` / a stray `port` alongside cluster
+ * mode causes it to build the URL with port 80 and do a TLS handshake
+ * — surfacing as "cURL error 35: SSL routines::packet length too long"
+ * on every broadcast (real production failure, April 4 2026).
+ *
+ * The config must produce a clean cluster-mode shape when PUSHER_HOST
+ * is absent, and a complete self-hosted shape when it's present. These
+ * tests guard the difference.
+ */
+class BroadcastingPusherConfigTest extends TestCase
+{
+    /**
+     * @param array<string, string> $env
+     * @return array<string, mixed>
+     */
+    private function loadPusherConfig(array $env): array
+    {
+        $previous = [];
+        foreach ($env as $key => $value) {
+            $previous[$key] = $_ENV[$key] ?? null;
+            $_ENV[$key] = $value;
+            putenv("{$key}={$value}");
+        }
+
+        try {
+            // Re-evaluate the config file in isolation
+            $config = require __DIR__ . '/../../../config/broadcasting.php';
+
+            return $config['connections']['pusher'];
+        } finally {
+            foreach ($previous as $key => $value) {
+                if ($value === null) {
+                    unset($_ENV[$key]);
+                    putenv($key);
+                } else {
+                    $_ENV[$key] = $value;
+                    putenv("{$key}={$value}");
+                }
+            }
+        }
+    }
+
+    public function test_cluster_mode_config_omits_scheme_and_host(): void
+    {
+        $config = $this->loadPusherConfig([
+            'PUSHER_APP_KEY'     => 'test-key',
+            'PUSHER_APP_SECRET'  => 'test-secret',
+            'PUSHER_APP_ID'      => 'test-id',
+            'PUSHER_APP_CLUSTER' => 'eu',
+            // PUSHER_HOST intentionally absent
+        ]);
+
+        $options = $config['options'];
+
+        $this->assertSame('eu', $options['cluster']);
+        $this->assertTrue($options['useTLS']);
+
+        // Explicit absences — these are what triggered cURL error 35
+        $this->assertArrayNotHasKey('scheme', $options);
+        $this->assertArrayNotHasKey('encrypted', $options);
+        $this->assertArrayNotHasKey('host', $options);
+        $this->assertArrayNotHasKey('port', $options);
+        $this->assertArrayNotHasKey('curl_options', $options);
+    }
+
+    public function test_self_hosted_mode_includes_host_port_scheme(): void
+    {
+        $config = $this->loadPusherConfig([
+            'PUSHER_APP_KEY'     => 'test-key',
+            'PUSHER_APP_SECRET'  => 'test-secret',
+            'PUSHER_APP_ID'      => 'test-id',
+            'PUSHER_APP_CLUSTER' => 'mt1',
+            'PUSHER_HOST'        => 'soketi.internal',
+            'PUSHER_PORT'        => '6001',
+            'PUSHER_SCHEME'      => 'http',
+        ]);
+
+        $options = $config['options'];
+
+        $this->assertSame('mt1', $options['cluster']);
+        $this->assertSame('soketi.internal', $options['host']);
+        $this->assertSame(6001, $options['port']);
+        $this->assertSame('http', $options['scheme']);
+        $this->assertFalse($options['useTLS']);
+    }
+}


### PR DESCRIPTION
## Summary

Production failure (April 4 2026, ~6 entries in \`failed_jobs\` queue=broadcasts):

\`\`\`
Illuminate\\Broadcasting\\BroadcastException:
Pusher error: cURL error 35: OpenSSL/3.3.1: error:0A0000C6:SSL routines::packet length too long
\`\`\`

Root cause: pusher/pusher-php-server 7.x builds the request URL as \`https://api-{cluster}.pusher.com:80\` — TLS handshake against the plaintext port — when the config passes \`scheme\`, \`encrypted\`, or stray \`port\` alongside cluster mode.

## Fix

Two clean config shapes branching on \`PUSHER_HOST\`:

\`\`\`php
'options' => env('PUSHER_HOST')
    // Self-hosted Soketi
    ? ['cluster', 'host', 'port', 'scheme', 'useTLS']
    // Pusher cloud — SDK derives api-{cluster}.pusher.com:443
    : ['cluster', 'useTLS'],
\`\`\`

Drops:
- \`encrypted\` — deprecated alias for \`useTLS\` in 7.x
- \`scheme\` for cluster mode — redundant with \`useTLS\`, triggers the bug
- explicit \`curl_options\` — SDK applies sane TLS defaults

## Test plan

- [x] 2 regression tests in \`tests/Unit/Config/BroadcastingPusherConfigTest\` pass
- [x] PHPStan clean
- [x] php-cs-fixer clean
- [ ] **After deploy:** trigger a Solana receive on prod, confirm \`WalletBalanceUpdated\` no longer appears in \`failed_jobs\` for queue=broadcasts (broken since April 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)