### PR TITLE
feat(auth): Privy email-OTP login — drop placeholder emails for real ones

### DIFF
--- a/app/Console/Commands/PrivyPurgePlaceholderUsersCommand.php
+++ b/app/Console/Commands/PrivyPurgePlaceholderUsersCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+
+/**
+ * One-off cleanup for users created by the v7.12.0 placeholder-email path
+ * before email-OTP login (v7.13.0) shipped. Their email is of the form
+ * `privy_<last16>@placeholder.zelta.app` and is never reachable.
+ *
+ * Pre-launch this is the easiest path: nuke the placeholder records and let
+ * users re-signup through the email-OTP flow. Post-launch, run a backfill
+ * that fetches each user's real email from Privy and updates them in place
+ * instead — but that is not what this command does.
+ *
+ *   php artisan privy:purge-placeholder-users --dry-run
+ *   php artisan privy:purge-placeholder-users --confirm
+ */
+class PrivyPurgePlaceholderUsersCommand extends Command
+{
+    private const PLACEHOLDER_EMAIL_PATTERN = 'privy\_%@placeholder.zelta.app';
+
+    protected $signature = 'privy:purge-placeholder-users
+        {--dry-run : Print the count without deleting anything}
+        {--confirm : Skip the interactive confirmation prompt (for scripted runs)}';
+
+    protected $description = 'Delete user rows whose email is a Privy placeholder (v7.12.0 transitional artefact)';
+
+    public function handle(): int
+    {
+        $query = User::query()->where('email', 'like', self::PLACEHOLDER_EMAIL_PATTERN);
+        $count = $query->count();
+
+        if ($count === 0) {
+            $this->info('No placeholder users found. Nothing to do.');
+
+            return self::SUCCESS;
+        }
+
+        $this->warn(sprintf('Found %d user(s) with placeholder emails.', $count));
+
+        if ($this->option('dry-run')) {
+            $this->info('Dry run — no rows deleted. Re-run without --dry-run to purge.');
+
+            return self::SUCCESS;
+        }
+
+        if (! $this->option('confirm')) {
+            if (! $this->confirm("Delete {$count} placeholder user(s)? This cannot be undone.", false)) {
+                $this->warn('Cancelled.');
+
+                return self::FAILURE;
+            }
+        }
+
+        $deleted = User::query()->where('email', 'like', self::PLACEHOLDER_EMAIL_PATTERN)->delete();
+        $this->info(sprintf('Purged %d placeholder user(s).', $deleted));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Domain/Auth/DataObjects/PrivyClaims.php
+++ b/app/Domain/Auth/DataObjects/PrivyClaims.php
@@ -70,7 +70,15 @@ final class PrivyClaims
         }
 
         $linked = $payload['linked_accounts'] ?? [];
-        if (! is_array($linked)) {
+        // JWT::decode emits nested JSON objects as stdClass, not arrays — so an
+        // array of objects comes through as `[stdClass, stdClass, ...]`.
+        // Round-trip through json to flatten everything to associative arrays
+        // matching the documented shape.
+        if (is_array($linked) || is_object($linked)) {
+            $encoded = json_encode($linked);
+            $decoded = $encoded !== false ? json_decode($encoded, true) : null;
+            $linked = is_array($decoded) ? $decoded : [];
+        } else {
             $linked = [];
         }
 
@@ -83,5 +91,23 @@ final class PrivyClaims
             expiresAt: (new DateTimeImmutable())->setTimestamp((int) $exp),
             linkedAccounts: $linked,
         );
+    }
+
+    /**
+     * First linked-account address whose `type` is `email`. The JWT may omit
+     * `linked_accounts` for some users — callers should fall back to
+     * `PrivyJwtVerifier::fetchUserEmail()` in that case.
+     */
+    public function email(): ?string
+    {
+        foreach ($this->linkedAccounts as $account) {
+            $type = $account['type'] ?? null;
+            $address = $account['address'] ?? null;
+            if ($type === 'email' && is_string($address) && $address !== '') {
+                return strtolower($address);
+            }
+        }
+
+        return null;
     }
 }

--- a/app/Domain/Auth/Services/PrivyJwtVerifier.php
+++ b/app/Domain/Auth/Services/PrivyJwtVerifier.php
@@ -122,4 +122,56 @@ final class PrivyJwtVerifier
             throw PrivyJwtException::malformed('JWKS could not be parsed: ' . $e->getMessage());
         }
     }
