### PR TITLE
feat(wallet): real on-chain send dispatch for Solana + EVM (custodial, gated)

### DIFF
--- a/app/Domain/Wallet/Exceptions/SolanaRpcException.php
+++ b/app/Domain/Wallet/Exceptions/SolanaRpcException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Wallet\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Thrown when a Solana JSON-RPC call returns an error envelope or the HTTP
+ * transport itself fails. Wraps the upstream RPC error code so dispatchers
+ * can decide whether to retry, mark the send failed, or surface to the user.
+ */
+class SolanaRpcException extends RuntimeException
+{
+    private int $rpcCode = 0;
+
+    public static function fromRpcError(int $code, string $message): self
+    {
+        $exception = new self("Solana RPC error {$code}: {$message}");
+        $exception->rpcCode = $code;
+
+        return $exception;
+    }
+
+    public function getRpcCode(): int
+    {
+        return $this->rpcCode;
+    }
+}

--- a/app/Domain/Wallet/Helpers/Crypto/Base58.php
+++ b/app/Domain/Wallet/Helpers/Crypto/Base58.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Wallet\Helpers\Crypto;
+
+use InvalidArgumentException;
+
+/**
+ * Pure-PHP Base58 codec (Bitcoin/Solana alphabet) using GMP.
+ *
+ * Solana addresses, transaction signatures, mints, and block hashes all use
+ * the Bitcoin Base58 alphabet (no '0', 'O', 'I', 'l'). This is the canonical
+ * round-trip codec for binary <-> Base58 conversions.
+ *
+ * Leading 0x00 bytes encode to leading '1' characters and vice-versa, so the
+ * round-trip preserves byte-length (e.g. the system-program 32-byte pubkey of
+ * all zeros decodes to 32 NUL bytes).
+ */
+final class Base58
+{
+    public const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+    /**
+     * Encode raw bytes to Base58.
+     */
+    public static function encode(string $bytes): string
+    {
+        if ($bytes === '') {
+            return '';
+        }
+
+        $alphabet = self::ALPHABET;
+
+        // Count leading zero bytes; each maps to a '1' prefix.
+        $leadingZeros = 0;
+        $len = strlen($bytes);
+        while ($leadingZeros < $len && $bytes[$leadingZeros] === "\x00") {
+            $leadingZeros++;
+        }
+
+        $num = gmp_import($bytes);
+        $encoded = '';
+        $base = gmp_init(58);
+        $zero = gmp_init(0);
+
+        while (gmp_cmp($num, $zero) > 0) {
+            [$num, $remainder] = gmp_div_qr($num, $base);
+            $encoded = $alphabet[gmp_intval($remainder)] . $encoded;
+        }
+
+        return str_repeat('1', $leadingZeros) . $encoded;
+    }
+
+    /**
+     * Decode a Base58 string to raw bytes.
+     *
+     * @throws InvalidArgumentException If the input contains characters outside the Base58 alphabet.
+     */
+    public static function decode(string $base58): string
+    {
+        if ($base58 === '') {
+            return '';
+        }
+
+        $alphabet = self::ALPHABET;
+        $len = strlen($base58);
+
+        // Count leading '1' characters; each maps to a 0x00 prefix byte.
+        $leadingOnes = 0;
+        while ($leadingOnes < $len && $base58[$leadingOnes] === '1') {
+            $leadingOnes++;
+        }
+
+        $num = gmp_init(0);
+        $base = gmp_init(58);
+
+        for ($i = 0; $i < $len; $i++) {
+            $char = $base58[$i];
+            $index = strpos($alphabet, $char);
+            if ($index === false) {
+                throw new InvalidArgumentException(
+                    "Invalid Base58 character '{$char}' at position {$i}"
+                );
+            }
+            $num = gmp_add(gmp_mul($num, $base), $index);
+        }
+
+        // gmp_export returns '' for zero — we still want the leading-zero prefix.
+        $bytes = gmp_cmp($num, gmp_init(0)) === 0 ? '' : gmp_export($num);
+
+        return str_repeat("\x00", $leadingOnes) . $bytes;
+    }
+}

--- a/app/Domain/Wallet/Helpers/Crypto/EvmKeyHelper.php
+++ b/app/Domain/Wallet/Helpers/Crypto/EvmKeyHelper.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Wallet\Helpers\Crypto;
+
+use BN\BN;
+use Elliptic\EC;
+use kornrunner\Keccak;
+use RuntimeException;
+
+/**
+ * Deterministic secp256k1 keypair derivation for EVM smart-account ownership.
+ *
+ * Replaces the legacy phantom-address derivation in
+ * {@see \App\Http\Controllers\Api\Relayer\SmartAccountController::deriveOwnerAddress()}
+ * — which produced a 20-byte hash of `(user_id . app_key)` with NO matching
+ * private key. Sends from such accounts were mathematically impossible.
+ *
+ * The derivation is custodial: the server is the sole holder of every user's
+ * private key material. The seed scheme mirrors the Solana ed25519 helper but
+ * uses the BIP-44 EVM path component (m/44'/60'/0'/0):
+ *
+ *   seed = sha256("evm:{userId}:{appKey}:m/44'/60'/0'/0", binary: true)
+ *   privateKey = seed (32 bytes), validated to be in [1, n-1) on secp256k1
+ *
+ * Sensitive data handling: the private key returned by {@see deriveForUser()}
+ * is hex-encoded. Callers MUST consume it inline (sign, then drop) and avoid
+ * persisting or logging it. Where only the public address is needed,
+ * {@see deriveAddressOnly()} avoids materialising the private key in PHP space.
+ */
+final class EvmKeyHelper
+{
+    /**
+     * EVM derivation path component baked into the seed.
+     */
+    private const SEED_PATH = "m/44'/60'/0'/0";
+
+    /**
+     * Derive a real secp256k1 keypair for the given user.
+     *
+     * @return array{address: string, publicKey: string, privateKey: string}
+     *               address    EIP-55 checksummed `0x`-prefixed 20-byte address.
+     *               publicKey  Hex string, `0x`-prefixed, 64 bytes (X || Y, no SEC1 prefix byte).
+     *               privateKey Hex string, `0x`-prefixed, 32 bytes. Treat as a secret.
+     */
+    public static function deriveForUser(int $userId, string $appKey): array
+    {
+        $privScalarHex = self::deriveValidPrivateScalarHex($userId, $appKey);
+
+        $ec = new EC('secp256k1');
+        $key = $ec->keyFromPrivate($privScalarHex, 'hex');
+
+        // Uncompressed encoding without the 0x04 SEC1 prefix: 64 bytes (X || Y).
+        $publicKeyHex = $key->getPublic(false, 'hex');
+        if (str_starts_with($publicKeyHex, '04')) {
+            $publicKeyHex = substr($publicKeyHex, 2);
+        }
+        $publicKeyHex = str_pad($publicKeyHex, 128, '0', STR_PAD_LEFT);
+
+        $address = self::addressFromPublicKeyHex($publicKeyHex);
+
+        return [
+            'address'    => self::toChecksumAddress($address),
+            'publicKey'  => '0x' . $publicKeyHex,
+            'privateKey' => '0x' . $privScalarHex,
+        ];
+    }
+
+    /**
+     * Convenience wrapper that returns only the EIP-55 checksummed owner address.
+     *
+     * Use this when you do not need to sign — it avoids returning the private
+     * key string to the caller, reducing the surface for accidental leaks.
+     */
+    public static function deriveAddressOnly(int $userId, string $appKey): string
+    {
+        $privScalarHex = self::deriveValidPrivateScalarHex($userId, $appKey);
+
+        $ec = new EC('secp256k1');
+        $key = $ec->keyFromPrivate($privScalarHex, 'hex');
+
+        $publicKeyHex = $key->getPublic(false, 'hex');
+        if (str_starts_with($publicKeyHex, '04')) {
+            $publicKeyHex = substr($publicKeyHex, 2);
+        }
+        $publicKeyHex = str_pad($publicKeyHex, 128, '0', STR_PAD_LEFT);
+
+        return self::toChecksumAddress(self::addressFromPublicKeyHex($publicKeyHex));
+    }
+
+    /**
+     * Apply EIP-55 mixed-case checksum to a 20-byte hex address.
+     *
+     * Input may be 0x-prefixed or not; output is always 0x-prefixed lower/upper
+     * mixed case per the spec.
+     */
+    public static function toChecksumAddress(string $address): string
+    {
+        $clean = strtolower(str_starts_with($address, '0x') ? substr($address, 2) : $address);
+        if (strlen($clean) !== 40 || preg_match('/^[0-9a-f]{40}$/', $clean) !== 1) {
+            throw new RuntimeException('Invalid EVM address: ' . $address);
+        }
+
+        $hash = Keccak::hash($clean, 256);
+
+        $checksummed = '';
+        for ($i = 0; $i < 40; $i++) {
+            $hashChar = $hash[$i];
+            $addrChar = $clean[$i];
+            // Per EIP-55: if the corresponding nibble of the hash is >= 8, uppercase the address char (only affects a-f).
+            $checksummed .= (hexdec($hashChar) >= 8) ? strtoupper($addrChar) : $addrChar;
+        }
+
+        return '0x' . $checksummed;
+    }
+
+    /**
+     * Derive a private scalar in [1, n) on secp256k1.
+     *
+     * Practically the first hash always lands inside the curve order — the
+     * probability of needing a counter bump is ~2^-128 — but we still iterate
+     * defensively so the result is always a valid secp256k1 scalar.
+     */
+    private static function deriveValidPrivateScalarHex(int $userId, string $appKey): string
+    {
+        $base = "evm:{$userId}:{$appKey}:" . self::SEED_PATH;
+
+        $ec = new EC('secp256k1');
+        /** @var BN $n */
+        $n = $ec->n;
+
+        for ($counter = 0; $counter < 256; $counter++) {
+            $material = $counter === 0
+                ? $base
+                : $base . ':' . chr($counter);
+            $seedBin = hash('sha256', $material, binary: true);
+            $hex = bin2hex($seedBin);
+            $candidate = new BN($hex, 16);
+
+            // Need 1 <= k < n.
+            if ($candidate->cmpn(0) > 0 && $candidate->cmp($n) < 0) {
+                return str_pad($hex, 64, '0', STR_PAD_LEFT);
+            }
+        }
+
+        // Astronomically unreachable; throw rather than silently return weak material.
+        throw new RuntimeException('Failed to derive a valid secp256k1 private scalar after 256 attempts');
+    }
+
+    /**
+     * Compute the lowercase, non-checksummed EVM address from a 64-byte
+     * public key hex string (X || Y, no 0x or 0x04 prefix).
+     */
+    private static function addressFromPublicKeyHex(string $publicKeyHex): string
+    {
+        $pubKeyBin = hex2bin($publicKeyHex);
+        if ($pubKeyBin === false || strlen($pubKeyBin) !== 64) {
+            throw new RuntimeException('Invalid public key hex; expected 64 bytes');
+        }
+
+        $hash = Keccak::hash($pubKeyBin, 256);
+
+        return '0x' . substr($hash, 24);
+    }
+}

--- a/app/Domain/Wallet/Jobs/PollEvmWalletSendConfirmations.php
+++ b/app/Domain/Wallet/Jobs/PollEvmWalletSendConfirmations.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Wallet\Jobs;
+
+use App\Domain\Relayer\Contracts\BundlerInterface;
+use App\Domain\Wallet\Models\WalletSendRecord;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Polls the bundler for receipt of submitted EVM wallet sends and flips
+ * matching wallet_send_records to confirmed (or failed) once the on-chain
+ * receipt is observed.
+ *
+ * Runs on a short interval — every minute is plenty for ERC-4337 typical
+ * confirmation latency. Only touches rows where status='submitted' and
+ * network is an EVM key.
+ *
+ * Solana confirmations are handled in HeliusTransactionProcessor (webhook
+ * path), not here.
+ */
+class PollEvmWalletSendConfirmations implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 1;
+
+    public int $timeout = 60;
+
+    public function handle(BundlerInterface $bundler): void
+    {
+        $records = WalletSendRecord::query()
+            ->where('status', WalletSendRecord::STATUS_SUBMITTED)
+            ->whereNotNull('user_op_hash')
+            ->whereIn('network', ['polygon', 'base', 'arbitrum', 'ethereum'])
+            ->where('submitted_at', '>=', now()->subHours(2))
+            ->limit(100)
+            ->get();
+
+        foreach ($records as $record) {
+            $this->reconcile($bundler, $record);
+        }
+    }
+
+    private function reconcile(BundlerInterface $bundler, WalletSendRecord $record): void
+    {
+        if ($record->user_op_hash === null) {
+            return;
+        }
+
+        try {
+            $status = $bundler->getUserOperationStatus((string) $record->user_op_hash);
+        } catch (Throwable $e) {
+            Log::warning('PollEvmWalletSendConfirmations: bundler error', [
+                'record_id'    => $record->id,
+                'user_op_hash' => $record->user_op_hash,
+                'network'      => $record->network,
+                'error'        => $e->getMessage(),
+            ]);
+
+            return;
+        }
+
+        if (! isset($status['status'])) {
+            return;
+        }
+
+        $reportedStatus = (string) $status['status'];
+        $txHash = isset($status['tx_hash']) && is_string($status['tx_hash']) ? $status['tx_hash'] : null;
+
+        if ($reportedStatus === 'confirmed') {
+            $record->update([
+                'status'       => WalletSendRecord::STATUS_CONFIRMED,
+                'tx_hash'      => $txHash,
+                'confirmed_at' => now(),
+            ]);
+
+            return;
+        }
+
+        if ($reportedStatus === 'failed') {
+            $record->update([
+                'status'        => WalletSendRecord::STATUS_FAILED,
+                'tx_hash'       => $txHash,
+                'failed_at'     => now(),
+                'error_code'    => 'BUNDLER_REVERTED',
+                'error_message' => 'UserOperation reverted on-chain. See bundler receipt for details.',
+            ]);
+        }
+
+        // pending / unknown → leave the row in submitted; we'll poll again next tick.
+    }
+}

--- a/app/Domain/Wallet/Models/WalletSendRecord.php
+++ b/app/Domain/Wallet/Models/WalletSendRecord.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Wallet\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property string $id
+ * @property string $public_id
+ * @property int $user_id
+ * @property string $network
+ * @property string $asset
+ * @property string $amount
+ * @property string $sender_address
+ * @property string $recipient_address
+ * @property string $status
+ * @property string|null $tx_hash
+ * @property string|null $user_op_hash
+ * @property string|null $idempotency_key
+ * @property string|null $quote_id
+ * @property string|null $error_code
+ * @property string|null $error_message
+ * @property array<string, mixed>|null $metadata
+ * @property \Illuminate\Support\Carbon|null $submitted_at
+ * @property \Illuminate\Support\Carbon|null $confirmed_at
+ * @property \Illuminate\Support\Carbon|null $failed_at
+ * @property \Illuminate\Support\Carbon $created_at
+ * @property \Illuminate\Support\Carbon $updated_at
+ */
+class WalletSendRecord extends Model
+{
+    use HasUuids;
+
+    protected $table = 'wallet_send_records';
+
+    protected $fillable = [
+        'public_id',
+        'user_id',
+        'network',
+        'asset',
+        'amount',
+        'sender_address',
+        'recipient_address',
+        'status',
+        'tx_hash',
+        'user_op_hash',
+        'idempotency_key',
+        'quote_id',
+        'error_code',
+        'error_message',
+        'metadata',
+        'submitted_at',
+        'confirmed_at',
+        'failed_at',
+    ];
+
+    protected $casts = [
+        'metadata'     => 'array',
+        'submitted_at' => 'datetime',
+        'confirmed_at' => 'datetime',
+        'failed_at'    => 'datetime',
+    ];
+
+    public const STATUS_PENDING = 'pending';
+
+    public const STATUS_SUBMITTED = 'submitted';
+
+    public const STATUS_CONFIRMED = 'confirmed';
+
+    public const STATUS_FAILED = 'failed';
+
+    /**
+     * Map record to the response shape mobile expects (matches PaymentIntent::toApiResponse()).
+     *
+     * @return array<string, mixed>
+     */
+    public function toApiResponse(): array
+    {
+        return [
+            'intentId'      => $this->public_id,
+            'merchantId'    => null,
+            'merchant'      => null,
+            'asset'         => $this->asset,
+            'network'       => $this->network,
+            'amount'        => $this->amount,
+            'status'        => strtoupper($this->status === self::STATUS_PENDING ? 'pending' : $this->status),
+            'shieldEnabled' => false,
+            'feesEstimate'  => null,
+            'createdAt'     => $this->created_at->toIso8601String(),
+            'expiresAt'     => $this->created_at->copy()->addMinutes(15)->toIso8601String(),
+            'tx'            => $this->tx_hash ? [
+                'hash'        => $this->tx_hash,
+                'explorerUrl' => $this->buildExplorerUrl(),
+            ] : null,
+            'confirmations'         => $this->status === self::STATUS_CONFIRMED ? 1 : 0,
+            'requiredConfirmations' => 1,
+            'error'                 => $this->error_code ? [
+                'code'    => $this->error_code,
+                'message' => $this->error_message,
+            ] : null,
+            'quoteId' => $this->quote_id,
+        ];
+    }
+
+    private function buildExplorerUrl(): ?string
+    {
+        if ($this->tx_hash === null) {
+            return null;
+        }
+
+        return match (strtolower($this->network)) {
+            'solana'   => "https://solscan.io/tx/{$this->tx_hash}",
+            'polygon'  => "https://polygonscan.com/tx/{$this->tx_hash}",
+            'base'     => "https://basescan.org/tx/{$this->tx_hash}",
+            'arbitrum' => "https://arbiscan.io/tx/{$this->tx_hash}",
+            'ethereum' => "https://etherscan.io/tx/{$this->tx_hash}",
+            default    => null,
+        };
+    }
+}

--- a/app/Domain/Wallet/Services/HeliusTransactionProcessor.php
+++ b/app/Domain/Wallet/Services/HeliusTransactionProcessor.php
@@ -140,6 +140,21 @@ class HeliusTransactionProcessor
                 ]
             );
 
+            // Outbound wallet send confirmation: if a wallet_send_records row
+            // is awaiting this signature, flip it to confirmed. This is the
+            // production confirmation path for Solana sends — the EVM side
+            // uses a polling job against bundler getUserOperationByHash.
+            if (! $isIncoming) {
+                \App\Domain\Wallet\Models\WalletSendRecord::query()
+                    ->where('tx_hash', $signature)
+                    ->where('network', 'solana')
+                    ->whereIn('status', ['pending', 'submitted'])
+                    ->update([
+                        'status'       => 'confirmed',
+                        'confirmed_at' => now(),
+                    ]);
+            }
+
             $wasCreated = $btx->wasRecentlyCreated;
         });
 

--- a/app/Domain/Wallet/Services/Send/Erc20Transfer.php
+++ b/app/Domain/Wallet/Services/Send/Erc20Transfer.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Wallet\Services\Send;
+
+use InvalidArgumentException;
+
+/**
+ * Encodes ERC-20 `transfer(address,uint256)` calldata.
+ *
+ * The function selector `0xa9059cbb` is the first 4 bytes of
+ * keccak256("transfer(address,uint256)") and is hardcoded here — it never
+ * changes for ERC-20.
+ *
+ * This class is intentionally tiny and stateless; it produces deterministic
+ * hex calldata that callers wrap into the smart account's `execute(...)`
+ * outer call (see {@see UserOpCallDataBuilder}).
+ */
+final class Erc20Transfer
+{
+    /**
+     * keccak256("transfer(address,uint256)")[0..4].
+     */
+    public const TRANSFER_SELECTOR = '0xa9059cbb';
+
+    /**
+     * Build ERC-20 transfer calldata.
+     *
+     * @param  string $to        20-byte EVM address (with or without 0x prefix). Lower-cased in calldata.
+     * @param  string $amountWei Decimal string in token's smallest unit (wei). Must be non-negative.
+     * @return string `0x`-prefixed calldata: selector || pad(to,32) || pad(amount,32) — exactly 138 chars.
+     *
+     * @throws InvalidArgumentException If `$to` is not a 20-byte hex address or `$amountWei` is invalid.
+     */
+    public static function encodeTransferCallData(string $to, string $amountWei): string
+    {
+        $cleanTo = strtolower(str_starts_with($to, '0x') || str_starts_with($to, '0X') ? substr($to, 2) : $to);
+        if (strlen($cleanTo) !== 40 || preg_match('/^[0-9a-f]{40}$/', $cleanTo) !== 1) {
+            throw new InvalidArgumentException("Invalid recipient address for ERC-20 transfer: {$to}");
+        }
+
+        if ($amountWei === '' || preg_match('/^\d+$/', $amountWei) !== 1) {
+            throw new InvalidArgumentException("Invalid uint256 amount (must be non-negative integer string): {$amountWei}");
+        }
+
+        $paddedTo = str_pad($cleanTo, 64, '0', STR_PAD_LEFT);
+        $paddedAmount = str_pad(self::bcDecToHex($amountWei), 64, '0', STR_PAD_LEFT);
+
+        if (strlen($paddedAmount) > 64) {
+            throw new InvalidArgumentException("Amount exceeds uint256 max: {$amountWei}");
+        }
+
+        return self::TRANSFER_SELECTOR . $paddedTo . $paddedAmount;
+    }
+
+    /**
+     * Decimal-string -> lowercase hex (no 0x prefix) using bcmath.
+     *
+     * Returns '0' for zero.
+     */
+    private static function bcDecToHex(string $dec): string
+    {
+        if ($dec === '0') {
+            return '0';
+        }
+
+        /** @var numeric-string $remaining */
+        $remaining = $dec;
+        $hex = '';
+        while (bccomp($remaining, '0', 0) > 0) {
+            $mod = bcmod($remaining, '16', 0);
+            $hex = dechex((int) $mod) . $hex;
+            /** @var numeric-string $remaining */
+            $remaining = bcdiv($remaining, '16', 0);
+        }
+
+        return $hex;
+    }
+}

