### PR TITLE
feat(trustcert): configurable Stripe Checkout deep-link return URLs

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -372,6 +372,10 @@ MFI_ENABLED=false
 STRIPE_SECRET=
 STRIPE_BRIDGE_WEBHOOK_SECRET=
 STRIPE_KYC_WEBHOOK_SECRET=
+# Mobile deep-link return URLs for KYC Checkout. Override per env if you
+# need a non-default scheme (e.g. demo or staging build).
+# STRIPE_KYC_SUCCESS_URL=zelta://trustcert/payment-return?status=success&session={CHECKOUT_SESSION_ID}
+# STRIPE_KYC_CANCEL_URL=zelta://trustcert/payment-return?status=cancel
 # Provider selection is via RAMP_PROVIDER below — no separate enable flag.
 RAMP_PROVIDER=stripe_bridge
 

--- a/.env.zelta.example
+++ b/.env.zelta.example
@@ -155,6 +155,9 @@ STRIPE_WEBHOOK_SECRET=
 STRIPE_TEST_MODE=false
 STRIPE_BRIDGE_WEBHOOK_SECRET=
 STRIPE_KYC_WEBHOOK_SECRET=
+# Mobile deep-link return URLs for KYC Checkout — defaults match the Zelta app scheme.
+# STRIPE_KYC_SUCCESS_URL=zelta://trustcert/payment-return?status=success&session={CHECKOUT_SESSION_ID}
+# STRIPE_KYC_CANCEL_URL=zelta://trustcert/payment-return?status=cancel
 # Provider selection is via RAMP_PROVIDER below — no separate enable flag.
 RAMP_PROVIDER=stripe_bridge
 CASHIER_CURRENCY=eur

--- a/app/Http/Controllers/Api/V1/TrustCertPaymentController.php
+++ b/app/Http/Controllers/Api/V1/TrustCertPaymentController.php
@@ -141,13 +141,16 @@ class TrustCertPaymentController extends Controller
             ], 503);
         }
 
