### PR TITLE
docs(mcp): logo asset, Linear ticket draft, push-approval design doc

### DIFF
--- a/docs/operations/linear-ticket-connected-ai-agents.md
+++ b/docs/operations/linear-ticket-connected-ai-agents.md
@@ -1,0 +1,113 @@
+# Linear ticket draft: Connected AI agents screen
+
+Copy-paste this into Linear when ready to scope. Title as `[wallet] Connected AI agents — list, view, revoke MCP grants`.
+
+---
+
+## Context
+
+We shipped the public MCP server in v7.11 and the web Privy email-OTP login in v7.12. Users now sign up on web from a Claude Connectors Directory click and authorize Claude/Cursor/Continue.dev/etc. to act on their wallet via OAuth scopes with per-token spending limits.
+
+Today there is no UI for managing those grants. Users cannot see which AI clients they've authorized, what scopes each has, or revoke them — that's a gap in trust posture (the Google Account "connected apps" pattern is what users expect from any OAuth-issuing platform) and a regulatory gap (GDPR-style data-subject control over third-party access).
+
+This ticket adds:
+
+1. A backend list/revoke endpoint exposing per-grant metadata
+2. A mobile "Connections" screen surfacing those grants with a revoke button
+3. (Future, separate ticket) the same UI on web
+
+## Backend
+
+### `GET /api/v1/grants`
+
+Lists active grants for the authenticated user. Active = not revoked, not expired.
+
+**Request:** Sanctum-authenticated, `read` scope.
+
+**Query:** `?include_revoked=1` to also return revoked grants for audit.
+
+**Response:**
+
+```json
+{
+  "data": [
+    {
+      "id": "01HXYZ...",
+      "client_name": "Claude Desktop",
+      "client_id": "client_abc123",
+      "scopes": ["accounts:read", "payments:write", "transactions:read"],
+      "spending_limit": {
+        "daily_minor": 50000,
+        "currency": "USD"
+      },
+      "spending_used_today_minor": 12345,
+      "issued_at": "2026-05-01T12:00:00Z",
+      "last_used_at": "2026-05-07T08:30:00Z",
+      "expires_at": null
+    }
+  ]
+}
+```
+
+Fields:
+
+- `id` — grant uuid (from `oauth_access_tokens.id`)
+- `client_name` — display name set during DCR registration; reserved-name policy from `config('mcp.dcr.reserved_name_substrings')` already prevents brand spoofing
+- `client_id` — for support diagnosis only; not displayed in mobile UI
+- `scopes` — array of scope strings from `config('mcp.scopes')`
+- `spending_limit` — null if no limit; else `{daily_minor: int, currency: string}`
+- `spending_used_today_minor` — resets at user-local midnight (see Timezone section)
+- `issued_at` / `last_used_at` / `expires_at` — ISO8601 strings; `last_used_at` null if never invoked
+- `is_revoked` field is intentionally omitted from default list response (filter applied server-side)
+
+### `DELETE /api/v1/grants/{id}`
+
+Revoke a grant. Deletes the `oauth_access_token` row, invalidates any refresh token bound to it, writes an audit log entry. Idempotent — a revoke on an already-revoked grant returns 204.
+
+**Request:** Sanctum-authenticated, `delete` scope, owns the grant.
+
+**Response:** `204 No Content` on success, `404` if not found / not owned.
+
+### Backing data
+
+- Source: `oauth_access_tokens` (Passport)
+- New table: `mcp_grant_metadata` — projection sourcing `client_name`, daily spend, `last_used_at`. Updated by the existing `ToolInvocationLogger` / `SpendingEnforcedToolCallSaga`.
+- Migration to add the table + a backfill projector for existing tokens (small data set today, reasonable to backfill in one pass).
+
+### Timezone
+
+Mobile + web both need to display a "spending resets at midnight" hint that matches the server-enforced reset. Two pieces:
+
+1. **`users.timezone`** column (IANA tz name, default `UTC`). New migration. Settable from the Profile screen on mobile.
+2. **Mobile login plumbing**: `/api/v1/auth/privy-login` accepts an optional `timezone` field in the request body (`Intl.DateTimeFormat().resolvedOptions().timeZone`). Server stores it on `users.timezone` if missing or different. Backwards-compat: missing field is a no-op.
+3. **Server-enforced reset**: `SpendingEnforcedToolCallSaga`'s daily reset uses `users.timezone` for the boundary computation rather than UTC.
+
+## Mobile
+
+- Path: `app/(profile)/connections.tsx` — naming chosen to avoid collision with existing `app/flows/agents/` (which is the user's own Virtuals AI agents that spend on their behalf via x402). "Connections" is the third-party-app metaphor users already understand from Google/Apple ID.
+- Service: `src/services/grants.ts` — `listGrants()`, `revokeGrant(id)`. Uses existing API client.
+- Type stubs: mobile dev pre-stubs based on this ticket; types are dead code until the screen ships.
+- UI: list of cards per grant. Each card shows `client_name`, scopes (chips), `spending_used_today_minor` / `spending_limit.daily_minor` as a progress bar with reset countdown, last-used relative time. Tap to expand for full detail + revoke button.
+- Revoke confirmation: native modal "Revoke access for Claude Desktop? It will need to authorize again to continue." Two buttons. Optimistic update (remove from list immediately, refetch on error).
+- Empty state: "No connected AI assistants yet" with a link to `/connect` on the web.
+
+## Web
+
+Out of scope for this ticket. Web equivalent ships in a follow-up — same data, different UI tree.
+
+## Acceptance criteria
+
+- [ ] `GET /api/v1/grants` returns active grants only by default; `?include_revoked=1` includes revoked
+- [ ] `DELETE /api/v1/grants/{id}` revokes the grant + invalidates refresh tokens + writes audit entry; idempotent
+- [ ] `mcp_grant_metadata` table populated for existing tokens via backfill projector
+- [ ] `users.timezone` column added; mobile sends device tz on `/api/v1/auth/privy-login`; server stores it
+- [ ] `SpendingEnforcedToolCallSaga` daily reset uses `users.timezone` not UTC
+- [ ] Mobile `(profile)/connections.tsx` lists grants, supports revoke, shows spend + reset countdown
+- [ ] Tests: feature tests on the two endpoints + a unit test for the timezone-aware spending reset
+
+## Non-goals
+
+- Per-grant transaction history (separate ticket if it ships)
+- Web UI (separate ticket)
+- Granting new permissions retroactively (always done via fresh OAuth flow)
+- Push approval for high-value MCP — see the design doc at `docs/superpowers/specs/2026-05-08-mcp-push-approval.md`

--- a/docs/superpowers/specs/2026-05-08-mcp-connected-agents-screen.md
+++ b/docs/superpowers/specs/2026-05-08-mcp-connected-agents-screen.md
@@ -1,8 +1,6 @@
-# Linear ticket draft: Connected AI agents screen
+# Spec: Connected AI agents screen
 
-Copy-paste this into Linear when ready to scope. Title as `[wallet] Connected AI agents — list, view, revoke MCP grants`.
-
----
+**Status:** Ready for implementation. Draft scoped to backend + mobile work; web UI is a follow-up.
 
 ## Context
 

--- a/docs/superpowers/specs/2026-05-08-mcp-push-approval-design.md
+++ b/docs/superpowers/specs/2026-05-08-mcp-push-approval-design.md
@@ -1,0 +1,254 @@
+# High-value MCP push approval — design
+
+**Status:** Draft for review with mobile dev. Loose answers from PR #1024 review thread are folded in.
+
+**Goal:** When a Claude/Cursor/etc. agent connected to Zelta via MCP attempts a write tool whose financial impact crosses a threshold, hold the operation, push a confirmation request to the user's mobile app, and resume only after the user biometric-approves it. Reject after a configurable window, returning a deterministic terminal state to the agent.
+
+**Non-goal:** Replacing the existing per-token spending limit. The spending limit is the *static* contract set on consent ("this agent can move at most $500/day"). Push approval is the *dynamic* gate ("any single move ≥$50 needs a fresh tap"). Both apply.
+
+## Why now
+
+We launched public MCP in v7.11 and web Privy login in v7.12. Token grants live indefinitely until revoked, so an agent that gets compromised between sessions can drain up to the daily spending cap before the user notices. Push approval converts the worst case from "lose the daily cap" to "ignore one push and lose nothing." Strong trust signal at the v7.13 marketing surface.
+
+## Threshold model
+
+Three layers, applied in order. First match wins.
+
+1. **Per-grant override** (highest priority) — when the user issues consent for a new client, the OAuth consent screen offers an "approval threshold" slider with options `none`, `$10`, `$50`, `$200`, `$1000`, custom. Default `$50`. Stored on `oauth_access_tokens.approval_threshold_minor` (new column).
+2. **Per-tool override** — `config('mcp.tools.<name>.approval_threshold_minor')`. For tools where a higher floor makes sense (e.g. `payment.transfer` defaults to `$50`, `exchange.trade` defaults to `$200` because exchange is rarely used for small amounts). Empty if no override.
+3. **System default** — `config('mcp.spending.default_approval_threshold_minor', 5000)` (= $50). Floor for any tool not otherwise specified.
+
+Reuse the X402 spending-limit table shape — the schema already has `daily_minor` + `per_tx_minor` slots; we add a third column `approval_threshold_minor`. Migration is small.
+
+## Hold-and-notify protocol
+
+`202 + Retry-After` polling, NOT streaming. Reasons:
+
+- **Streaming exhausts a PHP-FPM worker per pending approval.** Mobile dev's call window is "a few seconds to several minutes" (Doze, push delivery, user opening modal). Holding workers that long under any meaningful concurrency exhausts our pool.
+- **Polling gives idempotency for free.** The agent's retry within the polling window resolves to the same approval state via the in-flight idempotency lock we already use.
+- **Polling matches the X402 pattern.** Mobile already has a `X402PaymentModal` UX; the approval flow is shaped the same.
+
+### Sequence
+
+```
+agent              backend                  mobile
+  |                   |                       |
+  |-- tools/call ---->|                       |
+  |   payment.transfer|                       |
+  |   amount=200      |                       |
+  |                   |--- evaluate threshold |
+  |                   |--- create approval row|
+  |                   |--- push to mobile --->|
+  |                   |                       |--- biometric
+  |<-- 202 Accepted --|                       |    sheet
+  |   Retry-After: 5  |                       |
+  |   approval_id:..  |                       |
+  |                   |                       |
+  |--- tools/call --->|                       |
+  |   (same idempot.  |                       |
+  |    key)           |                       |
+  |<-- 202 Accepted --|                       |
+  |   Retry-After: 5  |                       |
+  |                   |                       |
+  |                   |<-- POST approval ---  |
+  |                   |    biometric attest.  |
+  |                   |--- resume saga        |
+  |                   |--- execute tool       |
+  |                   |--- audit log          |
+  |                   |                       |
+  |--- tools/call --->|                       |
+  |<-- 200 result ---|                       |
+```
+
+### MCP wire shape
+
+When a tool call hits the threshold:
+
+```json
+HTTP/1.1 202 Accepted
+Retry-After: 5
+
+{
+  "jsonrpc": "2.0",
+  "id": <client_request_id>,
+  "result": {
+    "_meta": {
+      "approval_status": "pending",
+      "approval_id": "01HXYZ...",
+      "approval_expires_at": "2026-05-08T12:05:00Z"
+    }
+  }
+}
+```
+
+Subsequent polls with the same idempotency key:
+
+- Still pending → same 202 shape
+- Approved → real tool result, 200, idempotency key locks the result
+- Rejected → MCP error code (see below)
+- Timed out → MCP error code
+
+## Mobile push payload
+
+```json
+{
+  "type": "mcp_approval_required",
+  "approval_id": "01HXYZ...",
+  "client_name": "Claude Desktop",
+  "tool_name": "payment.transfer",
+  "summary": "Send $200.00 to Alex's account",
+  "amount_minor": 20000,
+  "currency": "USD",
+  "expires_at": "2026-05-08T12:05:00Z",
+  "deep_link": "zelta://approvals/01HXYZ..."
+}
+```
+
+**Push priority:** `priority: high` on the FCM payload. Android Doze can delay non-priority pushes by minutes — for a 5-minute approval window that's catastrophic. Mobile dev confirmed `priority: high` is the right call.
+
+**Other push categories** (balance changed, transaction received, etc.) stay at `priority: normal` so the elevated priority remains a signal rather than the default.
+
+## Mobile UX
+
+`useApprovalQueue` hook (state outlives modal mount lifecycle) → `<X402PaymentModal>` component reused for the sheet UI:
+
+- Approval state lives in a global Zustand-style store, populated by FCM push handler and WebSocket fallback (existing infra).
+- Pushes that arrive while another modal is open enqueue a new approval. Badge on the modal header: "2 approvals waiting" (FIFO order, newest grays out behind).
+- User taps approve → biometric prompt → POST `/api/v1/grants/{grant_id}/approvals/{approval_id}` with `{decision: "approve", biometric_attestation: <signed token>, idempotency_key}`.
+- User taps reject → POST same endpoint with `{decision: "reject"}`.
+- Modal swipe-to-dismiss does NOT auto-reject; it just closes the modal. The approval stays in the queue (and in the dedicated `/approvals` list reachable from the home screen).
+
+## Stale push handling
+
+Auto-reject after **5 minutes** by default (configurable per-tool via `config('mcp.tools.<name>.approval_timeout_seconds')`).
+
+Why 5 minutes:
+
+- Long enough to cover Android Doze (typically 1-3 min, sometimes longer)
+- Long enough for the user to see, switch apps, biometric-auth
+- Short enough that the agent doesn't hold a turn for a meaningfully long time
+- Matches typical OS-level push-notification visibility windows
+
+After timeout, the approval row's status flips to `timed_out` server-side. Subsequent polls return the timeout error code.
+
+## Error code reference
+
+| Code | HTTP | Meaning | Agent-facing message |
+|---|---|---|---|
+| (no error) | 200 | Approved + tool executed | (tool result) |
+| `MCP_APPROVAL_PENDING` | 202 | Awaiting user response | Retry-After polling |
+| `MCP_USER_REJECTED` | 403 | User explicitly rejected | "User declined this action." |
+| `MCP_USER_TIMEOUT` | 408 | Approval window expired | "User did not respond in time. Try again or use a smaller amount." |
+| `MCP_APPROVAL_INVALIDATED` | 410 | Grant revoked while approval pending | "Authorization was revoked." |
+
+`MCP_USER_REJECTED` and `MCP_USER_TIMEOUT` are deliberately distinct — the agent's response to "user said no" is different from "user is unreachable." Telemetry on the rate of each is a quality signal for the threshold tuning.
+
+## Server-side data model
+
+New tables:
+
+```sql
+CREATE TABLE mcp_approval_requests (
+    id CHAR(26) PRIMARY KEY,                       -- ULID
+    user_id BIGINT NOT NULL,
+    grant_id CHAR(36) NOT NULL,                    -- oauth_access_tokens.id
+    tool_name VARCHAR(64) NOT NULL,
+    idempotency_key VARCHAR(64) NOT NULL,
+    amount_minor BIGINT NOT NULL,
+    currency CHAR(3) NOT NULL,
+    summary TEXT NOT NULL,                          -- denormalized human-readable summary
+    status ENUM('pending', 'approved', 'rejected', 'timed_out', 'invalidated') DEFAULT 'pending',
+    created_at TIMESTAMP NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    decided_at TIMESTAMP NULL,
+    decided_via ENUM('biometric_modal', 'auto_timeout', 'grant_revoked') NULL,
+    INDEX idx_user_status (user_id, status),
+    INDEX idx_expires_at (expires_at),              -- for the auto-timeout sweep
+    UNIQUE KEY idempotency_key (grant_id, idempotency_key)
+);
+```
+
+Plus the new column on `oauth_access_tokens`:
+
+```sql
+ALTER TABLE oauth_access_tokens
+    ADD COLUMN approval_threshold_minor BIGINT NULL DEFAULT NULL;
+```
+
+`null` = use per-tool / system default; explicit value overrides (including `0` = always require, `INT_MAX` = never).
+
+## Auto-timeout sweep
+
+Cron at `*/1 * * * *`: `UPDATE mcp_approval_requests SET status='timed_out' WHERE status='pending' AND expires_at < NOW()`. Cheap; index on `expires_at`.
+
+## Idempotency interaction
+
+The MCP saga's existing idempotency lock (`SpendingEnforcedToolCallSaga::handle()`) coordinates approval lookup. On the first call:
+
+1. Acquire idempotency lock
+2. Evaluate threshold → triggers approval flow
+3. Insert `mcp_approval_requests` row, send push
+4. Return 202 + approval_id
+5. Hold lock until approval terminal status
+
+On subsequent polls (same idempotency key):
+
+1. Lock is held → look up approval row by `(grant_id, idempotency_key)`
+2. Pending → return 202
+3. Approved → resume saga, execute tool, return 200, release lock
+4. Rejected/timed_out/invalidated → return error code, release lock
+
+The 202 + Retry-After polling means the lock-hold time is bounded by `expires_at + tool execution`. With a 5-min approval window + sub-second tool execution, lock-holds are reasonable.
+
+## Spending-limit interaction
+
+Approval is in addition to the spending limit. Order of checks in the saga:
+
+1. **Spending limit** check (existing) — `daily_minor` + `per_tx_minor`. Reject with `MCP_SPENDING_LIMIT_EXCEEDED` if exceeded.
+2. **Approval threshold** check (new) — if `amount >= threshold`, hold for approval.
+3. Tool execution.
+
+The reservation made by the spending-limit check is held during approval. If the user rejects, the reservation is released. If the user times out, same — reservation released.
+
+## Telemetry
+
+Add to existing `ToolInvocationLogger`:
+
+- `approval_required` boolean
+- `approval_decided_via` (biometric_modal / auto_timeout / grant_revoked / null if not approval-gated)
+- `approval_decision_latency_ms`
+
+Dashboards (Grafana):
+
+- Approval rate by tool / amount bucket
+- Time-to-decide percentiles (p50 / p95 / p99)
+- Timeout rate (high timeout rate signals the threshold is too low)
+
+## Rollout
+
+Behind feature flag `MCP_PUSH_APPROVAL_ENABLED` (default false). Phases:
+
+1. Ship with flag off; tables migrated; approval logic dormant.
+2. Internal smoke test: enable for staff users only via a per-user override.
+3. Open beta: enable for all users with `approval_threshold_minor` defaulting to `null` (no threshold) — users opt in via Profile → Connections settings.
+4. General availability: flip default threshold to `$50` for new grants. Existing grants keep `null` (no threshold) until user opts in.
+
+## Open questions for review
+
+- **Threshold UI on consent screen:** slider vs three-tier picker (none/standard/strict)? Picker is less powerful but harder to misset.
+- **Push category permission:** the OS-level "do you allow notifications" prompt is one toggle. We can't separately gate "balance updates" vs "approval requests." If a user has push off, fall back to WebSocket (works on app-open, doesn't work background) — and if neither delivers within `expires_at`, auto-reject. Mobile dev: confirm WebSocket fallback in foreground is wired.
+- **Concurrent-request edge case:** Claude calls 5 tools in parallel, all over threshold. Mobile shows 5 modals (FIFO queue). Is there a UX where the user batches them ("approve all 5")? Probably out of scope for v1.
+- **Web UI for approvals:** if the user is on web at the time of the request, do we route the approval to web (in-page modal) instead of mobile push? Cleaner UX but doubles the build cost. Probably v2.
+
+## Build sequence
+
+1. Migrations + threshold model + saga changes
+2. Feature flag + dormant code path
+3. Push delivery + auto-timeout sweep
+4. Mobile `useApprovalQueue` + reuse `X402PaymentModal`
+5. Approval submission endpoint + biometric attestation verification
+6. Telemetry + Grafana dashboard
+7. Internal smoke test
+8. Open beta
+
+Estimated 2 sprints with one engineer + mobile dev support.