--- a/app/Domain/Wallet/Services/Send/EvmSendDispatcher.php
+++ b/app/Domain/Wallet/Services/Send/EvmSendDispatcher.php
@@ -1,0 +1,386 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Wallet\Services\Send;
+
+use App\Domain\Relayer\Contracts\BundlerInterface;
+use App\Domain\Relayer\Contracts\PaymasterInterface;
+use App\Domain\Relayer\Enums\SupportedNetwork;
+use App\Domain\Relayer\Services\SmartAccountService;
+use App\Domain\Relayer\ValueObjects\UserOperation;
+use App\Domain\Wallet\Helpers\Crypto\EvmKeyHelper;
+use App\Domain\Wallet\Models\WalletSendRecord;
+use App\Models\User;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Orchestrates an outbound EVM ERC-20 transfer through the ERC-4337 stack.
+ *
+ * The flow is:
+ *
+ *   1. Validate network + asset, convert major-units amount → wei via bcmath.
+ *   2. Idempotency short-circuit on (user_id, idempotency_key).
+ *   3. Derive the user's owner EOA address (via {@see EvmKeyHelper}).
+ *   4. Get/create the counterfactual smart account (via {@see SmartAccountService}).
+ *   5. Build the inner ERC-20 `transfer(...)` calldata.
+ *   6. Wrap into the outer SimpleAccount `execute(target, 0, data)` calldata.
+ *   7. Build the unsigned UserOp, ask the bundler to estimate gas, ask the
+ *      paymaster for sponsorship data, then construct the FINAL UserOp.
+ *   8. Compute the final UserOp hash, sign it (server-only path), and submit
+ *      to the bundler.
+ *   9. Persist a WalletSendRecord row with status=submitted.
+ *
+ * The full UserOp signed here is the *finalised* one (gas + paymasterAndData
+ * filled in), matching what the bundler verifies on-chain. This is correct
+ * per ERC-4337 v0.6 — diverging from the slightly-incorrect path in
+ * {@see \App\Domain\Relayer\Services\GasStationService::sponsorTransaction()}
+ * which signs over the unsigned hash.
+ */
+class EvmSendDispatcher
+{
+    public function __construct(
+        private readonly SmartAccountService $smartAccountService,
+        private readonly BundlerInterface $bundler,
+        private readonly PaymasterInterface $paymaster,
+        private readonly ServerOnlyUserOpSigner $signer,
+    ) {
+    }
+
+    /**
+     * Dispatch an EVM ERC-20 transfer.
+     *
+     * @param  string $assetSymbol  e.g. 'USDC'
+     * @param  string $networkKey   e.g. 'polygon' (lowercase, matches SupportedNetwork enum value)
+     * @param  string $amountMajor  Decimal string in major units (e.g. "1.5")
+     */
+    public function dispatch(
+        User $user,
+        string $recipientAddress,
+        string $assetSymbol,
+        string $networkKey,
+        string $amountMajor,
+        ?string $idempotencyKey = null,
+        ?string $quoteId = null,
+    ): WalletSendRecord {
+        // Idempotency: short-circuit if we've already accepted this key for this user.
+        if ($idempotencyKey !== null) {
+            /** @var WalletSendRecord|null $existing */
+            $existing = WalletSendRecord::where('user_id', $user->id)
+                ->where('idempotency_key', $idempotencyKey)
+                ->first();
+            if ($existing !== null) {
+                return $existing;
+            }
+        }
+
+        // Pre-create a record so failures can be persisted; finalised on success.
+        $record = $this->createPendingRecord($user, $recipientAddress, $assetSymbol, $networkKey, $amountMajor, $idempotencyKey, $quoteId);
+
+        try {
+            $network = $this->resolveNetwork($networkKey);
+
+            [$tokenContract, $decimals] = $this->resolveTokenContract($assetSymbol, $networkKey);
+
+            $amountWei = $this->amountToWei($amountMajor, $decimals);
+
+            $appKey = (string) config('app.key');
+            $ownerAddress = EvmKeyHelper::deriveAddressOnly($user->id, $appKey);
+
+            $smartAccount = $this->smartAccountService->getOrCreateAccount($user, $ownerAddress, $networkKey);
+            $senderAddress = $smartAccount->account_address;
+
+            $record->sender_address = $senderAddress;
+            $record->save();
+
+            // 5. Inner ERC-20 transfer calldata
+            try {
+                $innerCallData = Erc20Transfer::encodeTransferCallData($recipientAddress, $amountWei);
+            } catch (InvalidArgumentException $e) {
+                $this->markFailed($record, 'INVALID_ARGUMENT', $e->getMessage());
+
+                return $record;
+            }
+
+            // 6. Outer execute() calldata
+            $outerCallData = UserOpCallDataBuilder::buildExecute($tokenContract, $innerCallData);
+
+            // 7. Build unsigned UserOp (with initCode if account isn't deployed yet).
+            $needsInitCode = $this->smartAccountService->needsInitCode($ownerAddress, $networkKey);
+            $initCode = $needsInitCode
+                ? ('0x' . ltrim($this->smartAccountService->getInitCode($ownerAddress, $networkKey), '0x'))
+                : null;
+            // Normalize: empty/'0x' should map to null for createUnsigned.
+            if ($initCode === null || $initCode === '0x' || $initCode === '0x0x') {
+                $initCode = null;
+            }
+
+            $nonce = $needsInitCode ? 0 : $smartAccount->nonce;
+
+            $unsignedOp = UserOperation::createUnsigned(
+                sender: $senderAddress,
+                nonce: $nonce,
+                callData: $outerCallData,
+                initCode: $initCode,
+            );
+
+            // 8. Gas estimation (bundler) + paymaster sponsorship.
+            try {
+                $gasEstimate = $this->bundler->estimateUserOperationGas($unsignedOp, $network);
+            } catch (Throwable $e) {
+                $this->markFailed($record, 'BUNDLER_REJECTED', 'Gas estimation failed: ' . $e->getMessage());
+
+                return $record;
+            }
+
+            try {
+                $paymasterData = $this->paymaster->getPaymasterData(
+                    $unsignedOp,
+                    (string) config('wallet.evm.fee_token', 'USDC'),
+                    0.0,
+                );
+            } catch (Throwable $e) {
+                $this->markFailed($record, 'PAYMASTER_REJECTED', 'Paymaster sponsorship failed: ' . $e->getMessage());
+
+                return $record;
+            }
+
+            // 9. Finalise UserOp with gas + paymaster fields.
+            [$maxFee, $maxPriorityFee] = self::staticGasPrices($network);
+
+            $finalUnsigned = $unsignedOp->withGasAndSignature(
+                callGasLimit: $gasEstimate['callGasLimit'],
+                verificationGasLimit: $gasEstimate['verificationGasLimit'],
+                preVerificationGas: $gasEstimate['preVerificationGas'],
+                maxFeePerGas: $maxFee,
+                maxPriorityFeePerGas: $maxPriorityFee,
+                paymasterAndData: $paymasterData === '' ? '0x' : $paymasterData,
+                signature: '0x',
+            );
+
+            // 10. Sign the *finalised* UserOp — this matches what the EntryPoint verifies on-chain.
+            $signature = $this->signer->signUserOp($finalUnsigned, $network, $user->id);
+
+            $userOpHash = ServerOnlyUserOpSigner::computeUserOpHash($finalUnsigned, $network);
+
+            $signedOp = $finalUnsigned->withGasAndSignature(
+                callGasLimit: $finalUnsigned->callGasLimit,
+                verificationGasLimit: $finalUnsigned->verificationGasLimit,
+                preVerificationGas: $finalUnsigned->preVerificationGas,
+                maxFeePerGas: $finalUnsigned->maxFeePerGas,
+                maxPriorityFeePerGas: $finalUnsigned->maxPriorityFeePerGas,
+                paymasterAndData: $finalUnsigned->paymasterAndData,
+                signature: $signature,
+            );
+
+            // 11. Submit to bundler.
+            try {
+                $bundlerHash = $this->bundler->submitUserOperation($signedOp, $network);
+            } catch (Throwable $e) {
+                $this->markFailed($record, 'BUNDLER_REJECTED', 'Submission failed: ' . $e->getMessage());
+
+                return $record;
+            }
+
+            // Bundler returns the userOpHash; it should match our locally computed hash.
+            $record->user_op_hash = $bundlerHash !== '' ? $bundlerHash : '0x' . $userOpHash;
+            $record->status = WalletSendRecord::STATUS_SUBMITTED;
+            $record->submitted_at = now();
+            $record->save();
+
+            $this->smartAccountService->incrementPendingOps($ownerAddress, $networkKey);
+
+            Log::info('Wallet EVM send dispatched', [
+                'record_id'    => $record->id,
+                'user_op_hash' => $record->user_op_hash,
+                'network'      => $networkKey,
+                'asset'        => $assetSymbol,
+                'amount'       => $amountMajor,
+            ]);
+
+            return $record;
+        } catch (DispatchValidationException $e) {
+            $this->markFailed($record, $e->errorCode, $e->getMessage());
+
+            return $record;
+        } catch (Throwable $e) {
+            Log::error('Wallet EVM send failed unexpectedly', [
+                'record_id' => $record->id,
+                'error'     => $e->getMessage(),
+                'trace'     => $e->getTraceAsString(),
+            ]);
+            $this->markFailed($record, 'INTERNAL_ERROR', $e->getMessage());
+
+            return $record;
+        }
+    }
+
+    private function createPendingRecord(
+        User $user,
+        string $recipientAddress,
+        string $assetSymbol,
+        string $networkKey,
+        string $amountMajor,
+        ?string $idempotencyKey,
+        ?string $quoteId,
+    ): WalletSendRecord {
+        // Money math: never floats.
+        if (preg_match('/^\d+(\.\d+)?$/', $amountMajor) === 1) {
+            /** @var numeric-string $numericAmount */
+            $numericAmount = $amountMajor;
+            $normalizedAmount = bcadd($numericAmount, '0', 8);
+        } else {
+            $normalizedAmount = '0';
+        }
+
+        /** @var WalletSendRecord $record */
+        $record = WalletSendRecord::create([
+            'public_id'         => 'pi_send_' . Str::random(24),
+            'user_id'           => $user->id,
+            'network'           => $networkKey,
+            'asset'             => $assetSymbol,
+            'amount'            => $normalizedAmount,
+            'sender_address'    => '',
+            'recipient_address' => $recipientAddress,
+            'status'            => WalletSendRecord::STATUS_PENDING,
+            'idempotency_key'   => $idempotencyKey,
+            'quote_id'          => $quoteId,
+        ]);
+
+        return $record;
+    }
+
+    private function markFailed(WalletSendRecord $record, string $code, string $message): void
+    {
+        $record->status = WalletSendRecord::STATUS_FAILED;
+        $record->error_code = $code;
+        $record->error_message = mb_substr($message, 0, 1000);
+        $record->failed_at = now();
+        $record->save();
+    }
+
+    private function resolveNetwork(string $networkKey): SupportedNetwork
+    {
+        /** @var array<int, string> $enabled */
+        $enabled = (array) config('wallet.evm.enabled_networks', []);
+        $enabledLower = array_map(static fn ($n): string => strtolower((string) $n), $enabled);
+
+        if (! in_array(strtolower($networkKey), $enabledLower, true)) {
+            throw new DispatchValidationException(
+                'NETWORK_DISABLED',
+                "Network '{$networkKey}' is not enabled for outbound EVM sends",
+            );
+        }
+
+        $network = SupportedNetwork::tryFrom(strtolower($networkKey));
+        if ($network === null) {
+            throw new DispatchValidationException('NETWORK_DISABLED', "Unknown network: {$networkKey}");
+        }
+
+        return $network;
+    }
+
+    /**
+     * @return array{0: string, 1: int} [contractAddress, decimals]
+     */
+    private function resolveTokenContract(string $assetSymbol, string $networkKey): array
+    {
+        /** @var array<string, mixed> $tokens */
+        $tokens = (array) config('supported_tokens', []);
+        $upper = strtoupper($assetSymbol);
+
+        if (! isset($tokens[$upper]) || ! is_array($tokens[$upper])) {
+            throw new DispatchValidationException('INVALID_ASSET', "Unknown asset: {$assetSymbol}");
+        }
+
+        $token = $tokens[$upper];
+        /** @var array<string, mixed> $networks */
+        $networks = (array) ($token['networks'] ?? []);
+
+        if (! isset($networks[strtolower($networkKey)])) {
+            throw new DispatchValidationException(
+                'INVALID_ASSET',
+                "Asset {$assetSymbol} is not configured on network {$networkKey}",
+            );
+        }
+
+        $contract = (string) $networks[strtolower($networkKey)];
+        if ($contract === '' || preg_match('/^0x[0-9a-fA-F]{40}$/', $contract) !== 1) {
+            throw new DispatchValidationException(
+                'INVALID_ASSET',
+                "Asset {$assetSymbol} on {$networkKey} has no valid contract address",
+            );
+        }
+
+        $decimals = (int) ($token['decimals'] ?? 0);
+        if ($decimals <= 0 || $decimals > 36) {
+            throw new DispatchValidationException(
+                'INVALID_ASSET',
+                "Asset {$assetSymbol} has invalid decimals configuration",
+            );
+        }
+
+        return [$contract, $decimals];
+    }
+
+    private function amountToWei(string $amountMajor, int $decimals): string
+    {
+        if (preg_match('/^\d+(\.\d+)?$/', $amountMajor) !== 1) {
+            throw new DispatchValidationException('INVALID_AMOUNT', "Amount '{$amountMajor}' is not a non-negative decimal");
+        }
+
+        /** @var numeric-string $numericAmount */
+        $numericAmount = $amountMajor;
+
+        if (bccomp($numericAmount, '0', $decimals) <= 0) {
+            throw new DispatchValidationException('INVALID_AMOUNT', "Amount must be greater than zero: {$amountMajor}");
+        }
+
+        /** @var numeric-string $multiplier */
+        $multiplier = bcpow('10', (string) $decimals, 0);
+
+        /** @var numeric-string $normalized */
+        $normalized = bcadd($numericAmount, '0', $decimals);
+
+        // Multiplying with scale=0 truncates fractional remainder; we already validated
+        // that amountMajor has at most $decimals fractional places by normalising.
+        return bcmul($normalized, $multiplier, 0);
+    }
+
+    /**
+     * Static gas-price defaults used as the maxFee/maxPriorityFee when the
+     * dispatcher cannot reach the chain. Mirrors
+     * {@see \App\Domain\Relayer\Services\GasStationService::getMaxFeePerGas()}.
+     *
+     * @return array{0: int, 1: int} [maxFeePerGas, maxPriorityFeePerGas]
+     */
+    private static function staticGasPrices(SupportedNetwork $network): array
+    {
+        return match ($network) {
+            SupportedNetwork::POLYGON  => [100_000_000_000, 30_000_000_000],
+            SupportedNetwork::ARBITRUM => [1_000_000_000, 100_000_000],
+            SupportedNetwork::OPTIMISM => [1_000_000_000, 100_000_000],
+            SupportedNetwork::BASE     => [1_000_000_000, 100_000_000],
+            SupportedNetwork::ETHEREUM => [50_000_000_000, 2_000_000_000],
+        };
+    }
+}
+
+/**
+ * Internal exception used by the dispatcher to short-circuit validation
+ * failures with a stable error_code suitable for persisting to the
+ * WalletSendRecord row. Not part of the public API.
+ *
+ * @internal
+ */
+final class DispatchValidationException extends RuntimeException
+{
+    public function __construct(public readonly string $errorCode, string $message)
+    {
+        parent::__construct($message);
+    }
+}

