### PR TITLE
feat(ops): mobile reviewer token for Privy-OTP-only builds

### DIFF
--- a/app/Console/Commands/AccountDisableReviewerCommand.php
+++ b/app/Console/Commands/AccountDisableReviewerCommand.php
@@ -41,19 +41,28 @@ class AccountDisableReviewerCommand extends Command
         if ($this->option('all-expired')) {
             $disabled = 0;
             $failed = 0;
+            $tokensRevoked = 0;
 
             AccountFlag::where('is_review_account', true)
                 ->whereNotNull('expires_at')
                 ->where('expires_at', '<', now())
                 ->whereNull('disabled_at')
                 ->with('user')
-                ->chunkById(100, function (Collection $chunk) use ($service, &$disabled, &$failed): void {
+                ->chunkById(100, function (Collection $chunk) use ($service, &$disabled, &$failed, &$tokensRevoked): void {
                     foreach ($chunk as $flag) {
                         if (! $flag->user instanceof User) {
                             continue;
                         }
                         try {
+                            // Count BEFORE delegating: the service's disable()
+                            // wipes the user's tokens table-wide, so a post-call
+                            // count would always be 0. Tally for the summary line.
+                            $preTokens = (int) $flag->user->tokens()
+                                ->where('name', 'reviewer-mobile')
+                                ->count();
                             $service->disable($flag->user);
+                            $flag->user->tokens()->where('name', 'reviewer-mobile')->delete();
+                            $tokensRevoked += $preTokens;
                             $this->line("disabled: {$flag->user->email}");
                             $disabled++;
                         } catch (Throwable $e) {
@@ -63,7 +72,7 @@ class AccountDisableReviewerCommand extends Command
                     }
                 });
 
-            $this->info("Sweep complete. disabled={$disabled} failed={$failed}");
+            $this->info("Sweep complete. disabled={$disabled} failed={$failed} tokens-revoked={$tokensRevoked}");
 
             return $failed > 0 ? 1 : 0;
         }
@@ -113,8 +122,16 @@ class AccountDisableReviewerCommand extends Command
             return 0;
         }
 
+        // Count paste-to-login tokens BEFORE delegating to the service: the
+        // service's disable() already wipes the user's tokens table-wide, so
+        // counting after would always be 0. We surface the count for operators
+        // so they have a clear "what got revoked" line in the output. 0 is fine
+        // — the operator may not have issued a token.
+        $revoked = (int) $user->tokens()->where('name', 'reviewer-mobile')->count();
         $service->disable($user);
+        $user->tokens()->where('name', 'reviewer-mobile')->delete();
         $this->info("disabled: {$email}");
+        $this->line("revoked-tokens: {$revoked}");
 
         return 0;
     }

--- a/app/Console/Commands/AccountProvisionReviewerCommand.php
+++ b/app/Console/Commands/AccountProvisionReviewerCommand.php
@@ -10,6 +10,7 @@ use App\Domain\AccountProvisioning\ValueObjects\ProvisioningContext;
 use App\Domain\User\Values\UserRoles;
 use App\Models\User;
 use Carbon\CarbonImmutable;
+use DateTimeInterface;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
 use RuntimeException;
@@ -27,6 +28,7 @@ class AccountProvisionReviewerCommand extends Command
                             {--allow-production : Required when APP_ENV=production}
                             {--rotate-password : Rotate password only, skip reseed}
                             {--force-convert : Convert a non-review user (blocked in production)}
+                            {--issue-mobile-token : Also issue a long-lived Sanctum token for app-store reviewer paste-to-login (shown once, treat like the password)}
                             {--dry-run : Print intended changes, write nothing}';
 
     /** @var string */
@@ -108,7 +110,7 @@ class AccountProvisionReviewerCommand extends Command
             return 1;
         }
 