+
+    /**
+     * Fallback when the JWT did not embed `linked_accounts`: pull the user
+     * record from the Privy server-side API and return the first linked email.
+     * Authenticates with `PRIVY_APP_ID:PRIVY_APP_SECRET` Basic auth.
+     *
+     * Returns `null` on any failure (bad config, network error, no email
+     * linked) so the caller can decide whether to fail closed or proceed
+     * without an email.
+     */
+    public function fetchUserEmail(string $privyUserId): ?string
+    {
+        $appId = (string) config('privy.app_id');
+        $appSecret = (string) config('privy.app_secret');
+        if ($appId === '' || $appSecret === '' || $privyUserId === '') {
+            return null;
+        }
+
+        $url = 'https://auth.privy.io/api/v1/users/' . rawurlencode($privyUserId);
+
+        try {
+            $response = $this->httpClient->request('GET', $url, [
+                'auth'    => [$appId, $appSecret],
+                'timeout' => 5,
+                'headers' => ['privy-app-id' => $appId],
+            ]);
+        } catch (GuzzleException) {
+            return null;
+        }
+
+        if ($response->getStatusCode() !== 200) {
+            return null;
+        }
+
+        $body = json_decode((string) $response->getBody(), true);
+        if (! is_array($body) || ! isset($body['linked_accounts']) || ! is_array($body['linked_accounts'])) {
+            return null;
+        }
+
+        foreach ($body['linked_accounts'] as $account) {
+            if (! is_array($account)) {
+                continue;
+            }
+            $type = $account['type'] ?? null;
+            $address = $account['address'] ?? null;
+            if ($type === 'email' && is_string($address) && $address !== '') {
+                return strtolower($address);
+            }
+        }
+
+        return null;
+    }
 }

--- a/app/Http/Controllers/Api/Auth/LoginController.php
+++ b/app/Http/Controllers/Api/Auth/LoginController.php
@@ -160,11 +160,12 @@ class LoginController extends Controller
     #[OA\Post(
         path: '/api/v1/auth/privy-login',
         summary: 'Exchange a Privy session JWT for a Sanctum token',
-        description: 'Verifies the Privy-issued session JWT against Privy\'s JWKS, finds or creates the backing user, and returns a Sanctum bearer token with read/write/delete abilities.',
+        description: 'Verifies the Privy-issued session JWT against Privy\'s JWKS, extracts the linked email (or fetches it from the Privy users API as fallback), finds or creates the backing user with the real email, and returns a Sanctum bearer token with read/write/delete abilities.',
         operationId: 'privyLogin',
         tags: ['Authentication'],
         requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(required: ['privy_token'], properties: [
         new OA\Property(property: 'privy_token', type: 'string', description: 'Privy-issued session JWT (RS256)', example: 'eyJhbGciOiJSUzI1NiIs...'),
+        new OA\Property(property: 'name', type: 'string', nullable: true, description: 'Optional display name captured during signup. Used only for new-user creation; ignored on returning logins.', example: 'Jane Doe'),
         ]))
     )]
     #[OA\Response(
@@ -175,11 +176,12 @@ class LoginController extends Controller
         new OA\Property(property: 'data', type: 'object', properties: [
         new OA\Property(property: 'user', type: 'object', properties: [
         new OA\Property(property: 'id', type: 'integer', example: 1),
-        new OA\Property(property: 'email', type: 'string', example: 'privy_abcdef1234567890@placeholder.zelta.app'),
+        new OA\Property(property: 'email', type: 'string', example: 'jane@example.com'),
         new OA\Property(property: 'privy_user_id', type: 'string', example: 'did:privy:cl9...'),
         ]),
         new OA\Property(property: 'token', type: 'string', example: '7|VVGVrIVokPBXkWLOi2yK...'),
         new OA\Property(property: 'token_type', type: 'string', example: 'Bearer'),
+        new OA\Property(property: 'is_new_user', type: 'boolean', example: true, description: 'True on first login (user record was just created); false on returning logins.'),
         ]),
         ])
     )]
@@ -195,8 +197,19 @@ class LoginController extends Controller
         ])
     )]
     #[OA\Response(
+        response: 409,
+        description: 'Email already in use by a non-Privy user',
+        content: new OA\JsonContent(properties: [
+        new OA\Property(property: 'success', type: 'boolean', example: false),
+        new OA\Property(property: 'error', type: 'object', properties: [
+        new OA\Property(property: 'code', type: 'string', example: 'EMAIL_ALREADY_EXISTS'),
+        new OA\Property(property: 'message', type: 'string', example: 'An account with this email already exists. Use a different Privy email or sign in with the existing credentials.'),
+        ]),
+        ])
+    )]
+    #[OA\Response(
         response: 422,