--- a/app/Domain/Wallet/Services/Send/HeliusRpcClient.php
+++ b/app/Domain/Wallet/Services/Send/HeliusRpcClient.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Wallet\Services\Send;
+
+use App\Domain\Wallet\Exceptions\SolanaRpcException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Thin JSON-RPC client over Helius mainnet RPC.
+ *
+ * Helius requires the API key as a `?api-key=` query parameter — the
+ * Authorization header is NOT supported (documented in CLAUDE.md). All
+ * methods throw {@see SolanaRpcException} on RPC error envelopes so callers
+ * can persist a failure record and surface a user-facing message without
+ * leaking PHP runtime warnings.
+ */
+final class HeliusRpcClient
+{
+    /**
+     * @return array{blockhash: string, lastValidBlockHeight: int}
+     */
+    public function getLatestBlockhash(): array
+    {
+        $result = $this->call('getLatestBlockhash', [
+            ['commitment' => $this->commitment()],
+        ]);
+
+        $value = is_array($result) && isset($result['value']) && is_array($result['value'])
+            ? $result['value']
+            : [];
+
+        return [
+            'blockhash'            => (string) ($value['blockhash'] ?? ''),
+            'lastValidBlockHeight' => (int) ($value['lastValidBlockHeight'] ?? 0),
+        ];
+    }
+
+    /**
+     * @return array{success: bool, err: array<int|string, mixed>|null, logs: array<int, string>}
+     */
+    public function simulateTransaction(string $base64Tx): array
+    {
+        $result = $this->call('simulateTransaction', [
+            $base64Tx,
+            [
+                'encoding'   => 'base64',
+                'commitment' => $this->commitment(),
+                'sigVerify'  => false,
+            ],
+        ]);
+
+        $value = is_array($result) && isset($result['value']) && is_array($result['value'])
+            ? $result['value']
+            : [];
+        $err = $value['err'] ?? null;
+        $logs = $value['logs'] ?? [];
+
+        return [
+            'success' => $err === null,
+            'err'     => is_array($err) ? $err : null,
+            'logs'    => is_array($logs) ? array_values(array_map('strval', $logs)) : [],
+        ];
+    }
+
+    /**
+     * Submit a fully-signed transaction. Returns the transaction signature.
+     *
+     * @throws SolanaRpcException
+     */
+    public function sendTransaction(string $base64Tx): string
+    {
+        $result = $this->call('sendTransaction', [
+            $base64Tx,
+            [
+                'encoding'            => 'base64',
+                'skipPreflight'       => false,
+                'preflightCommitment' => $this->commitment(),
+            ],
+        ]);
+
+        if (! is_string($result)) {
+            throw SolanaRpcException::fromRpcError(0, 'sendTransaction returned non-string result');
+        }
+
+        return $result;
+    }
+
+    /**
+     * Look up confirmation status for a batch of signatures.
+     *
+     * @param  array<int, string> $signatures
+     * @return array<string, array{confirmationStatus: string, err: array<int|string, mixed>|null}|null>
+     */
+    public function getSignatureStatuses(array $signatures): array
+    {
+        $result = $this->call('getSignatureStatuses', [
+            array_values($signatures),
+            ['searchTransactionHistory' => true],
+        ]);
+
+        $value = is_array($result) && isset($result['value']) && is_array($result['value'])
+            ? $result['value']
+            : [];
+
+        /** @var array<string, array{confirmationStatus: string, err: array<int|string, mixed>|null}|null> $out */
+        $out = [];
+        foreach (array_values($signatures) as $i => $sig) {
+            $entry = $value[$i] ?? null;
+            if (! is_array($entry)) {
+                $out[$sig] = null;
+                continue;
+            }
+            $err = $entry['err'] ?? null;
+            $out[$sig] = [
+                'confirmationStatus' => (string) ($entry['confirmationStatus'] ?? ''),
+                'err'                => is_array($err) ? $err : null,
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Fetch on-chain account info, JSON-encoded. Returns null when the account
+     * does not exist on-chain (used to detect missing recipient ATAs).
+     *
+     * @return array{owner: string, lamports: int, data: array<int|string, mixed>}|null
+     */
+    public function getAccountInfo(string $base58Address): ?array
+    {
+        $result = $this->call('getAccountInfo', [
+            $base58Address,
+            [
+                'encoding'   => 'jsonParsed',
+                'commitment' => $this->commitment(),
+            ],
+        ]);
+
+        if (! is_array($result) || ! isset($result['value']) || ! is_array($result['value'])) {
+            return null;
+        }
+        $value = $result['value'];
+
+        $data = $value['data'] ?? null;
+
+        return [
+            'owner'    => (string) ($value['owner'] ?? ''),
+            'lamports' => (int) ($value['lamports'] ?? 0),
+            'data'     => is_array($data) ? $data : [],
+        ];
+    }
+
+    /**
+     * Execute a JSON-RPC call. Throws on RPC error envelope or HTTP failure.
+     *
+     * @param  array<int, mixed> $params
+     * @return mixed
+     * @throws SolanaRpcException
+     */
+    private function call(string $method, array $params)
+    {
+        $endpoint = $this->endpoint();
+
+        try {
+            $response = Http::acceptJson()->asJson()
+                ->post($endpoint, [
+                    'jsonrpc' => '2.0',
+                    'id'      => 1,
+                    'method'  => $method,
+                    'params'  => $params,
+                ])
+                ->throw();
+        } catch (RequestException $e) {
+            throw SolanaRpcException::fromRpcError(
+                $e->response->status(),
+                "HTTP {$e->response->status()} from Helius RPC ({$method})"
+            );
+        }
+
+        /** @var array<string, mixed> $body */
+        $body = (array) $response->json();
+
+        if (isset($body['error']) && is_array($body['error'])) {
+            $code = (int) ($body['error']['code'] ?? 0);
+            $message = (string) ($body['error']['message'] ?? 'Unknown RPC error');
+            throw SolanaRpcException::fromRpcError($code, $message);
+        }
+
+        return $body['result'] ?? null;
+    }
+
+    private function endpoint(): string
+    {
+        $rpcUrl = (string) config('wallet.solana.rpc_url', 'https://mainnet.helius-rpc.com');
+        $apiKey = (string) config('services.helius.api_key', '');
+
+        if ($apiKey === '') {
+            return $rpcUrl;
+        }
+
+        $separator = str_contains($rpcUrl, '?') ? '&' : '?';
+
+        return $rpcUrl . $separator . 'api-key=' . rawurlencode($apiKey);
+    }
+
+    private function commitment(): string
+    {
+        return (string) config('wallet.solana.commitment', 'confirmed');
+    }
+}

--- a/app/Domain/Wallet/Services/Send/ServerOnlyUserOpSigner.php
+++ b/app/Domain/Wallet/Services/Send/ServerOnlyUserOpSigner.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Wallet\Services\Send;
+
+use App\Domain\Relayer\Enums\SupportedNetwork;
+use App\Domain\Relayer\ValueObjects\UserOperation;
+use App\Domain\Wallet\Helpers\Crypto\EvmKeyHelper;
+use Elliptic\EC;
+use kornrunner\Keccak;
+use RuntimeException;
+
+/**
+ * Server-only ERC-4337 v0.6 UserOperation signer.
+ *
+ * Bypasses the MPC {@see \App\Domain\Relayer\Services\UserOperationSigningService}
+ * — this is the custodial path where the server holds the user's full secp256k1
+ * private key and signs end-to-end. Use this only for the wallet send pipeline
+ * where keys are derived deterministically from the user identity.
+ *
+ * UserOpHash construction follows EntryPoint v0.6's `getUserOpHash`:
+ *
+ *   packed = abi.encode(
+ *       sender,
+ *       nonce,
+ *       keccak256(initCode),
+ *       keccak256(callData),
+ *       callGasLimit,
+ *       verificationGasLimit,
+ *       preVerificationGas,
+ *       maxFeePerGas,
+ *       maxPriorityFeePerGas,
+ *       keccak256(paymasterAndData)
+ *   )
+ *   userOpHash = keccak256(abi.encode(keccak256(packed), entryPoint, chainId))
+ *
+ * Signature format: `r (32) || s (32) || v (1)` where `v` is `27 + recoveryParam`
+ * (the standard Ethereum convention). Total length is 65 bytes / 132 hex chars
+ * (134 with the 0x prefix).
+ */
+final class ServerOnlyUserOpSigner
+{
+    /**
+     * Sign a UserOperation for the given network with the given user's derived key.
+     *
+     * @return string `0x`-prefixed 65-byte signature (`r || s || v`).
+     */
+    public function signUserOp(UserOperation $userOp, SupportedNetwork $network, int $userId): string
+    {
+        $appKey = (string) config('app.key');
+        $userOpHashHex = self::computeUserOpHash($userOp, $network);
+
+        $keys = EvmKeyHelper::deriveForUser($userId, $appKey);
+        $privKeyHex = $keys['privateKey'];
+        if (str_starts_with($privKeyHex, '0x')) {
+            $privKeyHex = substr($privKeyHex, 2);
+        }
+
+        try {
+            $ec = new EC('secp256k1');
+            $key = $ec->keyFromPrivate($privKeyHex, 'hex');
+            // Canonical signatures (low-s) match Ethereum's expectation.
+            $signature = $key->sign($userOpHashHex, ['canonical' => true]);
+
+            $r = str_pad($signature->r->toString(16, 2), 64, '0', STR_PAD_LEFT);
+            $s = str_pad($signature->s->toString(16, 2), 64, '0', STR_PAD_LEFT);
+
+            $recoveryParam = $signature->recoveryParam;
+            if ($recoveryParam === null || ($recoveryParam !== 0 && $recoveryParam !== 1)) {
+                throw new RuntimeException('Invalid recovery parameter from secp256k1 signing');
+            }
+
+            $v = 27 + $recoveryParam;
+            $vHex = str_pad(dechex($v), 2, '0', STR_PAD_LEFT);
+
+            return '0x' . $r . $s . $vHex;
+        } finally {
+            // Drop the local hex copy. PHP cannot guarantee zeroing of strings,
+            // but this minimises the residual lifetime in this scope.
+            $privKeyHex = str_repeat("\x00", strlen($privKeyHex));
+            unset($privKeyHex);
+        }
+    }
+
+    /**
+     * Compute the EntryPoint v0.6 UserOpHash for an already-finalised UserOp
+     * (gas + paymasterAndData filled in).
+     *
+     * Public to allow callers (e.g. the dispatcher) to verify that the hash
+     * passed to the signer matches what they're submitting.
+     */
+    public static function computeUserOpHash(UserOperation $userOp, SupportedNetwork $network): string
+    {
+        $packed = self::abiEncodeAddress($userOp->sender)
+            . self::abiEncodeUintFromInt($userOp->nonce)
+            . self::keccakOfHexBytes($userOp->initCode)
+            . self::keccakOfHexBytes($userOp->callData)
+            . self::abiEncodeUintFromInt($userOp->callGasLimit)
+            . self::abiEncodeUintFromInt($userOp->verificationGasLimit)
+            . self::abiEncodeUintFromInt($userOp->preVerificationGas)
+            . self::abiEncodeUintFromInt($userOp->maxFeePerGas)
+            . self::abiEncodeUintFromInt($userOp->maxPriorityFeePerGas)
+            . self::keccakOfHexBytes($userOp->paymasterAndData);
+
+        $packedBin = self::hexToBin($packed);
+        $packedHashHex = Keccak::hash($packedBin, 256);
+
+        $outer = self::abiEncodeBytes32($packedHashHex)
+            . self::abiEncodeAddress($network->getEntryPointAddress())
+            . self::abiEncodeUintFromInt($network->getChainId());
+
+        return Keccak::hash(self::hexToBin($outer), 256);
+    }
+
+    /**
+     * keccak256 of a 0x-prefixed (or bare) hex bytes payload, ABI-encoded as bytes32.
+     */
+    private static function keccakOfHexBytes(string $hex): string
+    {
+        $clean = str_starts_with($hex, '0x') || str_starts_with($hex, '0X') ? substr($hex, 2) : $hex;
+        if ($clean === '') {
+            // keccak256("") = c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470
+            return 'c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470';
+        }
+        if (preg_match('/^[0-9a-fA-F]*$/', $clean) !== 1) {
+            throw new RuntimeException('Invalid hex in UserOp field');
+        }
+        if ((strlen($clean) & 1) !== 0) {
+            $clean = '0' . $clean;
+        }
+
+        return Keccak::hash(self::hexToBin($clean), 256);
+    }
+
+    private static function abiEncodeAddress(string $address): string
+    {
+        $clean = strtolower(str_starts_with($address, '0x') || str_starts_with($address, '0X') ? substr($address, 2) : $address);
+        if (strlen($clean) > 40 || preg_match('/^[0-9a-f]*$/', $clean) !== 1) {
+            throw new RuntimeException("Invalid address: {$address}");
+        }
+
+        return str_pad($clean, 64, '0', STR_PAD_LEFT);
+    }
+
+    private static function abiEncodeUintFromInt(int $value): string
+    {
+        if ($value < 0) {
+            throw new RuntimeException("uint256 cannot be negative: {$value}");
+        }
+
+        return str_pad(dechex($value), 64, '0', STR_PAD_LEFT);
+    }
+
+    private static function abiEncodeBytes32(string $hex): string
+    {
+        $clean = str_starts_with($hex, '0x') || str_starts_with($hex, '0X') ? substr($hex, 2) : $hex;
+        if (strlen($clean) > 64 || preg_match('/^[0-9a-fA-F]*$/', $clean) !== 1) {
+            throw new RuntimeException("Invalid bytes32: {$hex}");
+        }
+
+        return str_pad($clean, 64, '0', STR_PAD_RIGHT);
+    }
+
+    private static function hexToBin(string $hex): string
+    {
+        $bin = hex2bin($hex);
+        if ($bin === false) {
+            throw new RuntimeException('Failed to decode hex bytes');
+        }
+
+        return $bin;
+    }
+}

--- a/app/Domain/Wallet/Services/Send/SolanaSendDispatcher.php
+++ b/app/Domain/Wallet/Services/Send/SolanaSendDispatcher.php
@@ -1,0 +1,378 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Wallet\Services\Send;
+
+use App\Domain\Wallet\Constants\SolanaTokens;
+use App\Domain\Wallet\Exceptions\SolanaRpcException;
+use App\Domain\Wallet\Helpers\Crypto\Base58;
+use App\Domain\Wallet\Helpers\SolanaAddressHelper;
+use App\Domain\Wallet\Models\WalletSendRecord;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use Throwable;
+
+/**
+ * Orchestrates the Solana branch of the wallet send pipeline.
+ *
+ * Pipeline:
+ *   1. Resolve mint + decimals from {@see SolanaTokens::KNOWN_MINTS} by symbol.
+ *   2. Convert major-unit decimal string to atomic integer via bcmath.
+ *   3. Honour idempotency: existing record short-circuits without re-broadcast.
+ *   4. Fetch latest blockhash, derive recipient ATA, check existence.
+ *   5. Build legacy transaction message, sign, splice signature, base64-encode.
+ *   6. Simulate to catch insufficient-balance / rent / signer errors before broadcasting.
+ *   7. Persist `WalletSendRecord(status=pending)`, broadcast, mark `submitted` with tx hash.
+ *
+ * Errors are persisted to the record (`error_code`, `error_message`) — the
+ * dispatcher never lets PHP runtime warnings reach the API caller.
+ */
+class SolanaSendDispatcher
+{
+    public const NETWORK = 'solana';
+
+    public function __construct(
+        private readonly HeliusRpcClient $rpc,
+        private readonly SolanaTransferBuilder $builder,
+        private readonly SolanaSigner $signer,
+    ) {
+    }
+
+    public function dispatch(
+        User $user,
+        string $recipientAddressBase58,
+        string $assetSymbol,
+        string $amountMajor,
+        ?string $idempotencyKey = null,
+        ?string $quoteId = null,
+    ): WalletSendRecord {
+        // 1. Idempotency short-circuit (best-effort: indexed unique column).
+        if ($idempotencyKey !== null && $idempotencyKey !== '') {
+            $existing = WalletSendRecord::query()
+                ->where('user_id', $user->id)
+                ->where('idempotency_key', $idempotencyKey)
+                ->first();
+            if ($existing instanceof WalletSendRecord) {
+                return $existing;
+            }
+        }
+
+        // 2. Resolve mint + decimals.
+        $mint = $this->resolveMint($assetSymbol);
+        if ($mint === null) {
+            return $this->persistFailedRecord(
+                $user,
+                $recipientAddressBase58,
+                $assetSymbol,
+                $amountMajor,
+                $idempotencyKey,
+                $quoteId,
+                'INVALID_ASSET',
+                "Unsupported Solana asset: {$assetSymbol}",
+            );
+        }
+        [$mintAddress, $decimals] = $mint;
+
+        // 3. Convert amount → atomic.
+        try {
+            $amountAtomic = $this->amountToAtomic($amountMajor, $decimals);
+        } catch (InvalidArgumentException $e) {
+            return $this->persistFailedRecord(
+                $user,
+                $recipientAddressBase58,
+                $assetSymbol,
+                $amountMajor,
+                $idempotencyKey,
+                $quoteId,
+                'INVALID_AMOUNT',
+                $e->getMessage(),
+            );
+        }
+
+        // 4. Derive sender pubkey.
+        $senderAddress = SolanaAddressHelper::deriveForUser($user->id, (string) config('app.key'));
+
+        // 5. Build, sign, simulate, broadcast — all wrapped so we never leak warnings.
+        try {
+            $blockhashInfo = $this->rpc->getLatestBlockhash();
+            $recipientAta = $this->builder->deriveAssociatedTokenAccountAddress($recipientAddressBase58, $mintAddress);
+            $accountInfo = $this->rpc->getAccountInfo($recipientAta);
+            $createRecipientAta = $accountInfo === null;
+
+            $built = $this->builder->buildSplTransfer(
+                $senderAddress,
+                $recipientAddressBase58,
+                $mintAddress,
+                $amountAtomic,
+                $blockhashInfo['blockhash'],
+                $createRecipientAta,
+            );
+            $messageBytes = $built['message'];
+
+            $signature = $this->signer->signMessage($user->id, (string) config('app.key'), $messageBytes);
+            $signedTx = $this->buildSignedTransaction([$signature], $messageBytes);
+            $base64Tx = base64_encode($signedTx);
+
+            $simulation = $this->rpc->simulateTransaction($base64Tx);
+            if (! $simulation['success']) {
+                return $this->persistFailedRecord(
+                    $user,
+                    $recipientAddressBase58,
+                    $assetSymbol,
+                    $amountMajor,
+                    $idempotencyKey,
+                    $quoteId,
+                    'SIMULATION_FAILED',
+                    $this->summariseSimulationFailure($simulation),
+                    $senderAddress,
+                    [
+                        'simulation_err'          => $simulation['err'],
+                        'simulation_logs'         => $simulation['logs'],
+                        'create_recipient_ata'    => $createRecipientAta,
+                        'recipient_ata'           => $built['recipientAta'],
+                        'last_valid_block_height' => $blockhashInfo['lastValidBlockHeight'],
+                    ],
+                );
+            }
+
+            $record = DB::transaction(function () use (
+                $user,
+                $senderAddress,
+                $recipientAddressBase58,
+                $assetSymbol,
+                $amountMajor,
+                $idempotencyKey,
+                $quoteId,
+                $built,
+                $createRecipientAta,
+                $blockhashInfo,
+            ): WalletSendRecord {
+                return WalletSendRecord::create([
+                    'public_id'         => $this->generatePublicId(),
+                    'user_id'           => $user->id,
+                    'network'           => self::NETWORK,
+                    'asset'             => strtoupper($assetSymbol),
+                    'amount'            => $amountMajor,
+                    'sender_address'    => $senderAddress,
+                    'recipient_address' => $recipientAddressBase58,
+                    'status'            => WalletSendRecord::STATUS_PENDING,
+                    'idempotency_key'   => $idempotencyKey,
+                    'quote_id'          => $quoteId,
+                    'metadata'          => [
+                        'create_recipient_ata'    => $createRecipientAta,
+                        'recipient_ata'           => $built['recipientAta'],
+                        'last_valid_block_height' => $blockhashInfo['lastValidBlockHeight'],
+                    ],
+                ]);
+            });
+
+            try {
+                $txSignature = $this->rpc->sendTransaction($base64Tx);
+            } catch (SolanaRpcException $e) {
+                $record->update([
+                    'status'        => WalletSendRecord::STATUS_FAILED,
+                    'error_code'    => 'RPC_ERROR',
+                    'error_message' => $this->safeErrorMessage($e->getMessage()),
+                    'failed_at'     => now(),
+                ]);
+
+                return $record->refresh();
+            }
+
+            $record->update([
+                'tx_hash'      => $txSignature,
+                'status'       => WalletSendRecord::STATUS_SUBMITTED,
+                'submitted_at' => now(),
+            ]);
+
+            return $record->refresh();
+        } catch (Throwable $e) {
+            // Catch-all for anything not handled above (RPC, builder, signer).
+            return $this->persistFailedRecord(
+                $user,
+                $recipientAddressBase58,
+                $assetSymbol,
+                $amountMajor,
+                $idempotencyKey,
+                $quoteId,
+                $e instanceof SolanaRpcException ? 'RPC_ERROR' : 'DISPATCH_ERROR',
+                $this->safeErrorMessage($e->getMessage()),
+                $senderAddress,
+            );
+        }
+    }
+
+    /**
+     * Resolve a symbol like 'USDC' to [mintAddress, decimals]. Null if unknown.
+     *
+     * @return array{0: string, 1: int}|null
+     */
+    private function resolveMint(string $symbol): ?array
+    {
+        $symbolUpper = strtoupper($symbol);
+        foreach (SolanaTokens::KNOWN_MINTS as $mintAddress => $info) {
+            if (strtoupper($info['symbol']) === $symbolUpper) {
+                return [$mintAddress, $info['decimals']];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Convert a major-unit decimal string to atomic integer using bcmath.
+     *
+     * Accepts forms like "1", "1.5", "0.000001". Rejects:
+     *   - non-numeric input,
+     *   - negatives or zero,
+     *   - more fractional digits than the mint's decimals.
+     */
+    private function amountToAtomic(string $amountMajor, int $decimals): int
+    {
+        if (! preg_match('/^(0|[1-9][0-9]*)(\.[0-9]+)?$/', $amountMajor) || ! is_numeric($amountMajor)) {
+            throw new InvalidArgumentException("Invalid amount: '{$amountMajor}'");
+        }
+        // Pin the type for static analysis: we just verified the input is numeric.
+        /** @var numeric-string $amountMajor */
+        // Normalize to a numeric-string with `decimals` precision.
+        $normalized = bcadd($amountMajor, '0', $decimals);
+
+        if (bccomp($normalized, '0', $decimals) <= 0) {
+            throw new InvalidArgumentException("Amount must be greater than zero: '{$amountMajor}'");
+        }
+
+        // Reject excess fractional precision (caller wrote more digits than the mint supports).
+        $dotPos = strpos($amountMajor, '.');
+        if ($dotPos !== false) {
+            $fractional = substr($amountMajor, $dotPos + 1);
+            if (strlen($fractional) > $decimals) {
+                throw new InvalidArgumentException(
+                    "Amount '{$amountMajor}' has more than {$decimals} fractional digits"
+                );
+            }
+        }
+
+        $multiplier = bcpow('10', (string) $decimals, 0);
+        $atomicString = bcmul($normalized, $multiplier, 0);
+
+        // PHP's int max is 9.22e18 — well above any realistic SPL transfer (USDC supply is ~1e15 atomic).
+        if (bccomp($atomicString, (string) PHP_INT_MAX, 0) > 0) {
+            throw new InvalidArgumentException("Amount '{$amountMajor}' exceeds maximum supported value");
+        }
+
+        return (int) $atomicString;
+    }
+
+    /**
+     * Splice signatures + message bytes into the Solana wire format:
+     *   shortvec(num_signatures) || signatures... || message_bytes
+     *
+     * @param  array<int, string> $signatures
+     */
+    private function buildSignedTransaction(array $signatures, string $messageBytes): string
+    {
+        $out = $this->encodeShortVec(count($signatures));
+        foreach ($signatures as $sig) {
+            if (strlen($sig) !== 64) {
+                throw new InvalidArgumentException('Solana signature must be 64 bytes');
+            }
+            $out .= $sig;
+        }
+
+        return $out . $messageBytes;
+    }
+
+    private function encodeShortVec(int $value): string
+    {
+        $out = '';
+        do {
+            $byte = $value & 0x7F;
+            $value >>= 7;
+            if ($value !== 0) {
+                $byte |= 0x80;
+            }
+            $out .= chr($byte);
+        } while ($value !== 0);
+
+        return $out;
+    }
+
+    /**
+     * @param  array{success: bool, err: array<int|string, mixed>|null, logs: array<int, string>} $simulation
+     */
+    private function summariseSimulationFailure(array $simulation): string
+    {
+        if (is_array($simulation['err']) && $simulation['err'] !== []) {
+            return 'Solana simulation rejected: ' . (string) json_encode($simulation['err']);
+        }
+
+        return 'Solana simulation rejected the transaction';
+    }
+
+    /**
+     * Strip raw PHP runtime-warning text so we never bubble undefined-index /
+     * undefined-variable / call-to-undefined messages back to the mobile client.
+     */
+    private function safeErrorMessage(string $message): string
+    {
+        if (preg_match('/^Undefined (variable|array key|index|property|offset)|Trying to access|Cannot access|Attempt to read|Call to undefined/i', $message) === 1) {
+            return 'Internal error while dispatching Solana send';
+        }
+
+        return $message;
+    }
+
+    private function generatePublicId(): string
+    {
+        return 'pi_send_' . Str::lower(Str::random(20));
+    }
+
+    /**
+     * @param  array<string, mixed>|null $extraMetadata
+     */
+    private function persistFailedRecord(
+        User $user,
+        string $recipientAddress,
+        string $assetSymbol,
+        string $amountMajor,
+        ?string $idempotencyKey,
+        ?string $quoteId,
+        string $errorCode,
+        string $errorMessage,
+        ?string $senderAddress = null,
+        ?array $extraMetadata = null,
+    ): WalletSendRecord {
+        $sender = $senderAddress ?? SolanaAddressHelper::deriveForUser($user->id, (string) config('app.key'));
+
+        return WalletSendRecord::create([
+            'public_id'         => $this->generatePublicId(),
+            'user_id'           => $user->id,
+            'network'           => self::NETWORK,
+            'asset'             => strtoupper($assetSymbol),
+            'amount'            => $amountMajor,
+            'sender_address'    => $sender,
+            'recipient_address' => $recipientAddress,
+            'status'            => WalletSendRecord::STATUS_FAILED,
+            'idempotency_key'   => $idempotencyKey,
+            'quote_id'          => $quoteId,
+            'error_code'        => $errorCode,
+            'error_message'     => $this->safeErrorMessage($errorMessage),
+            'failed_at'         => now(),
+            'metadata'          => $extraMetadata,
+        ]);
+    }
+
+    /**
+     * Public helper: Base58-encode a derived sender pubkey for callers that need it.
+     * Kept here so the dispatcher remains the single source of truth for address derivation.
+     */
+    public function senderAddressFor(User $user): string
+    {
+        $rawPubkey = $this->signer->getPublicKey($user->id, (string) config('app.key'));
+
+        return Base58::encode($rawPubkey);
+    }
+}

--- a/app/Domain/Wallet/Services/Send/SolanaSigner.php
+++ b/app/Domain/Wallet/Services/Send/SolanaSigner.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Wallet\Services\Send;
+
+/**
+ * Re-derives a user's deterministic ed25519 keypair on demand to sign Solana
+ * transaction messages. Uses the SAME seed scheme as
+ * {@see \App\Domain\Wallet\Helpers\SolanaAddressHelper::deriveAddress()} so the
+ * signing key always matches the public address registered on Helius.
+ *
+ * Secret key bytes are zeroed via sodium_memzero() immediately after each
+ * signing operation. This is best-effort on PHP strings (copy-on-write may
+ * leave residual copies) but provides defence-in-depth and matches the
+ * pattern already used in SolanaAddressHelper.
+ */
+final class SolanaSigner
+{
+    /**
+     * Sign arbitrary message bytes with the user's derived ed25519 secret key.
+     *
+     * Returns a 64-byte detached signature. Callers are responsible for
+     * splicing the signature into the Solana transaction wire format.
+     */
+    public function signMessage(int $userId, string $appKey, string $messageBytes): string
+    {
+        // Inline the keypair derivation so PHPStan keeps the non-empty-string
+        // flow and so raw seed bytes never live in a named variable.
+        $keypair = sodium_crypto_sign_seed_keypair(
+            hash('sha256', "solana:{$userId}:{$appKey}" . ":m/44'/501'/0'/0'", binary: true)
+        );
+        $secretKey = sodium_crypto_sign_secretkey($keypair);
+
+        try {
+            return sodium_crypto_sign_detached($messageBytes, $secretKey);
+        } finally {
+            sodium_memzero($secretKey);
+            sodium_memzero($keypair);
+        }
+    }
+
+    /**
+     * Return the raw 32-byte ed25519 public key for a user. Callers Base58-encode
+     * if they need the canonical Solana address representation.
+     */
+    public function getPublicKey(int $userId, string $appKey): string
+    {
+        $keypair = sodium_crypto_sign_seed_keypair(
+            hash('sha256', "solana:{$userId}:{$appKey}" . ":m/44'/501'/0'/0'", binary: true)
+        );
+
+        try {
+            return sodium_crypto_sign_publickey($keypair);
+        } finally {
+            sodium_memzero($keypair);
+        }
+    }
+}

--- a/app/Domain/Wallet/Services/Send/SolanaTransferBuilder.php
+++ b/app/Domain/Wallet/Services/Send/SolanaTransferBuilder.php
@@ -1,0 +1,353 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Wallet\Services\Send;
+
+use App\Domain\Wallet\Helpers\Crypto\Base58;
+use InvalidArgumentException;
+use SodiumException;
+
+/**
+ * Builds serialized Solana legacy transaction messages for SPL token transfers.
+ *
+ * Encodes a single user-signed transaction containing:
+ *   1. ComputeBudget::SetComputeUnitLimit
+ *   2. ComputeBudget::SetComputeUnitPrice
+ *   3. (optional) AssociatedTokenAccount::Create — when the recipient ATA is missing
+ *   4. SplToken::Transfer (NOT TransferChecked — keeping this minimal)
+ *
+ * The legacy message format is documented at
+ * https://docs.solana.com/developing/programming-model/transactions and uses
+ * Solana "shortvec" compact-array length encoding throughout. Account keys
+ * are sorted by:
+ *   1. signer + writable
+ *   2. signer + readonly
+ *   3. non-signer + writable
+ *   4. non-signer + readonly
+ * with the message header counting each class.
+ */
+final class SolanaTransferBuilder
+{
+    public const TOKEN_PROGRAM_ID = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA';
+
+    public const ASSOCIATED_TOKEN_PROGRAM_ID = 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL';
+
+    public const SYSTEM_PROGRAM_ID = '11111111111111111111111111111111';
+
+    public const SYSVAR_RENT_ID = 'SysvarRent111111111111111111111111111111111';
+
+    public const COMPUTE_BUDGET_PROGRAM_ID = 'ComputeBudget111111111111111111111111111111';
+
+    private const PDA_DOMAIN = 'ProgramDerivedAddress';
+
+    /**
+     * Build an SPL transfer message body ready to be signed.
+     *
+     * @return array{message: string, recipientAta: string}
+     */
+    public function buildSplTransfer(
+        string $senderPubkeyBase58,
+        string $recipientPubkeyBase58,
+        string $mintBase58,
+        int $amountAtomic,
+        string $recentBlockhashBase58,
+        bool $createRecipientAta,
+    ): array {
+        if ($amountAtomic <= 0) {
+            throw new InvalidArgumentException('amountAtomic must be positive');
+        }
+
+        $senderRaw = $this->decodePubkey($senderPubkeyBase58, 'sender');
+        $recipientRaw = $this->decodePubkey($recipientPubkeyBase58, 'recipient');
+        $mintRaw = $this->decodePubkey($mintBase58, 'mint');
+        $blockhashRaw = $this->decodePubkey($recentBlockhashBase58, 'blockhash');
+
+        $tokenProgramRaw = Base58::decode(self::TOKEN_PROGRAM_ID);
+        $assocProgramRaw = Base58::decode(self::ASSOCIATED_TOKEN_PROGRAM_ID);
+        $systemProgramRaw = Base58::decode(self::SYSTEM_PROGRAM_ID);
+        $rentSysvarRaw = Base58::decode(self::SYSVAR_RENT_ID);
+        $computeBudgetRaw = Base58::decode(self::COMPUTE_BUDGET_PROGRAM_ID);
+
+        $senderAtaRaw = $this->deriveAssociatedTokenAccount($senderRaw, $mintRaw, $tokenProgramRaw, $assocProgramRaw);
+        $recipientAtaRaw = $this->deriveAssociatedTokenAccount($recipientRaw, $mintRaw, $tokenProgramRaw, $assocProgramRaw);
+
+        // Account ordering: signer-writable, signer-readonly, nonsigner-writable, nonsigner-readonly.
+        // For a single-signer transaction the only signer is the sender (writable, since fee is debited).
+        $signerWritable = [$senderRaw];
+        $signerReadonly = [];
+        $nonSignerWritable = [$senderAtaRaw, $recipientAtaRaw];
+
+        // Readonly non-signers — collect uniquely. Recipient pubkey is only needed when we create
+        // their ATA (it's a passenger account on the create-ATA instruction). Mint same.
+        $nonSignerReadonly = [];
+        if ($createRecipientAta) {
+            $nonSignerReadonly[] = $recipientRaw;
+            $nonSignerReadonly[] = $mintRaw;
+            $nonSignerReadonly[] = $systemProgramRaw;
+            $nonSignerReadonly[] = $rentSysvarRaw;
+            $nonSignerReadonly[] = $assocProgramRaw;
+        }
+        // Token program is referenced by the transfer instruction.
+        $nonSignerReadonly[] = $tokenProgramRaw;
+        // Compute budget program.
+        $nonSignerReadonly[] = $computeBudgetRaw;
+
+        // Deduplicate while preserving order.
+        $nonSignerReadonly = $this->dedupePubkeys($nonSignerReadonly);
+
+        $accountKeys = array_merge($signerWritable, $signerReadonly, $nonSignerWritable, $nonSignerReadonly);
+        $accountIndex = $this->indexAccountKeys($accountKeys);
+
+        // Build instructions in dispatch order.
+        $instructions = [];
+
+        $instructions[] = $this->encodeInstruction(
+            $accountIndex[$computeBudgetRaw],
+            [],
+            $this->encodeSetComputeUnitLimit($this->computeUnitLimit()),
+        );
+        $instructions[] = $this->encodeInstruction(
+            $accountIndex[$computeBudgetRaw],
+            [],
+            $this->encodeSetComputeUnitPrice($this->priorityFeeMicroLamports()),
+        );
+
+        if ($createRecipientAta) {
+            // CreateAssociatedTokenAccount accounts:
+            //   [funder (signer, writable), ata (writable), owner (readonly),
+            //    mint (readonly), system_program, token_program, rent_sysvar]
+            $createAtaAccounts = [
+                $accountIndex[$senderRaw],
+                $accountIndex[$recipientAtaRaw],
+                $accountIndex[$recipientRaw],
+                $accountIndex[$mintRaw],
+                $accountIndex[$systemProgramRaw],
+                $accountIndex[$tokenProgramRaw],
+                $accountIndex[$rentSysvarRaw],
+            ];
+            $instructions[] = $this->encodeInstruction(
+                $accountIndex[$assocProgramRaw],
+                $createAtaAccounts,
+                '', // empty data
+            );
+        }
+
+        // SplToken::Transfer accounts: [source, destination, authority]
+        $transferAccounts = [
+            $accountIndex[$senderAtaRaw],
+            $accountIndex[$recipientAtaRaw],
+            $accountIndex[$senderRaw],
+        ];
+        $instructions[] = $this->encodeInstruction(
+            $accountIndex[$tokenProgramRaw],
+            $transferAccounts,
+            $this->encodeSplTransferData($amountAtomic),
+        );
+
+        $numRequiredSignatures = count($signerWritable) + count($signerReadonly);
+        $numReadonlySigned = count($signerReadonly);
+        $numReadonlyUnsigned = count($nonSignerReadonly);
+
+        $message = chr($numRequiredSignatures) . chr($numReadonlySigned) . chr($numReadonlyUnsigned);
+        $message .= $this->encodeShortVec(count($accountKeys));
+        foreach ($accountKeys as $key) {
+            $message .= $key;
+        }
+        $message .= $blockhashRaw;
+        $message .= $this->encodeShortVec(count($instructions));
+        foreach ($instructions as $ix) {
+            $message .= $ix;
+        }
+
+        return [
+            'message'      => $message,
+            'recipientAta' => Base58::encode($recipientAtaRaw),
+        ];
+    }
+
+    /**
+     * Public PDA derivation helper. Useful for callers that need to compute the
+     * recipient ATA without building a full message (e.g. balance pre-checks).
+     */
+    public function deriveAssociatedTokenAccountAddress(string $ownerBase58, string $mintBase58): string
+    {
+        return Base58::encode($this->deriveAssociatedTokenAccount(
+            $this->decodePubkey($ownerBase58, 'owner'),
+            $this->decodePubkey($mintBase58, 'mint'),
+            Base58::decode(self::TOKEN_PROGRAM_ID),
+            Base58::decode(self::ASSOCIATED_TOKEN_PROGRAM_ID),
+        ));
+    }
+
+    /**
+     * findProgramAddress for the Associated Token Account:
+     *   seeds = [owner, token_program, mint], programId = associated_token_program
+     */
+    private function deriveAssociatedTokenAccount(
+        string $ownerRaw,
+        string $mintRaw,
+        string $tokenProgramRaw,
+        string $assocProgramRaw,
+    ): string {
+        for ($bump = 255; $bump >= 0; $bump--) {
+            $seedBytes = $ownerRaw . $tokenProgramRaw . $mintRaw . chr($bump);
+            $candidate = hash('sha256', $seedBytes . $assocProgramRaw . self::PDA_DOMAIN, binary: true);
+
+            // PDAs are intentionally OFF-curve; if the candidate happens to be a valid
+            // ed25519 point, decrement the bump and try again.
+            if (! $this->isOnCurve25519($candidate)) {
+                return $candidate;
+            }
+        }
+
+        // Cryptographically negligible — included for type safety.
+        throw new InvalidArgumentException('Unable to derive PDA: all bumps exhausted');
+    }
+
+    /**
+     * Returns true if the 32-byte buffer encodes a point on the ed25519 curve.
+     *
+     * PHP's sodium binding does not expose `sodium_crypto_core_ed25519_is_valid_point`
+     * (introduced in libsodium 1.0.16) on every distro build, so we use the
+     * universally-available `sodium_crypto_sign_ed25519_pk_to_curve25519`, which
+     * throws SodiumException on off-curve / non-canonical points.
+     */
+    private function isOnCurve25519(string $pubkey): bool
+    {
+        if (strlen($pubkey) !== 32) {
+            return false;
+        }
+
+        try {
+            sodium_crypto_sign_ed25519_pk_to_curve25519($pubkey);
+
+            return true;
+        } catch (SodiumException) {
+            return false;
+        }
+    }
+
+    private function decodePubkey(string $base58, string $label): string
+    {
+        $raw = Base58::decode($base58);
+        if (strlen($raw) !== 32) {
+            throw new InvalidArgumentException("Invalid {$label} pubkey: expected 32 bytes after Base58 decode, got " . strlen($raw));
+        }
+
+        return $raw;
+    }
+
+    /**
+     * @param  array<int, string> $keys
+     * @return array<string, int>
+     */
+    private function indexAccountKeys(array $keys): array
+    {
+        $index = [];
+        foreach ($keys as $i => $key) {
+            $index[$key] = $i;
+        }
+
+        return $index;
+    }
+
+    /**
+     * @param  array<int, string> $keys
+     * @return array<int, string>
+     */
+    private function dedupePubkeys(array $keys): array
+    {
+        $seen = [];
+        $out = [];
+        foreach ($keys as $key) {
+            if (isset($seen[$key])) {
+                continue;
+            }
+            $seen[$key] = true;
+            $out[] = $key;
+        }
+
+        return $out;
+    }
+
+    /**
+     * Solana shortvec (compact-u16) length encoding.
+     */
+    private function encodeShortVec(int $value): string
+    {
+        if ($value < 0) {
+            throw new InvalidArgumentException('shortvec value must be non-negative');
+        }
+
+        $out = '';
+        do {
+            $byte = $value & 0x7F;
+            $value >>= 7;
+            if ($value !== 0) {
+                $byte |= 0x80;
+            }
+            $out .= chr($byte);
+        } while ($value !== 0);
+
+        return $out;
+    }
+
+    /**
+     * @param  array<int, int> $accountIndices
+     */
+    private function encodeInstruction(int $programIdIndex, array $accountIndices, string $data): string
+    {
+        $out = chr($programIdIndex);
+        $out .= $this->encodeShortVec(count($accountIndices));
+        foreach ($accountIndices as $i) {
+            $out .= chr($i);
+        }
+        $out .= $this->encodeShortVec(strlen($data));
+        $out .= $data;
+
+        return $out;
+    }
+
+    private function encodeSetComputeUnitLimit(int $units): string
+    {
+        // discriminator 0x02 + u32 LE
+        return chr(0x02) . pack('V', $units);
+    }
+
+    private function encodeSetComputeUnitPrice(int $microLamports): string
+    {
+        // discriminator 0x03 + u64 LE
+        return chr(0x03) . $this->packU64Le($microLamports);
+    }
+
+    private function encodeSplTransferData(int $amount): string
+    {
+        // discriminator 0x03 (Transfer) + u64 LE amount
+        return chr(0x03) . $this->packU64Le($amount);
+    }
+
+    /**
+     * pack('P', ...) is little-endian unsigned 64-bit, but emits zeros for
+     * negative ints on 64-bit PHP. We only ever encode positive amounts so
+     * the simpler form is fine, but we wrap it for clarity.
+     */
+    private function packU64Le(int $value): string
+    {
+        if ($value < 0) {
+            throw new InvalidArgumentException('u64 value must be non-negative');
+        }
+
+        return pack('P', $value);
+    }
+
+    private function computeUnitLimit(): int
+    {
+        return (int) config('wallet.solana.compute_unit_limit', 200000);
+    }
+
+    private function priorityFeeMicroLamports(): int
+    {
+        return (int) config('wallet.solana.priority_fee_microlamports', 1000);
+    }
+}

--- a/app/Domain/Wallet/Services/Send/UserOpCallDataBuilder.php
+++ b/app/Domain/Wallet/Services/Send/UserOpCallDataBuilder.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Wallet\Services\Send;
+
+use InvalidArgumentException;
+
+/**
+ * Builds the outer `execute(address target, uint256 value, bytes data)` calldata
+ * the ERC-4337 SimpleAccount uses to dispatch the inner ERC-20 transfer.
+ *
+ * Selector: keccak256("execute(address,uint256,bytes)")[0..4] = 0xb61d27f6.
+ * Used by the canonical eth-infinitism SimpleAccount implementation that the
+ * relayer's factory deploys.
+ *
+ * ABI layout for `execute(address,uint256,bytes)` calldata (after selector):
+ *   [head] address target          — 32 bytes, left-padded
+ *   [head] uint256 value           — 32 bytes, left-padded (we always pass 0 — no native value with ERC-20 transfers)
+ *   [head] bytes  data             — 32-byte offset to the dynamic tail (always 0x60 here)
+ *   [tail] uint256 length          — 32 bytes, byte-length of `data`
+ *   [tail] bytes  data...zero-pad  — multiple of 32 bytes
+ */
+final class UserOpCallDataBuilder
+{
+    /**
+     * keccak256("execute(address,uint256,bytes)")[0..4].
+     */
+    public const EXECUTE_SELECTOR = '0xb61d27f6';
+
+    /**
+     * Default value field for execute() — no native ETH/MATIC sent. The ERC-20
+     * transfer carries its own amount in `data`.
+     */
+    private const ZERO_VALUE_HEX = '0000000000000000000000000000000000000000000000000000000000000000';
+
+    /**
+     * Offset (in bytes) from the start of the head section to the dynamic
+     * `bytes data` tail. With three head slots of 32 bytes each, the offset
+     * is always 0x60 (96).
+     */
+    private const BYTES_HEAD_OFFSET_HEX = '0000000000000000000000000000000000000000000000000000000000000060';
+
+    /**
+     * Wrap an inner ERC-20 calldata as a SimpleAccount `execute()` call.
+     *
+     * @param  string $tokenContractAddress Token contract (the `target` of execute()).
+     * @param  string $erc20CallData        Inner calldata from {@see Erc20Transfer::encodeTransferCallData()}.
+     * @return string `0x`-prefixed outer calldata.
+     */
+    public static function buildExecute(string $tokenContractAddress, string $erc20CallData): string
+    {
+        $cleanTarget = strtolower(
+            str_starts_with($tokenContractAddress, '0x') || str_starts_with($tokenContractAddress, '0X')
+                ? substr($tokenContractAddress, 2)
+                : $tokenContractAddress
+        );
+        if (strlen($cleanTarget) !== 40 || preg_match('/^[0-9a-f]{40}$/', $cleanTarget) !== 1) {
+            throw new InvalidArgumentException("Invalid target contract address: {$tokenContractAddress}");
+        }
+
+        $cleanData = strtolower(
+            str_starts_with($erc20CallData, '0x') || str_starts_with($erc20CallData, '0X')
+                ? substr($erc20CallData, 2)
+                : $erc20CallData
+        );
+        if ($cleanData !== '' && preg_match('/^[0-9a-f]+$/', $cleanData) !== 1) {
+            throw new InvalidArgumentException('Inner calldata is not valid hex');
+        }
+        // Inner bytes must come in whole bytes (even hex length).
+        if ((strlen($cleanData) & 1) !== 0) {
+            throw new InvalidArgumentException('Inner calldata must have an even number of hex characters');
+        }
+
+        $byteLength = intdiv(strlen($cleanData), 2);
+
+        // Pad the bytes payload up to a multiple of 32 bytes (right-pad with zeros).
+        $paddedDataLen = (int) (ceil($byteLength / 32) * 32);
+        $paddedData = str_pad($cleanData, $paddedDataLen * 2, '0', STR_PAD_RIGHT);
+
+        $paddedTarget = str_pad($cleanTarget, 64, '0', STR_PAD_LEFT);
+        $lengthHex = str_pad(dechex($byteLength), 64, '0', STR_PAD_LEFT);
+
+        return self::EXECUTE_SELECTOR
+            . $paddedTarget
+            . self::ZERO_VALUE_HEX
+            . self::BYTES_HEAD_OFFSET_HEX
+            . $lengthHex
+            . $paddedData;
+    }
+}

--- a/app/Domain/Wallet/Services/Send/WalletSendDispatcher.php
+++ b/app/Domain/Wallet/Services/Send/WalletSendDispatcher.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Wallet\Services\Send;
+
+use App\Domain\Wallet\Models\WalletSendRecord;
+use App\Models\User;
+
+/**
+ * Routes a wallet send to the per-chain dispatcher.
+ *
+ * The chain branch is decided by the `network` value mobile sends:
+ *   SOLANA → SolanaSendDispatcher (USDC, USDT)
+ *   polygon | base | arbitrum | ethereum → EvmSendDispatcher (USDC, USDT, WETH, WBTC)
+ *
+ * Idempotency, persistence, and error reporting live inside each per-chain
+ * dispatcher; this class only routes.
+ */
+class WalletSendDispatcher
+{
+    public function __construct(
+        private readonly SolanaSendDispatcher $solana,
+        private readonly EvmSendDispatcher $evm,
+    ) {
+    }
+
+    public function dispatch(
+        User $user,
+        string $recipientAddress,
+        string $assetSymbol,
+        string $networkKey,
+        string $amountMajor,
+        ?string $idempotencyKey = null,
+        ?string $quoteId = null,
+    ): WalletSendRecord {
+        if ($this->isSolana($networkKey)) {
+            return $this->solana->dispatch(
+                user: $user,
+                recipientAddressBase58: $recipientAddress,
+                assetSymbol: $assetSymbol,
+                amountMajor: $amountMajor,
+                idempotencyKey: $idempotencyKey,
+                quoteId: $quoteId,
+            );
+        }
+
+        return $this->evm->dispatch(
+            user: $user,
+            recipientAddress: $recipientAddress,
+            assetSymbol: $assetSymbol,
+            networkKey: strtolower($networkKey),
+            amountMajor: $amountMajor,
+            idempotencyKey: $idempotencyKey,
+            quoteId: $quoteId,
+        );
+    }
+
+    private function isSolana(string $networkKey): bool
+    {
+        return strtoupper($networkKey) === 'SOLANA';
+    }
+}

--- a/app/Http/Controllers/Api/Relayer/SmartAccountController.php
+++ b/app/Http/Controllers/Api/Relayer/SmartAccountController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers\Api\Relayer;
 
 use App\Domain\Relayer\Exceptions\SmartAccountException;
 use App\Domain\Relayer\Services\SmartAccountService;
+use App\Domain\Wallet\Helpers\Crypto\EvmKeyHelper;
 use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Http\JsonResponse;
@@ -390,17 +391,15 @@ class SmartAccountController extends Controller
     }
 
     /**
-     * Derive a deterministic EOA-like address from a user's identity.
+     * Derive the EIP-55 checksummed owner EOA address for a user.
      *
-     * Used during onboarding when the user has no external wallet.
-     * The address is computed as keccak256(user_id + app_key)[12:] to produce
-     * a valid 20-byte Ethereum address deterministically.
+     * Backed by a real secp256k1 keypair (see {@see EvmKeyHelper::deriveForUser()})
+     * so the smart account this address owns can actually be operated by the
+     * server-held key — replacing the previous phantom-address derivation that
+     * had no corresponding private key.
      */
     private function deriveOwnerAddress(User $user): string
     {
-        $seed = $user->id . ':' . config('app.key');
-        $hash = hash('sha3-256', $seed);
-
-        return '0x' . substr($hash, 24); // Last 20 bytes (40 hex chars)
+        return EvmKeyHelper::deriveAddressOnly((int) $user->id, (string) config('app.key'));
     }
 }

--- a/app/Http/Controllers/Api/Wallet/MobileWalletController.php
+++ b/app/Http/Controllers/Api/Wallet/MobileWalletController.php
@@ -17,6 +17,7 @@ use App\Domain\Wallet\Constants\SolanaCacheKeys;
 use App\Domain\Wallet\Constants\SolanaTokens;
 use App\Domain\Wallet\Factories\BlockchainConnectorFactory;
 use App\Domain\Wallet\Helpers\SolanaAddressHelper;
+use App\Domain\Wallet\Services\Send\WalletSendDispatcher;
 use App\Domain\Wallet\Services\WalletTransferService;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
@@ -35,6 +36,7 @@ class MobileWalletController extends Controller
         private readonly ActivityFeedService $activityFeedService,
         private readonly TransactionDetailService $transactionDetailService,
         private readonly WalletTransferService $walletTransferService,
+        private readonly WalletSendDispatcher $walletSendDispatcher,
     ) {
     }
 
@@ -601,6 +603,12 @@ class MobileWalletController extends Controller
         ]);
 
         $user = $request->user();
+        if (! $user instanceof \App\Models\User) {
+            return response()->json([
+                'success' => false,
+                'error'   => ['code' => 'UNAUTHORIZED', 'message' => 'Not authenticated.'],
+            ], 401);
+        }
 
         try {
             // Wallet-to-wallet sends are deliberately NOT routed through
@@ -621,11 +629,32 @@ class MobileWalletController extends Controller
                 ], 422);
             }
 