-        $this->line((string) json_encode([
+        $output = [
             'email'    => $email,
             'password' => $result['password_action'] === 'unchanged' ? 'unchanged' : $password,
             'user_id'  => $result['user']->id,
@@ -119,7 +121,31 @@ class AccountProvisionReviewerCommand extends Command
             'expires_at' => $ctx->expiresAt?->toIso8601String(),
             'operator'   => $operator->email,
             'dry_run'    => $ctx->dryRun,
-        ], JSON_PRETTY_PRINT));
+        ];
+
+        if ((bool) $this->option('issue-mobile-token')) {
+            // Token expiry tracks the reviewer flag's expiry when set, otherwise
+            // hard-caps at 90 days so a stale token cannot outlive the review cycle.
+            $tokenExpiresAt = $ctx->expiresAt instanceof DateTimeInterface
+                ? $ctx->expiresAt
+                : CarbonImmutable::now()->addDays(90);
+
+            if ($ctx->dryRun) {
+                // Preview only — keep `dry_run: true` honest, never write a token row.
+                $output['mobile_token'] = '(would-be-issued)';
+            } else {
+                $newToken = $result['user']->createToken(
+                    'reviewer-mobile',
+                    ['read', 'write', 'delete'],
+                    $tokenExpiresAt,
+                );
+                // plainTextToken is shown ONCE; store in 1Password immediately,
+                // never log/Slack/email it. Disable revokes via name='reviewer-mobile'.
+                $output['mobile_token'] = $newToken->plainTextToken;
+            }
+        }
+
+        $this->line((string) json_encode($output, JSON_PRETTY_PRINT));
 
         return 0;
     }

--- a/docs/operations/reviewer-accounts.md
+++ b/docs/operations/reviewer-accounts.md
@@ -53,13 +53,80 @@ Expected JSON output shape:
   },
   "expires_at": "2026-06-23T12:00:00Z",
   "operator": "ops-admin@finaegis.com",
