### PR TITLE
feat(wallet): hourly Helius ↔ DB address reconciliation with self-heal

### DIFF
--- a/app/Console/Commands/SolanaReconcileHeliusCommand.php
+++ b/app/Console/Commands/SolanaReconcileHeliusCommand.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Account\Models\BlockchainAddress;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Reconcile Solana blockchain_addresses with Helius webhook config.
+ *
+ * The April 2026 incident traced to silent drift: addresses were
+ * created locally but the queued Helius sync (BlockchainAddressObserver)
+ * failed at the API boundary for 27 days, leaving Helius watching 1
+ * address while our DB had 4. No alarm fired because the failure was
+ * caught and only logged as a warning.
+ *
+ * This command surfaces the drift loudly so it never sits silently
+ * again. Schedule it hourly. On drift it logs at ERROR level and
+ * exits non-zero so monitoring/cron alerts fire.
+ */
+class SolanaReconcileHeliusCommand extends Command
+{
+    protected $signature = 'solana:reconcile-helius
+        {--auto-sync : Automatically run solana:sync if drift is detected}';
+
+    protected $description = 'Reconcile Solana blockchain_addresses count with Helius webhook config';
+
+    public function handle(): int
+    {
+        $webhookId = (string) config('services.helius.webhook_id', '');
+        $apiKey = (string) config('services.helius.api_key', '');
+
+        if ($webhookId === '' || $apiKey === '') {
+            $this->warn('Helius is not configured (HELIUS_WEBHOOK_ID / HELIUS_API_KEY missing).');
+
+            return self::SUCCESS;
+        }
+
+        $dbAddresses = BlockchainAddress::where('chain', 'solana')
+            ->where('is_active', true)
+            ->pluck('address')
+            ->unique()
+            ->values()
+            ->all();
+
+        $response = Http::timeout(15)
+            ->withQueryParameters(['api-key' => $apiKey])
+            ->get("https://api.helius.xyz/v0/webhooks/{$webhookId}");
+
+        if (! $response->successful()) {
+            Log::error('Helius reconcile: failed to fetch webhook config', [
+                'status' => $response->status(),
+                'body'   => $response->body(),
+            ]);
+            $this->error("Helius API returned {$response->status()}.");
+
+            return self::FAILURE;
+        }
+
+        /** @var array<int, string> $heliusAddresses */
+        $heliusAddresses = (array) $response->json('accountAddresses', []);
+
+        $missingFromHelius = array_values(array_diff($dbAddresses, $heliusAddresses));
+        $orphanedOnHelius = array_values(array_diff($heliusAddresses, $dbAddresses));
+
+        $dbCount = count($dbAddresses);
+        $heliusCount = count($heliusAddresses);
+
+        $this->info("DB active Solana addresses: {$dbCount}");
+        $this->info("Helius watched addresses:   {$heliusCount}");
+
+        if (empty($missingFromHelius) && empty($orphanedOnHelius)) {
+            $this->info('In sync — no drift detected.');
+
+            return self::SUCCESS;
+        }
+
+        Log::error('Helius reconcile: address drift detected', [
+            'db_count'            => $dbCount,
+            'helius_count'        => $heliusCount,
+            'missing_from_helius' => $missingFromHelius,
+            'orphaned_on_helius'  => $orphanedOnHelius,
+        ]);
+
+        $this->error(sprintf(
+            'Drift detected: %d missing from Helius, %d orphaned on Helius.',
+            count($missingFromHelius),
+            count($orphanedOnHelius),
+        ));
+
+        if (! empty($missingFromHelius)) {
+            $this->line('Missing from Helius:');
+            foreach ($missingFromHelius as $addr) {
+                $this->line("  - {$addr}");
+            }
+        }
+
+        if (! empty($orphanedOnHelius)) {
+            $this->line('Orphaned on Helius (in Helius but not in our DB):');
+            foreach ($orphanedOnHelius as $addr) {
+                $this->line("  - {$addr}");
+            }
+        }
+
+        if ($this->option('auto-sync')) {
+            $this->info('--auto-sync set; invoking solana:sync...');
+            $this->call('solana:sync');
+        } else {
+            $this->warn('Re-run with --auto-sync to push the missing addresses, or run `php artisan solana:sync` manually.');
+        }
+
+        return self::FAILURE;
+    }
+}

--- a/routes/console.php
+++ b/routes/console.php
@@ -222,3 +222,16 @@ Schedule::command('account:disable-reviewer --all-expired --allow-production')
     ->dailyAt('00:10')
     ->description('Auto-disable expired review accounts')
     ->appendOutputTo(storage_path('logs/account-expiry-sweep.log'));
+
+// Hourly reconciliation: detect Helius webhook ↔ DB address drift.
+// Caught silent for 27 days during the April 2026 incident — never again.
+// --auto-sync runs `solana:sync` whenever drift is found, so the system
+// self-heals between manual operator visits.
+Schedule::command('solana:reconcile-helius --auto-sync')
+    ->hourly()
+    ->description('Reconcile Solana addresses between local DB and Helius webhook config')
+    ->appendOutputTo(storage_path('logs/solana-reconcile-helius.log'))
+    ->withoutOverlapping()
+    ->onFailure(function () {
+        Log::error('Solana ↔ Helius reconciliation reported drift or failed');
+    });