+            // Real on-chain dispatch is gated behind config('wallet.real_dispatch_enabled')
+            // so the safe stub remains the default until staging signs off.
+            if ((bool) config('wallet.real_dispatch_enabled', false)) {
+                $idempotencyKey = $request->header('Idempotency-Key');
+                $record = $this->walletSendDispatcher->dispatch(
+                    user: $user,
+                    recipientAddress: (string) $validated['to'],
+                    assetSymbol: (string) $validated['token'],
+                    networkKey: (string) $validated['network'],
+                    amountMajor: (string) $validated['amount'],
+                    idempotencyKey: is_string($idempotencyKey) ? $idempotencyKey : null,
+                    quoteId: isset($validated['quote_id']) ? (string) $validated['quote_id'] : null,
+                );
+
+                $statusCode = $record->status === 'failed' ? 422 : 201;
+
+                return response()->json([
+                    'success' => $record->status !== 'failed',
+                    'data'    => $record->toApiResponse(),
+                ], $statusCode);
+            }
+
             $networkEnum = PaymentNetwork::from((string) $validated['network']);
 
-            // Stub dispatch: real on-chain submission is not yet wired for the
-            // wallet-send path. We acknowledge the intent so mobile can render a
-            // pending-state UI; status flips once the dispatcher lands.
+            // Stub dispatch (default): acknowledge with a pending response so
+            // mobile renders a pending-state UI without funds actually moving.
             $intentId = 'pi_send_' . Str::random(20);
 
             $response = [

--- a/config/wallet.php
+++ b/config/wallet.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Wallet Send (Outbound Transfer) Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Real on-chain dispatch is gated behind a feature flag. When the flag is
+    | OFF (default), POST /api/v1/wallet/transactions/send returns a stub
+    | PENDING acknowledgement matching the mobile contract — funds do not
+    | move on-chain. When ON, the WalletSendDispatcher routes to the
+    | per-chain pipeline (Solana via Helius RPC, EVM via Pimlico bundler).
+    |
+    | Flip the flag to true ONLY after smoke-testing on staging with small
+    | amounts and verifying tx confirmation propagates back through the
+    | webhook / polling path.
+    |
+    */
+
+    'real_dispatch_enabled' => (bool) env('WALLET_SEND_REAL_DISPATCH', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Solana Send Configuration
+    |--------------------------------------------------------------------------
+    */
+
+    'solana' => [
+        // Public RPC endpoint used to broadcast signed transactions.
+        // Helius mainnet RPC supports api-key as query param.
+        'rpc_url' => (string) env('HELIUS_RPC_URL', 'https://mainnet.helius-rpc.com'),
+        // Confirmation level required before treating a tx as confirmed.
+        // Options: processed | confirmed | finalized
+        'commitment' => (string) env('SOLANA_COMMITMENT', 'confirmed'),
+        // Microlamports per compute unit for priority fee. Bump under congestion.
+        'priority_fee_microlamports' => (int) env('SOLANA_PRIORITY_FEE_MICROLAMPORTS', 1000),
+        // Compute unit limit for a single SPL transfer (with optional ATA create).
+        'compute_unit_limit' => (int) env('SOLANA_COMPUTE_UNIT_LIMIT', 200000),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | EVM Send Configuration
+    |--------------------------------------------------------------------------
+    */
+
+    'evm' => [
+        // Networks enabled for outbound dispatch. Mobile validates against
+        // PaymentNetwork enum, so values must match (lowercase casing).
+        'enabled_networks' => array_filter(array_map(
+            'trim',
+            explode(',', (string) env('WALLET_SEND_EVM_NETWORKS', 'polygon,base,arbitrum,ethereum')),
+        )),
+        // Token used to pay sponsorship fee. Must be supported by the paymaster.
+        'fee_token' => (string) env('WALLET_SEND_EVM_FEE_TOKEN', 'USDC'),
+    ],
+];

--- a/database/migrations/2026_05_05_111200_create_wallet_send_records_table.php
+++ b/database/migrations/2026_05_05_111200_create_wallet_send_records_table.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Outbound wallet-to-wallet transfer records.
+ *
+ * Distinct from `payment_intents` (which is the merchant-payment flow with
+ * a non-nullable merchant_id). Wallet sends have no merchant.
+ *
+ * Status flow:
+ *   pending    → created in DB, signing in progress
+ *   submitted  → broadcast to RPC/bundler, tx hash known, awaiting confirmation
+ *   confirmed  → on-chain confirmation observed (via webhook or polling)
+ *   failed     → simulation/RPC/bundler rejected; error_code/message populated
+ */
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('wallet_send_records', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->string('public_id', 64)->unique()->comment('Public-facing intent ID (pi_send_...)');
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->string('network', 20);
+            $table->string('asset', 10);
+            // Decimal major units as a string. Always normalize via bcmath; never cast to float.
+            $table->decimal('amount', 30, 8);
+            $table->string('sender_address', 128);
+            $table->string('recipient_address', 128);
+            $table->string('status', 20)->default('pending');
+            $table->string('tx_hash', 128)->nullable()->index();
+            $table->string('user_op_hash', 128)->nullable()->index();
+            $table->string('idempotency_key', 128)->nullable()->unique();
+            $table->string('quote_id', 64)->nullable();
+            $table->string('error_code', 50)->nullable();
+            $table->text('error_message')->nullable();
+            $table->json('metadata')->nullable();
+            $table->dateTime('submitted_at')->nullable();
+            $table->dateTime('confirmed_at')->nullable();
+            $table->dateTime('failed_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['user_id', 'created_at']);
+            $table->index(['status', 'created_at']);
+            $table->index(['network', 'tx_hash']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('wallet_send_records');
+    }
+};

--- a/routes/console.php
+++ b/routes/console.php
@@ -215,6 +215,14 @@ Schedule::command('trustcert:check-expired')
         Log::warning('TrustCert expiry check failed to run');
     });
 
+// Wallet send (EVM) confirmation polling — every minute.
+// Solana confirmations come via the Helius webhook (HeliusTransactionProcessor),
+// not this job.
+Schedule::job(new App\Domain\Wallet\Jobs\PollEvmWalletSendConfirmations())
+    ->everyMinute()
+    ->description('Poll bundler for EVM wallet-send confirmations')
+    ->withoutOverlapping();
+
 // Daily sweep: auto-disable expired reviewer/demo accounts.
 // --allow-production is appended because the scheduled job runs as the system,
 // not a human operator — the production guard is only for manual invocation.

--- a/tests/Feature/Domain/Wallet/HeliusTransactionProcessorWalletSendConfirmationTest.php
+++ b/tests/Feature/Domain/Wallet/HeliusTransactionProcessorWalletSendConfirmationTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Account\Models\BlockchainAddress;
+use App\Domain\Wallet\Models\WalletSendRecord;
+use App\Domain\Wallet\Services\HeliusTransactionProcessor;
+use App\Models\User;
+use Illuminate\Support\Facades\Schema;
+use Tests\Traits\CreatesSolanaTestTables;
+
+uses(CreatesSolanaTestTables::class);
+
+beforeEach(function (): void {
+    $this->createSolanaTestTables();
+
+    // Real user satisfies activity_feed_items.user_id FK without disabling SQLite FK enforcement
+    $this->user = User::factory()->create(['id' => 42]);
+
+    Schema::dropIfExists('wallet_send_records');
+    Schema::create('wallet_send_records', function ($table): void {
+        $table->uuid('id')->primary();
+        $table->string('public_id', 64)->unique();
+        $table->unsignedBigInteger('user_id');
+        $table->string('network', 20);
+        $table->string('asset', 10);
+        $table->decimal('amount', 30, 8);
+        $table->string('sender_address', 128);
+        $table->string('recipient_address', 128);
+        $table->string('status', 20)->default('pending');
+        $table->string('tx_hash', 128)->nullable();
+        $table->string('user_op_hash', 128)->nullable();
+        $table->string('idempotency_key', 128)->nullable()->unique();
+        $table->string('quote_id', 64)->nullable();
+        $table->string('error_code', 50)->nullable();
+        $table->text('error_message')->nullable();
+        $table->json('metadata')->nullable();
+        $table->dateTime('submitted_at')->nullable();
+        $table->dateTime('confirmed_at')->nullable();
+        $table->dateTime('failed_at')->nullable();
+        $table->timestamps();
+    });
+});
+
+afterEach(function (): void {
+    $this->dropSolanaTestTables();
+});
+
+it('flips a submitted Solana wallet_send_records to confirmed when its tx hash arrives via webhook', function (): void {
+    $signature = '5xVgGJzqFVmLqnRkLGJpKfMoNu3ssKYfQYz4XbUmSqJxHfrx7c2yBz8tNvMwQs9X';
+
+    // Pre-existing wallet send awaiting confirmation
+    $sendRecord = WalletSendRecord::create([
+        'public_id'         => 'pi_send_outboundtest',
+        'user_id'           => 42,
+        'network'           => 'solana',
+        'asset'             => 'USDC',
+        'amount'            => '1.50000000',
+        'sender_address'    => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        'recipient_address' => 'BobxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxV',
+        'status'            => 'submitted',
+        'tx_hash'           => $signature,
+        'submitted_at'      => now(),
+    ]);
+
+    // BlockchainAddress + tx record (must be on-curve so HeliusTransactionProcessor doesn't reject)
+    $blockchainAddress = BlockchainAddress::create([
+        'uuid'       => '01234567-89ab-4def-0123-456789abcdef',
+        'user_uuid'  => 'user-uuid-42',
+        'address'    => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        'public_key' => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        'chain'      => 'solana',
+        'is_active'  => true,
+    ]);
+
+    // Outbound (sender = our address) Helius enhanced tx payload
+    $tx = [
+        'signature'      => $signature,
+        'fee'            => 5000,
+        'tokenTransfers' => [[
+            'fromUserAccount' => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+            'toUserAccount'   => 'BobxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxV',
+            'mint'            => 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', // USDC
+            'tokenAmount'     => '1.5',
+        ]],
+    ];
+
+    $processor = app(HeliusTransactionProcessor::class);
+    $processor->processTransaction(
+        'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        $blockchainAddress,
+        42,
+        $tx,
+    );
+
+    $sendRecord->refresh();
+    expect($sendRecord->status)->toBe('confirmed')
+        ->and($sendRecord->confirmed_at)->not->toBeNull();
+});
+
+it('does not touch wallet_send_records on incoming (receive) Solana tx', function (): void {
+    $signature = '6xa9999999999999999999999999999999999999999999999999999999999999999999999999999999999999';
+
+    $sendRecord = WalletSendRecord::create([
+        'public_id'         => 'pi_send_other',
+        'user_id'           => 42,
+        'network'           => 'solana',
+        'asset'             => 'USDC',
+        'amount'            => '1.00000000',
+        'sender_address'    => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        'recipient_address' => 'BobxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxV',
+        'status'            => 'submitted',
+        'tx_hash'           => $signature,
+        'submitted_at'      => now(),
+    ]);
+
+    $blockchainAddress = BlockchainAddress::create([
+        'uuid'       => '11111111-2222-4333-8444-555555555555',
+        'user_uuid'  => 'user-uuid-42',
+        'address'    => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        'public_key' => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        'chain'      => 'solana',
+        'is_active'  => true,
+    ]);
+
+    // Incoming tx: our address is the recipient, not the sender
+    $tx = [
+        'signature'      => $signature,
+        'fee'            => 5000,
+        'tokenTransfers' => [[
+            'fromUserAccount' => 'BobxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxV',
+            'toUserAccount'   => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+            'mint'            => 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+            'tokenAmount'     => '1.0',
+        ]],
+    ];
+
+    app(HeliusTransactionProcessor::class)->processTransaction(
+        'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        $blockchainAddress,
+        42,
+        $tx,
+    );
+
+    $sendRecord->refresh();
+    // Outbound record stays submitted — we don't confirm it from a receive event
+    expect($sendRecord->status)->toBe('submitted')
+        ->and($sendRecord->confirmed_at)->toBeNull();
+});

--- a/tests/Unit/Domain/Wallet/Helpers/Crypto/Base58Test.php
+++ b/tests/Unit/Domain/Wallet/Helpers/Crypto/Base58Test.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Wallet\Helpers\Crypto\Base58;
+
+uses(Tests\TestCase::class);
+
+it('round-trips random 32-byte payloads', function (): void {
+    $bytes = random_bytes(32);
+    $encoded = Base58::encode($bytes);
+    $decoded = Base58::decode($encoded);
+
+    expect($decoded)->toBe($bytes)
+        ->and(strlen($decoded))->toBe(32);
+});
+
+it('decodes USDC mint to 32 bytes that re-encode back to the canonical mint', function (): void {
+    $usdcMint = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+    $raw = Base58::decode($usdcMint);
+
+    expect(strlen($raw))->toBe(32)
+        ->and(Base58::encode($raw))->toBe($usdcMint);
+});
+
+it('decodes the system program ID to 32 zero bytes', function (): void {
+    // The Solana System Program is the all-zeroes pubkey, encoded as 32 '1' chars.
+    $systemProgram = '11111111111111111111111111111111';
+    $raw = Base58::decode($systemProgram);
+
+    expect(strlen($raw))->toBe(32)
+        ->and($raw)->toBe(str_repeat("\x00", 32))
+        ->and(Base58::encode($raw))->toBe($systemProgram);
+});
+
+it('decodes the token program to 32 bytes that round-trip', function (): void {
+    $tokenProgram = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA';
+    $raw = Base58::decode($tokenProgram);
+
+    expect(strlen($raw))->toBe(32)
+        ->and(Base58::encode($raw))->toBe($tokenProgram);
+});
+
+it('rejects invalid Base58 character', function (): void {
+    $threw = false;
+    try {
+        // '0', 'O', 'I', 'l' are excluded from the alphabet.
+        Base58::decode('0OIl');
+    } catch (InvalidArgumentException) {
+        $threw = true;
+    }
+    expect($threw)->toBeTrue();
+});
+
+it('rejects mixed-valid-and-invalid characters', function (): void {
+    $threw = false;
+    try {
+        Base58::decode('EPj+notvalid');
+    } catch (InvalidArgumentException) {
+        $threw = true;
+    }
+    expect($threw)->toBeTrue();
+});
+
+it('encodes empty bytes to empty string', function (): void {
+    expect(Base58::encode(''))->toBe('');
+});
+
+it('decodes empty string to empty bytes', function (): void {
+    expect(Base58::decode(''))->toBe('');
+});
+
+it('preserves leading zero bytes as 1 prefix', function (): void {
+    $bytes = "\x00\x00\x01\x02";
+    $encoded = Base58::encode($bytes);
+
+    expect($encoded)->toStartWith('11')
+        ->and(Base58::decode($encoded))->toBe($bytes);
+});
+
+it('round-trips 16-byte payloads', function (): void {
+    $bytes = random_bytes(16);
+    expect(Base58::decode(Base58::encode($bytes)))->toBe($bytes);
+});
+
+it('round-trips 20-byte payloads', function (): void {
+    $bytes = random_bytes(20);
+    expect(Base58::decode(Base58::encode($bytes)))->toBe($bytes);
+});
+
+it('round-trips 64-byte payloads', function (): void {
+    $bytes = random_bytes(64);
+    expect(Base58::decode(Base58::encode($bytes)))->toBe($bytes);
+});

--- a/tests/Unit/Domain/Wallet/Helpers/Crypto/EvmKeyHelperTest.php
+++ b/tests/Unit/Domain/Wallet/Helpers/Crypto/EvmKeyHelperTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Wallet\Helpers\Crypto\EvmKeyHelper;
+use Elliptic\EC;
+use kornrunner\Keccak;
+
+uses(Tests\TestCase::class);
+
+test('deriveForUser is deterministic for the same userId and appKey', function (): void {
+    $a = EvmKeyHelper::deriveForUser(42, 'test-app-key');
+    $b = EvmKeyHelper::deriveForUser(42, 'test-app-key');
+
+    expect($a['address'])->toBe($b['address']);
+    expect($a['publicKey'])->toBe($b['publicKey']);
+    expect($a['privateKey'])->toBe($b['privateKey']);
+});
+
+test('deriveForUser produces different keys for different userIds', function (): void {
+    $a = EvmKeyHelper::deriveForUser(1, 'key');
+    $b = EvmKeyHelper::deriveForUser(2, 'key');
+
+    expect($a['address'])->not->toBe($b['address']);
+    expect($a['privateKey'])->not->toBe($b['privateKey']);
+});
+
+test('deriveForUser produces different keys for different appKeys', function (): void {
+    $a = EvmKeyHelper::deriveForUser(42, 'key-a');
+    $b = EvmKeyHelper::deriveForUser(42, 'key-b');
+
+    expect($a['address'])->not->toBe($b['address']);
+});
+
+test('deriveAddressOnly matches deriveForUser address', function (): void {
+    $full = EvmKeyHelper::deriveForUser(7, 'app-key-x');
+    $addressOnly = EvmKeyHelper::deriveAddressOnly(7, 'app-key-x');
+
+    expect($addressOnly)->toBe($full['address']);
+});
+
+test('derived address is 0x-prefixed 20 bytes hex', function (): void {
+    $address = EvmKeyHelper::deriveAddressOnly(123, 'k');
+
+    expect($address)->toStartWith('0x');
+    expect(strlen($address))->toBe(42);
+    expect(substr($address, 2))->toMatch('/^[0-9a-fA-F]{40}$/');
+});
+
+test('derived address uses EIP-55 mixed-case checksum', function (): void {
+    // Try a small range until we hit one with at least one uppercase hex letter,
+    // proving the checksum is being applied (lowercase digits never round-trip
+    // through toUpperCase in EIP-55, so this is a strong signal).
+    $hadUppercase = false;
+    foreach (range(1, 10) as $userId) {
+        $address = EvmKeyHelper::deriveAddressOnly($userId, 'eip55-key');
+        $hex = substr($address, 2);
+        if (preg_match('/[A-F]/', $hex) === 1) {
+            $hadUppercase = true;
+            break;
+        }
+    }
+
+    expect($hadUppercase)->toBeTrue();
+});
+
+test('public key recovers the same address as keccak256(pubkey)[12:]', function (): void {
+    $derived = EvmKeyHelper::deriveForUser(99, 'recover-key');
+    $publicKeyHex = substr($derived['publicKey'], 2); // strip 0x
+
+    $hash = Keccak::hash(hex2bin($publicKeyHex), 256);
+    $expectedAddress = '0x' . substr($hash, 24);
+
+    expect(strtolower($derived['address']))->toBe(strtolower($expectedAddress));
+});
+
+test('signing with derived private key produces a valid ECDSA signature recoverable to the same public key', function (): void {
+    $derived = EvmKeyHelper::deriveForUser(101, 'sign-key');
+    $privKey = substr($derived['privateKey'], 2);
+
+    $ec = new EC('secp256k1');
+    $key = $ec->keyFromPrivate($privKey, 'hex');
+
+    // Hash a known message; sign expects msg as a hex string of digest.
+    $msgHashHex = Keccak::hash('hello-evm-key-helper', 256);
+    $signature = $key->sign($msgHashHex, ['canonical' => true]);
+
+    // r and s populated, recoveryParam set
+    expect($signature->r)->not->toBeNull();
+    expect($signature->s)->not->toBeNull();
+    expect($signature->recoveryParam)->toBeIn([0, 1]);
+
+    // Verify with the same key passes
+    $verified = $key->verify($msgHashHex, $signature);
+    expect($verified)->toBeTrue();
+
+    // Recover public key from signature and confirm it matches our derived public key
+    $recoveredPub = $ec->recoverPubKey($msgHashHex, $signature, $signature->recoveryParam);
+    $recoveredPubHex = $recoveredPub->encode('hex', false);
+    if (str_starts_with($recoveredPubHex, '04')) {
+        $recoveredPubHex = substr($recoveredPubHex, 2);
+    }
+    $recoveredPubHex = str_pad($recoveredPubHex, 128, '0', STR_PAD_LEFT);
+
+    expect($recoveredPubHex)->toBe(substr($derived['publicKey'], 2));
+});
+
+test('toChecksumAddress produces deterministic EIP-55 output', function (): void {
+    // Vitalik's published reference: 0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359 (mixed-case)
+    $expected = '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359';
+    $lower = strtolower($expected);
+
+    expect(EvmKeyHelper::toChecksumAddress($lower))->toBe($expected);
+    expect(EvmKeyHelper::toChecksumAddress($expected))->toBe($expected);
+});

--- a/tests/Unit/Domain/Wallet/Jobs/PollEvmWalletSendConfirmationsTest.php
+++ b/tests/Unit/Domain/Wallet/Jobs/PollEvmWalletSendConfirmationsTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Relayer\Contracts\BundlerInterface;
+use App\Domain\Wallet\Jobs\PollEvmWalletSendConfirmations;
+use App\Domain\Wallet\Models\WalletSendRecord;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+beforeEach(function (): void {
+    Schema::dropIfExists('wallet_send_records');
+    Schema::create('wallet_send_records', function ($table): void {
+        $table->uuid('id')->primary();
+        $table->string('public_id', 64)->unique();
+        $table->unsignedBigInteger('user_id');
+        $table->string('network', 20);
+        $table->string('asset', 10);
+        $table->decimal('amount', 30, 8);
+        $table->string('sender_address', 128);
+        $table->string('recipient_address', 128);
+        $table->string('status', 20)->default('pending');
+        $table->string('tx_hash', 128)->nullable();
+        $table->string('user_op_hash', 128)->nullable();
+        $table->string('idempotency_key', 128)->nullable()->unique();
+        $table->string('quote_id', 64)->nullable();
+        $table->string('error_code', 50)->nullable();
+        $table->text('error_message')->nullable();
+        $table->json('metadata')->nullable();
+        $table->dateTime('submitted_at')->nullable();
+        $table->dateTime('confirmed_at')->nullable();
+        $table->dateTime('failed_at')->nullable();
+        $table->timestamps();
+    });
+});
+
+function makeSubmittedRecord(string $network, ?string $userOpHash): WalletSendRecord
+{
+    return WalletSendRecord::create([
+        'public_id'         => 'pi_send_' . uniqid(),
+        'user_id'           => 1,
+        'network'           => $network,
+        'asset'             => 'USDC',
+        'amount'            => '1.00000000',
+        'sender_address'    => '0xsender',
+        'recipient_address' => '0xrecipient',
+        'status'            => 'submitted',
+        'user_op_hash'      => $userOpHash,
+        'submitted_at'      => now(),
+    ]);
+}
+
+it('flips submitted EVM record to confirmed when bundler reports a receipt', function (): void {
+    $record = makeSubmittedRecord('polygon', '0xUserOpHashConfirmed');
+
+    /** @var BundlerInterface&Mockery\MockInterface $bundler */
+    $bundler = Mockery::mock(BundlerInterface::class);
+    $bundler->shouldReceive('getUserOperationStatus')
+        ->once()
+        ->with('0xUserOpHashConfirmed')
+        ->andReturn([
+            'status'  => 'confirmed',
+            'tx_hash' => '0xrealTxHash123',
+            'receipt' => ['success' => true, 'gasUsed' => 0, 'blockNumber' => 1],
+        ]);
+
+    (new PollEvmWalletSendConfirmations())->handle($bundler);
+
+    $record->refresh();
+    expect($record->status)->toBe('confirmed')
+        ->and($record->tx_hash)->toBe('0xrealTxHash123')
+        ->and($record->confirmed_at)->not->toBeNull();
+});
+
+it('flips submitted EVM record to failed when bundler reports a reverted receipt', function (): void {
+    $record = makeSubmittedRecord('base', '0xUserOpHashReverted');
+
+    /** @var BundlerInterface&Mockery\MockInterface $bundler */
+    $bundler = Mockery::mock(BundlerInterface::class);
+    $bundler->shouldReceive('getUserOperationStatus')
+        ->once()
+        ->with('0xUserOpHashReverted')
+        ->andReturn([
+            'status'  => 'failed',
+            'tx_hash' => '0xrevertedTxHash',
+            'receipt' => null,
+        ]);
+
+    (new PollEvmWalletSendConfirmations())->handle($bundler);
+
+    $record->refresh();
+    expect($record->status)->toBe('failed')
+        ->and($record->error_code)->toBe('BUNDLER_REVERTED')
+        ->and($record->failed_at)->not->toBeNull();
+});
+
+it('leaves submitted record alone when bundler returns pending', function (): void {
+    $record = makeSubmittedRecord('arbitrum', '0xUserOpPending');
+
+    /** @var BundlerInterface&Mockery\MockInterface $bundler */
+    $bundler = Mockery::mock(BundlerInterface::class);
+    $bundler->shouldReceive('getUserOperationStatus')
+        ->once()
+        ->andReturn(['status' => 'pending', 'tx_hash' => null, 'receipt' => null]);
+
+    (new PollEvmWalletSendConfirmations())->handle($bundler);
+
+    $record->refresh();
+    expect($record->status)->toBe('submitted')
+        ->and($record->confirmed_at)->toBeNull()
+        ->and($record->failed_at)->toBeNull();
+});
+
+it('does not touch Solana records (those are handled by Helius webhook)', function (): void {
+    $record = makeSubmittedRecord('solana', null);
+    $record->user_op_hash = null;
+    $record->tx_hash = '5xa...someSig';
+    $record->save();
+
+    /** @var BundlerInterface&Mockery\MockInterface $bundler */
+    $bundler = Mockery::mock(BundlerInterface::class);
+    $bundler->shouldNotReceive('getUserOperationStatus');
+
+    (new PollEvmWalletSendConfirmations())->handle($bundler);
+
+    $record->refresh();
+    expect($record->status)->toBe('submitted'); // unchanged
+});
+
+it('skips records older than 2 hours (avoids unbounded backlog)', function (): void {
+    $record = makeSubmittedRecord('polygon', '0xUserOpStale');
+    $record->submitted_at = now()->subHours(3);
+    $record->save();
+
+    /** @var BundlerInterface&Mockery\MockInterface $bundler */
+    $bundler = Mockery::mock(BundlerInterface::class);
+    $bundler->shouldNotReceive('getUserOperationStatus');
+
+    (new PollEvmWalletSendConfirmations())->handle($bundler);
+
+    $record->refresh();
+    expect($record->status)->toBe('submitted');
+});
+
+it('logs and continues when bundler throws', function (): void {
+    $record = makeSubmittedRecord('polygon', '0xBundlerThrows');
+
+    /** @var BundlerInterface&Mockery\MockInterface $bundler */
+    $bundler = Mockery::mock(BundlerInterface::class);
+    $bundler->shouldReceive('getUserOperationStatus')
+        ->once()
+        ->andThrow(new RuntimeException('Bundler RPC down'));
+
+    (new PollEvmWalletSendConfirmations())->handle($bundler);
+
+    $record->refresh();
+    expect($record->status)->toBe('submitted'); // unchanged — caught & logged
+});

--- a/tests/Unit/Domain/Wallet/Services/Send/Erc20TransferTest.php
+++ b/tests/Unit/Domain/Wallet/Services/Send/Erc20TransferTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Wallet\Services\Send\Erc20Transfer;
+
+uses(Tests\TestCase::class);
+
+test('selector is hardcoded to 0xa9059cbb', function (): void {
+    expect(Erc20Transfer::TRANSFER_SELECTOR)->toBe('0xa9059cbb');
+});
+
+test('encodes a known reference vector for 1 USDC to a fixed address', function (): void {
+    $to = '0x742d35Cc6634C0532925a3b844Bc454e4438f44e';
+    $amount = '1000000'; // 1 USDC at 6 decimals
+
+    $expected = '0xa9059cbb'
+        . '000000000000000000000000742d35cc6634c0532925a3b844bc454e4438f44e'
+        . '00000000000000000000000000000000000000000000000000000000000f4240';
+
+    expect(Erc20Transfer::encodeTransferCallData($to, $amount))->toBe($expected);
+});
+
+test('output length is exactly 138 chars (selector + 64 + 64 with 0x)', function (): void {
+    $callData = Erc20Transfer::encodeTransferCallData('0x' . str_repeat('a', 40), '1');
+
+    expect(strlen($callData))->toBe(138);
+});
+
+it('rejects non-numeric amount', function (): void {
+    Erc20Transfer::encodeTransferCallData('0x' . str_repeat('a', 40), 'not-a-number');
+})->throws(InvalidArgumentException::class);
+
+it('rejects negative-looking amount string', function (): void {
+    Erc20Transfer::encodeTransferCallData('0x' . str_repeat('a', 40), '-1');
+})->throws(InvalidArgumentException::class);
+
+it('rejects empty amount', function (): void {
+    Erc20Transfer::encodeTransferCallData('0x' . str_repeat('a', 40), '');
+})->throws(InvalidArgumentException::class);
+
+it('rejects malformed address', function (): void {
+    Erc20Transfer::encodeTransferCallData('0x123', '1');
+})->throws(InvalidArgumentException::class);
+
+test('lowercases the recipient address in calldata regardless of input case', function (): void {
+    $upper = '0x742D35CC6634C0532925A3B844BC454E4438F44E';
+    $lower = '0x742d35cc6634c0532925a3b844bc454e4438f44e';
+
+    $cdUpper = Erc20Transfer::encodeTransferCallData($upper, '1000000');
+    $cdLower = Erc20Transfer::encodeTransferCallData($lower, '1000000');
+
+    expect($cdUpper)->toBe($cdLower);
+    // Address segment lives at hex chars [10..74); strip 0x then offset 8.
+    $addressSegment = substr($cdUpper, 10 + 24, 40); // pad-left zeros, then 40-char address
+    expect($addressSegment)->toBe('742d35cc6634c0532925a3b844bc454e4438f44e');
+});
+
+test('encodes a large uint256 amount correctly', function (): void {
+    // 1 ETH at 18 decimals = 10^18
+    $amount = bcpow('10', '18', 0);
+    $callData = Erc20Transfer::encodeTransferCallData('0x' . str_repeat('a', 40), $amount);
+
+    // 10^18 in hex = 0xde0b6b3a7640000
+    expect($callData)->toEndWith('0000000000000000000000000000000000000000000000000de0b6b3a7640000');
+});

--- a/tests/Unit/Domain/Wallet/Services/Send/EvmSendDispatcherTest.php
+++ b/tests/Unit/Domain/Wallet/Services/Send/EvmSendDispatcherTest.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Relayer\Contracts\BundlerInterface;
+use App\Domain\Relayer\Contracts\PaymasterInterface;
+use App\Domain\Relayer\Models\SmartAccount;
+use App\Domain\Relayer\Services\SmartAccountService;
+use App\Domain\Wallet\Models\WalletSendRecord;
+use App\Domain\Wallet\Services\Send\EvmSendDispatcher;
+use App\Domain\Wallet\Services\Send\ServerOnlyUserOpSigner;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(Tests\TestCase::class, RefreshDatabase::class);
+
+beforeEach(function (): void {
+    config()->set('app.key', 'base64:' . base64_encode(str_repeat('a', 32)));
+    config()->set('wallet.evm.enabled_networks', ['polygon', 'base', 'arbitrum', 'ethereum']);
+    config()->set('wallet.evm.fee_token', 'USDC');
+});
+
+/**
+ * @param  array<string, mixed>|null $overrides
+ * @return array<string, mixed>
+ */
+function makeDispatcherWithMocks(?array $overrides = null): array
+{
+    $overrides ??= [];
+
+    /** @var SmartAccountService&Mockery\MockInterface $accounts */
+    $accounts = $overrides['accounts'] ?? Mockery::mock(SmartAccountService::class);
+    /** @var BundlerInterface&Mockery\MockInterface $bundler */
+    $bundler = $overrides['bundler'] ?? Mockery::mock(BundlerInterface::class);
+    /** @var PaymasterInterface&Mockery\MockInterface $paymaster */
+    $paymaster = $overrides['paymaster'] ?? Mockery::mock(PaymasterInterface::class);
+
+    $signer = $overrides['signer'] ?? new ServerOnlyUserOpSigner();
+
+    $dispatcher = new EvmSendDispatcher($accounts, $bundler, $paymaster, $signer);
+
+    return [
+        'dispatcher' => $dispatcher,
+        'accounts'   => $accounts,
+        'bundler'    => $bundler,
+        'paymaster'  => $paymaster,
+        'signer'     => $signer,
+    ];
+}
+
+test('disabled network is rejected with NETWORK_DISABLED', function (): void {
+    config()->set('wallet.evm.enabled_networks', ['polygon']);
+    $user = User::factory()->create();
+
+    ['dispatcher' => $d] = makeDispatcherWithMocks();
+    $record = $d->dispatch(
+        $user,
+        '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+        'USDC',
+        'arbitrum',
+        '1.0',
+    );
+
+    expect($record->status)->toBe(WalletSendRecord::STATUS_FAILED);
+    expect($record->error_code)->toBe('NETWORK_DISABLED');
+});
+
+test('unknown asset is rejected with INVALID_ASSET', function (): void {
+    $user = User::factory()->create();
+
+    ['dispatcher' => $d] = makeDispatcherWithMocks();
+    $record = $d->dispatch(
+        $user,
+        '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+        'NOTACOIN',
+        'polygon',
+        '1.0',
+    );
+
+    expect($record->status)->toBe(WalletSendRecord::STATUS_FAILED);
+    expect($record->error_code)->toBe('INVALID_ASSET');
+});
+
+test('zero amount is rejected with INVALID_AMOUNT', function (): void {
+    $user = User::factory()->create();
+
+    ['dispatcher' => $d] = makeDispatcherWithMocks();
+    $record = $d->dispatch(
+        $user,
+        '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+        'USDC',
+        'polygon',
+        '0',
+    );
+
+    expect($record->status)->toBe(WalletSendRecord::STATUS_FAILED);
+    expect($record->error_code)->toBe('INVALID_AMOUNT');
+});
+
+test('successful USDC send on polygon creates a submitted record', function (): void {
+    $user = User::factory()->create();
+
+    /** @var SmartAccountService&Mockery\MockInterface $accounts */
+    $accounts = Mockery::mock(SmartAccountService::class);
+    $smartAccount = new SmartAccount([
+        'user_id'         => $user->id,
+        'owner_address'   => '0xownerowner',
+        'account_address' => '0xabcdef0000000000000000000000000000000001',
+        'network'         => 'polygon',
+        'deployed'        => false,
+        'nonce'           => 0,
+        'pending_ops'     => 0,
+    ]);
+    $accounts->shouldReceive('getOrCreateAccount')->once()->andReturn($smartAccount);
+    $accounts->shouldReceive('needsInitCode')->once()->andReturn(false); // skip initCode in test
+    $accounts->shouldReceive('incrementPendingOps')->once();
+
+    /** @var BundlerInterface&Mockery\MockInterface $bundler */
+    $bundler = Mockery::mock(BundlerInterface::class);
+    $bundler->shouldReceive('estimateUserOperationGas')->once()->andReturn([
+        'callGasLimit'         => 100000,
+        'verificationGasLimit' => 200000,
+        'preVerificationGas'   => 50000,
+    ]);
+    $bundler->shouldReceive('submitUserOperation')->once()->andReturn('0x' . str_repeat('a', 64));
+
+    /** @var PaymasterInterface&Mockery\MockInterface $paymaster */
+    $paymaster = Mockery::mock(PaymasterInterface::class);
+    $paymaster->shouldReceive('getPaymasterData')->once()->andReturn('0xdeadbeef');
+
+    ['dispatcher' => $d] = makeDispatcherWithMocks([
+        'accounts'  => $accounts,
+        'bundler'   => $bundler,
+        'paymaster' => $paymaster,
+    ]);
+
+    $record = $d->dispatch(
+        $user,
+        '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+        'USDC',
+        'polygon',
+        '1.5',
+        idempotencyKey: 'idem-key-1',
+    );
+
+    expect($record->status)->toBe(WalletSendRecord::STATUS_SUBMITTED);
+    expect($record->user_op_hash)->toBe('0x' . str_repeat('a', 64));
+    expect($record->submitted_at)->not->toBeNull();
+    expect($record->error_code)->toBeNull();
+    expect($record->sender_address)->toBe('0xabcdef0000000000000000000000000000000001');
+    expect($record->idempotency_key)->toBe('idem-key-1');
+});
+
+test('idempotency: same key returns existing record without re-dispatch', function (): void {
+    $user = User::factory()->create();
+
+    $existing = WalletSendRecord::create([
+        'public_id'         => 'pi_send_existing',
+        'user_id'           => $user->id,
+        'network'           => 'polygon',
+        'asset'             => 'USDC',
+        'amount'            => '1.50000000',
+        'sender_address'    => '0xpriorprior',
+        'recipient_address' => '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+        'status'            => WalletSendRecord::STATUS_SUBMITTED,
+        'idempotency_key'   => 'idem-replay',
+    ]);
+
+    /** @var SmartAccountService&Mockery\MockInterface $accounts */
+    $accounts = Mockery::mock(SmartAccountService::class);
+    $accounts->shouldNotReceive('getOrCreateAccount');
+
+    /** @var BundlerInterface&Mockery\MockInterface $bundler */
+    $bundler = Mockery::mock(BundlerInterface::class);
+    $bundler->shouldNotReceive('submitUserOperation');
+
+    /** @var PaymasterInterface&Mockery\MockInterface $paymaster */
+    $paymaster = Mockery::mock(PaymasterInterface::class);
+
+    ['dispatcher' => $d] = makeDispatcherWithMocks([
+        'accounts' => $accounts, 'bundler' => $bundler, 'paymaster' => $paymaster,
+    ]);
+
+    $record = $d->dispatch(
+        $user,
+        '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+        'USDC',
+        'polygon',
+        '1.5',
+        idempotencyKey: 'idem-replay',
+    );
+
+    expect($record->id)->toBe($existing->id);
+    expect($record->status)->toBe(WalletSendRecord::STATUS_SUBMITTED);
+});
+
+test('bundler error during submit marks record as BUNDLER_REJECTED', function (): void {
+    $user = User::factory()->create();
+
+    /** @var SmartAccountService&Mockery\MockInterface $accounts */
+    $accounts = Mockery::mock(SmartAccountService::class);
+    $smartAccount = new SmartAccount([
+        'user_id'         => $user->id,
+        'owner_address'   => '0xownerowner',
+        'account_address' => '0xabcdef0000000000000000000000000000000001',
+        'network'         => 'polygon',
+        'deployed'        => false,
+        'nonce'           => 0,
+        'pending_ops'     => 0,
+    ]);
+    $accounts->shouldReceive('getOrCreateAccount')->once()->andReturn($smartAccount);
+    $accounts->shouldReceive('needsInitCode')->once()->andReturn(false);
+
+    /** @var BundlerInterface&Mockery\MockInterface $bundler */
+    $bundler = Mockery::mock(BundlerInterface::class);
+    $bundler->shouldReceive('estimateUserOperationGas')->once()->andReturn([
+        'callGasLimit'         => 100000,
+        'verificationGasLimit' => 200000,
+        'preVerificationGas'   => 50000,
+    ]);
+    $bundler->shouldReceive('submitUserOperation')->once()->andThrow(new RuntimeException('bundler down'));
+
+    /** @var PaymasterInterface&Mockery\MockInterface $paymaster */
+    $paymaster = Mockery::mock(PaymasterInterface::class);
+    $paymaster->shouldReceive('getPaymasterData')->once()->andReturn('0xdeadbeef');
+
+    ['dispatcher' => $d] = makeDispatcherWithMocks([
+        'accounts' => $accounts, 'bundler' => $bundler, 'paymaster' => $paymaster,
+    ]);
+
+    $record = $d->dispatch(
+        $user,
+        '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+        'USDC',
+        'polygon',
+        '1.0',
+    );
+
+    expect($record->status)->toBe(WalletSendRecord::STATUS_FAILED);
+    expect($record->error_code)->toBe('BUNDLER_REJECTED');
+    expect($record->error_message)->toContain('bundler down');
+});
+
+test('paymaster error marks record as PAYMASTER_REJECTED', function (): void {
+    $user = User::factory()->create();
+
+    /** @var SmartAccountService&Mockery\MockInterface $accounts */
+    $accounts = Mockery::mock(SmartAccountService::class);
+    $smartAccount = new SmartAccount([
+        'user_id'         => $user->id,
+        'owner_address'   => '0xownerowner',
+        'account_address' => '0xabcdef0000000000000000000000000000000001',
+        'network'         => 'polygon',
+        'deployed'        => false,
+        'nonce'           => 0,
+        'pending_ops'     => 0,
+    ]);
+    $accounts->shouldReceive('getOrCreateAccount')->once()->andReturn($smartAccount);
+    $accounts->shouldReceive('needsInitCode')->once()->andReturn(false);
+
+    /** @var BundlerInterface&Mockery\MockInterface $bundler */
+    $bundler = Mockery::mock(BundlerInterface::class);
+    $bundler->shouldReceive('estimateUserOperationGas')->once()->andReturn([
+        'callGasLimit'         => 100000,
+        'verificationGasLimit' => 200000,
+        'preVerificationGas'   => 50000,
+    ]);
+
+    /** @var PaymasterInterface&Mockery\MockInterface $paymaster */
+    $paymaster = Mockery::mock(PaymasterInterface::class);
+    $paymaster->shouldReceive('getPaymasterData')->once()->andThrow(new RuntimeException('sponsorship denied'));
+
+    ['dispatcher' => $d] = makeDispatcherWithMocks([
+        'accounts' => $accounts, 'bundler' => $bundler, 'paymaster' => $paymaster,
+    ]);
+
+    $record = $d->dispatch(
+        $user,
+        '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+        'USDC',
+        'polygon',
+        '1.0',
+    );
+
+    expect($record->status)->toBe(WalletSendRecord::STATUS_FAILED);
+    expect($record->error_code)->toBe('PAYMASTER_REJECTED');
+});

--- a/tests/Unit/Domain/Wallet/Services/Send/HeliusRpcClientTest.php
+++ b/tests/Unit/Domain/Wallet/Services/Send/HeliusRpcClientTest.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Wallet\Exceptions\SolanaRpcException;
+use App\Domain\Wallet\Services\Send\HeliusRpcClient;
+use Illuminate\Support\Facades\Http;
+
+uses(Tests\TestCase::class);
+
+beforeEach(function (): void {
+    config([
+        'wallet.solana.rpc_url'    => 'https://mainnet.helius-rpc.com',
+        'wallet.solana.commitment' => 'confirmed',
+        'services.helius.api_key'  => 'test-helius-key',
+    ]);
+});
+
+const HELIUS_URL_PATTERN = 'mainnet.helius-rpc.com*';
+
+test('getLatestBlockhash returns blockhash and last valid block height', function (): void {
+    Http::fake([
+        HELIUS_URL_PATTERN => Http::response([
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'result'  => [
+                'context' => ['slot' => 12345],
+                'value'   => [
+                    'blockhash'            => 'BlockHashBase58Encoded123',
+                    'lastValidBlockHeight' => 999,
+                ],
+            ],
+        ]),
+    ]);
+
+    $client = new HeliusRpcClient();
+    $result = $client->getLatestBlockhash();
+
+    expect($result['blockhash'])->toBe('BlockHashBase58Encoded123')
+        ->and($result['lastValidBlockHeight'])->toBe(999);
+
+    Http::assertSent(function ($request): bool {
+        return str_contains($request->url(), 'api-key=test-helius-key')
+            && $request['method'] === 'getLatestBlockhash';
+    });
+});
+
+test('simulateTransaction returns success when err is null', function (): void {
+    Http::fake([
+        HELIUS_URL_PATTERN => Http::response([
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'result'  => [
+                'context' => ['slot' => 1],
+                'value'   => [
+                    'err'  => null,
+                    'logs' => ['Program 11111111111111111111111111111111 invoke [1]'],
+                ],
+            ],
+        ]),
+    ]);
+
+    $client = new HeliusRpcClient();
+    $result = $client->simulateTransaction('AABB');
+
+    expect($result['success'])->toBeTrue()
+        ->and($result['err'])->toBeNull()
+        ->and($result['logs'])->toBe(['Program 11111111111111111111111111111111 invoke [1]']);
+});
+
+test('simulateTransaction returns failure when err is set', function (): void {
+    Http::fake([
+        HELIUS_URL_PATTERN => Http::response([
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'result'  => [
+                'context' => ['slot' => 1],
+                'value'   => [
+                    'err'  => ['InstructionError' => [0, 'InsufficientFunds']],
+                    'logs' => ['Program log: insufficient funds'],
+                ],
+            ],
+        ]),
+    ]);
+
+    $client = new HeliusRpcClient();
+    $result = $client->simulateTransaction('AABB');
+
+    expect($result['success'])->toBeFalse()
+        ->and($result['err'])->toBeArray()
+        ->and($result['logs'])->toContain('Program log: insufficient funds');
+});
+
+test('sendTransaction returns the tx signature on success', function (): void {
+    Http::fake([
+        HELIUS_URL_PATTERN => Http::response([
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'result'  => '5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW',
+        ]),
+    ]);
+
+    $client = new HeliusRpcClient();
+    $sig = $client->sendTransaction('AABB');
+
+    expect($sig)->toBe('5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW');
+});
+
+test('sendTransaction throws SolanaRpcException on RPC error envelope', function (): void {
+    Http::fake([
+        HELIUS_URL_PATTERN => Http::response([
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'error'   => [
+                'code'    => -32602,
+                'message' => 'Transaction simulation failed: Blockhash not found',
+            ],
+        ]),
+    ]);
+
+    $client = new HeliusRpcClient();
+
+    try {
+        $client->sendTransaction('AABB');
+        $this->fail('Expected SolanaRpcException');
+    } catch (SolanaRpcException $e) {
+        expect($e->getRpcCode())->toBe(-32602)
+            ->and($e->getMessage())->toContain('Blockhash not found');
+    }
+});
+
+test('getSignatureStatuses keys responses by signature', function (): void {
+    Http::fake([
+        HELIUS_URL_PATTERN => Http::response([
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'result'  => [
+                'context' => ['slot' => 1],
+                'value'   => [
+                    [
+                        'confirmationStatus' => 'confirmed',
+                        'err'                => null,
+                    ],
+                    null,
+                ],
+            ],
+        ]),
+    ]);
+
+    $client = new HeliusRpcClient();
+    $result = $client->getSignatureStatuses(['sigA', 'sigB']);
+
+    expect($result['sigA'])->not->toBeNull()
+        ->and($result['sigB'])->toBeNull();
+
+    $sigAEntry = $result['sigA'];
+    if ($sigAEntry === null) {
+        throw new RuntimeException('Expected sigA entry to be present');
+    }
+    expect($sigAEntry['confirmationStatus'])->toBe('confirmed');
+});
+
+test('getAccountInfo returns null when account is missing', function (): void {
+    Http::fake([
+        HELIUS_URL_PATTERN => Http::response([
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'result'  => [
+                'context' => ['slot' => 1],
+                'value'   => null,
+            ],
+        ]),
+    ]);
+
+    $client = new HeliusRpcClient();
+    $result = $client->getAccountInfo('SomeAccountAddress');
+
+    expect($result)->toBeNull();
+});
+
+test('getAccountInfo returns owner and lamports when account exists', function (): void {
+    Http::fake([
+        HELIUS_URL_PATTERN => Http::response([
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'result'  => [
+                'context' => ['slot' => 1],
+                'value'   => [
+                    'owner'      => 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+                    'lamports'   => 2039280,
+                    'data'       => ['parsed' => ['info' => []]],
+                    'executable' => false,
+                    'rentEpoch'  => 0,
+                ],
+            ],
+        ]),
+    ]);
+
+    $client = new HeliusRpcClient();
+    $result = $client->getAccountInfo('AnExistingAta');
+
+    expect($result)->not->toBeNull();
+    if ($result === null) {
+        throw new RuntimeException('Expected account info to be present');
+    }
+    expect($result['owner'])->toBe('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA')
+        ->and($result['lamports'])->toBe(2039280);
+});
+
+test('rpc client appends api key as query param not header', function (): void {
+    Http::fake([
+        HELIUS_URL_PATTERN => Http::response([
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'result'  => [
+                'context' => ['slot' => 1],
+                'value'   => ['blockhash' => 'x', 'lastValidBlockHeight' => 1],
+            ],
+        ]),
+    ]);
+
+    (new HeliusRpcClient())->getLatestBlockhash();
+
+    Http::assertSent(function ($request): bool {
+        return str_contains($request->url(), '?api-key=test-helius-key')
+            && ! $request->hasHeader('Authorization');
+    });
+});

--- a/tests/Unit/Domain/Wallet/Services/Send/ServerOnlyUserOpSignerTest.php
+++ b/tests/Unit/Domain/Wallet/Services/Send/ServerOnlyUserOpSignerTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Relayer\Enums\SupportedNetwork;
+use App\Domain\Relayer\ValueObjects\UserOperation;
+use App\Domain\Wallet\Helpers\Crypto\EvmKeyHelper;
+use App\Domain\Wallet\Services\Send\ServerOnlyUserOpSigner;
+use Elliptic\EC;
+
+uses(Tests\TestCase::class);
+
+beforeEach(function (): void {
+    config()->set('app.key', 'base64:' . base64_encode(str_repeat('a', 32)));
+});
+
+function makeFinalisedUserOp(): UserOperation
+{
+    return new UserOperation(
+        sender: '0x742d35cc6634c0532925a3b844bc454e4438f44e',
+        nonce: 0,
+        initCode: '0x',
+        callData: '0xb61d27f6' . str_repeat('0', 8 * 64),
+        callGasLimit: 100000,
+        verificationGasLimit: 200000,
+        preVerificationGas: 50000,
+        maxFeePerGas: 100_000_000_000,
+        maxPriorityFeePerGas: 30_000_000_000,
+        paymasterAndData: '0x',
+        signature: '0x',
+    );
+}
+
+test('signature is exactly 0x + 130 hex chars (65 bytes)', function (): void {
+    $signer = new ServerOnlyUserOpSigner();
+    $userOp = makeFinalisedUserOp();
+
+    $sig = $signer->signUserOp($userOp, SupportedNetwork::POLYGON, 42);
+
+    expect($sig)->toStartWith('0x');
+    expect(strlen($sig))->toBe(2 + 130); // 65 bytes
+});
+
+test('v byte is 27 or 28', function (): void {
+    $signer = new ServerOnlyUserOpSigner();
+    $userOp = makeFinalisedUserOp();
+
+    $sig = $signer->signUserOp($userOp, SupportedNetwork::POLYGON, 42);
+    $vHex = substr($sig, -2);
+    $v = (int) hexdec($vHex);
+
+    expect($v)->toBeIn([27, 28]);
+});
+
+test('signing the same UserOp twice yields identical signatures (deterministic RFC6979)', function (): void {
+    $signer = new ServerOnlyUserOpSigner();
+    $userOp = makeFinalisedUserOp();
+
+    $a = $signer->signUserOp($userOp, SupportedNetwork::POLYGON, 42);
+    $b = $signer->signUserOp($userOp, SupportedNetwork::POLYGON, 42);
+
+    expect($a)->toBe($b);
+});
+
+test('signing a different UserOp yields a different signature', function (): void {
+    $signer = new ServerOnlyUserOpSigner();
+    $userOpA = makeFinalisedUserOp();
+    $userOpB = $userOpA->withGasAndSignature(
+        callGasLimit: $userOpA->callGasLimit + 1,
+        verificationGasLimit: $userOpA->verificationGasLimit,
+        preVerificationGas: $userOpA->preVerificationGas,
+        maxFeePerGas: $userOpA->maxFeePerGas,
+        maxPriorityFeePerGas: $userOpA->maxPriorityFeePerGas,
+        paymasterAndData: $userOpA->paymasterAndData,
+        signature: '0x',
+    );
+
+    $sigA = $signer->signUserOp($userOpA, SupportedNetwork::POLYGON, 42);
+    $sigB = $signer->signUserOp($userOpB, SupportedNetwork::POLYGON, 42);
+
+    expect($sigA)->not->toBe($sigB);
+});
+
+test('recovered public key from signature matches the derived public key', function (): void {
+    $signer = new ServerOnlyUserOpSigner();
+    $userOp = makeFinalisedUserOp();
+    $userId = 42;
+
+    $sig = $signer->signUserOp($userOp, SupportedNetwork::POLYGON, $userId);
+    $hashHex = ServerOnlyUserOpSigner::computeUserOpHash($userOp, SupportedNetwork::POLYGON);
+
+    // Decode r, s, v
+    $sigBody = substr($sig, 2);
+    $r = substr($sigBody, 0, 64);
+    $s = substr($sigBody, 64, 64);
+    $v = (int) hexdec(substr($sigBody, 128, 2));
+    $recoveryParam = $v - 27;
+
+    $ec = new EC('secp256k1');
+    $recoveredPub = $ec->recoverPubKey($hashHex, ['r' => $r, 's' => $s], $recoveryParam);
+
+    $recoveredHex = $recoveredPub->encode('hex', false);
+    if (str_starts_with($recoveredHex, '04')) {
+        $recoveredHex = substr($recoveredHex, 2);
+    }
+    $recoveredHex = str_pad($recoveredHex, 128, '0', STR_PAD_LEFT);
+
+    $expected = EvmKeyHelper::deriveForUser($userId, (string) config('app.key'));
+    $expectedPubHex = substr($expected['publicKey'], 2);
+
+    expect($recoveredHex)->toBe($expectedPubHex);
+});
+
+test('computeUserOpHash is deterministic and 64 hex chars', function (): void {
+    $userOp = makeFinalisedUserOp();
+    $a = ServerOnlyUserOpSigner::computeUserOpHash($userOp, SupportedNetwork::POLYGON);
+    $b = ServerOnlyUserOpSigner::computeUserOpHash($userOp, SupportedNetwork::POLYGON);
+
+    expect($a)->toBe($b);
+    expect(strlen($a))->toBe(64);
+    expect($a)->toMatch('/^[0-9a-f]{64}$/');
+});
+
+test('computeUserOpHash differs across networks (chainId is part of the outer hash)', function (): void {
+    $userOp = makeFinalisedUserOp();
+
+    $polygon = ServerOnlyUserOpSigner::computeUserOpHash($userOp, SupportedNetwork::POLYGON);
+    $base = ServerOnlyUserOpSigner::computeUserOpHash($userOp, SupportedNetwork::BASE);
+
+    expect($polygon)->not->toBe($base);
+});

--- a/tests/Unit/Domain/Wallet/Services/Send/SolanaSendDispatcherTest.php
+++ b/tests/Unit/Domain/Wallet/Services/Send/SolanaSendDispatcherTest.php
@@ -1,0 +1,306 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Wallet\Helpers\Crypto\Base58;
+use App\Domain\Wallet\Models\WalletSendRecord;
+use App\Domain\Wallet\Services\Send\HeliusRpcClient;
+use App\Domain\Wallet\Services\Send\SolanaSendDispatcher;
+use App\Domain\Wallet\Services\Send\SolanaSigner;
+use App\Domain\Wallet\Services\Send\SolanaTransferBuilder;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+
+uses(Tests\TestCase::class, RefreshDatabase::class);
+
+beforeEach(function (): void {
+    config([
+        'wallet.solana.rpc_url'                    => 'https://mainnet.helius-rpc.com',
+        'wallet.solana.commitment'                 => 'confirmed',
+        'wallet.solana.priority_fee_microlamports' => 1000,
+        'wallet.solana.compute_unit_limit'         => 200000,
+        'services.helius.api_key'                  => 'test-helius-key',
+        'app.key'                                  => 'base64:' . base64_encode(str_repeat('a', 32)),
+    ]);
+});
+
+function makeDispatcher(): SolanaSendDispatcher
+{
+    return new SolanaSendDispatcher(
+        new HeliusRpcClient(),
+        new SolanaTransferBuilder(),
+        new SolanaSigner(),
+    );
+}
+
+function fakeRecipient(): string
+{
+    $kp = sodium_crypto_sign_seed_keypair(hash('sha256', 'recipient-' . random_bytes(8), true));
+
+    return Base58::encode(sodium_crypto_sign_publickey($kp));
+}
+
+function fakeBlockhashB58(): string
+{
+    return Base58::encode(random_bytes(32));
+}
+
+it('dispatches a USDC transfer and persists a submitted record with tx hash', function (): void {
+    $blockhash = fakeBlockhashB58();
+    $signature = '5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQUW';
+
+    $sequence = Http::sequence()
+        ->push([
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'result'  => [
+                'context' => ['slot' => 1],
+                'value'   => ['blockhash' => $blockhash, 'lastValidBlockHeight' => 12345],
+            ],
+        ])
+        ->push([
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'result'  => [
+                'context' => ['slot' => 1],
+                'value'   => null, // recipient ATA missing → triggers create
+            ],
+        ])
+        ->push([
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'result'  => [
+                'context' => ['slot' => 1],
+                'value'   => ['err' => null, 'logs' => []],
+            ],
+        ])
+        ->push([
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'result'  => $signature,
+        ]);
+    Http::fake(['*' => $sequence]);
+
+    $user = User::factory()->create();
+    $recipient = fakeRecipient();
+
+    $record = makeDispatcher()->dispatch($user, $recipient, 'USDC', '1.5');
+
+    expect($record->status)->toBe(WalletSendRecord::STATUS_SUBMITTED)
+        ->and($record->tx_hash)->toBe($signature)
+        ->and($record->network)->toBe('solana')
+        ->and($record->asset)->toBe('USDC')
+        ->and((float) $record->amount)->toBe(1.5)
+        ->and($record->submitted_at)->not->toBeNull()
+        ->and($record->error_code)->toBeNull();
+});
+
+it('returns the same record for an idempotent retry without calling RPC', function (): void {
+    $user = User::factory()->create();
+
+    $existing = WalletSendRecord::create([
+        'public_id'         => 'pi_send_existing123',
+        'user_id'           => $user->id,
+        'network'           => 'solana',
+        'asset'             => 'USDC',
+        'amount'            => '1.0',
+        'sender_address'    => 'sender',
+        'recipient_address' => 'recipient',
+        'status'            => WalletSendRecord::STATUS_SUBMITTED,
+        'tx_hash'           => 'existing-tx-sig',
+        'idempotency_key'   => 'idem-key-1',
+    ]);
+
+    Http::fake(); // no RPC should be hit
+
+    $record = makeDispatcher()->dispatch($user, fakeRecipient(), 'USDC', '1.0', 'idem-key-1');
+
+    expect($record->id)->toBe($existing->id)
+        ->and($record->tx_hash)->toBe('existing-tx-sig');
+
+    Http::assertNothingSent();
+});
+
+it('rejects unknown asset symbol with INVALID_ASSET', function (): void {
+    Http::fake();
+    $user = User::factory()->create();
+
+    $record = makeDispatcher()->dispatch($user, fakeRecipient(), 'NOT_A_TOKEN', '1.0');
+
+    expect($record->status)->toBe(WalletSendRecord::STATUS_FAILED)
+        ->and($record->error_code)->toBe('INVALID_ASSET');
+
+    Http::assertNothingSent();
+});
+
+it('marks record failed when simulation rejects the transaction and never broadcasts', function (): void {
+    $sequence = Http::sequence()
+        ->push([
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'result'  => [
+                'context' => ['slot' => 1],
+                'value'   => ['blockhash' => fakeBlockhashB58(), 'lastValidBlockHeight' => 1],
+            ],
+        ])
+        ->push([
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'result'  => [
+                'context' => ['slot' => 1],
+                'value'   => [
+                    'owner'    => 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+                    'lamports' => 2039280,
+                    'data'     => [],
+                ],
+            ],
+        ])
+        ->push([
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'result'  => [
+                'context' => ['slot' => 1],
+                'value'   => [
+                    'err'  => ['InstructionError' => [2, 'InsufficientFunds']],
+                    'logs' => ['Program log: insufficient funds'],
+                ],
+            ],
+        ]);
+    Http::fake(['*' => $sequence]);
+
+    $user = User::factory()->create();
+
+    $record = makeDispatcher()->dispatch($user, fakeRecipient(), 'USDC', '0.5');
+
+    expect($record->status)->toBe(WalletSendRecord::STATUS_FAILED)
+        ->and($record->error_code)->toBe('SIMULATION_FAILED')
+        ->and($record->tx_hash)->toBeNull();
+
+    // Confirm sendTransaction was never invoked.
+    Http::assertNotSent(function ($request): bool {
+        return ($request['method'] ?? null) === 'sendTransaction';
+    });
+});
+
+it('captures RPC error on send and marks record failed', function (): void {
+    $sequence = Http::sequence()
+        ->push([
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'result'  => [
+                'context' => ['slot' => 1],
+                'value'   => ['blockhash' => fakeBlockhashB58(), 'lastValidBlockHeight' => 1],
+            ],
+        ])
+        ->push([
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'result'  => [
+                'context' => ['slot' => 1],
+                'value'   => [
+                    'owner'    => 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+                    'lamports' => 2039280,
+                    'data'     => [],
+                ],
+            ],
+        ])
+        ->push([
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'result'  => [
+                'context' => ['slot' => 1],
+                'value'   => ['err' => null, 'logs' => []],
+            ],
+        ])
+        ->push([
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'error'   => [
+                'code'    => -32000,
+                'message' => 'Node is behind',
+            ],
+        ]);
+    Http::fake(['*' => $sequence]);
+
+    $user = User::factory()->create();
+    $record = makeDispatcher()->dispatch($user, fakeRecipient(), 'USDT', '2.0');
+
+    expect($record->status)->toBe(WalletSendRecord::STATUS_FAILED)
+        ->and($record->error_code)->toBe('RPC_ERROR')
+        ->and($record->error_message)->toContain('Node is behind')
+        ->and($record->failed_at)->not->toBeNull();
+});
+
+it('rejects amount with too many fractional digits', function (): void {
+    Http::fake();
+    $user = User::factory()->create();
+
+    // USDC has 6 decimals; pass 7 fractional digits.
+    $record = makeDispatcher()->dispatch($user, fakeRecipient(), 'USDC', '1.0000001');
+
+    expect($record->status)->toBe(WalletSendRecord::STATUS_FAILED)
+        ->and($record->error_code)->toBe('INVALID_AMOUNT');
+});
+
+it('rejects negative or zero amount', function (): void {
+    Http::fake();
+    $user = User::factory()->create();
+
+    $record = makeDispatcher()->dispatch($user, fakeRecipient(), 'USDC', '0');
+
+    expect($record->status)->toBe(WalletSendRecord::STATUS_FAILED)
+        ->and($record->error_code)->toBe('INVALID_AMOUNT');
+});
+
+it('rejects non-numeric amount', function (): void {
+    Http::fake();
+    $user = User::factory()->create();
+
+    $record = makeDispatcher()->dispatch($user, fakeRecipient(), 'USDC', 'abc');
+
+    expect($record->status)->toBe(WalletSendRecord::STATUS_FAILED)
+        ->and($record->error_code)->toBe('INVALID_AMOUNT');
+});
+
+it('persists metadata.create_recipient_ata flag when ATA is missing', function (): void {
+    $sequence = Http::sequence()
+        ->push([
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'result'  => [
+                'context' => ['slot' => 1],
+                'value'   => ['blockhash' => fakeBlockhashB58(), 'lastValidBlockHeight' => 1],
+            ],
+        ])
+        ->push([
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'result'  => [
+                'context' => ['slot' => 1],
+                'value'   => null, // ATA missing
+            ],
+        ])
+        ->push([
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'result'  => [
+                'context' => ['slot' => 1],
+                'value'   => ['err' => null, 'logs' => []],
+            ],
+        ])
+        ->push([
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'result'  => 'tx-sig',
+        ]);
+    Http::fake(['*' => $sequence]);
+
+    $user = User::factory()->create();
+    $record = makeDispatcher()->dispatch($user, fakeRecipient(), 'USDC', '1.0');
+
+    expect($record->status)->toBe(WalletSendRecord::STATUS_SUBMITTED)
+        ->and($record->metadata)->toHaveKey('create_recipient_ata')
+        ->and($record->metadata['create_recipient_ata'])->toBeTrue()
+        ->and($record->metadata)->toHaveKey('recipient_ata');
+});

--- a/tests/Unit/Domain/Wallet/Services/Send/SolanaSignerTest.php
+++ b/tests/Unit/Domain/Wallet/Services/Send/SolanaSignerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Wallet\Helpers\Crypto\Base58;
+use App\Domain\Wallet\Helpers\SolanaAddressHelper;
+use App\Domain\Wallet\Services\Send\SolanaSigner;
+
+uses(Tests\TestCase::class);
+
+test('signMessage is deterministic for identical inputs', function (): void {
+    $signer = new SolanaSigner();
+    $message = 'hello solana ' . str_repeat('x', 100);
+
+    $a = $signer->signMessage(42, 'app-key-1', $message);
+    $b = $signer->signMessage(42, 'app-key-1', $message);
+
+    expect($a)->toBe($b);
+});
+
+test('signMessage produces 64-byte ed25519 signature', function (): void {
+    $signer = new SolanaSigner();
+
+    $sig = $signer->signMessage(1, 'k', random_bytes(80));
+
+    expect(strlen($sig))->toBe(64);
+});
+
+test('signature verifies against the user-derived public key', function (): void {
+    $signer = new SolanaSigner();
+    $userId = 7;
+    $appKey = 'verify-test-key';
+    $message = 'message-bytes-' . random_bytes(32);
+
+    $sig = $signer->signMessage($userId, $appKey, $message);
+    $pubkey = $signer->getPublicKey($userId, $appKey);
+
+    if ($sig === '' || $pubkey === '') {
+        throw new RuntimeException('Signer returned empty signature or pubkey');
+    }
+
+    expect(sodium_crypto_sign_verify_detached($sig, $message, $pubkey))->toBeTrue();
+});
+
+test('getPublicKey matches SolanaAddressHelper derivation', function (): void {
+    $signer = new SolanaSigner();
+    $userId = 99;
+    $appKey = 'consistency-key';
+
+    $rawPubkey = $signer->getPublicKey($userId, $appKey);
+    $signerAddress = Base58::encode($rawPubkey);
+    $helperAddress = SolanaAddressHelper::deriveForUser($userId, $appKey);
+
+    expect($signerAddress)->toBe($helperAddress)
+        ->and(strlen($rawPubkey))->toBe(32);
+});
+
+test('different users produce different signatures for the same message', function (): void {
+    $signer = new SolanaSigner();
+    $message = 'same-message';
+
+    $sigA = $signer->signMessage(1, 'k', $message);
+    $sigB = $signer->signMessage(2, 'k', $message);
+
+    expect($sigA)->not->toBe($sigB);
+});

--- a/tests/Unit/Domain/Wallet/Services/Send/SolanaTransferBuilderTest.php
+++ b/tests/Unit/Domain/Wallet/Services/Send/SolanaTransferBuilderTest.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Wallet\Helpers\Crypto\Base58;
+use App\Domain\Wallet\Helpers\SolanaAddressHelper;
+use App\Domain\Wallet\Services\Send\SolanaTransferBuilder;
+
+uses(Tests\TestCase::class);
+
+beforeEach(function (): void {
+    config([
+        'wallet.solana.compute_unit_limit'         => 200000,
+        'wallet.solana.priority_fee_microlamports' => 1000,
+    ]);
+});
+
+const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
+/**
+ * Returns 32 random ed25519-curve public-key bytes derived from a seed string.
+ * Using sodium ensures the bytes are a valid on-curve point so they cannot
+ * accidentally collide with our PDA derivation logic.
+ */
+function makePubkey(string $seed): string
+{
+    $kp = sodium_crypto_sign_seed_keypair(hash('sha256', $seed, true));
+
+    return Base58::encode(sodium_crypto_sign_publickey($kp));
+}
+
+it('produces a deterministic 32-byte off-curve PDA for ATA derivation', function (): void {
+    $owner = makePubkey('owner-seed-1');
+    $builder = new SolanaTransferBuilder();
+
+    $ata1 = $builder->deriveAssociatedTokenAccountAddress($owner, USDC_MINT);
+    $ata2 = $builder->deriveAssociatedTokenAccountAddress($owner, USDC_MINT);
+
+    expect($ata1)->toBe($ata2)
+        ->and(strlen(Base58::decode($ata1)))->toBe(32);
+
+    // PDAs MUST be off the ed25519 curve.
+    $rawPda = Base58::decode($ata1);
+    if ($rawPda === '') {
+        throw new RuntimeException('PDA decoded to empty bytes');
+    }
+    $isOnCurve = false;
+    try {
+        sodium_crypto_sign_ed25519_pk_to_curve25519($rawPda);
+        $isOnCurve = true;
+    } catch (SodiumException) {
+        // Off-curve, as expected.
+    }
+    expect($isOnCurve)->toBeFalse();
+});
+
+test('different owners produce different ATAs for same mint', function (): void {
+    $a = makePubkey('owner-A');
+    $b = makePubkey('owner-B');
+    $builder = new SolanaTransferBuilder();
+
+    $ataA = $builder->deriveAssociatedTokenAccountAddress($a, USDC_MINT);
+    $ataB = $builder->deriveAssociatedTokenAccountAddress($b, USDC_MINT);
+
+    expect($ataA)->not->toBe($ataB);
+});
+
+test('SPL transfer message contains compute-budget instructions before transfer', function (): void {
+    $sender = SolanaAddressHelper::deriveForUser(1, 'k');
+    $recipient = makePubkey('recipient');
+    $blockhash = Base58::encode(random_bytes(32));
+
+    $built = (new SolanaTransferBuilder())->buildSplTransfer(
+        $sender,
+        $recipient,
+        USDC_MINT,
+        1_000_000,
+        $blockhash,
+        false,
+    );
+
+    $message = $built['message'];
+
+    // Compute-budget program ID (raw bytes) must be present in account_keys.
+    expect($message)->toContain(Base58::decode(SolanaTransferBuilder::COMPUTE_BUDGET_PROGRAM_ID));
+
+    // SetComputeUnitLimit data: 0x02 + u32 LE 200000 = 0x02 0x40 0x0d 0x03 0x00
+    $unitLimitData = chr(0x02) . pack('V', 200000);
+    expect($message)->toContain($unitLimitData);
+
+    // SetComputeUnitPrice data: 0x03 + u64 LE 1000
+    $unitPriceData = chr(0x03) . pack('P', 1000);
+    expect($message)->toContain($unitPriceData);
+});
+
+test('SPL transfer instruction encodes 0x03 discriminator and 8-byte LE amount', function (): void {
+    $sender = SolanaAddressHelper::deriveForUser(2, 'k');
+    $recipient = makePubkey('recipient-2');
+    $blockhash = Base58::encode(random_bytes(32));
+    $amount = 12_345_678;
+
+    $built = (new SolanaTransferBuilder())->buildSplTransfer(
+        $sender,
+        $recipient,
+        USDC_MINT,
+        $amount,
+        $blockhash,
+        false,
+    );
+
+    // Transfer discriminator + LE amount (9 bytes total) must appear in the message.
+    $transferData = chr(0x03) . pack('P', $amount);
+
+    expect($built['message'])->toContain($transferData);
+});
+
+test('without createRecipientAta the message excludes associated-token-program', function (): void {
+    $sender = SolanaAddressHelper::deriveForUser(3, 'k');
+    $recipient = makePubkey('recipient-3');
+    $blockhash = Base58::encode(random_bytes(32));
+
+    $built = (new SolanaTransferBuilder())->buildSplTransfer(
+        $sender,
+        $recipient,
+        USDC_MINT,
+        100_000,
+        $blockhash,
+        false,
+    );
+
+    $assocProgramRaw = Base58::decode(SolanaTransferBuilder::ASSOCIATED_TOKEN_PROGRAM_ID);
+    expect($built['message'])->not->toContain($assocProgramRaw);
+});
+
+test('with createRecipientAta the message includes associated-token-program before transfer', function (): void {
+    $sender = SolanaAddressHelper::deriveForUser(4, 'k');
+    $recipient = makePubkey('recipient-4');
+    $blockhash = Base58::encode(random_bytes(32));
+
+    $built = (new SolanaTransferBuilder())->buildSplTransfer(
+        $sender,
+        $recipient,
+        USDC_MINT,
+        100_000,
+        $blockhash,
+        true, // create ATA
+    );
+
+    $message = $built['message'];
+    $assocProgramRaw = Base58::decode(SolanaTransferBuilder::ASSOCIATED_TOKEN_PROGRAM_ID);
+    expect($message)->toContain($assocProgramRaw);
+
+    // ATA passenger accounts (system program, rent sysvar) should also be present.
+    expect($message)->toContain(Base58::decode(SolanaTransferBuilder::SYSTEM_PROGRAM_ID));
+    expect($message)->toContain(Base58::decode(SolanaTransferBuilder::SYSVAR_RENT_ID));
+});
+
+test('account list ordering: header has 1 required signature and 0 readonly signers', function (): void {
+    $sender = SolanaAddressHelper::deriveForUser(5, 'k');
+    $recipient = makePubkey('recipient-5');
+    $blockhash = Base58::encode(random_bytes(32));
+
+    $built = (new SolanaTransferBuilder())->buildSplTransfer(
+        $sender,
+        $recipient,
+        USDC_MINT,
+        50_000,
+        $blockhash,
+        false,
+    );
+
+    $message = $built['message'];
+    // First three bytes are the message header.
+    $numRequiredSignatures = ord($message[0]);
+    $numReadonlySigned = ord($message[1]);
+    $numReadonlyUnsigned = ord($message[2]);
+
+    expect($numRequiredSignatures)->toBe(1)
+        ->and($numReadonlySigned)->toBe(0)
+        // No-create branch: token program + compute-budget program = 2 readonly non-signers.
+        ->and($numReadonlyUnsigned)->toBe(2);
+});
+
+test('account list ordering: with createATA, readonly-unsigned count grows', function (): void {
+    $sender = SolanaAddressHelper::deriveForUser(6, 'k');
+    $recipient = makePubkey('recipient-6');
+    $blockhash = Base58::encode(random_bytes(32));
+
+    $built = (new SolanaTransferBuilder())->buildSplTransfer(
+        $sender,
+        $recipient,
+        USDC_MINT,
+        50_000,
+        $blockhash,
+        true,
+    );
+
+    $numReadonlyUnsigned = ord($built['message'][2]);
+    // With createATA we additionally need: recipient pubkey, mint, system_program, rent, assoc_token_program
+    // → 5 + previous 2 (token + compute) = 7.
+    expect($numReadonlyUnsigned)->toBe(7);
+});
+
+test('first account key in the message is the signer (sender pubkey)', function (): void {
+    $sender = SolanaAddressHelper::deriveForUser(7, 'k');
+    $recipient = makePubkey('recipient-7');
+    $blockhash = Base58::encode(random_bytes(32));
+
+    $built = (new SolanaTransferBuilder())->buildSplTransfer(
+        $sender,
+        $recipient,
+        USDC_MINT,
+        1,
+        $blockhash,
+        false,
+    );
+
+    $message = $built['message'];
+    // header (3) + shortvec(account_key_count) — for our small lists shortvec is 1 byte.
+    $offset = 4;
+    $firstKey = substr($message, $offset, 32);
+
+    expect($firstKey)->toBe(Base58::decode($sender));
+});
+
+it('rejects non-32-byte pubkey', function (): void {
+    $threw = false;
+    try {
+        (new SolanaTransferBuilder())->buildSplTransfer(
+            'shortbad', // not a 32-byte Base58 pubkey
+            makePubkey('r'),
+            USDC_MINT,
+            1,
+            Base58::encode(random_bytes(32)),
+            false,
+        );
+    } catch (InvalidArgumentException) {
+        $threw = true;
+    }
+    expect($threw)->toBeTrue();
+});
+
+it('rejects zero or negative amount', function (): void {
+    $threw = false;
+    try {
+        (new SolanaTransferBuilder())->buildSplTransfer(
+            makePubkey('s'),
+            makePubkey('r'),
+            USDC_MINT,
+            0,
+            Base58::encode(random_bytes(32)),
+            false,
+        );
+    } catch (InvalidArgumentException) {
+        $threw = true;
+    }
+    expect($threw)->toBeTrue();
+});
+
+test('blockhash is embedded verbatim in the message after account keys', function (): void {
+    $sender = SolanaAddressHelper::deriveForUser(8, 'k');
+    $recipient = makePubkey('recipient-8');
+    $blockhashBytes = random_bytes(32);
+    $blockhash = Base58::encode($blockhashBytes);
+
+    $built = (new SolanaTransferBuilder())->buildSplTransfer(
+        $sender,
+        $recipient,
+        USDC_MINT,
+        1,
+        $blockhash,
+        false,
+    );
+
+    expect($built['message'])->toContain($blockhashBytes);
+});

--- a/tests/Unit/Domain/Wallet/Services/Send/UserOpCallDataBuilderTest.php
+++ b/tests/Unit/Domain/Wallet/Services/Send/UserOpCallDataBuilderTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Wallet\Services\Send\Erc20Transfer;
+use App\Domain\Wallet\Services\Send\UserOpCallDataBuilder;
+
+uses(Tests\TestCase::class);
+
+test('selector is the canonical 0xb61d27f6 for execute(address,uint256,bytes)', function (): void {
+    expect(UserOpCallDataBuilder::EXECUTE_SELECTOR)->toBe('0xb61d27f6');
+});
+
+test('builds the expected layout for a USDC transfer (selector + target + 0 + offset 0x60 + length 0x44 + payload)', function (): void {
+    $token = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'; // USDC mainnet
+    $inner = Erc20Transfer::encodeTransferCallData(
+        '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+        '1000000'
+    );
+
+    $outer = UserOpCallDataBuilder::buildExecute($token, $inner);
+
+    // Strip 0x for layout assertions.
+    expect($outer)->toStartWith('0xb61d27f6');
+    $body = substr($outer, 10); // after selector
+
+    // 1) target (32 bytes / 64 hex)
+    expect(substr($body, 0, 64))->toBe(
+        str_pad('a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', 64, '0', STR_PAD_LEFT)
+    );
+    // 2) value = 0 (32 bytes)
+    expect(substr($body, 64, 64))->toBe(str_repeat('0', 64));
+    // 3) bytes-offset = 0x60 (head was 3 slots = 96 bytes)
+    expect(substr($body, 128, 64))->toBe(str_pad('60', 64, '0', STR_PAD_LEFT));
+    // 4) bytes length = 0x44 (68 bytes — 4 selector + 32 + 32)
+    expect(substr($body, 192, 64))->toBe(str_pad('44', 64, '0', STR_PAD_LEFT));
+    // 5) bytes payload — the inner calldata (without 0x), then right-padded to 32-byte boundary.
+    $innerHex = substr($inner, 2);
+    $expectedTail = str_pad($innerHex, (int) (ceil(strlen($innerHex) / 2 / 32) * 32 * 2), '0', STR_PAD_RIGHT);
+    expect(substr($body, 256))->toBe($expectedTail);
+});
+
+test('total outer calldata length is deterministic for a given inner length', function (): void {
+    $inner = Erc20Transfer::encodeTransferCallData(
+        '0x' . str_repeat('a', 40),
+        '1'
+    );
+
+    $outer = UserOpCallDataBuilder::buildExecute('0x' . str_repeat('b', 40), $inner);
+
+    // 0x + selector(8) + 4 head slots * 64 + bytes-tail.
+    // inner is 68 bytes (= 0x44) which fits in 96 bytes of 32-byte-aligned tail.
+    // So total: 2 + 8 + 64 + 64 + 64 + 64 + 192 = 458.
+    expect(strlen($outer))->toBe(458);
+});
+
+it('rejects malformed target contract address', function (): void {
+    UserOpCallDataBuilder::buildExecute('0xnothex', '0xa9059cbb' . str_repeat('0', 128));
+})->throws(InvalidArgumentException::class);
+
+it('rejects inner calldata with odd hex length', function (): void {
+    UserOpCallDataBuilder::buildExecute('0x' . str_repeat('a', 40), '0xabc');
+})->throws(InvalidArgumentException::class);
+
+it('rejects non-hex inner calldata', function (): void {
+    UserOpCallDataBuilder::buildExecute('0x' . str_repeat('a', 40), '0xzzzz');
+})->throws(InvalidArgumentException::class);

--- a/tests/Unit/Domain/Wallet/Services/Send/WalletSendDispatcherTest.php
+++ b/tests/Unit/Domain/Wallet/Services/Send/WalletSendDispatcherTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Wallet\Models\WalletSendRecord;
+use App\Domain\Wallet\Services\Send\EvmSendDispatcher;
+use App\Domain\Wallet\Services\Send\SolanaSendDispatcher;
+use App\Domain\Wallet\Services\Send\WalletSendDispatcher;
+use App\Models\User;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+it('routes SOLANA (uppercase) to the Solana dispatcher', function (): void {
+    /** @var SolanaSendDispatcher&Mockery\MockInterface $solana */
+    $solana = Mockery::mock(SolanaSendDispatcher::class);
+    /** @var EvmSendDispatcher&Mockery\MockInterface $evm */
+    $evm = Mockery::mock(EvmSendDispatcher::class);
+    /** @var User&Mockery\MockInterface $user */
+    $user = Mockery::mock(User::class)->makePartial();
+    $user->id = 7;
+
+    $expected = new WalletSendRecord();
+    $solana->shouldReceive('dispatch')
+        ->once()
+        ->withArgs(function ($u, $recipient, $asset, $amount, $idem, $quote) use ($user) {
+            return $u === $user
+                && $recipient === 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z'
+                && $asset === 'USDC'
+                && $amount === '1.5'
+                && $idem === 'idempotency-key-solana'
+                && $quote === 'quote_xyz';
+        })
+        ->andReturn($expected);
+
+    $evm->shouldNotReceive('dispatch');
+
+    $dispatcher = new WalletSendDispatcher($solana, $evm);
+    $result = $dispatcher->dispatch(
+        user: $user,
+        recipientAddress: 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        assetSymbol: 'USDC',
+        networkKey: 'SOLANA',
+        amountMajor: '1.5',
+        idempotencyKey: 'idempotency-key-solana',
+        quoteId: 'quote_xyz',
+    );
+
+    expect($result)->toBe($expected);
+});
+
+it('routes lowercase solana to the Solana dispatcher (case-insensitive)', function (): void {
+    /** @var SolanaSendDispatcher&Mockery\MockInterface $solana */
+    $solana = Mockery::mock(SolanaSendDispatcher::class);
+    /** @var EvmSendDispatcher&Mockery\MockInterface $evm */
+    $evm = Mockery::mock(EvmSendDispatcher::class);
+    /** @var User&Mockery\MockInterface $user */
+    $user = Mockery::mock(User::class)->makePartial();
+    $user->id = 1;
+
+    $solana->shouldReceive('dispatch')->once()->andReturn(new WalletSendRecord());
+    $evm->shouldNotReceive('dispatch');
+
+    (new WalletSendDispatcher($solana, $evm))->dispatch(
+        user: $user,
+        recipientAddress: 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        assetSymbol: 'USDC',
+        networkKey: 'solana',
+        amountMajor: '1',
+    );
+});
+
+it('routes polygon to the EVM dispatcher with lowercased network key', function (): void {
+    /** @var SolanaSendDispatcher&Mockery\MockInterface $solana */
+    $solana = Mockery::mock(SolanaSendDispatcher::class);
+    /** @var EvmSendDispatcher&Mockery\MockInterface $evm */
+    $evm = Mockery::mock(EvmSendDispatcher::class);
+    /** @var User&Mockery\MockInterface $user */
+    $user = Mockery::mock(User::class)->makePartial();
+    $user->id = 9;
+
+    $solana->shouldNotReceive('dispatch');
+    $evm->shouldReceive('dispatch')
+        ->once()
+        ->withArgs(function ($u, $recipient, $asset, $network, $amount, $idem, $quote) {
+            return $recipient === '0x742d35Cc6634C0532925a3b844Bc454e4438f44e'
+                && $asset === 'USDC'
+                && $network === 'polygon'
+                && $amount === '25.5';
+        })
+        ->andReturn(new WalletSendRecord());
+
+    (new WalletSendDispatcher($solana, $evm))->dispatch(
+        user: $user,
+        recipientAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+        assetSymbol: 'USDC',
+        networkKey: 'POLYGON',
+        amountMajor: '25.5',
+    );
+});
+
+it('routes each EVM network to the EVM dispatcher', function (): void {
+    foreach (['polygon', 'base', 'arbitrum', 'ethereum'] as $network) {
+        /** @var SolanaSendDispatcher&Mockery\MockInterface $solana */
+        $solana = Mockery::mock(SolanaSendDispatcher::class);
+        /** @var EvmSendDispatcher&Mockery\MockInterface $evm */
+        $evm = Mockery::mock(EvmSendDispatcher::class);
+        /** @var User&Mockery\MockInterface $user */
+        $user = Mockery::mock(User::class)->makePartial();
+        $user->id = 1;
+
+        $solana->shouldNotReceive('dispatch');
+        $evm->shouldReceive('dispatch')->once()->andReturn(new WalletSendRecord());
+
+        (new WalletSendDispatcher($solana, $evm))->dispatch(
+            user: $user,
+            recipientAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+            assetSymbol: 'USDC',
+            networkKey: $network,
+            amountMajor: '1',
+        );
+    }
+});

--- a/tests/Unit/Http/Controllers/Api/Relayer/SmartAccountControllerOwnerDerivationTest.php
+++ b/tests/Unit/Http/Controllers/Api/Relayer/SmartAccountControllerOwnerDerivationTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Wallet\Helpers\Crypto\EvmKeyHelper;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(Tests\TestCase::class, RefreshDatabase::class);
+
+beforeEach(function (): void {
+    config()->set('app.key', 'base64:' . base64_encode(str_repeat('a', 32)));
+});
+
+/**
+ * Regression test: SmartAccountController::deriveOwnerAddress() now produces
+ * the same address that EvmKeyHelper does — i.e. an address backed by a real
+ * secp256k1 keypair, not the legacy phantom hash.
+ *
+ * We invoke the private method via reflection because it's the cheapest way
+ * to assert the derivation while leaving the public API untouched. If this
+ * test breaks because the method is renamed/removed, that's fine — but the
+ * replacement must keep using EvmKeyHelper or this regression returns.
+ */
+test('controller derived owner address matches EvmKeyHelper output', function (): void {
+    $user = User::factory()->create();
+
+    $controller = app(App\Http\Controllers\Api\Relayer\SmartAccountController::class);
+    $reflected = new ReflectionClass($controller);
+    $method = $reflected->getMethod('deriveOwnerAddress');
+    $method->setAccessible(true);
+
+    $derived = (string) $method->invoke($controller, $user);
+    $expected = EvmKeyHelper::deriveAddressOnly((int) $user->id, (string) config('app.key'));
+
+    expect($derived)->toBe($expected);
+});
+
+test('controller no longer returns the legacy phantom hash', function (): void {
+    $user = User::factory()->create();
+
+    $legacy = '0x' . substr(hash('sha3-256', $user->id . ':' . config('app.key')), 24);
+
+    $controller = app(App\Http\Controllers\Api\Relayer\SmartAccountController::class);
+    $reflected = new ReflectionClass($controller);
+    $method = $reflected->getMethod('deriveOwnerAddress');
+    $method->setAccessible(true);
+
+    $derived = (string) $method->invoke($controller, $user);
+
+    expect(strtolower($derived))->not->toBe(strtolower($legacy));
+});

--- a/tests/Unit/Http/Controllers/Api/Wallet/MobileWalletControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/Wallet/MobileWalletControllerTest.php
@@ -6,6 +6,7 @@ use App\Domain\MobilePayment\Services\ActivityFeedService;
 use App\Domain\MobilePayment\Services\TransactionDetailService;
 use App\Domain\Relayer\Services\SmartAccountService;
 use App\Domain\Relayer\Services\WalletBalanceService;
+use App\Domain\Wallet\Services\Send\WalletSendDispatcher;
 use App\Domain\Wallet\Services\WalletTransferService;
 use App\Http\Controllers\Api\Wallet\MobileWalletController;
 use App\Models\User;
@@ -22,6 +23,7 @@ beforeEach(function (): void {
     $this->activityFeedService = Mockery::mock(ActivityFeedService::class);
     $this->transactionDetailService = Mockery::mock(TransactionDetailService::class);
     $this->walletTransferService = Mockery::mock(WalletTransferService::class);
+    $this->walletSendDispatcher = Mockery::mock(WalletSendDispatcher::class);
 });
 
 function makeWalletController($test): MobileWalletController
@@ -32,6 +34,7 @@ function makeWalletController($test): MobileWalletController
         $test->activityFeedService,
         $test->transactionDetailService,
         $test->walletTransferService,
+        $test->walletSendDispatcher,
     );
 }
 
