### PR TITLE
feat(auth): web Privy email-OTP login (gated by MCP_WEB_PRIVY_LOGIN)

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -443,6 +443,16 @@ PRIVY_APP_ID=
 PRIVY_APP_SECRET=
 PRIVY_JWKS_URL=
 
+# Optional: override Privy REST API base URL (defaults to https://auth.privy.io).
+# Used for server-to-server email OTP via POST /api/v1/passwordless/{init,authenticate}.
+# PRIVY_API_BASE_URL=https://auth.privy.io
+
+# Web Privy email-OTP login. When true, /login renders Privy email-OTP
+# (replacing legacy email+password Jetstream) and signup happens on first
+# successful OTP. Coordinate Privy dashboard wallet auto-create config
+# with mobile dev before flipping — mobile relies on auto-create today.
+MCP_WEB_PRIVY_LOGIN=false
+
 # =============================================================================
 # POST-DEPLOYMENT
 # =============================================================================

--- a/.env.production.example
+++ b/.env.production.example
@@ -449,8 +449,16 @@ PRIVY_JWKS_URL=
 
 # Web Privy email-OTP login. When true, /login renders Privy email-OTP
 # (replacing legacy email+password Jetstream) and signup happens on first
-# successful OTP. Coordinate Privy dashboard wallet auto-create config
-# with mobile dev before flipping — mobile relies on auto-create today.
+# successful OTP.
+#
+# This flag is independent of the Privy dashboard "auto-create wallet on
+# login" setting. Flipping the dashboard auto-create OFF (to mitigate
+# Privy MAU billing on speculative web signups) requires the mobile
+# defensive ethereum.create() / solana.create() useEffect to be deployed
+# to production first — mobile commit 6a1744b on feat/wallet-privy-
+# noncustodial. Confirm with mobile dev that the build is on prod before
+# flipping the dashboard config; the MCP_WEB_PRIVY_LOGIN flag itself can
+# be toggled freely.
 MCP_WEB_PRIVY_LOGIN=false
 
 # =============================================================================

--- a/.env.zelta.example
+++ b/.env.zelta.example
@@ -531,8 +531,16 @@ PRIVY_JWKS_URL=
 
 # Web Privy email-OTP login. When true, /login renders Privy email-OTP
 # (replacing legacy email+password Jetstream) and signup happens on first
-# successful OTP. Coordinate Privy dashboard wallet auto-create config
-# with mobile dev before flipping — mobile relies on auto-create today.
+# successful OTP.
+#
+# This flag is independent of the Privy dashboard "auto-create wallet on
+# login" setting. Flipping the dashboard auto-create OFF (to mitigate
+# Privy MAU billing on speculative web signups) requires the mobile
+# defensive ethereum.create() / solana.create() useEffect to be deployed
+# to production first — mobile commit 6a1744b on feat/wallet-privy-
+# noncustodial. Confirm with mobile dev that the build is on prod before
+# flipping the dashboard config; the MCP_WEB_PRIVY_LOGIN flag itself can
+# be toggled freely.
 MCP_WEB_PRIVY_LOGIN=false
 
 # =============================================================================

--- a/.env.zelta.example
+++ b/.env.zelta.example
@@ -525,6 +525,16 @@ PRIVY_APP_ID=
 PRIVY_APP_SECRET=
 PRIVY_JWKS_URL=
 
+# Optional: override Privy REST API base URL (defaults to https://auth.privy.io).
+# Used for server-to-server email OTP via POST /api/v1/passwordless/{init,authenticate}.
+# PRIVY_API_BASE_URL=https://auth.privy.io
+
+# Web Privy email-OTP login. When true, /login renders Privy email-OTP
+# (replacing legacy email+password Jetstream) and signup happens on first
+# successful OTP. Coordinate Privy dashboard wallet auto-create config
+# with mobile dev before flipping — mobile relies on auto-create today.
+MCP_WEB_PRIVY_LOGIN=false
+
 # =============================================================================
 # POST-DEPLOYMENT
 # =============================================================================

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,7 @@ Packagist sources the three PHP packages from **split-mirror repos**, not the mo
 Non-custodial flow. Privy holds the keys (passkey-controlled smart accounts on EVM, device-bound ed25519 on Solana); the device signs every transaction. Backend never sees private key material.
 
 - Auth bridge: `POST /api/v1/auth/privy-login` — JWT verified via JWKS (firebase/php-jwt), exchanged for a Sanctum token
+- Web `/login` Privy email-OTP (gated by `MCP_WEB_PRIVY_LOGIN=true`): server-side REST proxy to `POST /api/v1/passwordless/{init,authenticate}` on `auth.privy.io`. Issues a Laravel session via `Auth::login()` and redirects to `intended()`. Replaces legacy Jetstream email+password when the flag is on. Same `User` table + `firstOrCreate(privy_user_id)` lookup as mobile, so cross-client account merging Just Works. See `app/Http/Controllers/Web/PrivyWebAuthController.php`
 - Address registration: `POST /api/v1/wallet/addresses` — mirrors EVM smart-account address across polygon/base/arbitrum/ethereum, plus one Solana ed25519 row in `blockchain_addresses`
 - Send: `POST /api/v1/wallet/transactions/prepare` returns unsigned payload, `POST /api/v1/wallet/transactions/submit` accepts the signed blob
 - Wire contract is camelCase: `quoteId`, `intentId`, `evm.ownerPasskeyCredentialId`. `Idempotency-Key` is an HTTP header, not a body field.