--- a/resources/img/zelta-logo.svg
+++ b/resources/img/zelta-logo.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="none" role="img" aria-label="Zelta">
+  <title>Zelta</title>
+  <!-- Brutalist drop shadow -->
+  <rect x="40" y="40" width="448" height="448" rx="96" fill="#0a0a0a"/>
+  <!-- Mint card -->
+  <rect x="16" y="16" width="448" height="448" rx="96" fill="#a8f0c4" stroke="#0a0a0a" stroke-width="24"/>
+  <!-- Letter Z (brutalist, slab) -->
+  <path d="M132 132h216v68L218 348h130v68H132v-68l130-148H132z" fill="#0a0a0a"/>
+</svg>


### PR DESCRIPTION
## Summary

Three artifacts that close out the operational follow-ups from the MCP onboarding chain (#1021–#1024):

### `resources/img/zelta-logo.svg`

Brutalist mint-card mark with an offset black drop-shadow + bold "Z". Matches the visual language of `app.blade.php` and `connect.blade.php`. Goes in the Anthropic Connectors Directory submission as the server logo / favicon. Renders cleanly from 16px favicon up to multi-MB billboard scale (pure SVG geometry, no rasterized assets).

### `docs/operations/linear-ticket-connected-ai-agents.md`

Copy-paste draft for the Linear ticket that adds `GET /api/v1/grants` + `DELETE /api/v1/grants/{id}` + the mobile `(profile)/connections.tsx` screen. Folds in all three of mobile dev's review notes:

- Filter `is_revoked` from default list response (`?include_revoked=1` for audit)
- `users.timezone` column + device-tz plumbing through `/api/v1/auth/privy-login` so the displayed and enforced "midnight" matches
- ISO8601 timestamp granularity stays at seconds; per-grant transaction history is its own future ticket

Mobile path uses `(profile)/connections.tsx` (avoiding the naming collision with `app/flows/agents/` which is for Virtuals AI agents).

### `docs/superpowers/specs/2026-05-08-mcp-push-approval-design.md`

Full design doc for the high-value MCP push approval flow. Goal: when an MCP write tool crosses a threshold (default $50), hold the operation, push to mobile, biometric-confirm, resume. Doc covers:

- **Threshold model** — three layers (per-grant override → per-tool override → system default), reuses X402 spending-limit table shape
- **Hold-and-notify protocol** — 202 + Retry-After polling (not streaming, to avoid PHP-FPM worker exhaustion)
- **Mobile UX** — `useApprovalQueue` hook with state outliving modal mount lifecycle, `X402PaymentModal` reuse, queue-with-badge for concurrent approvals, FCM `priority: high` for Android Doze
- **Stale push handling** — auto-reject after 5 minutes
- **Error codes** — distinct `MCP_USER_REJECTED` / `MCP_USER_TIMEOUT` / `MCP_APPROVAL_INVALIDATED` so agents can surface "user declined" vs "user away" differently
- **Data model** — `mcp_approval_requests` table + `oauth_access_tokens.approval_threshold_minor` column
- **Rollout phases** behind `MCP_PUSH_APPROVAL_ENABLED` flag
- **Open questions** for mobile dev review

Aligned 1:1 with mobile dev's PR #1024 thread feedback.

## What this PR is *not*

- No code changes. All three artifacts are docs/assets.
- No Connectors Directory submission itself — that's a manual ops step. The runbook at `docs/operations/mcp-directory-submissions.md` (shipped in #1021) has the form values pre-filled.
- No Linear ticket created — the markdown is meant to be copy-pasted.
- No design-doc *implementation*. That's a separate PR after mobile dev reviews.

## Test plan

- [x] Logo renders correctly at 16px / 32px / 64px / 256px (visual)
- [ ] Reviewer eyeballs both markdown docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)