-        description: 'Validation failed',
+        description: 'Validation failed or no email linked to Privy account',
         content: new OA\JsonContent(properties: [
         new OA\Property(property: 'message', type: 'string', example: 'The privy token field is required.'),
         new OA\Property(property: 'errors', type: 'object'),
@@ -206,6 +219,7 @@ class LoginController extends Controller
     {
         $validated = $request->validate([
             'privy_token' => ['required', 'string'],
+            'name'        => ['nullable', 'string', 'max:120'],
         ]);
 
         try {
@@ -220,16 +234,41 @@ class LoginController extends Controller
             ], 401);
         }
 
+        $email = $claims->email() ?? $verifier->fetchUserEmail($claims->privyUserId);
+        if ($email === null) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'NO_EMAIL_LINKED',
+                    'message' => 'Privy session is missing a linked email. Complete email verification in the app and try again.',
+                ],
+            ], 422);
+        }
+
         $user = User::where('privy_user_id', $claims->privyUserId)->first();
 
         if (! $user instanceof User) {
-            $placeholderEmail = 'privy_' . substr($claims->privyUserId, -16) . '@placeholder.zelta.app';
+            // A non-Privy user may already own this email. Refuse to silently
+            // attach the Privy identity to that account — that's account-takeover-
+            // shaped. Surface a clear conflict so mobile can prompt the user.
+            $existing = User::where('email', $email)->first();
+            if ($existing instanceof User) {
+                return response()->json([
+                    'success' => false,
+                    'error'   => [
+                        'code'    => 'EMAIL_ALREADY_EXISTS',
+                        'message' => 'An account with this email already exists. Use a different Privy email or sign in with the existing credentials.',
+                    ],
+                ], 409);
+            }
+
+            $name = is_string($validated['name'] ?? null) ? trim((string) $validated['name']) : '';
 
             $user = User::create([
-                'name'              => 'Privy User',
-                'email'             => $placeholderEmail,
-                'password'          => Str::random(64),
-                'email_verified_at' => now(),
+                'name'              => $name !== '' ? $name : 'New User',
+                'email'             => $email,
+                'password'          => Str::random(64),  // unusable; auth gated by Privy
+                'email_verified_at' => now(),  // Privy already verified
                 'privy_user_id'     => $claims->privyUserId,
                 'privy_linked_at'   => now(),
             ]);
@@ -240,9 +279,10 @@ class LoginController extends Controller
         return response()->json([
             'success' => true,
             'data'    => [
-                'user'       => $user,
-                'token'      => $token,
-                'token_type' => 'Bearer',
+                'user'        => $user,
+                'token'       => $token,
+                'token_type'  => 'Bearer',
+                'is_new_user' => $user->wasRecentlyCreated,
             ],
         ]);
     }

--- a/tests/Feature/Http/Auth/PrivyLoginTest.php
+++ b/tests/Feature/Http/Auth/PrivyLoginTest.php
@@ -71,64 +71,167 @@ beforeEach(function (): void {
 
     /** @var ClientInterface&MockInterface $httpClient */
     $httpClient = Mockery::mock(ClientInterface::class);
-    $httpClient->shouldReceive('request')
-        ->byDefault()
-        ->andReturn(new PsrResponse(200, [], (string) json_encode(['keys' => [$this->keypair['jwk']]])));
+    $jwksResponse = new PsrResponse(200, [], (string) json_encode(['keys' => [$this->keypair['jwk']]]));
+
+    // Per-test overrides go into this map — keyed by URL prefix. Anything
+    // not in the map and not the JWKS URL returns 404. Tests that need a
+    // specific Privy users-API response set $this->usersApiResponses[<url>].
+    $this->usersApiResponses = [];
+
+    /** @var Mockery\Expectation $expectation */
+    $expectation = $httpClient->shouldReceive('request');
+    $expectation->andReturnUsing(function (string $method, string $url) use ($jwksResponse) {
+        if ($url === 'https://privy.example/.well-known/jwks.json') {
+            return $jwksResponse;
+        }
+        foreach ($this->usersApiResponses as $prefix => $response) {
+            if (str_starts_with($url, (string) $prefix)) {
+                return $response;
+            }
+        }
+
+        return new PsrResponse(404, [], '{}');
+    });
+
+    $this->httpClient = $httpClient;
 
     // Bind a verifier that uses the mocked HTTP client into the container so
     // controller-resolved instances pick it up.
     $this->app->bind(PrivyJwtVerifier::class, fn () => new PrivyJwtVerifier($httpClient));
 });
 