--- a/app/Domain/Auth/Exceptions/PrivyEmailOtpException.php
+++ b/app/Domain/Auth/Exceptions/PrivyEmailOtpException.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Auth\Exceptions;
+
+use RuntimeException;
+use Throwable;
+
+/**
+ * Thrown when the server-side Privy email-OTP REST flow fails.
+ *
+ * Mirrors the named-constructor style of PrivyJwtException so tests can
+ * assert on the specific failure mode rather than parsing message strings.
+ */
+final class PrivyEmailOtpException extends RuntimeException
+{
+    public static function misconfigured(): self
+    {
+        return new self('Privy app credentials are not configured.');
+    }
+
+    public static function transport(string $path, Throwable $previous): self
+    {
+        return new self(sprintf('Privy %s request failed (transport).', $path), 0, $previous);
+    }
+
+    public static function apiError(string $path, int $status, string $message): self
+    {
+        return new self(sprintf('Privy %s returned %d: %s', $path, $status, $message));
+    }
+
+    public static function malformedResponse(string $path, string $reason): self
+    {
+        return new self(sprintf('Privy %s response is malformed: %s', $path, $reason));
+    }
+}

--- a/app/Domain/Auth/Services/PrivyEmailOtpClient.php
+++ b/app/Domain/Auth/Services/PrivyEmailOtpClient.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Auth\Services;
+
+use App\Domain\Auth\Exceptions\PrivyEmailOtpException;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Psr7\Request as GuzzleRequest;
+use JsonException;
+
+/**
+ * Server-side wrapper for Privy's REST email-OTP endpoints.
+ *
+ * Authenticates with Basic Auth using the configured app_id + app_secret —
+ * we make these calls server-to-server so the response is authoritative
+ * without an additional JWT verification step.
+ *
+ * The mobile flow (/api/v1/auth/privy-login) takes a JWT minted by the
+ * Privy SDK on-device; this service is the parallel for the web /login
+ * surface where the OTP form is rendered by us, not by a Privy SDK.
+ */
+class PrivyEmailOtpClient
+{
+    private const SEND_CODE_PATH = '/api/v1/passwordless/init';
+
+    private const LOGIN_PATH = '/api/v1/passwordless/authenticate';
+
+    public function __construct(
+        private readonly ClientInterface $http,
+    ) {
+    }
+
+    /**
+     * Ask Privy to email an OTP to the given address.
+     *
+     * @throws PrivyEmailOtpException when Privy refuses the request (rate-limit, bad email, etc.)
+     */
+    public function sendCode(string $email): void
+    {
+        $email = strtolower(trim($email));
+        $this->call(self::SEND_CODE_PATH, [
+            'email'  => $email,
+            'method' => 'email',
+        ]);
+    }
+
+    /**
+     * Verify the OTP and return the resolved Privy user.
+     *
+     * @return array{id: string, email: string} Privy DID + linked email lower-cased
+     *
+     * @throws PrivyEmailOtpException when the code is wrong, expired, or Privy returns malformed data
+     */
+    public function loginWithCode(string $email, string $code): array
+    {
+        $email = strtolower(trim($email));
+        $code = trim($code);
+
+        $payload = $this->call(self::LOGIN_PATH, [
+            'email' => $email,
+            'code'  => $code,
+        ]);
+
+        $userId = $payload['user']['id'] ?? null;
+        if (! is_string($userId) || $userId === '') {
+            throw PrivyEmailOtpException::malformedResponse('login_with_code', 'missing user.id');
+        }
+
+        $resolvedEmail = $this->resolveEmail($payload, $email);
+
+        return ['id' => $userId, 'email' => $resolvedEmail];
+    }
+
+    /**
+     * @param  array<string, mixed> $body
+     * @return array<string, mixed>
+     *
+     * @throws PrivyEmailOtpException
+     */
+    private function call(string $path, array $body): array
+    {
+        $base = rtrim((string) config('privy.api_base_url', 'https://auth.privy.io'), '/');
+        $appId = (string) config('privy.app_id');
+        $appSecret = (string) config('privy.app_secret');
+
+        if ($appId === '' || $appSecret === '') {
+            throw PrivyEmailOtpException::misconfigured();
+        }
+
+        $request = new GuzzleRequest(
+            'POST',
+            $base . $path,
+            [
+                'Content-Type'  => 'application/json',
+                'Accept'        => 'application/json',
+                'privy-app-id'  => $appId,
+                'Authorization' => 'Basic ' . base64_encode($appId . ':' . $appSecret),
+            ],
+            (string) json_encode($body, JSON_THROW_ON_ERROR),
+        );
+
+        try {
+            $response = $this->http->send($request, ['http_errors' => false]);
+        } catch (GuzzleException $e) {
+            throw PrivyEmailOtpException::transport($path, $e);
+        }
+
+        $status = $response->getStatusCode();
+        $rawBody = (string) $response->getBody();
+
+        if ($status >= 400) {
+            $message = $this->extractErrorMessage($rawBody) ?? "Privy returned HTTP {$status}";
+            throw PrivyEmailOtpException::apiError($path, $status, $message);
+        }
+
+        if ($rawBody === '') {
+            return [];
+        }
+
+        try {
+            /** @var mixed $decoded */
+            $decoded = json_decode($rawBody, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            throw PrivyEmailOtpException::malformedResponse($path, 'response is not JSON');
+        }
+
+        if (! is_array($decoded)) {
+            throw PrivyEmailOtpException::malformedResponse($path, 'response is not a JSON object');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function resolveEmail(array $payload, string $fallback): string
+    {
+        $linked = $payload['user']['linked_accounts'] ?? null;
+        if (is_array($linked)) {
+            foreach ($linked as $account) {
+                if (! is_array($account)) {
+                    continue;
+                }
+                $type = $account['type'] ?? null;
+                $address = $account['address'] ?? null;
+                if ($type === 'email' && is_string($address) && $address !== '') {
+                    return strtolower($address);
+                }
+            }
+        }
+
+        return $fallback;
+    }
+
+    private function extractErrorMessage(string $body): ?string
+    {
+        try {
+            /** @var mixed $decoded */
+            $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return null;
+        }
+        if (! is_array($decoded)) {
+            return null;
+        }
+        $message = $decoded['error'] ?? $decoded['message'] ?? null;
+        if (is_string($message) && $message !== '') {
+            return $message;
+        }
+        if (is_array($message) && isset($message['message']) && is_string($message['message'])) {
+            return $message['message'];
+        }
+
+        return null;
+    }
+}

--- a/app/Http/Controllers/Web/PrivyWebAuthController.php
+++ b/app/Http/Controllers/Web/PrivyWebAuthController.php
@@ -104,10 +104,17 @@ final class PrivyWebAuthController extends Controller
         // Returning a 409 Conflict from a redirect form is awkward; instead we
         // surface a flash error and bounce back to /login. This is the rare
         // case where a Privy email collides with an existing non-Privy account.
+        // The mobile flow returns 409 + {error.code: EMAIL_ALREADY_EXISTS}; we
+        // mirror the same error.code in the flash session so support can
+        // diagnose tickets across both transports without copy-pasting flash
+        // strings. Mirrors the alignment ask from the mobile dev review.
         if ($user === null) {
             return redirect()
                 ->route('login')
-                ->withErrors(['email' => __('An account with this email already exists. Sign in with your existing credentials.')]);
+                ->withErrors([
+                    'email' => __('An account with this email already exists. Sign in with your existing credentials.'),
+                ])
+                ->with('error_code', 'EMAIL_ALREADY_EXISTS');
         }
 
         $this->rateLimiter->clear($throttleKey);

--- a/app/Http/Controllers/Web/PrivyWebAuthController.php
+++ b/app/Http/Controllers/Web/PrivyWebAuthController.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Web;
+
+use App\Domain\Auth\Exceptions\PrivyEmailOtpException;
+use App\Domain\Auth\Services\PrivyEmailOtpClient;
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Cache\RateLimiter;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+
+/**
+ * Web-facing Privy email-OTP login (and signup) flow.
+ *
+ * Mirrors the mobile /api/v1/auth/privy-login flow, except:
+ *  - We render the OTP form ourselves (no Privy SDK in the browser).
+ *  - We call Privy's REST API server-side with our app secret to send +
+ *    verify the code, so the response is authoritative without a
+ *    separate JWT verification step.
+ *  - On success we issue a Laravel session via Auth::login() and redirect
+ *    to ->intended('/dashboard'), so the OAuth signup-during-OAuth case
+ *    "just works" via the standard Laravel intended-URL machinery.
+ *
+ * Gated by config('privy.web_login_enabled') (env: MCP_WEB_PRIVY_LOGIN).
+ */
+final class PrivyWebAuthController extends Controller
+{
+    public function __construct(
+        private readonly PrivyEmailOtpClient $privy,
+        private readonly RateLimiter $rateLimiter,
+    ) {
+    }
+
+    /**
+     * Step 1: user submitted their email — ask Privy to send an OTP.
+     */
+    public function sendCode(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'email' => ['required', 'string', 'email:rfc', 'max:191'],
+        ]);
+        $email = strtolower((string) $validated['email']);
+
+        $throttleKey = 'privy-web-login:send:' . sha1($email . '|' . (string) $request->ip());
+        if ($this->rateLimiter->tooManyAttempts($throttleKey, 5)) {
+            return back()
+                ->withInput($request->only('email'))
+                ->withErrors(['email' => __('Too many attempts. Try again in a minute.')]);
+        }
+        $this->rateLimiter->hit($throttleKey, 60);
+
+        try {
+            $this->privy->sendCode($email);
+        } catch (PrivyEmailOtpException $e) {
+            report($e);
+
+            return back()
+                ->withInput($request->only('email'))
+                ->withErrors(['email' => __('We could not send the code right now. Please try again.')]);
+        }
+
+        return redirect()
+            ->route('login', ['email' => $email, 'step' => 'verify'])
+            ->with('status', __('We sent a 6-digit code to :email.', ['email' => $email]));
+    }
+
+    /**
+     * Step 2: user submitted the OTP — verify with Privy, log in / sign up.
+     */
+    public function verifyCode(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'email' => ['required', 'string', 'email:rfc', 'max:191'],
+            'code'  => ['required', 'string', 'min:4', 'max:12'],
+        ]);
+        $email = strtolower((string) $validated['email']);
+        $code = (string) $validated['code'];
+
+        $throttleKey = 'privy-web-login:verify:' . sha1($email . '|' . (string) $request->ip());
+        if ($this->rateLimiter->tooManyAttempts($throttleKey, 6)) {
+            return redirect()
+                ->route('login', ['email' => $email, 'step' => 'verify'])
+                ->withErrors(['code' => __('Too many attempts. Request a new code.')]);
+        }
+        $this->rateLimiter->hit($throttleKey, 600);
+
+        try {
+            $resolved = $this->privy->loginWithCode($email, $code);
+        } catch (PrivyEmailOtpException $e) {
+            report($e);
+
+            return redirect()
+                ->route('login', ['email' => $email, 'step' => 'verify'])
+                ->withErrors(['code' => __('That code did not work. Try again or request a new one.')]);
+        }
+
+        $user = $this->resolveOrCreateUser($resolved['id'], $resolved['email']);
+
+        // Returning a 409 Conflict from a redirect form is awkward; instead we
+        // surface a flash error and bounce back to /login. This is the rare
+        // case where a Privy email collides with an existing non-Privy account.
+        if ($user === null) {
+            return redirect()
+                ->route('login')
+                ->withErrors(['email' => __('An account with this email already exists. Sign in with your existing credentials.')]);
+        }
+
+        $this->rateLimiter->clear($throttleKey);
+
+        Auth::login($user, remember: true);
+        $request->session()->regenerate();
+
+        return redirect()->intended(route('dashboard'));
+    }
+
+    /**
+     * Match the mobile flow: lookup by privy_user_id; if not found and an
+     * unrelated user already owns the email, refuse (account-takeover-shaped);
+     * otherwise create. Web signup is intentionally one-step — there's no
+     * separate /register surface, the first OTP success either signs you in
+     * or signs you up depending on whether the Privy DID is known.
+     */
+    private function resolveOrCreateUser(string $privyUserId, string $email): ?User
+    {
+        $user = User::where('privy_user_id', $privyUserId)->first();
+        if ($user instanceof User) {
+            return $user;
+        }
+
+        $existing = User::where('email', $email)->first();
+        if ($existing instanceof User) {
+            return null;
+        }
+
+        return User::create([
+            'name'              => 'New User',
+            'email'             => $email,
+            'password'          => Str::random(64),
+            'email_verified_at' => now(),
+            'privy_user_id'     => $privyUserId,
+            'privy_linked_at'   => now(),
+        ]);
+    }
+}

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -33,6 +33,19 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::updateUserPasswordsUsing(UpdateUserPassword::class);
         Fortify::resetUserPasswordsUsing(ResetUserPassword::class);
 
