### PR TITLE
fix(bootstrap): stop double-registering routes/console.php — every Schedule:: fired twice

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -51,9 +51,6 @@ return Application::configure(basePath: dirname(__DIR__))
                 ), status: $exception ? 500 : 200);
             });
 
-            // Always load console routes
-            Route::group([], base_path('routes/console.php'));
-
             if ($isMcpSubdomain) {
                 // MCP subdomain — minimal middleware stack (no CSRF, no Sanctum, no web session)
                 Route::middleware(['api'])

--- a/tests/Feature/Console/ScheduleNoDuplicatesTest.php
+++ b/tests/Feature/Console/ScheduleNoDuplicatesTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Console\Scheduling\Schedule;
+
+it('registers each scheduled command only once', function (): void {
+    /** @var Schedule $schedule */
+    $schedule = app(Schedule::class);
+
+    $commands = collect($schedule->events())
+        ->map(fn ($event) => $event->command ?? $event->description ?? null)
+        ->filter()
+        ->values();
+
+    $duplicates = $commands
+        ->countBy()
+        ->filter(fn (int $count) => $count > 1);
+
+    expect($duplicates->all())->toBe(
+        [],
+        'Scheduled commands registered more than once: ' . json_encode($duplicates->all())
+    );
+});


### PR DESCRIPTION
## Summary

`schedule:list` shows every cron registered twice on production:

```
0    *   *  * *  php artisan solana:reconcile-helius --auto-sync ...
0    *   *  * *  php artisan solana:reconcile-helius --auto-sync ...
```

This affects **all** scheduled tasks, not just the new Solana reconciliation one — `voting:setup`, `baskets:rebalance`, `banks:monitor-health`, `compliance:generate-reports`, `liquidity:*`, `cgo:verify-payments`, `trustcert:check-expired`, `account:disable-reviewer`, etc. all get scheduled twice.

## Root cause

`routes/console.php` was loaded twice on every boot:

1. Via `Route::group([], base_path('routes/console.php'))` in the routing `then` callback (a no-op for routing because the file defines no routes — but PHP still `require`s the file)
2. Via the official `commands:` parameter on `withRouting()` (the correct mechanism)

Every `Schedule::command(...)` and `Schedule::job(...)` call therefore fired twice, registering every cron entry as two distinct schedule events with the same expression.

## Real-world impact

Any scheduled task without `->withoutOverlapping()` ran in parallel against itself every tick. Tasks with `->withoutOverlapping()` were saved by the lock but still wasted a worker slot per tick — the second invocation would acquire-lock-check, see the first was running, and exit.

## Fix

Removed the `Route::group` call. Verified with `grep -c "Route::" routes/console.php` → `0`: the file has zero route registrations, only Artisan commands and schedules, and those are correctly wired through the `commands:` parameter on line 102.

## Test plan

- [x] `tests/Feature/Console/ScheduleNoDuplicatesTest.php` — resolves `Schedule` from the container and asserts no duplicate command strings; passes after the fix
- [x] PHPStan + cs-fixer clean

## Operator follow-up after merge

Run on prod once after deploy:
```
php artisan schedule:list | grep solana:reconcile-helius
```
should now show **one** row, not two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)