-  "dry_run": false
+  "dry_run": false,
+  "mobile_token": "<PLAINTEXT-SANCTUM-TOKEN-ONCE-ONLY>"
 }
 ```
 
+The `mobile_token` field is only present when `--issue-mobile-token` is passed (see "Issuing a mobile reviewer token" below). Without that flag, the key is omitted entirely.
+
 Re-running the command with the same `--email` is idempotent — `"password": "unchanged"` is emitted instead when no password rotation was requested.
 
-Copy the full JSON into a new 1Password item titled `reviewer:<email>`; share the vault entry with the mobile team. **Never paste the password into email, Slack, Linear, Jira, or commit logs.** The password is displayed once and not recoverable.
+Copy the full JSON into a new 1Password item titled `reviewer:<email>`; share the vault entry with the mobile team. **Never paste the password (or `mobile_token`) into email, Slack, Linear, Jira, or commit logs.** Both are displayed once and not recoverable.
+
+## Issuing a mobile reviewer token
+
+### Why this exists
+
+Mobile went Privy-OTP-only on the login screen in v7.12.0. Email + password login is no longer reachable in shipped builds — Privy delivers the OTP, but reviewer emails use the RFC 2606 `.invalid` TLD by policy and never receive mail. App-store reviewers (Apple App Review, Google Play review) therefore cannot complete sign-in unless we hand them a long-lived credential that bypasses OTP.
+
+### How it works
+
+The `--issue-mobile-token` flag mints a Sanctum personal-access token (`reviewer-mobile`, abilities `read,write,delete`) with an expiry equal to the reviewer flag's `expires_at`, hard-capped at 90 days. The reviewer pastes the token into a hidden "Reviewer access" gesture on the mobile login screen; the app stores it like any other access token. Mobile owns the gesture; ops owns the token issuance and revocation.
+
+### Command
+
+```bash
+php artisan account:provision-reviewer \
+  --email=appreview-2026-q2@example-reviewer.invalid \
+  --operator-email=ops-admin@finaegis.com \
+  --expires-days=60 \
+  --note="Apple App Review 2026-Q2 submission" \
+  --issue-mobile-token
+# production only, append:
+#   --allow-production
+```
+
+The output adds a `mobile_token` field:
+
+```json
+{
+  "email": "appreview-2026-q2@example-reviewer.invalid",
+  "password": "<GENERATED-ONCE-ONLY>",
+  "user_id": 41234,
+  "expires_at": "2026-07-07T12:00:00Z",
+  "operator": "ops-admin@finaegis.com",
+  "dry_run": false,
+  "mobile_token": "12|abcDEF...token-shown-once...XYZ987"
+}
+```
+
+Use `--dry-run --issue-mobile-token` to preview without writing — the field renders as `"mobile_token": "(would-be-issued)"`.
+
+### Storage rule
+
+Same as the password: paste into the 1Password item titled `reviewer:<email>`, share the vault entry with the mobile team, never log/Slack/email/commit it. The plaintext token is displayed once and not recoverable.
+
+### Revoking the token
+
+`account:disable-reviewer --email=<email>` revokes the `reviewer-mobile` token alongside the bypasses, atomically. Confirm the line `revoked-tokens: 1` in the output.
+
+```bash
+php artisan account:disable-reviewer \
+  --email=appreview-2026-q2@example-reviewer.invalid \
+  --operator-email=ops-admin@finaegis.com
+# disabled: appreview-2026-q2@example-reviewer.invalid
+# revoked-tokens: 1
+```
+
+The `--all-expired` sweep does the same per row and reports a total: `Sweep complete. disabled={n} failed={m} tokens-revoked={k}`.
+
+`--re-enable` deliberately does NOT mint a new token. If the cycle re-opens, run `account:provision-reviewer --rotate-password --issue-mobile-token` to issue a fresh one.
+
+### Limitations
+
+- The token lives in `personal_access_tokens` and is **not** bound to a device. If it leaks before the cycle ends, run `account:disable-reviewer --email=<email>` immediately to revoke.
+- The reviewer email uses the RFC 2606 `.invalid` TLD — operators do **not** need a real mailbox for the reviewer. The token is the only credential the reviewer ever needs.
 
 ## Listing and audit
 
@@ -145,3 +212,4 @@ Symptom: alert fires on `bypass.fired` log volume spike (>100 events/min from on
 - No Filament admin UI in v1 — all operations are CLI.
 - Single-tenant provisioning only; multi-tenant reviewer accounts are out of scope for v1.
 - No automated 1Password delivery — operators copy/paste manually.
+- Reviewer emails use RFC 2606 reserved TLDs (`.invalid`, `.example`, `.test`) by policy — operators do **not** need a real mailbox; the password and (when issued) `mobile_token` are the only credentials needed.

--- a/tests/Feature/AccountProvisioning/DisableReviewerCommandTest.php
+++ b/tests/Feature/AccountProvisioning/DisableReviewerCommandTest.php
@@ -8,6 +8,8 @@ use App\Domain\AccountProvisioning\Models\AccountFlag;
 use App\Domain\User\Values\UserRoles;
 use App\Models\User;
 use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
 use Spatie\Permission\Models\Role;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
@@ -195,4 +197,110 @@ it('exits 1 when --operator-email resolves to a non-admin user', function () {
         '--email'          => 'reviewer@finaegis.com',
         '--operator-email' => $nonAdmin->email,
     ])->assertExitCode(1);
+});
+
+it('revokes the reviewer-mobile token on disable and reports the count', function () {
+    $reviewer = User::factory()->create(['email' => 'reviewer@finaegis.com']);
+    AccountFlag::create([
+        'user_id'                   => $reviewer->id,
+        'is_review_account'         => true,
+        'bypass_device_attestation' => true,
+        'created_by'                => $this->operator->id,
+    ]);
+    $reviewer->createToken('reviewer-mobile', ['read', 'write', 'delete'], CarbonImmutable::now()->addDays(60));
+
+    expect(DB::table('personal_access_tokens')->count())->toBe(1);
+
+    $exit = Artisan::call('account:disable-reviewer', [
+        '--email'          => 'reviewer@finaegis.com',
+        '--operator-email' => 'op@finaegis.com',
+    ]);
+
+    expect($exit)->toBe(0);
+    expect(DB::table('personal_access_tokens')->count())->toBe(0);
+    expect(Artisan::output())->toContain('revoked-tokens: 1');
+});
+
+it('reports zero revoked when no reviewer-mobile token was issued', function () {
+    $reviewer = User::factory()->create(['email' => 'reviewer@finaegis.com']);
+    AccountFlag::create([
+        'user_id'                   => $reviewer->id,
+        'is_review_account'         => true,
+        'bypass_device_attestation' => true,
+        'created_by'                => $this->operator->id,
+    ]);
+
+    $exit = Artisan::call('account:disable-reviewer', [
+        '--email'          => 'reviewer@finaegis.com',
+        '--operator-email' => 'op@finaegis.com',
+    ]);
+
+    expect($exit)->toBe(0);
+    expect(Artisan::output())->toContain('revoked-tokens: 0');
+});
+
+it('revokes only expired reviewer tokens during the --all-expired sweep', function () {
+    // Expired reviewer with token
+    $expired = User::factory()->create(['email' => 'expired@finaegis.com']);
+    AccountFlag::create([
+        'user_id'                   => $expired->id,
+        'is_review_account'         => true,
+        'bypass_device_attestation' => true,
+        'expires_at'                => CarbonImmutable::now()->subDay(),
+        'created_by'                => $this->operator->id,
+    ]);
+    $expired->createToken('reviewer-mobile', ['read', 'write', 'delete'], CarbonImmutable::now()->addDays(60));
+
+    // Active reviewer with token (should survive)
+    $active = User::factory()->create(['email' => 'active@finaegis.com']);
+    AccountFlag::create([
+        'user_id'                   => $active->id,
+        'is_review_account'         => true,
+        'bypass_device_attestation' => true,
+        'expires_at'                => CarbonImmutable::now()->addDays(30),
+        'created_by'                => $this->operator->id,
+    ]);
+    $active->createToken('reviewer-mobile', ['read', 'write', 'delete'], CarbonImmutable::now()->addDays(30));
+
+    expect(DB::table('personal_access_tokens')->count())->toBe(2);
+
+    $exit = Artisan::call('account:disable-reviewer', ['--all-expired' => true]);
+
+    expect($exit)->toBe(0);
+
+    // Expired reviewer's token is gone, active reviewer's token preserved.
+    expect(DB::table('personal_access_tokens')->where('tokenable_id', $expired->id)->count())->toBe(0);
+    expect(DB::table('personal_access_tokens')->where('tokenable_id', $active->id)->count())->toBe(1);
+
+    // Sweep summary surfaces the tokens-revoked tally.
+    expect(Artisan::output())->toContain('tokens-revoked=1');
+});
+
+it('does NOT issue a new token on --re-enable', function () {
+    $reviewer = User::factory()->create(['email' => 'reviewer@finaegis.com']);
+    AccountFlag::create([
+        'user_id'                   => $reviewer->id,
+        'is_review_account'         => true,
+        'bypass_device_attestation' => true,
+        'created_by'                => $this->operator->id,
+    ]);
+    $reviewer->createToken('reviewer-mobile', ['read', 'write', 'delete'], CarbonImmutable::now()->addDays(60));
+
+    // Disable wipes the token (asserted separately).
+    Artisan::call('account:disable-reviewer', [
+        '--email'          => 'reviewer@finaegis.com',
+        '--operator-email' => 'op@finaegis.com',
+    ]);
+    expect(DB::table('personal_access_tokens')->count())->toBe(0);
+
+    // Re-enable must not silently mint a new token; operator runs
+    // provision-reviewer --rotate-password --issue-mobile-token if they need one.
+    $exit = Artisan::call('account:disable-reviewer', [
+        '--email'          => 'reviewer@finaegis.com',
+        '--operator-email' => 'op@finaegis.com',
+        '--re-enable'      => true,
+    ]);
+
+    expect($exit)->toBe(0);
+    expect(DB::table('personal_access_tokens')->count())->toBe(0);
 });

--- a/tests/Feature/AccountProvisioning/ProvisionReviewerCommandTest.php
+++ b/tests/Feature/AccountProvisioning/ProvisionReviewerCommandTest.php
@@ -8,6 +8,8 @@ use App\Domain\Account\Models\BlockchainAddress;
 use App\Domain\AccountProvisioning\Models\AccountFlag;
 use App\Domain\User\Values\UserRoles;
 use App\Models\User;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
 use Spatie\Permission\Models\Role;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
@@ -101,4 +103,110 @@ it('exits 1 when --expires-days exceeds the 90-day hard cap', function () {
         '--operator-email' => 'op@finaegis.com',
         '--expires-days'   => 365,
     ])->assertExitCode(1);
+});
+
+it('issues a mobile token when --issue-mobile-token is set', function () {
+    $exit = Artisan::call('account:provision-reviewer', [
+        '--email'              => 'appreview@finaegis.com',
+        '--operator-email'     => 'op@finaegis.com',
+        '--expires-days'       => 30,
+        '--issue-mobile-token' => true,
+    ]);
+
+    expect($exit)->toBe(0);
+
+    $user = User::where('email', 'appreview@finaegis.com')->firstOrFail();
+
+    // Single token was written, named `reviewer-mobile`, with read/write/delete.
+    $tokens = DB::table('personal_access_tokens')
+        ->where('tokenable_id', $user->id)
+        ->where('name', 'reviewer-mobile')
+        ->get();
+    expect($tokens)->toHaveCount(1);
+
+    $token = $tokens->first();
+    expect($token)->not->toBeNull();
+    if ($token === null) {
+        return;
+    }
+    expect($token->expires_at)->not->toBeNull();
+    /** @var array<int, string> $abilities */
+    $abilities = (array) json_decode((string) $token->abilities, true);
+    expect($abilities)->toBe(['read', 'write', 'delete']);
+
+    // Token expires near the reviewer flag expiry (within 1s).
+    $flag = AccountFlag::where('user_id', $user->id)->firstOrFail();
+    expect($flag->expires_at)->not->toBeNull();
+    if ($flag->expires_at !== null) {
+        $tokenExpiresAt = \Carbon\CarbonImmutable::parse((string) $token->expires_at);
+        expect(abs($tokenExpiresAt->diffInSeconds($flag->expires_at)))->toBeLessThan(2);
+    }
+
+    // Output JSON includes the plain-text token under `mobile_token`.
+    $output = Artisan::output();
+    $jsonStart = (int) strpos($output, '{');
+    $payload = json_decode(substr($output, $jsonStart), true);
+    expect($payload)->toBeArray();
+    expect($payload)->toHaveKey('mobile_token');
+    expect($payload['mobile_token'])->toBeString();
+    expect($payload['mobile_token'])->not->toBe('(would-be-issued)');
+    expect(strlen((string) $payload['mobile_token']))->toBeGreaterThan(20);
+});
+
+it('does NOT issue a token by default (no --issue-mobile-token)', function () {
+    $exit = Artisan::call('account:provision-reviewer', [
+        '--email'          => 'appreview@finaegis.com',
+        '--operator-email' => 'op@finaegis.com',
+    ]);
+
+    expect($exit)->toBe(0);
+    expect(DB::table('personal_access_tokens')->count())->toBe(0);
+
+    $output = Artisan::output();
+    $jsonStart = (int) strpos($output, '{');
+    $payload = json_decode(substr($output, $jsonStart), true);
+    expect($payload)->toBeArray();
+    expect($payload)->not->toHaveKey('mobile_token');
+});
+
+it('does NOT actually issue a token in --dry-run, but previews it in the output', function () {
+    $exit = Artisan::call('account:provision-reviewer', [
+        '--email'              => 'appreview@finaegis.com',
+        '--operator-email'     => 'op@finaegis.com',
+        '--issue-mobile-token' => true,
+        '--dry-run'            => true,
+    ]);
+
+    expect($exit)->toBe(0);
+    expect(DB::table('personal_access_tokens')->count())->toBe(0);
+
+    $output = Artisan::output();
+    expect($output)->toContain('"mobile_token": "(would-be-issued)"');
+});
+
+it('issues a 90-day token when --expires-days=0 and --issue-mobile-token is set', function () {
+    $exit = Artisan::call('account:provision-reviewer', [
+        '--email'              => 'appreview@finaegis.com',
+        '--operator-email'     => 'op@finaegis.com',
+        '--expires-days'       => 0,
+        '--issue-mobile-token' => true,
+    ]);
+
+    expect($exit)->toBe(0);
+
+    $user = User::where('email', 'appreview@finaegis.com')->firstOrFail();
+    $token = DB::table('personal_access_tokens')
+        ->where('tokenable_id', $user->id)
+        ->where('name', 'reviewer-mobile')
+        ->first();
+    expect($token)->not->toBeNull();
+    if ($token === null) {
+        return;
+    }
+    expect($token->expires_at)->not->toBeNull();
+
+    $tokenExpiresAt = \Carbon\CarbonImmutable::parse((string) $token->expires_at);
+    $expected = \Carbon\CarbonImmutable::now()->addDays(90);
+    // 5-second tolerance covers test runtime; 90d is the hard cap.
+    expect(abs($tokenExpiresAt->diffInSeconds($expected)))->toBeLessThan(5);
 });


### PR DESCRIPTION
## Summary
- New `--issue-mobile-token` flag on `account:provision-reviewer` mints a Sanctum token (`read,write,delete`, 90d cap or shorter via `--expires-days`) for app-store reviewer paste-to-login
- `account:disable-reviewer` revokes the `reviewer-mobile` token alongside the bypasses, atomically; works in `--all-expired` sweep too
- Token shown once in JSON output (same handling as password); 1Password storage required
- Runbook (`docs/operations/reviewer-accounts.md`) documents the flow + the mobile gesture handoff

## Why
Mobile is Privy-OTP-only in v7.12.0+ shipped builds. App-store reviewers can't receive Privy OTPs at `.invalid` reviewer emails. Mobile is adding a hidden "Reviewer access" gesture that accepts a pasted token; this PR is the backend half that mints and revokes it.

## Test plan
- [ ] Tests pass locally
- [ ] CI green
- [ ] Coordinate with mobile-dev when their gesture lands; smoke on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)