-it('creates a new user and returns a Sanctum token for a previously-unseen Privy user', function (): void {
-    $token = privy_login_make_token([
-        'sub' => 'did:privy:newuser0123456789',
+/**
+ * @param array<string, mixed> $extraClaims
+ */
+function privy_login_jwt(array $extraClaims, object $context): string
+{
+    return privy_login_make_token([
+        'sub' => 'did:privy:default0123456789',
         'iss' => 'privy.io',
         'aud' => 'mobile-app-id',
         'iat' => time() - 60,
         'exp' => time() + 3600,
-    ], $this->keypair['privatePem'], $this->keypair['kid']);
+        ...$extraClaims,
+    ], $context->keypair['privatePem'], $context->keypair['kid']);
+}
+
+it('creates a new user with the linked email from the JWT', function (): void {
+    $token = privy_login_jwt([
+        'sub'             => 'did:privy:newuser0123456789',
+        'linked_accounts' => [
+            ['type' => 'email', 'address' => 'Jane@Example.com', 'verified_at' => time() - 100],
+        ],
+    ], $this);
+
+    $response = $this->postJson('/api/v1/auth/privy-login', [
+        'privy_token' => $token,
+        'name'        => 'Jane Doe',
+    ]);
+
+    $response->assertOk()
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.is_new_user', true)
+        ->assertJsonPath('data.token_type', 'Bearer')
+        ->assertJsonPath('data.user.email', 'jane@example.com');
+
+    $user = User::where('privy_user_id', 'did:privy:newuser0123456789')->firstOrFail();
+    expect($user->email)->toBe('jane@example.com')
+        ->and($user->name)->toBe('Jane Doe')
+        ->and($user->email_verified_at)->not->toBeNull()
+        ->and($user->privy_linked_at)->not->toBeNull()
+        ->and($user->tokens()->count())->toBe(1);
+});
+
+it('falls back to the Privy users API when the JWT has no linked email', function (): void {
+    $this->usersApiResponses['https://auth.privy.io/api/v1/users/did%3Aprivy%3Anolinkedclaim'] =
+        new PsrResponse(200, [], (string) json_encode([
+            'id'              => 'did:privy:nolinkedclaim',
+            'linked_accounts' => [
+                ['type' => 'wallet', 'address' => '0xabc'],
+                ['type' => 'email', 'address' => 'fallback@example.com'],
+            ],
+        ]));
+
+    $token = privy_login_jwt([
+        'sub' => 'did:privy:nolinkedclaim',
+    ], $this);
 
     $response = $this->postJson('/api/v1/auth/privy-login', ['privy_token' => $token]);
 
     $response->assertOk()
-        ->assertJsonPath('success', true)
-        ->assertJsonStructure(['data' => ['user' => ['id', 'email'], 'token', 'token_type']])
-        ->assertJsonPath('data.token_type', 'Bearer');
-
-    $this->assertDatabaseHas('users', [
-        'privy_user_id' => 'did:privy:newuser0123456789',
-        'email'         => 'privy_ewuser0123456789@placeholder.zelta.app',
-    ]);
-
-    $user = User::where('privy_user_id', 'did:privy:newuser0123456789')->firstOrFail();
-    expect($user->tokens()->count())->toBe(1)
-        ->and($user->email_verified_at)->not->toBeNull()
-        ->and($user->privy_linked_at)->not->toBeNull();
+        ->assertJsonPath('data.user.email', 'fallback@example.com')
+        ->assertJsonPath('data.is_new_user', true);
 });
 
-it('returns a Sanctum token for an existing Privy user without creating a duplicate', function (): void {
+it('returns 422 NO_EMAIL_LINKED when neither the JWT nor Privy API yield an email', function (): void {
+    $this->usersApiResponses['https://auth.privy.io/api/v1/users/'] =
+        new PsrResponse(200, [], (string) json_encode([
+            'id'              => 'did:privy:noemail',
+            'linked_accounts' => [['type' => 'wallet', 'address' => '0xdeadbeef']],
+        ]));
+
+    $token = privy_login_jwt(['sub' => 'did:privy:noemail'], $this);
+
+    $response = $this->postJson('/api/v1/auth/privy-login', ['privy_token' => $token]);
+
+    $response->assertStatus(422)
+        ->assertJsonPath('success', false)
+        ->assertJsonPath('error.code', 'NO_EMAIL_LINKED');
+
+    expect(User::where('privy_user_id', 'did:privy:noemail')->count())->toBe(0);
+});
+
+it('returns 409 EMAIL_ALREADY_EXISTS when a non-Privy user already owns the email', function (): void {
+    User::factory()->create([
+        'email'         => 'taken@example.com',
+        'privy_user_id' => null,
+    ]);
+
+    $token = privy_login_jwt([
+        'sub'             => 'did:privy:tryingtotakeover',
+        'linked_accounts' => [['type' => 'email', 'address' => 'taken@example.com']],
+    ], $this);
+
+    $response = $this->postJson('/api/v1/auth/privy-login', ['privy_token' => $token]);
+
+    $response->assertStatus(409)
+        ->assertJsonPath('success', false)
+        ->assertJsonPath('error.code', 'EMAIL_ALREADY_EXISTS');
+
+    expect(User::where('privy_user_id', 'did:privy:tryingtotakeover')->count())->toBe(0);
+});
+
+it('returns is_new_user=false and the existing user on a returning login', function (): void {
     $existing = User::factory()->create([
-        'email'           => 'existing@example.com',
-        'privy_user_id'   => 'did:privy:existing12345',
+        'email'           => 'returning@example.com',
+        'privy_user_id'   => 'did:privy:returning',
         'privy_linked_at' => now(),
     ]);
 
-    $token = privy_login_make_token([
-        'sub' => 'did:privy:existing12345',
-        'iss' => 'privy.io',
-        'aud' => 'mobile-app-id',
-        'iat' => time() - 60,
-        'exp' => time() + 3600,
-    ], $this->keypair['privatePem'], $this->keypair['kid']);
+    $token = privy_login_jwt([
+        'sub'             => 'did:privy:returning',
+        'linked_accounts' => [['type' => 'email', 'address' => 'returning@example.com']],
+    ], $this);
 
     $response = $this->postJson('/api/v1/auth/privy-login', ['privy_token' => $token]);
 
     $response->assertOk()
-        ->assertJsonPath('success', true)
-        ->assertJsonPath('data.user.id', $existing->id);
+        ->assertJsonPath('data.user.id', $existing->id)
+        ->assertJsonPath('data.is_new_user', false);
 
-    expect(User::where('privy_user_id', 'did:privy:existing12345')->count())->toBe(1);
+    expect(User::where('privy_user_id', 'did:privy:returning')->count())->toBe(1);
+});
+
+it('uses "New User" when no name is supplied on signup', function (): void {
+    $token = privy_login_jwt([
+        'sub'             => 'did:privy:noname0123456789',
+        'linked_accounts' => [['type' => 'email', 'address' => 'noname@example.com']],
+    ], $this);
+
+    $response = $this->postJson('/api/v1/auth/privy-login', ['privy_token' => $token]);
+
+    $response->assertOk();
+    expect(User::where('privy_user_id', 'did:privy:noname0123456789')->value('name'))->toBe('New User');
 });
 
 it('returns 401 INVALID_PRIVY_TOKEN for an invalid Privy token', function (): void {

--- a/tests/Unit/Domain/Auth/DataObjects/PrivyClaimsTest.php
+++ b/tests/Unit/Domain/Auth/DataObjects/PrivyClaimsTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Auth\DataObjects\PrivyClaims;
+
+uses(Tests\TestCase::class);
+
+/**
+ * @param array<int, array<string, mixed>> $linkedAccounts
+ */
+function privy_claims_with(array $linkedAccounts): PrivyClaims
+{
+    return PrivyClaims::fromPayload([
+        'sub'             => 'did:privy:test',
+        'iss'             => 'privy.io',
+        'aud'             => 'app',
+        'iat'             => time() - 60,
+        'exp'             => time() + 3600,
+        'linked_accounts' => $linkedAccounts,
+    ]);
+}
+
+it('returns the first linked email lowercased', function (): void {
+    $claims = privy_claims_with([
+        ['type' => 'wallet', 'address' => '0xabc'],
+        ['type' => 'email', 'address' => 'Jane@Example.com'],
+        ['type' => 'email', 'address' => 'second@example.com'],
+    ]);
+
+    expect($claims->email())->toBe('jane@example.com');
+});
+
+it('returns null when there are no linked accounts', function (): void {
+    expect(privy_claims_with([])->email())->toBeNull();
+});
+
+it('returns null when no linked account is of type email', function (): void {
+    $claims = privy_claims_with([
+        ['type' => 'wallet', 'address' => '0xabc'],
+        ['type' => 'phone', 'address' => '+15551234'],
+    ]);
+
+    expect($claims->email())->toBeNull();
+});
+
+it('skips email accounts with empty addresses', function (): void {
+    $claims = privy_claims_with([
+        ['type' => 'email', 'address' => ''],
+        ['type' => 'email', 'address' => 'real@example.com'],
+    ]);
+
+    expect($claims->email())->toBe('real@example.com');
+});
+
+it('skips email accounts where the address field is missing or non-string', function (): void {
+    $claims = privy_claims_with([
+        ['type' => 'email'],
+        ['type' => 'email', 'address' => 123],
+        ['type' => 'email', 'address' => 'good@example.com'],
+    ]);
+
+    expect($claims->email())->toBe('good@example.com');
+});


### PR DESCRIPTION
## Summary

Mobile is switching from passkey-only signup to **email-OTP-first** with passkey as an optional device-binding upgrade. The current backend mints a placeholder email like `privy_<last16>@placeholder.zelta.app` for every Privy user, which breaks **KYC name capture, transactional emails, sanctions screening, audit trails, and Apple/Google review for fintech**. Email-OTP gives Privy a verified email up-front so we can use the real value.

**Wire-compatible**: mobile already sends `{ privy_token, name? }` and the current backend silently ignores `name` while creating placeholder records. After this PR ships, the same mobile build starts getting clean user records — no rebuild needed.

Mobile preview build for testing: `fbbe4632-88b3-4755-82f2-a2a7b062de5c` (mobile branch `feat/wallet-privy-noncustodial`, commit `7aa7fed`).

### Changes

**`PrivyClaims::email()`** — extracts the first linked-account address whose type is `email`, lowercased. Also fixes a latent bug: `JWT::decode` emits nested JSON objects as `stdClass`, not arrays, so `linked_accounts` would have thrown *"Cannot use object of type stdClass as array"* on first iteration. Round-trip through `json_encode/decode` flattens to associative arrays.

**`PrivyJwtVerifier::fetchUserEmail($privyUserId)`** — fallback for users whose JWT doesn't embed `linked_accounts`. Calls Privy's `GET /api/v1/users/{user_id}` with `PRIVY_APP_ID:PRIVY_APP_SECRET` Basic auth. Returns null on any failure.

**`LoginController::privyLogin`**:
- Accepts optional `name` (max 120 chars) for new-user creation
- Resolves `email = JWT linked email ?? Privy users API ?? null`
- **422 NO_EMAIL_LINKED** when neither path yields an email
- **409 EMAIL_ALREADY_EXISTS** if a non-Privy user already owns the email — refuses to silently link Privy to that account (account-takeover-shaped). Mobile prompts for a different email or sign-in with existing credentials.
- Drops the placeholder generation entirely
- Adds `is_new_user` to the response (`$user->wasRecentlyCreated`) so mobile doesn't infer from email format

**`php artisan privy:purge-placeholder-users`** — operator cleanup for the v7.12.0 placeholder rows. Pre-launch, easiest path is purge-and-let-people-resignup. Post-launch, replace with a backfill that pulls real emails from Privy and updates rows in place.

```bash
php artisan privy:purge-placeholder-users --dry-run
php artisan privy:purge-placeholder-users --confirm
```

### Privy dashboard task (operator)

Verify "Email" is enabled as a login method on app `cmosihy0b02t10cjsj2njiw00` so mobile's `useLoginWithEmail` works. Probably already on by default.

## Test plan
- [x] PHPStan level 8 clean (16 files in scope)
- [x] PHP CS Fixer clean
- [x] 20 tests pass (8 controller + 5 PrivyClaims unit + 7 PrivyJwtVerifier unit)
- [ ] CI green
- [ ] Mobile preview app round-trip on staging:
  - [ ] First login with email-OTP → user created with real email + name
  - [ ] Returning login → same user, `is_new_user=false`
  - [ ] No-email-linked Privy account → 422 NO_EMAIL_LINKED
  - [ ] Email collision with legacy user → 409 EMAIL_ALREADY_EXISTS
- [ ] Run `privy:purge-placeholder-users --dry-run` on prod, verify count, then `--confirm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)