+        // Replace Jetstream's email+password login view with our Privy
+        // email-OTP flow when the feature flag is on. The matching POST
+        // routes live in routes/web.php under the login.privy.* names.
+        // Evaluate the flag inside the closure so tests can flip the config
+        // after boot — and so a future env reload picks it up without a
+        // process restart.
+        Fortify::loginView(fn () => view(
+            (bool) config('privy.web_login_enabled', false) ? 'auth.privy-login' : 'auth.login'
+        ));
+        Fortify::registerView(fn () => view(
+            (bool) config('privy.web_login_enabled', false) ? 'auth.privy-login' : 'auth.register'
+        ));
+
         RateLimiter::for(
             'login',
             function (Request $request) {

--- a/config/privy.php
+++ b/config/privy.php
@@ -53,4 +53,30 @@ return [
     */
 
     'jwks_cache_ttl_seconds' => 3600,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Privy REST API base URL
+    |--------------------------------------------------------------------------
+    |
+    | The host for server-to-server REST calls (email OTP, user lookup, wallet
+    | provisioning). Defaults to the production endpoint.
+    |
+    */
+
+    'api_base_url' => env('PRIVY_API_BASE_URL', 'https://auth.privy.io'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Web login feature flag
+    |--------------------------------------------------------------------------
+    |
+    | When true, the public web /login surface uses Privy email-OTP via the
+    | server-side REST API. Off by default while we ramp; flip on per
+    | environment to migrate web auth off the legacy email+password Jetstream
+    | flow. No effect on the existing mobile flow at /api/v1/auth/privy-login.
+    |
+    */
+
+    'web_login_enabled' => (bool) env('MCP_WEB_PRIVY_LOGIN', false),
 ];

--- a/resources/views/auth/privy-login.blade.php
+++ b/resources/views/auth/privy-login.blade.php
@@ -1,0 +1,87 @@
+@php
+    $brand = config('brand.name', 'Zelta');
+    $step  = $step ?? request('step', 'email');
+    $email = $email ?? old('email', (string) request('email', ''));
+@endphp
+
+<x-guest-layout>
+    <x-authentication-card>
+        <x-slot name="logo">
+            <x-authentication-card-logo />
+        </x-slot>
+
+        <h1 class="text-xl font-bold mb-1">Sign in to {{ $brand }}</h1>
+        <p class="text-sm text-gray-600 dark:text-gray-300 mb-4">
+            Email-only, passwordless. New here? The same form signs you up.
+        </p>
+
+        <x-validation-errors class="mb-4" />
+
+        @session('status')
+            <div class="mb-4 font-medium text-sm text-emerald-700 dark:text-emerald-300">
+                {{ $value }}
+            </div>
+        @endsession
+
+        @if ($step === 'verify')
+            {{-- Step 2: enter the code --}}
+            <form method="POST" action="{{ route('login.privy.verify') }}">
+                @csrf
+                <input type="hidden" name="email" value="{{ $email }}">
+
+                <div>
+                    <x-label for="email-readonly" value="Email" />
+                    <x-input id="email-readonly" class="block mt-1 w-full bg-gray-50 dark:bg-gray-900" type="email"
+                             :value="$email" disabled readonly />
+                </div>
+
+                <div class="mt-4">
+                    <x-label for="code" value="6-digit code" />
+                    <x-input id="code" class="block mt-1 w-full font-mono tracking-widest text-lg"
+                             type="text" name="code" required autocomplete="one-time-code"
+                             inputmode="numeric" pattern="[0-9]*" autofocus
+                             aria-describedby="code-help" />
+                    <p id="code-help" class="text-xs text-gray-500 mt-1">Check your inbox for the code we sent to {{ $email }}.</p>
+                </div>
+
+                <div class="flex items-center justify-between mt-5">
+                    <a href="{{ route('login') }}" class="text-sm text-gray-600 dark:text-gray-400 underline hover:no-underline">
+                        Use a different email
+                    </a>
+                    <x-button>Verify and continue</x-button>
+                </div>
+            </form>
+
+            <form method="POST" action="{{ route('login.privy.send') }}" class="mt-4">
+                @csrf
+                <input type="hidden" name="email" value="{{ $email }}">
+                <button type="submit" class="text-sm text-gray-600 dark:text-gray-400 underline hover:no-underline">
+                    Resend code
+                </button>
+            </form>
+        @else
+            {{-- Step 1: enter the email --}}
+            <form method="POST" action="{{ route('login.privy.send') }}">
+                @csrf
+
+                <div>
+                    <x-label for="email" value="Email" />
+                    <x-input id="email" class="block mt-1 w-full" type="email" name="email"
+                             :value="old('email', $email)" required autofocus autocomplete="email" />
+                </div>
+
+                <div class="flex items-center justify-end mt-4">
+                    <x-button>Send code</x-button>
+                </div>
+            </form>
+        @endif
+
+        <p class="text-xs text-gray-500 mt-6 leading-relaxed">
+            By signing in you agree to {{ $brand }}'s
+            <a href="{{ route('legal.terms') }}" class="underline hover:no-underline">Terms</a>
+            and
+            <a href="{{ route('legal.privacy') }}" class="underline hover:no-underline">Privacy Policy</a>.
+            We email you a one-time code; we never ask for a password.
+        </p>
+    </x-authentication-card>
+</x-guest-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,6 +26,18 @@ Route::get('/connect', function () {
     return view('connect');
 })->name('connect');
 
+// Privy email-OTP web login (gated by MCP_WEB_PRIVY_LOGIN). The matching
+// GET /login view is registered by Fortify::loginView() in the service
+// provider when the flag is on. POST routes are always registered so the
+// URLs are stable across envs; if the feature flag is off the legacy
+// Jetstream login form continues to work and these endpoints are unused.
+Route::post('/login/privy/send', [App\Http\Controllers\Web\PrivyWebAuthController::class, 'sendCode'])
+    ->middleware('throttle:6,1')
+    ->name('login.privy.send');
+Route::post('/login/privy/verify', [App\Http\Controllers\Web\PrivyWebAuthController::class, 'verifyCode'])
+    ->middleware('throttle:10,1')
+    ->name('login.privy.verify');
+
 // WebSocket endpoint with origin validation
 Route::get('/ws', function (Request $request) {
     $origin = $request->header('Origin');

--- a/tests/Feature/Web/LoginViewToggleTest.php
+++ b/tests/Feature/Web/LoginViewToggleTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+it('still serves the legacy email+password login when the flag is off', function (): void {
+    config(['privy.web_login_enabled' => false]);
+
+    $response = $this->get(route('login'));
+    $response->assertOk()
+        // Legacy form has password field; Privy form does not
+        ->assertSee('name="password"', false);
+});
+
+it('renders the Privy view when the flag is on', function (): void {
+    config(['privy.web_login_enabled' => true]);
+
+    $response = $this->get(route('login'));
+    $response->assertOk()
+        ->assertSee('name="email"', false)
+        ->assertDontSee('name="password"', false);
+});

--- a/tests/Feature/Web/PrivyWebLoginTest.php
+++ b/tests/Feature/Web/PrivyWebLoginTest.php
@@ -128,7 +128,9 @@ it('refuses verifyCode when the email is already owned by a non-Privy account', 
     ]);
 
     $response->assertRedirect(route('login'))
-        ->assertSessionHasErrors('email');
+        ->assertSessionHasErrors('email')
+        // Mirror the mobile transport: error.code is parseable for support diagnosis.
+        ->assertSessionHas('error_code', 'EMAIL_ALREADY_EXISTS');
     $this->assertGuest();
     expect(User::where('privy_user_id', 'did:privy:tryingtotakeover')->count())->toBe(0);
 });

--- a/tests/Feature/Web/PrivyWebLoginTest.php
+++ b/tests/Feature/Web/PrivyWebLoginTest.php
@@ -9,6 +9,24 @@ use Mockery\MockInterface;
 
 uses(RefreshDatabase::class);
 
+/**
+ * Bind a Mockery mock for PrivyEmailOtpClient into the container.
+ *
+ * Using app()->instance() instead of $this->mock() so PHPStan resolves
+ * cleanly — Pest test files have no class declaration, so PHPStan sees
+ * $this as the bare PHPUnit\Framework\TestCase rather than our
+ * Tests\TestCase (where the mock() helper lives).
+ *
+ * @param  callable(MockInterface): void $configure
+ */
+function mock_privy_otp_client(callable $configure): void
+{
+    /** @var PrivyEmailOtpClient&MockInterface $mock */
+    $mock = Mockery::mock(PrivyEmailOtpClient::class);
+    $configure($mock);
+    app()->instance(PrivyEmailOtpClient::class, $mock);
+}
+
 beforeEach(function (): void {
     config([
         'privy.app_id'            => 'test-app-id',
@@ -20,7 +38,7 @@ beforeEach(function (): void {
 });
 
 it('sends an OTP and redirects to the verify step on POST /login/privy/send', function (): void {
-    $this->mock(PrivyEmailOtpClient::class, function (MockInterface $m): void {
+    mock_privy_otp_client(function (MockInterface $m): void {
         $m->shouldReceive('sendCode')->once()->with('jane@example.com');
     });
 
@@ -33,7 +51,7 @@ it('sends an OTP and redirects to the verify step on POST /login/privy/send', fu
 });
 
 it('rejects an invalid email with a validation error', function (): void {
-    $this->mock(PrivyEmailOtpClient::class, function (MockInterface $m): void {
+    mock_privy_otp_client(function (MockInterface $m): void {
         $m->shouldReceive('sendCode')->never();
     });
 
@@ -46,7 +64,7 @@ it('rejects an invalid email with a validation error', function (): void {
 });
 
 it('signs up a new user when verifyCode resolves a Privy DID with no existing record', function (): void {
-    $this->mock(PrivyEmailOtpClient::class, function (MockInterface $m): void {
+    mock_privy_otp_client(function (MockInterface $m): void {
         $m->shouldReceive('loginWithCode')
             ->once()
             ->with('jane@example.com', '123456')
@@ -74,7 +92,7 @@ it('signs in an existing Privy user without creating a duplicate row', function 
         'privy_linked_at' => now(),
     ]);
 
-    $this->mock(PrivyEmailOtpClient::class, function (MockInterface $m): void {
+    mock_privy_otp_client(function (MockInterface $m): void {
         $m->shouldReceive('loginWithCode')
             ->once()
             ->with('returning@example.com', '999999')
@@ -98,7 +116,7 @@ it('refuses verifyCode when the email is already owned by a non-Privy account', 
         'privy_user_id' => null,
     ]);
 
-    $this->mock(PrivyEmailOtpClient::class, function (MockInterface $m): void {
+    mock_privy_otp_client(function (MockInterface $m): void {
         $m->shouldReceive('loginWithCode')
             ->once()
             ->andReturn(['id' => 'did:privy:tryingtotakeover', 'email' => 'taken@example.com']);
@@ -116,7 +134,7 @@ it('refuses verifyCode when the email is already owned by a non-Privy account', 
 });
 
 it('returns to verify step with an error when the OTP code is wrong', function (): void {
-    $this->mock(PrivyEmailOtpClient::class, function (MockInterface $m): void {
+    mock_privy_otp_client(function (MockInterface $m): void {
         $m->shouldReceive('loginWithCode')
             ->once()
             ->andThrow(new App\Domain\Auth\Exceptions\PrivyEmailOtpException('Privy /api/v1/passwordless/authenticate returned 400: Invalid code'));
@@ -142,7 +160,7 @@ it('serves the Privy OTP login view at GET /login when the feature flag is on', 
 });
 
 it('preserves intended URL across the OTP flow (signup-during-OAuth)', function (): void {
-    $this->mock(PrivyEmailOtpClient::class, function (MockInterface $m): void {
+    mock_privy_otp_client(function (MockInterface $m): void {
         $m->shouldReceive('loginWithCode')
             ->once()
             ->andReturn(['id' => 'did:privy:intended', 'email' => 'i@example.com']);

--- a/tests/Feature/Web/PrivyWebLoginTest.php
+++ b/tests/Feature/Web/PrivyWebLoginTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Auth\Services\PrivyEmailOtpClient;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery\MockInterface;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    config([
+        'privy.app_id'            => 'test-app-id',
+        'privy.app_secret'        => 'test-app-secret',
+        'privy.api_base_url'      => 'https://auth.privy.io',
+        'privy.web_login_enabled' => true,
+        'cache.default'           => 'array',
+    ]);
+});
+
+it('sends an OTP and redirects to the verify step on POST /login/privy/send', function (): void {
+    $this->mock(PrivyEmailOtpClient::class, function (MockInterface $m): void {
+        $m->shouldReceive('sendCode')->once()->with('jane@example.com');
+    });
+
+    $response = $this->from(route('login'))->post(route('login.privy.send'), [
+        'email' => 'Jane@Example.COM',
+    ]);
+
+    $response->assertRedirect(route('login', ['email' => 'jane@example.com', 'step' => 'verify']))
+        ->assertSessionHas('status');
+});
+
+it('rejects an invalid email with a validation error', function (): void {
+    $this->mock(PrivyEmailOtpClient::class, function (MockInterface $m): void {
+        $m->shouldReceive('sendCode')->never();
+    });
+
+    $response = $this->from(route('login'))->post(route('login.privy.send'), [
+        'email' => 'not-an-email',
+    ]);
+
+    $response->assertRedirect(route('login'))
+        ->assertSessionHasErrors('email');
+});
+
+it('signs up a new user when verifyCode resolves a Privy DID with no existing record', function (): void {
+    $this->mock(PrivyEmailOtpClient::class, function (MockInterface $m): void {
+        $m->shouldReceive('loginWithCode')
+            ->once()
+            ->with('jane@example.com', '123456')
+            ->andReturn(['id' => 'did:privy:newuser', 'email' => 'jane@example.com']);
+    });
+
+    $response = $this->post(route('login.privy.verify'), [
+        'email' => 'jane@example.com',
+        'code'  => '123456',
+    ]);
+
+    $response->assertRedirect(); // intended() falls back to /dashboard
+    $this->assertAuthenticated();
+
+    $user = User::where('privy_user_id', 'did:privy:newuser')->firstOrFail();
+    expect($user->email)->toBe('jane@example.com')
+        ->and($user->email_verified_at)->not->toBeNull()
+        ->and($user->privy_linked_at)->not->toBeNull();
+});
+
+it('signs in an existing Privy user without creating a duplicate row', function (): void {
+    $existing = User::factory()->create([
+        'email'           => 'returning@example.com',
+        'privy_user_id'   => 'did:privy:returning',
+        'privy_linked_at' => now(),
+    ]);
+
+    $this->mock(PrivyEmailOtpClient::class, function (MockInterface $m): void {
+        $m->shouldReceive('loginWithCode')
+            ->once()
+            ->with('returning@example.com', '999999')
+            ->andReturn(['id' => 'did:privy:returning', 'email' => 'returning@example.com']);
+    });
+
+    $response = $this->post(route('login.privy.verify'), [
+        'email' => 'returning@example.com',
+        'code'  => '999999',
+    ]);
+
+    $response->assertRedirect();
+    $this->assertAuthenticated();
+    expect(User::where('privy_user_id', 'did:privy:returning')->count())->toBe(1);
+    expect(auth()->id())->toBe($existing->id);
+});
+
+it('refuses verifyCode when the email is already owned by a non-Privy account', function (): void {
+    User::factory()->create([
+        'email'         => 'taken@example.com',
+        'privy_user_id' => null,
+    ]);
+
+    $this->mock(PrivyEmailOtpClient::class, function (MockInterface $m): void {
+        $m->shouldReceive('loginWithCode')
+            ->once()
+            ->andReturn(['id' => 'did:privy:tryingtotakeover', 'email' => 'taken@example.com']);
+    });
+
+    $response = $this->post(route('login.privy.verify'), [
+        'email' => 'taken@example.com',
+        'code'  => '654321',
+    ]);
+
+    $response->assertRedirect(route('login'))
+        ->assertSessionHasErrors('email');
+    $this->assertGuest();
+    expect(User::where('privy_user_id', 'did:privy:tryingtotakeover')->count())->toBe(0);
+});
+
+it('returns to verify step with an error when the OTP code is wrong', function (): void {
+    $this->mock(PrivyEmailOtpClient::class, function (MockInterface $m): void {
+        $m->shouldReceive('loginWithCode')
+            ->once()
+            ->andThrow(new App\Domain\Auth\Exceptions\PrivyEmailOtpException('Privy /api/v1/passwordless/authenticate returned 400: Invalid code'));
+    });
+
+    $response = $this->post(route('login.privy.verify'), [
+        'email' => 'jane@example.com',
+        'code'  => '000000',
+    ]);
+
+    $response->assertRedirect(route('login', ['email' => 'jane@example.com', 'step' => 'verify']))
+        ->assertSessionHasErrors('code');
+    $this->assertGuest();
+});
+
+it('serves the Privy OTP login view at GET /login when the feature flag is on', function (): void {
+    $response = $this->get(route('login'));
+
+    $response->assertOk()
+        ->assertSee('Sign in to')
+        ->assertSee('Send code')
+        ->assertSeeText('Email-only, passwordless');
+});
+
+it('preserves intended URL across the OTP flow (signup-during-OAuth)', function (): void {
+    $this->mock(PrivyEmailOtpClient::class, function (MockInterface $m): void {
+        $m->shouldReceive('loginWithCode')
+            ->once()
+            ->andReturn(['id' => 'did:privy:intended', 'email' => 'i@example.com']);
+    });
+
+    // Simulate the OAuth-authorize path setting an intended URL before login.
+    $this->withSession(['url.intended' => 'https://zelta.test/oauth/authorize?client_id=abc']);
+
+    $response = $this->post(route('login.privy.verify'), [
+        'email' => 'i@example.com',
+        'code'  => '111111',
+    ]);
+
+    $response->assertRedirect('https://zelta.test/oauth/authorize?client_id=abc');
+    $this->assertAuthenticated();
+});

--- a/tests/Unit/Domain/Auth/Services/PrivyEmailOtpClientTest.php
+++ b/tests/Unit/Domain/Auth/Services/PrivyEmailOtpClientTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Auth\Exceptions\PrivyEmailOtpException;
+use App\Domain\Auth\Services\PrivyEmailOtpClient;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7\Response as PsrResponse;
+use Mockery\MockInterface;
+use Psr\Http\Message\RequestInterface;
+
+uses(Tests\TestCase::class);
+
+beforeEach(function (): void {
+    config([
+        'privy.app_id'       => 'test-app-id',
+        'privy.app_secret'   => 'test-app-secret',
+        'privy.api_base_url' => 'https://auth.privy.io',
+    ]);
+});
+
+it('sends email + method on sendCode and includes Basic Auth + privy-app-id headers', function (): void {
+    /** @var ClientInterface&MockInterface $http */
+    $http = Mockery::mock(ClientInterface::class);
+    /** @var Mockery\Expectation $expect */
+    $expect = $http->shouldReceive('send');
+    $expect->once()->andReturnUsing(function (RequestInterface $request) {
+        expect($request->getMethod())->toBe('POST');
+        expect((string) $request->getUri())->toBe('https://auth.privy.io/api/v1/passwordless/init');
+        expect($request->getHeaderLine('privy-app-id'))->toBe('test-app-id');
+        expect($request->getHeaderLine('Authorization'))->toBe('Basic ' . base64_encode('test-app-id:test-app-secret'));
+        $body = json_decode((string) $request->getBody(), true);
+        expect($body)->toBe(['email' => 'jane@example.com', 'method' => 'email']);
+
+        return new PsrResponse(200, [], '{"success":true}');
+    });
+
+    $client = new PrivyEmailOtpClient($http);
+    $client->sendCode('Jane@Example.COM');
+});
+
+it('returns Privy user id + linked email on loginWithCode', function (): void {
+    /** @var ClientInterface&MockInterface $http */
+    $http = Mockery::mock(ClientInterface::class);
+    /** @var Mockery\Expectation $expect */
+    $expect = $http->shouldReceive('send');
+    $expect->once()->andReturn(new PsrResponse(200, [], (string) json_encode([
+        'user' => [
+            'id'              => 'did:privy:test123',
+            'linked_accounts' => [
+                ['type' => 'wallet', 'address' => '0xabc'],
+                ['type' => 'email', 'address' => 'Jane@Example.COM'],
+            ],
+        ],
+    ])));
+
+    $client = new PrivyEmailOtpClient($http);
+    $resolved = $client->loginWithCode('jane@example.com', '123456');
+
+    expect($resolved)->toBe([
+        'id'    => 'did:privy:test123',
+        'email' => 'jane@example.com',
+    ]);
+});
+
+it('falls back to the input email when linked_accounts has no email entry', function (): void {
+    /** @var ClientInterface&MockInterface $http */
+    $http = Mockery::mock(ClientInterface::class);
+    /** @var Mockery\Expectation $expect */
+    $expect = $http->shouldReceive('send');
+    $expect->once()->andReturn(new PsrResponse(200, [], (string) json_encode([
+        'user' => ['id' => 'did:privy:noemail'],
+    ])));
+
+    $client = new PrivyEmailOtpClient($http);
+    $resolved = $client->loginWithCode('jane@example.com', '123456');
+
+    expect($resolved['email'])->toBe('jane@example.com');
+    expect($resolved['id'])->toBe('did:privy:noemail');
+});
+
+it('throws apiError with the upstream message on a 4xx response', function (): void {
+    /** @var ClientInterface&MockInterface $http */
+    $http = Mockery::mock(ClientInterface::class);
+    /** @var Mockery\Expectation $expect */
+    $expect = $http->shouldReceive('send');
+    $expect->once()->andReturn(new PsrResponse(400, [], (string) json_encode(['error' => 'Invalid email address'])));
+
+    $client = new PrivyEmailOtpClient($http);
+    expect(fn () => $client->sendCode('bad'))->toThrow(PrivyEmailOtpException::class, 'Invalid email address');
+});
+
+it('throws malformedResponse when login response has no user.id', function (): void {
+    /** @var ClientInterface&MockInterface $http */
+    $http = Mockery::mock(ClientInterface::class);
+    /** @var Mockery\Expectation $expect */
+    $expect = $http->shouldReceive('send');
+    $expect->once()->andReturn(new PsrResponse(200, [], (string) json_encode(['user' => []])));
+
+    $client = new PrivyEmailOtpClient($http);
+    expect(fn () => $client->loginWithCode('jane@example.com', '123456'))
+        ->toThrow(PrivyEmailOtpException::class, 'missing user.id');
+});
+
+it('throws misconfigured when app_id or app_secret is empty', function (): void {
+    config(['privy.app_id' => '', 'privy.app_secret' => '']);
+
+    /** @var ClientInterface&MockInterface $http */
+    $http = Mockery::mock(ClientInterface::class);
+    $http->shouldReceive('send')->never();
+
+    $client = new PrivyEmailOtpClient($http);
+    expect(fn () => $client->sendCode('jane@example.com'))->toThrow(PrivyEmailOtpException::class, 'credentials');
+});


### PR DESCRIPTION
## Summary

Closes the gap that blocked MCP-onboarded web users from getting Privy keys. With this PR, a fresh user signing in on the web from a Claude Connectors Directory click goes through the same Privy email-OTP flow that mobile already uses, lands in the same `User` row, and gets a Privy DID that mobile can later attach a wallet to.

This is the third PR in the MCP onboarding series:
- **#1021** (merged) — public-directory submission manifests + tool annotations
- **#1022** (open) — demo marketing additions on finaegis.org
- **#1023** (open) — production landing MCP section + `/connect` page
- **This PR** — web Privy email-OTP login (replaces legacy email+password Jetstream when flag is on)

## Architecture

**Server-side REST proxy, no Privy SDK in the browser.** The Privy app secret stays server-side; we render the OTP form ourselves in ordinary Blade. Two POSTs to Privy's `/api/v1/passwordless/{init,authenticate}` with HTTP Basic Auth + `privy-app-id` header. The authenticate response is authoritative since we made the call with our credentials, so no separate JWT verification step is needed.

**Same `User` table + same `firstOrCreate(privy_user_id)` lookup as mobile.** Cross-client account merging works:

- Web-first then mobile-later: mobile's `/api/v1/auth/privy-login` finds the existing row by DID, returns `wasRecentlyCreated: false`, mobile reports `is_new_user: false`, no duplicate created.
- Mobile-first then web-later: same code path, web finds the existing row by DID and signs in.
- Email collision with an existing non-Privy account is refused (account-takeover-shaped, mirrors mobile's behavior).

Mobile dev has confirmed `firstOrCreate(privy_user_id)` is robust to all three scenarios.

**On success:** `Auth::login($user, remember: true)`, session regenerate, `redirect()->intended(route('dashboard'))`. So when an unauthenticated user hits `/oauth/authorize`, gets bounced to `/login`, and completes Privy OTP, they land back on the OAuth consent screen with a fresh authenticated session — signup-during-OAuth Just Works via Laravel's standard intended-URL machinery.

## What's in the box

| File | Purpose |
|---|---|
| `app/Domain/Auth/Services/PrivyEmailOtpClient.php` | Guzzle wrapper around Privy's REST email-OTP endpoints. Server-to-server, Basic Auth |
| `app/Domain/Auth/Exceptions/PrivyEmailOtpException.php` | Named-constructor exception (mirrors `PrivyJwtException`) |
| `app/Http/Controllers/Web/PrivyWebAuthController.php` | `sendCode` + `verifyCode` actions, per-IP+email rate limiting (5 send / 6 verify per minute), no separate `/register` surface |
| `resources/views/auth/privy-login.blade.php` | Two-stage Jetstream-styled OTP form: email step → code step via `?step=verify&email=…` query |
| `app/Providers/FortifyServiceProvider.php` | `Fortify::loginView()` + `registerView()` now switch between legacy and Privy views inside the closure (closure-time, not boot-time, so runtime config flips take effect without process restart) |
| `routes/web.php` | `POST /login/privy/{send,verify}` (always registered for URL stability) |
| `config/privy.php` | New `api_base_url` + `web_login_enabled` |
| `.env.production.example`, `.env.zelta.example` | New `MCP_WEB_PRIVY_LOGIN=false` default |
| `CLAUDE.md` | Documents the web-side flow alongside the existing mobile mention |

## Tests

16 tests, all green:

- `tests/Unit/Domain/Auth/Services/PrivyEmailOtpClientTest.php` — 6 unit tests: request shape, headers (Basic Auth + `privy-app-id`), response parsing, email fallback, error mapping, misconfigured guard
- `tests/Feature/Web/PrivyWebLoginTest.php` — 8 feature tests: happy-path send + verify, signup vs returning user, email-collision refusal (409-shaped), OTP failure flash, intended-URL preservation (signup-during-OAuth), validation errors
- `tests/Feature/Web/LoginViewToggleTest.php` — 2 tests confirming legacy view renders when flag off, Privy view replaces it when on

## Operational notes

- **`MCP_WEB_PRIVY_LOGIN` defaults to `false`.** This PR ships dormant. Flip per-environment when ready.
- **Coordinate with mobile dev before flipping on production.** Mobile currently relies on Privy dashboard "auto-create wallet on login" being on. Mobile dev is shipping a defensive `ethereum.create()` `useEffect` on `feat/wallet-privy-noncustodial`; that lands first, then we can consider flipping auto-create off in the Privy dashboard if speculative web signups inflate the MAU bill. **Auto-create stays on for now.**
- **No changes to `/api/v1/auth/privy-login`** — mobile path is untouched.

## Test plan

- [x] `tests/Unit/Domain/Auth/Services/PrivyEmailOtpClientTest.php` — 6/6 pass
- [x] `tests/Feature/Web/PrivyWebLoginTest.php` — 8/8 pass
- [x] `tests/Feature/Web/LoginViewToggleTest.php` — 2/2 pass
- [x] Smoke: homepage still renders 200 (legacy view served when flag off)
- [x] PHPStan clean
- [x] php-cs-fixer clean
- [ ] CI green
- [ ] Manual flow on staging with real Privy app: enable `MCP_WEB_PRIVY_LOGIN=true`, request OTP at `/login`, complete signup, verify session created and intended-URL works
- [ ] Manual flow on staging: `/oauth/authorize` → bounce to `/login` → OTP → bounce back to consent → token issued

🤖 Generated with [Claude Code](https://claude.com/claude-code)