@@ -366,6 +369,89 @@ describe('MobileWalletController send', function (): void {
             ->and($data['error']['message'])->not->toContain('merchantId')
             ->and($data['error']['message'])->not->toContain('Undefined array key')
             ->and($data['error']['message'])->toBe('Send could not be processed.');
+    });
+
+    it('routes through WalletSendDispatcher when real_dispatch_enabled is true', function (): void {
+        config(['wallet.real_dispatch_enabled' => true]);
+
+        $this->walletTransferService->shouldReceive('validateAddress')
+            ->once()
+            ->andReturn([
+                'valid'        => true,
+                'network'      => 'SOLANA',
+                'address'      => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+                'address_type' => 'wallet',
+                'error'        => null,
+            ]);
+
+        $record = Mockery::mock(App\Domain\Wallet\Models\WalletSendRecord::class)->makePartial();
+        $record->status = 'submitted';
+        $record->shouldReceive('toApiResponse')->andReturn([
+            'intentId' => 'pi_send_real_xyz',
+            'status'   => 'SUBMITTED',
+            'tx'       => ['hash' => '5xa...solSig', 'explorerUrl' => 'https://solscan.io/tx/5xa...solSig'],
+        ]);
+
+        $this->walletSendDispatcher->shouldReceive('dispatch')
+            ->once()
+            ->withArgs(function ($user, $recipient, $asset, $network, $amount, $idempotencyKey, $quoteId) {
+                return $recipient === 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z'
+                    && $asset === 'USDC'
+                    && $network === 'SOLANA'
+                    && $amount === '1';
+            })
+            ->andReturn($record);
+
+        $controller = makeWalletController($this);
+
+        $request = walletUserRequest('/api/v1/wallet/transactions/send', 'POST', [
+            'to'      => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+            'token'   => 'USDC',
+            'amount'  => '1',
+            'network' => 'SOLANA',
+        ]);
+
+        $response = $controller->send($request);
+        $data = $response->getData(true);
+
+        expect($response->getStatusCode())->toBe(201)
+            ->and($data['success'])->toBeTrue()
+            ->and($data['data']['intentId'])->toBe('pi_send_real_xyz')
+            ->and($data['data']['status'])->toBe('SUBMITTED');
+    });
+
+    it('returns 422 when dispatcher reports a failed record', function (): void {
+        config(['wallet.real_dispatch_enabled' => true]);
+
+        $this->walletTransferService->shouldReceive('validateAddress')
+            ->once()
+            ->andReturn(['valid' => true, 'network' => 'SOLANA', 'address' => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z', 'address_type' => 'wallet', 'error' => null]);
+
+        $record = Mockery::mock(App\Domain\Wallet\Models\WalletSendRecord::class)->makePartial();
+        $record->status = 'failed';
+        $record->shouldReceive('toApiResponse')->andReturn([
+            'intentId' => 'pi_send_x',
+            'status'   => 'FAILED',
+            'error'    => ['code' => 'SIMULATION_FAILED', 'message' => 'Insufficient lamports'],
+        ]);
+
+        $this->walletSendDispatcher->shouldReceive('dispatch')->andReturn($record);
+
+        $controller = makeWalletController($this);
+
+        $request = walletUserRequest('/api/v1/wallet/transactions/send', 'POST', [
+            'to'      => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+            'token'   => 'USDC',
+            'amount'  => '1',
+            'network' => 'SOLANA',
+        ]);
+
+        $response = $controller->send($request);
+        $data = $response->getData(true);
+
+        expect($response->getStatusCode())->toBe(422)
+            ->and($data['success'])->toBeFalse()
+            ->and($data['data']['error']['code'])->toBe('SIMULATION_FAILED');
     });
 
     it('returns the unsanitized message for non-runtime-warning failures', function (): void {


### PR DESCRIPTION
## Summary

- Wires `POST /api/v1/wallet/transactions/send` to **real on-chain dispatch** on Solana + Polygon + Base + Arbitrum + Ethereum, behind the `WALLET_SEND_REAL_DISPATCH=true` flag (default off).
- Adds custodial server-side signing: ed25519 (libsodium) for Solana SPL transfers; secp256k1 (RFC 6979) for ERC-4337 v0.6 UserOps.
- Persists every send in new `wallet_send_records` table; tracks `pending → submitted → confirmed | failed`. Solana confirmations land via the existing Helius webhook; EVM confirmations land via a per-minute scheduled bundler poll.

## Why

PR #1015 unblocked the API contract by returning a synthetic `PENDING` shape for wallet sends, but no funds actually moved. Mobile is shipping; the same endpoint must drive real transfers end-to-end.

## What's new

**Domain code (`app/Domain/Wallet/Services/Send/`)**
- `WalletSendDispatcher` — case-insensitive network router (`SOLANA` → Solana stack; `polygon|base|arbitrum|ethereum` → ERC-4337 stack).
- Solana: `SolanaSigner`, `HeliusRpcClient`, `SolanaTransferBuilder`, `SolanaSendDispatcher` — SPL Token Program transfer (incl. ATA detection + creation), compute budget priority fees, legacy tx encoding, simulate-then-send.
- EVM: `Erc20Transfer`, `UserOpCallDataBuilder`, `ServerOnlyUserOpSigner`, `EvmSendDispatcher` — encode `transfer(address,uint256)`, wrap in `execute()`, build & sign UserOp, submit via Pimlico bundler with paymaster sponsorship.
- Helpers: `Base58.php` (pure-PHP via GMP), `EvmKeyHelper.php` (replaces phantom hash address in `SmartAccountController::deriveOwnerAddress()`).

**Persistence**
- `wallet_send_records` migration with `idempotency_key` UNIQUE.
- `HeliusTransactionProcessor` flips outbound Solana records to `confirmed` when their tx hash arrives via webhook.
- `PollEvmWalletSendConfirmations` (scheduled every minute via `routes/console.php`) flips EVM records based on `BundlerInterface::getUserOperationStatus()`. Skips records older than 2h.

**Controller**
- `MobileWalletController::send()` reads `Idempotency-Key`, validates recipient via `WalletTransferService`, then routes through `WalletSendDispatcher` only when `wallet.real_dispatch_enabled` is true. Returns `WalletSendRecord::toApiResponse()` shape, identical to the mobile contract.

## Operator runbook

**Required env**
- `WALLET_SEND_REAL_DISPATCH=true` — gate (default false; staying false keeps the existing safe stub).
- `SOLANA_RPC_URL` — Helius RPC URL with API key as query param.
- `WALLET_SOLANA_PRIORITY_FEE_MICROLAMPORTS` (optional, default 100000), `WALLET_SOLANA_COMPUTE_UNIT_LIMIT` (default 200000).
- `WALLET_EVM_ENABLED_NETWORKS=polygon,base,arbitrum,ethereum`
- Existing relayer env: `RELAYER_BUNDLER_URL`, `RELAYER_PAYMASTER_URL`, `APP_KEY` (used in seed derivation).

**Smoke test (Solana, after flipping the flag in staging)**
1. `POST /api/v1/wallet/transactions/send` with `{token: USDC, network: solana, to: <recipient>, amount: 0.01}`.
2. Response should be `201` with `status: SUBMITTED` (not `PENDING`).
3. Within ~30s the Helius webhook should flip the record to `confirmed`; `GET /api/v1/wallet/transactions/{intentId}` should return `status: CONFIRMED` with `tx.hash` and `tx.explorerUrl` set.

**Smoke test (EVM)**
1. Same call with `network: polygon`.
2. Within ~1 minute the scheduled poll should flip status to `confirmed` once the bundler reports a receipt.

**Rollback**
- Set `WALLET_SEND_REAL_DISPATCH=false` and redeploy. The stub path resumes immediately.

## Concerns flagged for follow-up

- **EntryPoint v0.6 hardcoded** in `ServerOnlyUserOpSigner`. If the relayer moves to v0.7, both must update jointly.
- **Sponsor signer mismatch** — `GasStationService::sponsorTransaction` signs the unsigned hash, which is incorrect ERC-4337. `ServerOnlyUserOpSigner` deliberately bypasses it and signs the finalized UserOp hash; we should reconcile that path so all callers use the correct hash.
- **On-curve detection on Solana** uses `sodium_crypto_sign_ed25519_pk_to_curve25519()` (throws on off-curve) since `…is_valid_point` isn't always exposed by libsodium.
- **Pre-balance check on Solana** relies on `simulateTransaction` rather than an explicit `getBalance` round-trip — fine for first launch.
- **Existing EVM smart accounts** get a NEW counterfactual owner address as a side effect of fixing `deriveOwnerAddress()`. Pre-launch this is fine because there are no production smart accounts yet.

## Test plan

- [x] 223 wallet-send unit + feature tests pass locally (`./vendor/bin/pest tests/Unit/Domain/Wallet tests/Feature/Domain/Wallet/HeliusTransactionProcessorWalletSendConfirmationTest.php tests/Unit/Http/Controllers/Api/Relayer/SmartAccountControllerOwnerDerivationTest.php tests/Unit/Http/Controllers/Api/Wallet/MobileWalletControllerTest.php`).
- [x] PHPStan level 8 clean across all changed/new files.
- [x] PHP CS Fixer clean.
- [ ] Smoke test in staging with the flag on for both Solana USDC and Polygon USDC.
- [ ] Verify Helius webhook ↔ `wallet_send_records` confirmation in staging.
- [ ] Verify scheduled `PollEvmWalletSendConfirmations` runs every minute (`php artisan schedule:list`).
- [ ] Mobile: send happy-path on each of solana / polygon / base / arbitrum / ethereum and verify status transitions.

## Mobile contract notes

The success response is unchanged from the stub shape (`intentId`, `status`, `tx`, `error`, `quoteId`, `feesEstimate`, `confirmations`, `requiredConfirmations`). The only behavioral difference is that `status` will now be `SUBMITTED` (not `PENDING`) on the initial 201 when the flag is on, and the record will eventually flip to `CONFIRMED` (or `FAILED`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)