### PR TITLE
feat(ops): user:delete artisan command for staging cleanup

### DIFF
--- a/app/Console/Commands/UserDeleteCommand.php
+++ b/app/Console/Commands/UserDeleteCommand.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Account\Models\Account;
+use App\Domain\User\Values\UserRoles;
+use App\Domain\Wallet\Models\WalletSendRecord;
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+/**
+ * Hard-delete a single User row plus its Sanctum tokens for staging cleanup.
+ *
+ * Cleans Sanctum tokens explicitly because `personal_access_tokens` is a
+ * morph-keyed table without an FK to `users`, so onDelete cascades miss it.
+ * Accounts are also deleted explicitly: the original `accounts.user_uuid`
+ * FK was created without `onDelete('cascade')`, so a bare `$user->delete()`
+ * would fail with a constraint violation. Tables that DO cascade (kyc_documents,
+ * bank_accounts, votes, smart_accounts, multi_sig_*, hardware_*, rewards_*,
+ * payment_intents, etc.) are swept by the FK on `users.id` / `users.uuid`.
+ * Audit logs use `set null`, preserving the trail.
+ *
+ *   php artisan user:delete --email=test@example.com --confirm \
+ *       --operator-email=admin@zelta.app
+ *   php artisan user:delete --email=test@example.com --confirm \
+ *       --allow-production --operator-email=admin@zelta.app
+ */
+final class UserDeleteCommand extends Command
+{
+    /** @var string */
+    protected $signature = 'user:delete
+                            {--email= : Email of the user to delete}
+                            {--confirm : Required. This is destructive and irreversible.}
+                            {--allow-production : Required when APP_ENV=production}
+                            {--operator-email= : Admin operator email (required, must have admin role)}';
+
+    /** @var string */
+    protected $description = 'Hard-delete a user (staging cleanup); refuses on admins, KYC-approved, balance, or wallet-send history';
+
+    public function handle(): int
+    {
+        if (! $this->option('confirm')) {
+            $this->error('--confirm is required. This is destructive and irreversible.');
+
+            return self::FAILURE;
+        }
+
+        $email = trim((string) $this->option('email'));
+        if ($email === '') {
+            $this->error('--email is required.');
+
+            return self::FAILURE;
+        }
+
+        $operatorEmail = trim((string) $this->option('operator-email'));
+        if ($operatorEmail === '') {
+            $this->error('--operator-email is required.');
+
+            return self::FAILURE;
+        }
+
+        $operator = User::where('email', $operatorEmail)->first();
+        if ($operator === null || ! $operator->hasRole(UserRoles::ADMIN->value)) {
+            $this->error("Operator {$operatorEmail} not found or not an admin.");
+
+            return self::FAILURE;
+        }
+
+        if (app()->environment('production') && ! $this->option('allow-production')) {
+            $this->error('Production guard: --allow-production is required.');
+
+            return self::FAILURE;
+        }
+
+        $user = User::where('email', $email)->first();
+        if ($user === null) {
+            $this->error("User {$email} not found.");
+
+            return self::FAILURE;
+        }
+
+        if ($user->hasRole(UserRoles::ADMIN->value)) {
+            $this->error("Refusing to delete admin user {$email}. Demote first.");
+
+            return self::FAILURE;
+        }
+
+        if ($user->kyc_status === 'approved') {
+            $this->error("Refusing to delete KYC-approved user {$email}.");
+
+            return self::FAILURE;
+        }
+
+        if ($this->userHasNonZeroBalance($user)) {
+            $this->error("Refusing to delete user {$email} with non-zero account balance.");
+
+            return self::FAILURE;
+        }
+
+        if (WalletSendRecord::where('user_id', $user->id)->exists()) {
+            $this->error("Refusing to delete user {$email} with wallet send history.");
+
+            return self::FAILURE;
+        }
+
+        $userId = (int) $user->id;
+
+        try {
+            DB::transaction(function () use ($user): void {
+                // personal_access_tokens uses morph keys with no FK — cascades miss it.
+                $user->tokens()->delete();
+
+                // accounts.user_uuid was created without onDelete('cascade') in the
+                // original migration; delete explicitly so account_balances (which
+                // does cascade off accounts.uuid) is swept too.
+                foreach ($user->accounts()->get() as $account) {
+                    /** @var Account $account */
+                    $account->delete();
+                }
+
+                $user->delete();
+            });
+        } catch (Throwable $e) {
+            $this->error("Delete failed for {$email}: {$e->getMessage()}");
+
+            return self::FAILURE;
+        }
+
+        $this->info("deleted: {$email} (user_id={$userId})");
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Returns true if the user has any account whose `balance` column or
+     * AccountBalance row is greater than zero in any asset.
+     */
+    private function userHasNonZeroBalance(User $user): bool
+    {
+        foreach ($user->accounts()->get() as $account) {
+            /** @var Account $account */
+            if ((int) $account->getAttributes()['balance'] > 0) {
+                return true;
+            }
+
+            $hasNonZeroAssetBalance = $account->balances()->where('balance', '>', 0)->exists();
+            if ($hasNonZeroAssetBalance) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Feature/Console/UserDeleteCommandTest.php
+++ b/tests/Feature/Console/UserDeleteCommandTest.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Account\Models\Account;
+use App\Domain\User\Values\UserRoles;
+use App\Domain\Wallet\Models\WalletSendRecord;
+use App\Models\User;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+/**
+ * Build a test admin operator. The default factory state assigns the
+ * `private` role only via afterMaking; we need to actually persist the
+ * admin role via Spatie so `hasRole(UserRoles::ADMIN->value)` returns true.
+ */
+function makeAdminOperator(string $email = 'admin-operator@example.test'): User
+{
+    /** @var User $admin */
+    $admin = User::factory()->create(['email' => $email]);
+    $admin->assignRole(UserRoles::ADMIN->value);
+
+    return $admin;
+}
+
+function makeRegularUser(string $email): User
+{
+    /** @var User $user */
+    $user = User::factory()->create([
+        'email'      => $email,
+        'kyc_status' => 'not_started',
+    ]);
+
+    return $user;
+}
+
+it('requires --confirm', function (): void {
+    $admin = makeAdminOperator();
+    $target = makeRegularUser('drop-me-1@example.test');
+
+    $exitCode = Artisan::call('user:delete', [
+        '--email'          => $target->email,
+        '--operator-email' => $admin->email,
+    ]);
+
+    expect($exitCode)->not->toBe(0);
+    expect(User::where('email', $target->email)->exists())->toBeTrue();
+});
+
+it('refuses to delete in production without --allow-production', function (): void {
+    app()->detectEnvironment(fn () => 'production');
+
+    $admin = makeAdminOperator();
+    $target = makeRegularUser('drop-me-prod@example.test');
+
+    $exitCode = Artisan::call('user:delete', [
+        '--email'          => $target->email,
+        '--confirm'        => true,
+        '--operator-email' => $admin->email,
+    ]);
+
+    expect($exitCode)->not->toBe(0);
+    expect(Artisan::output())->toContain('Production guard');
+    expect(User::where('email', $target->email)->exists())->toBeTrue();
+});
+
+it('refuses without an admin operator', function (): void {
+    /** @var User $nonAdmin */
+    $nonAdmin = User::factory()->create(['email' => 'not-an-admin@example.test']);
+    // Default factory assigns the `private` role on make only; no DB role is
+    // attached here, so hasRole(ADMIN) is false.
+
+    $target = makeRegularUser('drop-me-2@example.test');
+
+    $exitCode = Artisan::call('user:delete', [
+        '--email'          => $target->email,
+        '--confirm'        => true,
+        '--operator-email' => $nonAdmin->email,
+    ]);
+
+    expect($exitCode)->not->toBe(0);
+    expect(Artisan::output())->toContain('not found or not an admin');
+    expect(User::where('email', $target->email)->exists())->toBeTrue();
+});
+
+it('refuses to delete a missing user', function (): void {
+    $admin = makeAdminOperator();
+
+    $exitCode = Artisan::call('user:delete', [
+        '--email'          => 'never-existed@example.test',
+        '--confirm'        => true,
+        '--operator-email' => $admin->email,
+    ]);
+
+    expect($exitCode)->not->toBe(0);
+    expect(Artisan::output())->toContain('User never-existed@example.test not found');
+});
+
+it('refuses to delete an admin user', function (): void {
+    $admin = makeAdminOperator('admin-op-1@example.test');
+
+    /** @var User $targetAdmin */
+    $targetAdmin = User::factory()->create(['email' => 'other-admin@example.test']);
+    $targetAdmin->assignRole(UserRoles::ADMIN->value);
+
+    $exitCode = Artisan::call('user:delete', [
+        '--email'          => $targetAdmin->email,
+        '--confirm'        => true,
+        '--operator-email' => $admin->email,
+    ]);
+
+    expect($exitCode)->not->toBe(0);
+    expect(Artisan::output())->toContain('Refusing to delete admin user');
+    expect(User::where('email', $targetAdmin->email)->exists())->toBeTrue();
+});
+
+it('refuses to delete a KYC-approved user', function (): void {
+    $admin = makeAdminOperator();
+
+    /** @var User $target */
+    $target = User::factory()->create([
+        'email'      => 'kyc-approved@example.test',
+        'kyc_status' => 'approved',
+    ]);
+
+    $exitCode = Artisan::call('user:delete', [
+        '--email'          => $target->email,
+        '--confirm'        => true,
+        '--operator-email' => $admin->email,
+    ]);
+
+    expect($exitCode)->not->toBe(0);
+    expect(Artisan::output())->toContain('KYC-approved');
+    expect(User::where('email', $target->email)->exists())->toBeTrue();
+});
+
+it('refuses if the user has a non-zero account balance', function (): void {
+    $admin = makeAdminOperator();
+    $target = makeRegularUser('balance-holder@example.test');
+
+    Account::create([
+        'uuid'      => (string) Str::uuid(),
+        'name'      => 'Primary',
+        'user_uuid' => $target->uuid,
+        'balance'   => 5000,
+        'frozen'    => false,
+    ]);
+
+    $exitCode = Artisan::call('user:delete', [
+        '--email'          => $target->email,
+        '--confirm'        => true,
+        '--operator-email' => $admin->email,
+    ]);
+
+    expect($exitCode)->not->toBe(0);
+    expect(Artisan::output())->toContain('non-zero account balance');
+    expect(User::where('email', $target->email)->exists())->toBeTrue();
+});
+
+it('refuses if the user has wallet send history', function (): void {
+    $admin = makeAdminOperator();
+    $target = makeRegularUser('has-sends@example.test');
+
+    WalletSendRecord::create([
+        'public_id'         => 'pi_send_' . Str::random(16),
+        'user_id'           => $target->id,
+        'network'           => 'solana',
+        'asset'             => 'USDC',
+        'amount'            => '1.0',
+        'sender_address'    => 'SoMeBaSe58SeNdEr',
+        'recipient_address' => 'SoMeBaSe58RcPnT',
+        'status'            => 'confirmed',
+    ]);
+
+    $exitCode = Artisan::call('user:delete', [
+        '--email'          => $target->email,
+        '--confirm'        => true,
+        '--operator-email' => $admin->email,
+    ]);
+
+    expect($exitCode)->not->toBe(0);
+    expect(Artisan::output())->toContain('wallet send history');
+    expect(User::where('email', $target->email)->exists())->toBeTrue();
+});
+
+it('cleans up Sanctum tokens explicitly on delete', function (): void {
+    $admin = makeAdminOperator();
+    $target = makeRegularUser('token-holder@example.test');
+
+    $target->createToken('mobile-app', ['read', 'write']);
+    expect(DB::table('personal_access_tokens')
+        ->where('tokenable_id', $target->id)
+        ->where('tokenable_type', $target->getMorphClass())
+        ->count())->toBe(1);
+
+    $exitCode = Artisan::call('user:delete', [
+        '--email'          => $target->email,
+        '--confirm'        => true,
+        '--operator-email' => $admin->email,
+    ]);
+
+    expect($exitCode)->toBe(0);
+    expect(DB::table('personal_access_tokens')
+        ->where('tokenable_id', $target->id)
+        ->where('tokenable_type', $target->getMorphClass())
+        ->count())->toBe(0);
+    expect(User::where('email', $target->email)->exists())->toBeFalse();
+});
+
+it('cascades to user-keyed tables', function (): void {
+    $admin = makeAdminOperator();
+    $target = makeRegularUser('cascade-target@example.test');
+
+    $account = Account::create([
+        'uuid'      => (string) Str::uuid(),
+        'name'      => 'Primary',
+        'user_uuid' => $target->uuid,
+        'balance'   => 0,
+        'frozen'    => false,
+    ]);
+
+    $exitCode = Artisan::call('user:delete', [
+        '--email'          => $target->email,
+        '--confirm'        => true,
+        '--operator-email' => $admin->email,
+    ]);
+
+    expect($exitCode)->toBe(0);
+    expect(User::where('email', $target->email)->exists())->toBeFalse();
+    expect(Account::where('uuid', $account->uuid)->exists())->toBeFalse();
+});
+
+it('succeeds with all guards passing on staging', function (): void {
+    $admin = makeAdminOperator();
+    $target = makeRegularUser('happy-path@example.test');
+    $targetId = $target->id;
+
+    $exitCode = Artisan::call('user:delete', [
+        '--email'          => $target->email,
+        '--confirm'        => true,
+        '--operator-email' => $admin->email,
+    ]);
+
+    expect($exitCode)->toBe(0);
+    expect(Artisan::output())->toContain("deleted: {$target->email} (user_id={$targetId})");
+    expect(User::where('email', $target->email)->exists())->toBeFalse();
+});


### PR DESCRIPTION
## Summary
- New `php artisan user:delete --email=X --confirm` for staging-only test-user cleanup
- Production-blocked unless `--allow-production` is passed
- Refuses on: admin role, KYC-approved, non-zero balance, wallet send history
- Explicit Sanctum token cleanup; FK cascades handle the rest of the user-keyed tables
- Mirrors the safety pattern from `account:purge-reviewer`

## Implementation notes
- The original `accounts.user_uuid` FK (`2024_08_27_164259_create_accounts_table.php`) was created without `onDelete('cascade')`, so a bare `$user->delete()` would fail with a constraint violation when the user has accounts. The command therefore deletes accounts explicitly inside the transaction (which then cascades to `account_balances` correctly via that FK). Tables that *do* cascade off `users.id` / `users.uuid` (`kyc_documents`, `bank_accounts`, `votes`, `smart_accounts`, `multi_sig_*`, `hardware_*`, `rewards_*`, `payment_intents`, `payment_receipts`, `referrals`, `cgo_investments`, `ramp_sessions`, `cards`, `card_transactions`, `activity_feed_items`, `referral_codes`, `recovery_shard_cloud_backups`, `railgun_wallets`, `sepa_mandates`, `payment_rail_transactions`, `visa_cli_enrolled_cards`) are swept by their FK definitions.
- `personal_access_tokens` (Sanctum) uses `morphs('tokenable')` with no FK; cleaned explicitly inside the transaction.
- Wallet send history check looks at `wallet_send_records` (the only `wallet_send_*` table currently).

## Test plan
- [x] `./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php` — clean
- [x] `XDEBUG_MODE=off vendor/bin/phpstan analyse --memory-limit=2G` (Level 8) — OK
- [x] `./vendor/bin/pest tests/Feature/Console/UserDeleteCommandTest.php` — 11 passed (32 assertions)
- [ ] CI green
- [ ] Smoke on staging: provision throwaway user, run command, confirm row + tokens + accounts gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)