--- a/tests/Feature/Console/SolanaReconcileHeliusCommandTest.php
+++ b/tests/Feature/Console/SolanaReconcileHeliusCommandTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Account\Models\BlockchainAddress;
+use App\Models\User;
+use Illuminate\Support\Facades\Http;
+use Tests\Traits\CreatesSolanaTestTables;
+
+uses(CreatesSolanaTestTables::class);
+
+beforeEach(function (): void {
+    config([
+        'cache.default'              => 'array',
+        'services.helius.webhook_id' => 'test-webhook-id',
+        'services.helius.api_key'    => 'test-api-key',
+    ]);
+
+    $this->createSolanaTestTables();
+});
+
+afterEach(function (): void {
+    $this->dropSolanaTestTables();
+});
+
+it('reports success when DB and Helius addresses match', function (): void {
+    $user = User::factory()->create();
+    $address = '9UYjpLnTu78B5kqNoKgghLTcRKsUUZNRGUfxEZiwpR7L';
+
+    BlockchainAddress::create([
+        'user_uuid'  => $user->uuid,
+        'chain'      => 'solana',
+        'address'    => $address,
+        'public_key' => $address,
+        'is_active'  => true,
+    ]);
+
+    Http::fake([
+        'https://api.helius.xyz/v0/webhooks/test-webhook-id*' => Http::response([
+            'webhookID'        => 'test-webhook-id',
+            'accountAddresses' => [$address],
+        ], 200),
+    ]);
+
+    $this->artisan('solana:reconcile-helius')
+        ->expectsOutputToContain('In sync')
+        ->assertSuccessful();
+});
+
+it('exits non-zero when DB has addresses Helius does not watch', function (): void {
+    $user = User::factory()->create();
+
+    BlockchainAddress::create([
+        'user_uuid'  => $user->uuid,
+        'chain'      => 'solana',
+        'address'    => 'address-in-db',
+        'public_key' => 'address-in-db',
+        'is_active'  => true,
+    ]);
+
+    Http::fake([
+        'https://api.helius.xyz/v0/webhooks/test-webhook-id*' => Http::response([
+            'webhookID'        => 'test-webhook-id',
+            'accountAddresses' => [],
+        ], 200),
+    ]);
+
+    $this->artisan('solana:reconcile-helius')
+        ->expectsOutputToContain('Drift detected')
+        ->expectsOutputToContain('address-in-db')
+        ->assertFailed();
+});
+
+it('reports drift when Helius watches addresses not in our DB', function (): void {
+    Http::fake([
+        'https://api.helius.xyz/v0/webhooks/test-webhook-id*' => Http::response([
+            'webhookID'        => 'test-webhook-id',
+            'accountAddresses' => ['orphan-address'],
+        ], 200),
+    ]);
+
+    $this->artisan('solana:reconcile-helius')
+        ->expectsOutputToContain('Orphaned on Helius')
+        ->expectsOutputToContain('orphan-address')
+        ->assertFailed();
+});
+
+it('skips silently when Helius is not configured', function (): void {
+    config([
+        'services.helius.webhook_id' => '',
+        'services.helius.api_key'    => '',
+    ]);
+
+    $this->artisan('solana:reconcile-helius')
+        ->expectsOutputToContain('not configured')
+        ->assertSuccessful();
+});


### PR DESCRIPTION
## Summary

Direct follow-up from the April 2026 incident (PRs #1003 → #1005). For 27 days, Solana receives produced no push notifications and no activity-feed entries because Helius silently dropped addresses from its watch list while our DB still listed them as active. The drift went unnoticed because \`BlockchainAddressObserver\`'s sync failures fell into a \`try/catch\` that only logged at warning level.

This ships an hourly reconciliation loop so the same drift can never sit silent again.

## What it does

\`solana:reconcile-helius\` GETs the Helius webhook config and compares \`accountAddresses\` against \`blockchain_addresses\` rows where \`chain='solana' AND is_active=true\`. Reports drift in both directions:

- Addresses present locally but not on Helius (the April bug)
- Addresses present on Helius but not in our DB (orphan watch — could indicate user account deletion that didn't propagate)

On drift it logs at \`Log::error\` and exits non-zero so cron monitoring fires. With \`--auto-sync\`, it invokes \`solana:sync\` to self-heal between manual operator visits.

## Schedule

\`\`\`php
Schedule::command('solana:reconcile-helius --auto-sync')
    ->hourly()
    ->withoutOverlapping()
    ->onFailure(fn() => Log::error('Solana ↔ Helius reconciliation reported drift or failed'));
\`\`\`

## Test plan

- [x] 4 tests pass:
  - in-sync state → SUCCESS
  - DB-only addresses → FAILURE with the missing addresses listed
  - Helius-orphaned addresses → FAILURE with the orphans listed
  - missing \`HELIUS_*\` env → SUCCESS silently
- [x] PHPStan clean
- [x] php-cs-fixer clean
- [ ] **After deploy:** verify the schedule fires (check \`storage/logs/solana-reconcile-helius.log\` after the next hour rolls over).

🤖 Generated with [Claude Code](https://claude.com/claude-code)