+        $successUrl = (string) config('services.stripe.kyc_success_url');
+        $cancelUrl = (string) config('services.stripe.kyc_cancel_url');
+
         // Create Stripe Checkout Session
         $response = Http::withToken($stripeSecret)
             ->asForm()
             ->post('https://api.stripe.com/v1/checkout/sessions', [
                 'mode'                                          => 'payment',
-                'success_url'                                   => 'zelta://kyc-payment-success?session_id={CHECKOUT_SESSION_ID}',
-                'cancel_url'                                    => 'zelta://kyc-payment-cancel',
+                'success_url'                                   => $successUrl,
+                'cancel_url'                                    => $cancelUrl,
                 'line_items[0][price_data][currency]'           => 'usd',
                 'line_items[0][price_data][product_data][name]' => 'KYC Verification - Level ' . ucfirst($level),
                 'line_items[0][price_data][unit_amount]'        => (string) ((int) bcmul($fee, '100', 0)),

--- a/config/services.php
+++ b/config/services.php
@@ -78,6 +78,19 @@ return [
         'webhook_secret'        => env('STRIPE_WEBHOOK_SECRET'),
         'kyc_webhook_secret'    => env('STRIPE_KYC_WEBHOOK_SECRET'),
         'bridge_webhook_secret' => env('STRIPE_BRIDGE_WEBHOOK_SECRET'),
+
+        // Mobile deep-link return URLs for KYC Checkout. Stripe substitutes
+        // {CHECKOUT_SESSION_ID} on the success URL. Both URLs share a single
+        // 'trustcert/payment-return' route on the mobile side that branches
+        // on the 'status' query param.
+        'kyc_success_url' => env(
+            'STRIPE_KYC_SUCCESS_URL',
+            'zelta://trustcert/payment-return?status=success&session={CHECKOUT_SESSION_ID}'
+        ),
+        'kyc_cancel_url' => env(
+            'STRIPE_KYC_CANCEL_URL',
+            'zelta://trustcert/payment-return?status=cancel'
+        ),
     ],
 
     /*

--- a/tests/Unit/Http/Controllers/Api/V1/TrustCertPaymentControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/V1/TrustCertPaymentControllerTest.php
@@ -211,6 +211,70 @@ describe('TrustCertPaymentController payCard', function (): void {
 
         expect($response->getStatusCode())->toBe(503);
     });
+
+    it('passes configured deep-link return URLs to Stripe', function (): void {
+        $applicationId = 'app_deeplinks';
+        storeTestApplication(1, $applicationId, 'basic');
+
+        config([
+            'services.stripe.secret'          => 'sk_test_fake',
+            'services.stripe.kyc_success_url' => 'zelta://trustcert/payment-return?status=success&session={CHECKOUT_SESSION_ID}',
+            'services.stripe.kyc_cancel_url'  => 'zelta://trustcert/payment-return?status=cancel',
+        ]);
+
+        Http::fake([
+            'api.stripe.com/v1/checkout/sessions' => Http::response([
+                'id'         => 'cs_test_dl',
+                'url'        => 'https://checkout.stripe.com/pay/cs_test_dl',
+                'expires_at' => now()->addMinutes(30)->timestamp,
+            ], 200),
+        ]);
+
+        $controller = new TrustCertPaymentController();
+        $response = $controller->payCard($applicationId, makePaymentRequest('/pay/card'));
+        expect($response->getStatusCode())->toBe(200);
+
+        Http::assertSent(function ($request): bool {
+            $body = $request->body();
+            // Form-encoded body — assert decoded values match config.
+            parse_str($body, $parsed);
+
+            return ($parsed['success_url'] ?? '') === 'zelta://trustcert/payment-return?status=success&session={CHECKOUT_SESSION_ID}'
+                && ($parsed['cancel_url'] ?? '') === 'zelta://trustcert/payment-return?status=cancel';
+        });
+    });
+
+    it('honors env override for deep-link return URLs', function (): void {
+        $applicationId = 'app_deeplinks_override';
+        storeTestApplication(1, $applicationId, 'basic');
+
+        config([
+            'services.stripe.secret'          => 'sk_test_fake',
+            'services.stripe.kyc_success_url' => 'zelta-staging://trustcert/payment-return?status=success&session={CHECKOUT_SESSION_ID}',
+            'services.stripe.kyc_cancel_url'  => 'zelta-staging://trustcert/payment-return?status=cancel',
+        ]);
+
+        Http::fake([
+            'api.stripe.com/v1/checkout/sessions' => Http::response([
+                'id'         => 'cs_test_dl2',
+                'url'        => 'https://checkout.stripe.com/pay/cs_test_dl2',
+                'expires_at' => now()->addMinutes(30)->timestamp,
+            ], 200),
+        ]);
+
+        $controller = new TrustCertPaymentController();
+        $response = $controller->payCard($applicationId, makePaymentRequest('/pay/card'));
+        expect($response->getStatusCode())->toBe(200);
+
+        Http::assertSent(function ($request): bool {
+            parse_str($request->body(), $parsed);
+            $success = $parsed['success_url'] ?? '';
+            $cancel = $parsed['cancel_url'] ?? '';
+
+            return is_string($success) && str_starts_with($success, 'zelta-staging://')
+                && is_string($cancel) && str_starts_with($cancel, 'zelta-staging://');
+        });
+    });
 });
 
 // ---------- IAP payment tests ----------


### PR DESCRIPTION
## Summary

Mobile asked for a single `trustcert/payment-return` deep-link route that branches on a `status` query param, instead of two separate handlers (`kyc-payment-success` / `kyc-payment-cancel`) we used to ship. (TrustCert HIGH ask #6.)

This PR:
- Adds `services.stripe.kyc_success_url` and `services.stripe.kyc_cancel_url` config keys (env-overridable via `STRIPE_KYC_SUCCESS_URL` / `STRIPE_KYC_CANCEL_URL`).
- Wires them into `TrustCertPaymentController::payCard()` in place of the old hardcoded URLs.
- Default success: `zelta://trustcert/payment-return?status=success&session={CHECKOUT_SESSION_ID}`
- Default cancel:  `zelta://trustcert/payment-return?status=cancel`
- Documents both vars in `.env.production.example` and `.env.zelta.example`.

The override path is intentional: staging/demo builds may use a different scheme (`zelta-staging://`) without rebuilding the backend.

## Mobile contract

Mobile must register the route once, then branch on `status`:

```
zelta://trustcert/payment-return?status=success&session=cs_test_...
zelta://trustcert/payment-return?status=cancel
```

On `status=success`, mobile should poll `GET /v1/trustcert/applications/{id}` (or wait for push) — Stripe's redirect fires before our webhook acks the payment, so the cached app status may still be `payment_required` for a moment.

## Test plan

- [x] `tests/Unit/Http/Controllers/Api/V1/TrustCertPaymentControllerTest.php` — two new tests assert the form-encoded body sent to Stripe carries the configured URLs verbatim, including `{CHECKOUT_SESSION_ID}` substitution token, and that env override is honored
- [x] PHPStan Level 8 clean
- [x] php-cs-fixer clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)