### PR TITLE
feat(web): /invest investor landing page (FinAegis brand, gated data room)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,6 +104,9 @@ MAIL_FROM_NAME="${APP_NAME}"
 # Resend Email Service (https://resend.com)
 RESEND_KEY=
 
+# Investor lead-capture (/invest) — recipient for new-inquiry notifications.
+INVESTOR_NOTIFICATION_EMAIL=investors@finaegis.com
+
 # =============================================================================
 # AWS
 # =============================================================================

--- a/app/Console/Commands/InvestorPurgeOldInquiriesCommand.php
+++ b/app/Console/Commands/InvestorPurgeOldInquiriesCommand.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\InvestorInquiry;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+
+/**
+ * Daily retention sweep for the public investor inquiry form.
+ *
+ * Drops `investor_inquiries` rows older than 24 months. Runs daily at 03:00
+ * via routes/console.php. Idempotent — safe to re-run on the same day.
+ *
+ *   php artisan investor:purge-old-inquiries
+ *   php artisan investor:purge-old-inquiries --dry-run
+ */
+class InvestorPurgeOldInquiriesCommand extends Command
+{
+    protected $signature = 'investor:purge-old-inquiries
+        {--dry-run : Print the count without deleting anything}';
+
+    protected $description = 'Delete investor_inquiries rows older than 24 months (GDPR retention).';
+
+    public function handle(): int
+    {
+        $cutoff = Carbon::now()->subMonths(24);
+
+        $query = InvestorInquiry::query()->where('created_at', '<', $cutoff);
+        $count = $query->count();
+
+        if ($count === 0) {
+            $this->info('No investor inquiries older than 24 months. Nothing to do.');
+
+            return self::SUCCESS;
+        }
+
+        if ($this->option('dry-run')) {
+            $this->warn(sprintf(
+                'Found %d inquiry/inquiries older than %s. Re-run without --dry-run to purge.',
+                $count,
+                $cutoff->toDateTimeString(),
+            ));
+
+            return self::SUCCESS;
+        }
+
+        $deleted = InvestorInquiry::query()->where('created_at', '<', $cutoff)->delete();
+        $this->info(sprintf('Purged %d investor inquiry/inquiries older than 24 months.', $deleted));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/Web/InvestorController.php
+++ b/app/Http/Controllers/Web/InvestorController.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Web;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\InvestorInquiryRequest;
+use App\Models\InvestorInquiry;
+use App\Notifications\InvestorInquirySubmitted;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Notification;
+use Throwable;
+
+/**
+ * Public investor lead-capture controller for /invest.
+ *
+ * The page itself is statically rendered Blade. Submissions persist a row
+ * to `investor_inquiries`, queue a founder notification, and redirect to
+ * a thanks page. Honeypot submissions are silently swallowed (no DB write,
+ * no notification, but the user sees the same thanks page so a bot can't
+ * differentiate).
+ *
+ * Data-room access is gated; for now the route returns a 403-style "request
+ * access" page. Manual approval will be added in a later iteration.
+ */
+final class InvestorController extends Controller
+{
+    public function show(): View
+    {
+        return view('invest');
+    }
+
+    public function submit(InvestorInquiryRequest $request): RedirectResponse
+    {
+        // Honeypot — silently swallow without writing to DB. Do NOT return a
+        // validation error: that would tip off the bot. We pretend success.
+        if ($request->filled('website')) {
+            return redirect()->route('invest.thanks');
+        }
+
+        $validated = $request->validated();
+
+        $inquiry = InvestorInquiry::create([
+            'name'             => (string) $validated['name'],
+            'email'            => (string) $validated['email'],
+            'linkedin_url'     => (string) $validated['linkedin_url'],
+            'investing_as'     => (string) $validated['investing_as'],
+            'path_of_interest' => (string) $validated['path_of_interest'],
+            'check_size_range' => (string) $validated['check_size_range'],
+            'questions'        => isset($validated['questions']) && $validated['questions'] !== ''
+                ? (string) $validated['questions']
+                : null,
+            'ip_hash'    => $this->hashIp((string) ($request->ip() ?? '')),
+            'user_agent' => substr((string) ($request->userAgent() ?? ''), 0, 500),
+        ]);
+
+        // Email failure must not break the user-facing submission flow.
+        // The notification is queued (ShouldQueue), so even if dispatch fails
+        // synchronously we still want the submission persisted.
+        try {
+            Notification::route('mail', (string) config('investor.notification_email'))
+                ->notify(new InvestorInquirySubmitted($inquiry));
+        } catch (Throwable $e) {
+            report($e);
+        }
+
+        return redirect()->route('invest.thanks');
+    }
+
+    public function thanks(): View
+    {
+        return view('invest.thanks');
+    }
+
+    public function dataRoom(): \Illuminate\Http\Response
+    {
+        return response()->view('invest.data-room-gated', [], 403);
+    }
+
+    private function hashIp(string $ip): string
+    {
+        return hash('sha256', $ip . '|' . (string) config('app.key'));
+    }
+}

--- a/app/Http/Requests/InvestorInquiryRequest.php
+++ b/app/Http/Requests/InvestorInquiryRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validation for /invest form submissions.
+ *
+ * Honeypot strategy: the `website` field is rendered hidden and humans can't
+ * fill it. If a bot does, the controller silently swallows the submission
+ * (returns thanks redirect without writing). We do NOT add a `max:0` rule on
+ * `website` here, because that would surface a validation error and signal
+ * to the bot that the form has bot-detection — defeating the purpose.
+ */
+class InvestorInquiryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'name'             => ['required', 'string', 'min:2', 'max:120'],
+            'email'            => ['required', 'email:rfc,dns', 'max:255'],
+            'linkedin_url'     => ['required', 'url', 'max:500', 'regex:#linkedin\.com/in/#i'],
+            'investing_as'     => ['required', Rule::in(['angel', 'vc', 'family_office', 'other'])],
+            'path_of_interest' => ['required', Rule::in(['licensed', 'non_custodial', 'both'])],
+            'check_size_range' => ['required', Rule::in(['under_25k', '25k_100k', '100k_500k', '500k_plus'])],
+            'questions'        => ['nullable', 'string', 'max:500'],
+            'gdpr_consent'     => ['accepted'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'linkedin_url.regex'    => 'Please paste a LinkedIn profile URL (must contain linkedin.com/in/).',
+            'gdpr_consent.accepted' => 'Please confirm you consent to us storing this submission.',
+        ];
+    }
+}

--- a/app/Models/InvestorInquiry.php
+++ b/app/Models/InvestorInquiry.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Public investor lead-capture submission from /invest.
+ *
+ * Append-only: the table has `created_at` only (no `updated_at`).
+ * IP addresses are never stored raw; `ip_hash` is sha256(ip + app.key).
+ *
+ * @property int         $id
+ * @property string      $name
+ * @property string      $email
+ * @property string      $linkedin_url
+ * @property string      $investing_as
+ * @property string      $path_of_interest
+ * @property string      $check_size_range
+ * @property string|null $questions
+ * @property string      $ip_hash
+ * @property string      $user_agent
+ * @property \Illuminate\Support\Carbon $created_at
+ */
+class InvestorInquiry extends Model
+{
+    /**
+     * Disable Eloquent's `updated_at` — the table has only `created_at`.
+     */
+    public const UPDATED_AT = null;
+
+    /**
+     * @var string
+     */
+    protected $table = 'investor_inquiries';
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'email',
+        'linkedin_url',
+        'investing_as',
+        'path_of_interest',
+        'check_size_range',
+        'questions',
+        'ip_hash',
+        'user_agent',
+    ];
+}

--- a/app/Notifications/InvestorInquirySubmitted.php
+++ b/app/Notifications/InvestorInquirySubmitted.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Models\InvestorInquiry;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+/**
+ * Notify the founder when a new investor inquiry is submitted at /invest.
+ *
+ * Queued so submission latency stays low and a transient SMTP outage does
+ * not surface a 500 to a prospective investor. The InvestorController must
+ * already have persisted the row before queuing this; if Mail later fails,
+ * the row remains for manual triage.
+ */
+class InvestorInquirySubmitted extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        public InvestorInquiry $inquiry,
+    ) {
+    }
+
+    /**
+     * @param mixed $notifiable
+     * @return array<int, string>
+     */
+    public function via(mixed $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(mixed $notifiable): MailMessage
+    {
+        $i = $this->inquiry;
+
+        $pathLabels = [
+            'licensed'      => 'Licensed (MiCA + EMI)',
+            'non_custodial' => 'Non-custodial SaaS',
+            'both'          => 'Both / undecided',
+        ];
+        $investingAsLabels = [
+            'angel'         => 'Angel',
+            'vc'            => 'VC',
+            'family_office' => 'Family office',
+            'other'         => 'Other',
+        ];
+        $checkSizeLabels = [
+            'under_25k' => 'Under €25k',
+            '25k_100k'  => '€25k–€100k',
+            '100k_500k' => '€100k–€500k',
+            '500k_plus' => '€500k+',
+        ];
+
+        return (new MailMessage())
+            ->subject('New investor inquiry — ' . $i->name . ' (' . ($pathLabels[$i->path_of_interest] ?? $i->path_of_interest) . ')')
+            ->greeting('New investor inquiry')
+            ->line('Name: ' . $i->name)
+            ->line('Email: ' . $i->email)
+            ->line('LinkedIn: ' . $i->linkedin_url)
+            ->line('Investing as: ' . ($investingAsLabels[$i->investing_as] ?? $i->investing_as))
+            ->line('Path of interest: ' . ($pathLabels[$i->path_of_interest] ?? $i->path_of_interest))
+            ->line('Check size: ' . ($checkSizeLabels[$i->check_size_range] ?? $i->check_size_range))
+            ->line('Questions:')
+            ->line($i->questions !== null && $i->questions !== '' ? $i->questions : '(none)')
+            ->action('Open LinkedIn profile', $i->linkedin_url)
+            ->line('Submitted at ' . $i->created_at->toDateTimeString() . ' (UTC).')
+            ->line('IP hash: ' . $i->ip_hash)
+            ->line('User agent: ' . $i->user_agent);
+    }
+}

--- a/config/investor.php
+++ b/config/investor.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Investor inquiry notification recipient
+    |--------------------------------------------------------------------------
+    |
+    | Email address that receives a notification each time the public /invest
+    | form is submitted. Single recipient — keep this an inbox the founder
+    | reads daily.
+    |
+    */
+    'notification_email' => env('INVESTOR_NOTIFICATION_EMAIL', 'investors@finaegis.com'),
+];

--- a/database/migrations/2026_05_08_221255_create_investor_inquiries_table.php
+++ b/database/migrations/2026_05_08_221255_create_investor_inquiries_table.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Public investor lead-capture submissions from /invest.
+ *
+ * Append-only — these rows are never updated, only inserted (form submit) and
+ * deleted (24-month retention sweep). Hence no `updated_at` column.
+ *
+ * IP is stored as sha256(ip + app.key) for abuse triage without keeping the
+ * raw address. user_agent is kept verbatim (capped at 500 chars) for spam
+ * triage; PII risk is acceptable for an opt-in marketing form.
+ */
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('investor_inquiries', function (Blueprint $table): void {
+            $table->id();
+            $table->string('name', 120);
+            $table->string('email', 255);
+            $table->string('linkedin_url', 500);
+            $table->string('investing_as', 32);              // angel | vc | family_office | other
+            $table->string('path_of_interest', 32);          // licensed | non_custodial | both
+            $table->string('check_size_range', 32);          // under_25k | 25k_100k | 100k_500k | 500k_plus
+            $table->text('questions')->nullable();           // 500-char cap enforced in form request
+            $table->char('ip_hash', 64);                     // sha256(ip + app.key) — never store raw IP
+            $table->string('user_agent', 500);
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index('created_at', 'idx_inquiries_created');
+            $table->index('path_of_interest', 'idx_inquiries_path');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('investor_inquiries');
+    }
+};

--- a/resources/views/invest.blade.php
+++ b/resources/views/invest.blade.php
@@ -1,0 +1,635 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+
+    @php
+        // Brand decision: header/nav/footer stay "Zelta" (matching the rest of zelta.app),
+        // but the investor-facing body copy says "FinAegis" because investors invest
+        // in the legal entity. This is a deliberate, documented exception.
+        $brand = config('brand.name', 'Zelta');
+    @endphp
+
+    <title>FinAegis. Two ways to invest. — {{ $brand }}</title>
+
+    @include('partials.favicon')
+
+    {{-- TODO: remove noindex when ready to launch publicly --}}
+    <meta name="robots" content="noindex,nofollow">
+
+    {{-- Open Graph / Twitter --}}
+    {{-- TODO: founder to add 1200x630 OG card image at public/images/og/invest-card.png before launch. --}}
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="{{ url('/invest') }}">
+    <meta property="og:title" content="FinAegis. Two ways to invest.">
+    <meta property="og:description" content="Regulated EU banking, or non-custodial software. Founder: ex-CEO of Paysera.">
+    <meta property="og:image" content="{{ asset('images/og/invest-card.png') }}">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:site_name" content="{{ $brand }}">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="FinAegis. Two ways to invest.">
+    <meta name="twitter:description" content="Regulated EU banking, or non-custodial software. Founder: ex-CEO of Paysera.">
+    <meta name="twitter:image" content="{{ asset('images/og/invest-card.png') }}">
+
+    <link rel="preconnect" href="https://fonts.bunny.net">
+    <link href="https://fonts.bunny.net/css?family=space-grotesk:400,500,600,700&dm-sans:400,500,600,700&jetbrains-mono:400,500,700&display=swap" rel="stylesheet" />
+
+    {{-- Pre-compiled Tailwind utility CSS used by the Zelta brutalist pages. --}}
+    <link rel="stylesheet" href="/css/app-landing.css">
+
+    <style>
+        html { scroll-behavior: smooth; }
+        body {
+            background: #faf9f6;
+            color: #0a0a0a;
+            font-family: 'Space Grotesk', system-ui, sans-serif;
+            min-height: 100vh;
+            overflow-x: hidden;
+        }
+        ::selection { background: #ccff00; color: #000; }
+
+        /* Brutalist palette + utilities (kept in-file so the page renders even if app-landing.css is missing) */
+        .bg-z-purple { background-color: #c8a8f0; }
+        .bg-acid { background-color: #ccff00; }
+        .bg-mint { background-color: #a8f0c4; }
+        .bg-obsidian { background-color: #0a0a0a; }
+        .bg-bg-tertiary { background-color: #f5f5f5; }
+        .text-text-sec { color: #404040; }
+        .text-text-muted { color: #737373; }
+        .text-z-purple { color: #c8a8f0; }
+        .text-z-green { color: #16a34a; }
+        .text-acid { color: #ccff00; }
+
+        .bru-border { border: 3px solid #0a0a0a; }
+        .bru-card { border: 3px solid #0a0a0a; box-shadow: 6px 6px 0px #0a0a0a; }
+        .bru-card-sm { border: 3px solid #0a0a0a; box-shadow: 3px 3px 0px #0a0a0a; }
+        .bru-card-lg { border: 3px solid #0a0a0a; box-shadow: 8px 8px 0px #0a0a0a; }
+
+        .btn-hover { transition: transform 0.15s ease; }
+        .btn-hover:hover { transform: scale(1.04); }
+        .btn-hover:active { transform: scale(0.96); }
+        .btn-hover:focus-visible { outline: 3px solid #7000ff; outline-offset: 2px; }
+        button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible {
+            outline: 3px solid #7000ff; outline-offset: 2px;
+        }
+
+        .font-heading { font-family: 'Space Grotesk', system-ui, sans-serif; letter-spacing: -0.04em; }
+        .font-mono { font-family: 'JetBrains Mono', ui-monospace, monospace; }
+
+        /* Comparison table — desktop */
+        .compare-table { border-collapse: separate; border-spacing: 0; width: 100%; }
+        .compare-table th, .compare-table td {
+            padding: 0.85rem 1rem;
+            border-bottom: 3px solid #0a0a0a;
+            border-right: 3px solid #0a0a0a;
+            font-size: 0.875rem;
+            vertical-align: top;
+            text-align: left;
+        }
+        .compare-table tr > *:first-child { border-left: 3px solid #0a0a0a; }
+        .compare-table tr:first-child > * { border-top: 3px solid #0a0a0a; }
+        .compare-table thead th { font-weight: 800; background: #f5f5f5; font-size: 0.95rem; }
+        .compare-table thead th:nth-child(2) { background: #ccff00; }
+        .compare-table thead th:nth-child(3) { background: #c8a8f0; }
+        .compare-table tbody th { font-weight: 700; background: #fff; }
+
+        /* Hide desktop comparison table on phone, show stacked cards instead */
+        .compare-stack { display: none; }
+        @media (max-width: 767px) {
+            .compare-table-wrap { display: none; }
+            .compare-stack { display: block; }
+        }
+
+        /* Stacked use-of-funds bar */
+        .uof-bar {
+            display: flex;
+            border: 3px solid #0a0a0a;
+            box-shadow: 6px 6px 0 #0a0a0a;
+            background: #fff;
+            overflow: hidden;
+        }
+        .uof-bar > div {
+            padding: 1rem 0.75rem;
+            font-size: 0.8rem;
+            font-weight: 700;
+            border-right: 3px solid #0a0a0a;
+            min-width: 0;
+        }
+        .uof-bar > div:last-child { border-right: 0; }
+        @media (max-width: 767px) {
+            .uof-bar { flex-direction: column; }
+            .uof-bar > div { border-right: 0; border-bottom: 3px solid #0a0a0a; }
+            .uof-bar > div:last-child { border-bottom: 0; }
+        }
+
+        /* Form polish */
+        .field-label { display: block; font-weight: 700; font-size: 0.875rem; margin-bottom: 0.4rem; }
+        .field-input,
+        .field-select,
+        .field-textarea {
+            width: 100%;
+            padding: 0.7rem 0.85rem;
+            border: 3px solid #0a0a0a;
+            background: #fff;
+            font-size: 1rem;
+            font-family: inherit;
+            border-radius: 0;
+        }
+        .field-textarea { resize: vertical; min-height: 110px; }
+        .field-error { color: #b91c1c; font-size: 0.8rem; margin-top: 0.35rem; font-weight: 600; }
+
+        @media (prefers-reduced-motion: reduce) {
+            *, *::before, *::after {
+                animation-duration: 0.01ms !important;
+                transition-duration: 0.01ms !important;
+            }
+            html { scroll-behavior: auto; }
+        }
+    </style>
+</head>
+<body class="antialiased">
+
+    {{-- Skip link --}}
+    <a href="#main" class="sr-only focus:not-sr-only" style="position:absolute;left:1rem;top:1rem;padding:0.5rem 1rem;background:#ccff00;border:3px solid #000;font-weight:700;z-index:50;">Skip to content</a>
+
+    {{-- Top bar: Zelta brand stays here (header/nav/footer never say FinAegis). --}}
+    <header class="px-5 py-5 md:py-6">
+        <div class="mx-auto max-w-6xl flex items-center justify-between">
+            <a href="{{ url('/') }}" class="flex items-center gap-3 btn-hover">
+                <div class="flex h-11 w-11 items-center justify-center rounded-xl text-xl font-black bg-mint bru-border" style="font-family: 'Space Grotesk', sans-serif; letter-spacing: -0.04em;">
+                    Z
+                </div>
+                <span class="text-2xl font-black font-heading">{{ $brand }}</span>
+            </a>
+            <a href="{{ url('/') }}" class="text-sm font-semibold text-text-sec hover:text-black">&larr; Home</a>
+        </div>
+    </header>
+
+    <main id="main" class="px-5 pb-24">
+        <div class="mx-auto max-w-6xl">
+
+            {{-- ═══════════════════════════════════════
+                 HERO
+                 ═══════════════════════════════════════ --}}
+            <section class="text-center mb-16 mt-4">
+                <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-acid bru-border text-sm font-bold mb-6" style="transform: rotate(-1deg);">
+                    <span class="w-2 h-2 rounded-full bg-obsidian"></span>
+                    INVESTOR PAGE &middot; FINAEGIS LTD.
+                </div>
+                <h1 class="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-black mb-6 font-heading max-w-5xl mx-auto" style="line-height: 0.95;">
+                    FinAegis. <span class="block sm:inline">Two ways to invest.</span> <span class="block text-z-purple">One operator who&rsquo;s done this before.</span>
+                </h1>
+                <p class="text-lg md:text-xl max-w-2xl mx-auto text-text-sec font-medium mb-8">
+                    Choose the path that matches your thesis: regulated EU banking infrastructure, or non-custodial software margins without a licence.
+                </p>
+                <div class="flex flex-col sm:flex-row gap-4 justify-center mb-6">
+                    <a href="#licensed" class="btn-hover inline-flex items-center justify-center gap-2 px-6 py-3 text-base font-black bg-acid text-obsidian bru-border">
+                        MiCA path <span class="font-mono">&rarr;&nbsp;&euro;1.0M</span>&nbsp;raise
+                    </a>
+                    <a href="#non-custodial" class="btn-hover inline-flex items-center justify-center gap-2 px-6 py-3 text-base font-black bg-z-purple text-obsidian bru-border">
+                        Non-custodial path <span class="font-mono">&rarr;&nbsp;&euro;300&ndash;500k</span>&nbsp;raise
+                    </a>
+                </div>
+                <p class="text-sm text-text-sec max-w-2xl mx-auto font-medium">
+                    Founded by the former CEO of Paysera (1M+ users scaled, MLRO/CFO/legal in-house). Production codebase live.
+                </p>
+            </section>
+
+            {{-- ═══════════════════════════════════════
+                 TWO-PATHS COMPARISON TABLE
+                 ═══════════════════════════════════════ --}}
+            <section class="mb-20">
+                <h2 class="text-3xl md:text-4xl font-black font-heading mb-6 text-center">Side by side.</h2>
+                <p class="text-center text-text-sec font-medium max-w-2xl mx-auto mb-10">
+                    Two paths, one company. Same engineering team, same founder, very different capital and regulatory profiles.
+                </p>
+
+                {{-- Desktop / tablet table --}}
+                <div class="compare-table-wrap overflow-x-auto">
+                    <table class="compare-table bru-card" style="background:#fff;">
+                        <thead>
+                            <tr>
+                                <th>Dimension</th>
+                                <th>Path A &mdash; Licensed</th>
+                                <th>Path B &mdash; Non-custodial</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <th>Capital ask</th>
+                                <td><span class="font-mono font-bold">&euro;1.0M</span> (founder-discounted from <span class="font-mono">&euro;1.5&ndash;2M</span>)</td>
+                                <td><span class="font-mono font-bold">&euro;300&ndash;500k</span></td>
+                            </tr>
+                            <tr>
+                                <th>Use of capital</th>
+                                <td><span class="font-mono">&euro;250k</span> locked regulatory capital + <span class="font-mono">&euro;160k</span> setup + <span class="font-mono">&euro;450k</span> runway + <span class="font-mono">&euro;140k</span> buffer</td>
+                                <td>Engineering + GTM + 12&nbsp;mo runway</td>
+                            </tr>
+                            <tr>
+                                <th>Regulatory burden</th>
+                                <td>MiCA Class&nbsp;2 + EMI Lithuania</td>
+                                <td>None (software vendor)</td>
+                            </tr>
+                            <tr>
+                                <th>Time to revenue</th>
+                                <td><span class="font-mono">M3</span> (post-licence-grant)</td>
+                                <td><span class="font-mono">M0</span> (already shipping)</td>
+                            </tr>
+                            <tr>
+                                <th>Monthly break-even</th>
+                                <td><span class="font-mono">~M17</span> / <span class="font-mono">~16k</span> active users</td>
+                                <td><span class="font-mono">~M22</span> / <span class="font-mono">~33k</span> active users</td>
+                            </tr>
+                            <tr>
+                                <th>Cumulative cash break-even</th>
+                                <td><span class="font-mono">~M30</span> / <span class="font-mono">~30k</span> users</td>
+                                <td><span class="font-mono">~M28</span> / <span class="font-mono">~28k</span> users</td>
+                            </tr>
+                            <tr>
+                                <th>ARPU at scale</th>
+                                <td><span class="font-mono">~&euro;3.50</span></td>
+                                <td><span class="font-mono">~&euro;3.31</span></td>
+                            </tr>
+                            <tr>
+                                <th>Moat</th>
+                                <td>Regulatory (12+ month licence cycle)</td>
+                                <td>Engineering velocity + founder distribution</td>
+                            </tr>
+                            <tr>
+                                <th>Exit profile</th>
+                                <td>Acquihire by EU bank, or PE roll-up</td>
+                                <td>SaaS multiple acquisition by crypto-fiat ramp</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                {{-- Mobile stack — accordion-style cards per row --}}
+                <div class="compare-stack space-y-4">
+                    @php
+                        $rows = [
+                            ['Capital ask',                'Path A — Licensed', '<span class="font-mono font-bold">€1.0M</span> (founder-discounted from <span class="font-mono">€1.5–2M</span>)', 'Path B — Non-custodial', '<span class="font-mono font-bold">€300–500k</span>'],
+                            ['Use of capital',             'Path A',            '<span class="font-mono">€250k</span> locked regulatory capital + <span class="font-mono">€160k</span> setup + <span class="font-mono">€450k</span> runway + <span class="font-mono">€140k</span> buffer', 'Path B', 'Engineering + GTM + 12 mo runway'],
+                            ['Regulatory burden',          'Path A',            'MiCA Class 2 + EMI Lithuania', 'Path B', 'None (software vendor)'],
+                            ['Time to revenue',            'Path A',            '<span class="font-mono">M3</span> (post-licence-grant)', 'Path B', '<span class="font-mono">M0</span> (already shipping)'],
+                            ['Monthly break-even',         'Path A',            '<span class="font-mono">~M17</span> / <span class="font-mono">~16k</span> active users', 'Path B', '<span class="font-mono">~M22</span> / <span class="font-mono">~33k</span> active users'],
+                            ['Cumulative cash break-even', 'Path A',            '<span class="font-mono">~M30</span> / <span class="font-mono">~30k</span> users', 'Path B', '<span class="font-mono">~M28</span> / <span class="font-mono">~28k</span> users'],
+                            ['ARPU at scale',              'Path A',            '<span class="font-mono">~€3.50</span>', 'Path B', '<span class="font-mono">~€3.31</span>'],
+                            ['Moat',                       'Path A',            'Regulatory (12+ month licence cycle)', 'Path B', 'Engineering velocity + founder distribution'],
+                            ['Exit profile',               'Path A',            'Acquihire by EU bank, or PE roll-up', 'Path B', 'SaaS multiple acquisition by crypto-fiat ramp'],
+                        ];
+                    @endphp
+                    @foreach ($rows as $row)
+                        <details class="bg-white bru-card-sm" {{ $loop->first ? 'open' : '' }}>
+                            <summary class="cursor-pointer p-4 font-black text-base">{{ $row[0] }}</summary>
+                            <div class="px-4 pb-4 pt-1 space-y-3 text-sm">
+                                <div class="bg-acid bru-border p-3">
+                                    <div class="text-xs font-black uppercase tracking-wide mb-1">A &mdash; Licensed</div>
+                                    <div>{!! $row[2] !!}</div>
+                                </div>
+                                <div class="bg-z-purple bru-border p-3">
+                                    <div class="text-xs font-black uppercase tracking-wide mb-1">B &mdash; Non-custodial</div>
+                                    <div>{!! $row[4] !!}</div>
+                                </div>
+                            </div>
+                        </details>
+                    @endforeach
+                </div>
+            </section>
+
+            {{-- ═══════════════════════════════════════
+                 PATH A — LICENSED
+                 ═══════════════════════════════════════ --}}
+            <section id="licensed" class="mb-20 scroll-mt-24">
+                <div class="bg-acid bru-card-lg p-6 md:p-10">
+                    <div class="inline-block px-3 py-1 bg-obsidian text-acid font-black text-xs tracking-widest mb-4 bru-border" style="transform: rotate(-1deg);">PATH A</div>
+                    <h2 class="text-3xl md:text-5xl font-black font-heading mb-4">Licensed banking. <span class="block">€1.0M raise.</span></h2>
+                    <p class="text-base md:text-lg font-medium text-obsidian max-w-3xl mb-8">
+                        MiCA Class&nbsp;2 + EMI Lithuania. Regulatory moat takes a year to replicate; we have the in-house team to clear the licence cycle without hiring out.
+                    </p>
+
+                    {{-- Use of funds bar --}}
+                    <h3 class="font-black font-heading text-xl mb-3">Use of funds</h3>
+                    <div class="uof-bar mb-2" aria-label="Use of funds breakdown">
+                        <div class="bg-mint" style="flex: 250;">
+                            <div class="font-mono font-black text-base">&euro;250k</div>
+                            <div class="text-xs">Regulatory capital (locked)</div>
+                        </div>
+                        <div class="bg-z-purple" style="flex: 160;">
+                            <div class="font-mono font-black text-base">&euro;160k</div>
+                            <div class="text-xs">Licence setup</div>
+                        </div>
+                        <div class="bg-white" style="flex: 450;">
+                            <div class="font-mono font-black text-base">&euro;450k</div>
+                            <div class="text-xs">18-month runway</div>
+                        </div>
+                        <div class="bg-bg-tertiary" style="flex: 140;">
+                            <div class="font-mono font-black text-base">&euro;140k</div>
+                            <div class="text-xs">Buffer</div>
+                        </div>
+                    </div>
+                    <p class="text-xs text-text-sec font-mono mb-8">€250k + €160k + €450k + €140k = €1.0M</p>
+
+                    {{-- 18-month plan ASCII chart --}}
+                    <h3 class="font-black font-heading text-xl mb-3">18-month plan</h3>
+<pre class="bg-obsidian text-acid font-mono text-xs sm:text-sm p-4 sm:p-6 bru-border overflow-x-auto whitespace-pre" aria-label="Cumulative cash position over 18 months, breaking even at month 17">
+Month  Cumulative cash position
+M0    ████ -€1.0M
+M3    ████████ -€800k  (revenue starts)
+M6    ████████████ -€600k
+M12   ████████████████ -€400k
+M17   ████████████████████ €0  ← break-even
+M18   ███████████████████████ +€80k
+</pre>
+                    <p class="text-xs text-text-sec font-medium mt-2 mb-8">Full month-by-month detail in data room.</p>
+
+                    {{-- Why MiCA + EMI --}}
+                    <h3 class="font-black font-heading text-xl mb-3">Why MiCA + EMI</h3>
+                    <ul class="space-y-3">
+                        @foreach ([
+                            'Regulatory moat takes 12+ months to replicate; licensed competitor count in Lithuania ≤ 5',
+                            'EMI unlocks IBANs + card issuance — recurring revenue from interchange',
+                            'MiCA opens crypto custody + structured products — second product line',
+                        ] as $item)
+                            <li class="flex gap-3 items-start bg-white bru-border p-4">
+                                <span class="flex-none w-6 h-6 bg-obsidian text-acid font-black flex items-center justify-center text-sm" aria-hidden="true">✓</span>
+                                <span class="text-sm md:text-base font-medium">{{ $item }}</span>
+                            </li>
+                        @endforeach
+                    </ul>
+                </div>
+            </section>
+
+            {{-- ═══════════════════════════════════════
+                 PATH B — NON-CUSTODIAL
+                 ═══════════════════════════════════════ --}}
+            <section id="non-custodial" class="mb-20 scroll-mt-24">
+                <div class="bg-z-purple bru-card-lg p-6 md:p-10">
+                    <div class="inline-block px-3 py-1 bg-obsidian text-acid font-black text-xs tracking-widest mb-4 bru-border" style="transform: rotate(1deg);">PATH B</div>
+                    <h2 class="text-3xl md:text-5xl font-black font-heading mb-4">Non-custodial SaaS. <span class="block">€300&ndash;500k raise.</span></h2>
+                    <p class="text-base md:text-lg font-medium text-obsidian max-w-3xl mb-8">
+                        Smart wallets, software margins, no licence. Already shipping. Range tracks GTM ambition: <span class="font-mono">€300k</span> for an organic launch, <span class="font-mono">€500k</span> for paid acquisition.
+                    </p>
+
+                    {{-- Use of funds bar --}}
+                    <h3 class="font-black font-heading text-xl mb-3">Use of funds</h3>
+                    <div class="uof-bar mb-8" aria-label="Use of funds breakdown">
+                        <div class="bg-acid" style="flex: 1;">
+                            <div class="font-mono font-black text-base">~40%</div>
+                            <div class="text-xs">Engineering buildout</div>
+                        </div>
+                        <div class="bg-mint" style="flex: 1;">
+                            <div class="font-mono font-black text-base">~30%</div>
+                            <div class="text-xs">GTM / paid acquisition</div>
+                        </div>
+                        <div class="bg-white" style="flex: 1;">
+                            <div class="font-mono font-black text-base">~30%</div>
+                            <div class="text-xs">12-month runway</div>
+                        </div>
+                    </div>
+
+                    {{-- Pricing cards --}}
+                    <h3 class="font-black font-heading text-xl mb-3">Unit economics &mdash; pricing tiers</h3>
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-5 mb-8">
+                        {{-- Free --}}
+                        <div class="bg-white bru-card p-6">
+                            <div class="text-xs font-black tracking-widest text-text-muted mb-2">FREE</div>
+                            <div class="font-mono font-black text-3xl mb-4">&euro;0<span class="text-base font-medium">/mo</span></div>
+                            <ul class="space-y-2 text-sm">
+                                <li class="flex justify-between"><span>Send fee</span><span class="font-mono font-bold">&euro;0.20</span></li>
+                                <li class="flex justify-between"><span>Ramp margin</span><span class="font-mono font-bold">1%</span></li>
+                                <li class="flex justify-between"><span>Swap margin</span><span class="font-mono font-bold">0.5%</span></li>
+                            </ul>
+                        </div>
+
+                        {{-- Pro --}}
+                        <div class="bg-acid bru-card p-6 relative">
+                            <div class="absolute -top-3 -right-3 bg-obsidian text-acid font-black text-xs px-3 py-1 bru-border tracking-widest" style="transform: rotate(3deg);">RECOMMENDED</div>
+                            <div class="text-xs font-black tracking-widest text-obsidian mb-2">PRO</div>
+                            <div class="font-mono font-black text-3xl mb-1">&euro;4.99<span class="text-base font-medium">/mo</span></div>
+                            <div class="text-xs font-medium text-obsidian mb-4">or <span class="font-mono">&euro;49/yr</span> &middot; 7-day trial</div>
+                            <ul class="space-y-2 text-sm">
+                                <li class="flex justify-between"><span>Send fee</span><span class="font-mono font-bold">&euro;0.05</span></li>
+                                <li class="flex justify-between"><span>Ramp margin</span><span class="font-mono font-bold">0.5%</span></li>
+                                <li class="flex justify-between"><span>Swap margin</span><span class="font-mono font-bold">0.2%</span></li>
+                            </ul>
+                        </div>
+                    </div>
+
+                    {{-- Why non-custodial works --}}
+                    <h3 class="font-black font-heading text-xl mb-3">Why non-custodial works</h3>
+                    <ul class="space-y-3">
+                        @foreach ([
+                            'Smart wallet (ERC-4337) means user holds keys; we never hold client money',
+                            'Stripe Bridge handles fiat ramp; we charge software margin only — no MoR risk',
+                            'Same regulatory category as Spotify (software vendor), not as a payment service',
+                        ] as $item)
+                            <li class="flex gap-3 items-start bg-white bru-border p-4">
+                                <span class="flex-none w-6 h-6 bg-obsidian text-acid font-black flex items-center justify-center text-sm" aria-hidden="true">✓</span>
+                                <span class="text-sm md:text-base font-medium">{{ $item }}</span>
+                            </li>
+                        @endforeach
+                    </ul>
+                </div>
+            </section>
+
+            {{-- ═══════════════════════════════════════
+                 FOUNDER CREDIBILITY
+                 ═══════════════════════════════════════ --}}
+            <section class="mb-20">
+                <div class="bg-white bru-card-lg p-6 md:p-10">
+                    <div class="inline-block px-3 py-1 bg-mint text-obsidian font-black text-xs tracking-widest mb-4 bru-border">FOUNDER</div>
+                    <h2 class="text-3xl md:text-4xl font-black font-heading mb-6">Operator credibility.</h2>
+
+                    <div class="space-y-0 mb-8">
+                        @php
+                            $credRows = [
+                                ['Prior role',         'CEO, Paysera (Lithuania&rsquo;s largest fintech, 1M+ users at exit)'],
+                                ['Stack capability',   'MLRO + CFO + legal in-house — saves <span class="font-mono">~&euro;200k/year</span> vs hiring out'],
+                                ['Network',            'Direct working relationships with Bank of Lithuania, EU passport regulators, Stripe / Pimlico / Privy partnerships'],
+                                ['References',        'Available in data room (3 prior board members + 2 regulators)'],
+                            ];
+                        @endphp
+                        @foreach ($credRows as $r)
+                            <div class="grid grid-cols-1 md:grid-cols-[200px_1fr] gap-2 md:gap-6 py-3 border-b-2 border-obsidian/10">
+                                <div class="font-black font-heading text-sm md:text-base text-text-sec uppercase tracking-wide">{{ $r[0] }}</div>
+                                <div class="text-base font-medium">{!! $r[1] !!}</div>
+                            </div>
+                        @endforeach
+                    </div>
+
+                    <a href="#contact" class="btn-hover inline-flex items-center gap-2 px-6 py-3 text-sm font-black bg-acid text-obsidian bru-border">
+                        Request founder bio + references &rarr;
+                    </a>
+                </div>
+            </section>
+
+            {{-- ═══════════════════════════════════════
+                 ENGINEERING RIGOR
+                 ═══════════════════════════════════════ --}}
+            <section class="mb-20">
+                <h2 class="text-3xl md:text-4xl font-black font-heading mb-3">Engineering rigor.</h2>
+                <p class="text-text-sec font-medium max-w-2xl mb-8">Three claims, each backed by something a technical diligence partner can read.</p>
+
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-5">
+                    {{-- 1 --}}
+                    <div class="bg-white bru-card p-6">
+                        <div class="font-mono text-xs font-black bg-acid bru-border inline-block px-2 py-0.5 mb-3">01</div>
+                        <h3 class="font-black font-heading text-lg mb-2">Production codebase live</h3>
+                        <p class="text-sm font-medium text-text-sec mb-3">
+                            Backend on Laravel 12 / PHP 8.4 with 57 bounded contexts, event-sourced, multi-tenant. Mobile on Expo SDK 54 / React Native New Architecture. Both repos auditable.
+                        </p>
+                        <span class="inline-block text-xs font-mono font-bold bg-bg-tertiary bru-border px-2 py-0.5">[in data room]</span>
+                    </div>
+
+                    {{-- 2 --}}
+                    <div class="bg-white bru-card p-6">
+                        <div class="font-mono text-xs font-black bg-z-purple bru-border inline-block px-2 py-0.5 mb-3">02</div>
+                        <h3 class="font-black font-heading text-lg mb-2">v1.3.0 fully spec&rsquo;d</h3>
+                        <p class="text-sm font-medium text-text-sec mb-3">
+                            16 architectural decisions documented across subscription, quote pipeline, entitlements, reconciliation, GDPR compliance, App Store / Google Play submission readiness.
+                        </p>
+                        <span class="inline-block text-xs font-mono font-bold bg-bg-tertiary bru-border px-2 py-0.5">[engineering handover doc in data room]</span>
+                    </div>
+
+                    {{-- 3 --}}
+                    <div class="bg-white bru-card p-6">
+                        <div class="font-mono text-xs font-black bg-mint bru-border inline-block px-2 py-0.5 mb-3">03</div>
+                        <h3 class="font-black font-heading text-lg mb-2">Realistic timelines</h3>
+                        <p class="text-sm font-medium text-text-sec mb-3">
+                            Ship date for v1.3.0 (commercial pricing) is <span class="font-mono">~7.25</span> calendar weeks from kickoff. EU localization (v1.3.1) adds <span class="font-mono">~3&ndash;4</span> weeks. No vapor.
+                        </p>
+                        <span class="inline-block text-xs font-mono font-bold bg-bg-tertiary bru-border px-2 py-0.5">[plan + commit log in data room]</span>
+                    </div>
+                </div>
+            </section>
+
+            {{-- Traction section: omit until there's content. --}}
+
+            {{-- ═══════════════════════════════════════
+                 DATA ROOM CTA + CONTACT FORM
+                 ═══════════════════════════════════════ --}}
+            <section id="contact" class="mb-12 scroll-mt-24">
+                <div class="bg-obsidian text-white bru-card-lg p-6 md:p-10">
+                    <h2 class="text-3xl md:text-5xl font-black font-heading mb-4 max-w-3xl">
+                        See the numbers, the model, and the team&rsquo;s references.
+                    </h2>
+                    <p class="text-base md:text-lg text-white/80 max-w-2xl mb-8 font-medium">
+                        Submit below. We review every inquiry personally. Expect a reply within 48 hours.
+                    </p>
+
+                    @if ($errors->any())
+                        <div class="bg-acid text-obsidian bru-border p-4 mb-6">
+                            <p class="font-black mb-1">Please fix the following:</p>
+                            <ul class="list-disc pl-5 text-sm space-y-0.5">
+                                @foreach ($errors->all() as $err)
+                                    <li>{{ $err }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
+
+                    <form method="POST" action="{{ route('invest.submit') }}" class="grid grid-cols-1 md:grid-cols-2 gap-5">
+                        @csrf
+
+                        {{-- Honeypot — humans never see this; bots fill it; controller silently swallows. --}}
+                        <input type="text" name="website" tabindex="-1" autocomplete="off" aria-hidden="true" tabindex="-1" style="position:absolute;left:-9999px;top:-9999px;height:1px;width:1px;opacity:0;">
+
+                        <div>
+                            <label for="f-name" class="field-label text-white">Name</label>
+                            <input id="f-name" type="text" name="name" required minlength="2" maxlength="120" value="{{ old('name') }}" class="field-input">
+                        </div>
+
+                        <div>
+                            <label for="f-email" class="field-label text-white">Email</label>
+                            <input id="f-email" type="email" name="email" required maxlength="255" value="{{ old('email') }}" class="field-input">
+                        </div>
+
+                        <div class="md:col-span-2">
+                            <label for="f-linkedin" class="field-label text-white">LinkedIn URL</label>
+                            <input id="f-linkedin" type="url" name="linkedin_url" required maxlength="500" placeholder="https://linkedin.com/in/your-handle" value="{{ old('linkedin_url') }}" class="field-input">
+                        </div>
+
+                        <div>
+                            <span class="field-label text-white">Investing as</span>
+                            <div class="space-y-2 bg-white p-3 bru-border" role="radiogroup" aria-label="Investing as">
+                                @foreach ([
+                                    'angel'         => 'Angel',
+                                    'vc'            => 'VC',
+                                    'family_office' => 'Family office',
+                                    'other'         => 'Other',
+                                ] as $value => $label)
+                                    <label class="flex items-center gap-2 text-obsidian font-medium cursor-pointer">
+                                        <input type="radio" name="investing_as" value="{{ $value }}" {{ old('investing_as') === $value ? 'checked' : '' }} required>
+                                        <span class="text-sm">{{ $label }}</span>
+                                    </label>
+                                @endforeach
+                            </div>
+                        </div>
+
+                        <div>
+                            <span class="field-label text-white">Path of interest</span>
+                            <div class="space-y-2 bg-white p-3 bru-border" role="radiogroup" aria-label="Path of interest">
+                                @foreach ([
+                                    'licensed'      => 'Licensed (MiCA + EMI)',
+                                    'non_custodial' => 'Non-custodial SaaS',
+                                    'both'          => 'Both / undecided',
+                                ] as $value => $label)
+                                    <label class="flex items-center gap-2 text-obsidian font-medium cursor-pointer">
+                                        <input type="radio" name="path_of_interest" value="{{ $value }}" {{ old('path_of_interest') === $value ? 'checked' : '' }} required>
+                                        <span class="text-sm">{{ $label }}</span>
+                                    </label>
+                                @endforeach
+                            </div>
+                        </div>
+
+                        <div class="md:col-span-2">
+                            <label for="f-check" class="field-label text-white">Check size range</label>
+                            <select id="f-check" name="check_size_range" required class="field-select">
+                                <option value="" {{ old('check_size_range') ? '' : 'selected' }} disabled>Select a range</option>
+                                @foreach ([
+                                    'under_25k'  => 'Under €25k',
+                                    '25k_100k'   => '€25k – €100k',
+                                    '100k_500k'  => '€100k – €500k',
+                                    '500k_plus'  => '€500k+',
+                                ] as $value => $label)
+                                    <option value="{{ $value }}" {{ old('check_size_range') === $value ? 'selected' : '' }}>{{ $label }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+
+                        <div class="md:col-span-2">
+                            <label for="f-q" class="field-label text-white">What questions do you want answered first? <span class="font-medium text-white/60">(optional, 500 chars)</span></label>
+                            <textarea id="f-q" name="questions" maxlength="500" rows="4" class="field-textarea">{{ old('questions') }}</textarea>
+                        </div>
+
+                        <div class="md:col-span-2 flex items-start gap-3 bg-white p-4 bru-border">
+                            <input type="checkbox" id="f-gdpr" name="gdpr_consent" value="1" required class="mt-1 flex-none w-5 h-5">
+                            <label for="f-gdpr" class="text-obsidian text-sm font-medium">
+                                I consent to FinAegis storing this submission to contact me about this investment opportunity.
+                                <a href="{{ route('legal.privacy') }}" target="_blank" rel="noopener" class="font-bold underline hover:no-underline">Privacy Policy</a>.
+                            </label>
+                        </div>
+
+                        <div class="md:col-span-2">
+                            <button type="submit" class="btn-hover inline-flex items-center gap-2 px-7 py-3.5 text-base font-black bg-acid text-obsidian bru-border">
+                                Submit inquiry &rarr;
+                            </button>
+                            <p class="text-xs text-white/60 mt-3">5 submissions per IP per 24 hours. We never share your details.</p>
+                        </div>
+                    </form>
+                </div>
+            </section>
+
+            {{-- Footer note --}}
+            <p class="text-center text-sm text-text-muted">
+                FinAegis Ltd. is the legal entity behind {{ $brand }}. This page is for accredited investors only.
+            </p>
+        </div>
+    </main>
+
+</body>
+</html>

--- a/resources/views/invest/data-room-gated.blade.php
+++ b/resources/views/invest/data-room-gated.blade.php
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    @php $brand = config('brand.name', 'Zelta'); @endphp
+
+    <title>Data room &mdash; access required &mdash; {{ $brand }}</title>
+
+    @include('partials.favicon')
+    <meta name="robots" content="noindex,nofollow">
+
+    <link rel="preconnect" href="https://fonts.bunny.net">
+    <link href="https://fonts.bunny.net/css?family=space-grotesk:400,500,600,700&dm-sans:400,500,600,700&jetbrains-mono:400,500,700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/css/app-landing.css">
+
+    <style>
+        body {
+            background: #faf9f6;
+            color: #0a0a0a;
+            font-family: 'Space Grotesk', system-ui, sans-serif;
+            min-height: 100vh;
+        }
+        ::selection { background: #ccff00; color: #000; }
+        .bg-acid { background-color: #ccff00; }
+        .bg-mint { background-color: #a8f0c4; }
+        .text-text-sec { color: #404040; }
+        .bru-border { border: 3px solid #0a0a0a; }
+        .bru-card-lg { border: 3px solid #0a0a0a; box-shadow: 8px 8px 0 #0a0a0a; }
+        .btn-hover { transition: transform 0.15s ease; }
+        .btn-hover:hover { transform: scale(1.04); }
+        .font-heading { font-family: 'Space Grotesk', system-ui, sans-serif; letter-spacing: -0.04em; }
+        .font-mono { font-family: 'JetBrains Mono', ui-monospace, monospace; }
+    </style>
+</head>
+<body class="antialiased">
+    <header class="px-5 py-5 md:py-6">
+        <div class="mx-auto max-w-4xl flex items-center justify-between">
+            <a href="{{ url('/') }}" class="flex items-center gap-3 btn-hover">
+                <div class="flex h-11 w-11 items-center justify-center rounded-xl text-xl font-black bg-mint bru-border" style="font-family: 'Space Grotesk', sans-serif; letter-spacing: -0.04em;">
+                    Z
+                </div>
+                <span class="text-2xl font-black font-heading">{{ $brand }}</span>
+            </a>
+        </div>
+    </header>
+
+    <main class="px-5 pb-24">
+        <div class="mx-auto max-w-2xl text-center mt-12">
+            <div class="inline-block bg-acid bru-border px-4 py-1 text-sm font-black mb-6 font-mono" style="transform: rotate(-1deg);">
+                403 &middot; ACCESS REQUIRED
+            </div>
+            <h1 class="text-4xl md:text-5xl font-black font-heading mb-6" style="line-height: 0.95;">
+                You need to request access first.
+            </h1>
+            <div class="bg-white bru-card-lg p-6 md:p-8 mb-8 text-left">
+                <p class="text-base md:text-lg font-medium text-text-sec mb-3">
+                    The data room is gated. We review every request personally and grant access individually &mdash; usually within 48 hours.
+                </p>
+                <p class="text-sm text-text-sec font-medium">
+                    Submit the inquiry form on the investor page and we&rsquo;ll come back to you with a link.
+                </p>
+            </div>
+            <a href="{{ route('invest.show') }}#contact" class="btn-hover inline-flex items-center gap-2 px-6 py-3 text-base font-black bg-acid text-obsidian bru-border">
+                Request access &rarr;
+            </a>
+        </div>
+    </main>
+</body>
+</html>

--- a/resources/views/invest/thanks.blade.php
+++ b/resources/views/invest/thanks.blade.php
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+
+    @php $brand = config('brand.name', 'Zelta'); @endphp
+
+    <title>Thank you &mdash; {{ $brand }}</title>
+
+    @include('partials.favicon')
+    <meta name="robots" content="noindex,nofollow">
+
+    <link rel="preconnect" href="https://fonts.bunny.net">
+    <link href="https://fonts.bunny.net/css?family=space-grotesk:400,500,600,700&dm-sans:400,500,600,700&jetbrains-mono:400,500,700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/css/app-landing.css">
+
+    <style>
+        body {
+            background: #faf9f6;
+            color: #0a0a0a;
+            font-family: 'Space Grotesk', system-ui, sans-serif;
+            min-height: 100vh;
+        }
+        ::selection { background: #ccff00; color: #000; }
+        .bg-acid { background-color: #ccff00; }
+        .bg-mint { background-color: #a8f0c4; }
+        .text-text-sec { color: #404040; }
+        .bru-border { border: 3px solid #0a0a0a; }
+        .bru-card-lg { border: 3px solid #0a0a0a; box-shadow: 8px 8px 0 #0a0a0a; }
+        .btn-hover { transition: transform 0.15s ease; }
+        .btn-hover:hover { transform: scale(1.04); }
+        .font-heading { font-family: 'Space Grotesk', system-ui, sans-serif; letter-spacing: -0.04em; }
+    </style>
+</head>
+<body class="antialiased">
+    <header class="px-5 py-5 md:py-6">
+        <div class="mx-auto max-w-4xl flex items-center justify-between">
+            <a href="{{ url('/') }}" class="flex items-center gap-3 btn-hover">
+                <div class="flex h-11 w-11 items-center justify-center rounded-xl text-xl font-black bg-mint bru-border" style="font-family: 'Space Grotesk', sans-serif; letter-spacing: -0.04em;">
+                    Z
+                </div>
+                <span class="text-2xl font-black font-heading">{{ $brand }}</span>
+            </a>
+        </div>
+    </header>
+
+    <main class="px-5 pb-24">
+        <div class="mx-auto max-w-2xl text-center mt-12">
+            <div class="inline-block bg-acid bru-border px-4 py-1 text-sm font-black mb-6" style="transform: rotate(-1deg);">
+                INQUIRY RECEIVED
+            </div>
+            <h1 class="text-4xl md:text-5xl font-black font-heading mb-6" style="line-height: 0.95;">Thank you.</h1>
+            <div class="bg-white bru-card-lg p-6 md:p-8 mb-8 text-left">
+                <p class="text-base md:text-lg font-medium text-text-sec mb-3">
+                    We review every inquiry personally. Expect a reply within 48 hours.
+                </p>
+                <p class="text-sm text-text-sec font-medium">
+                    If your fit looks like a match, we&rsquo;ll send a data-room link in that reply.
+                </p>
+            </div>
+            <a href="{{ url('/') }}" class="btn-hover inline-flex items-center gap-2 px-6 py-3 text-base font-black bg-acid text-obsidian bru-border">
+                &larr; Return to home
+            </a>
+        </div>
+    </main>
+</body>
+</html>

--- a/routes/console.php
+++ b/routes/console.php
@@ -223,6 +223,13 @@ Schedule::job(new App\Domain\Wallet\Jobs\PollEvmWalletSendConfirmations())
     ->description('Poll bundler for EVM wallet-send confirmations')
     ->withoutOverlapping();
 
+// Daily retention sweep for the public investor lead-capture form.
+// Drops investor_inquiries rows older than 24 months. Idempotent.
+Schedule::command('investor:purge-old-inquiries')
+    ->dailyAt('03:00')
+    ->description('Purge investor inquiries older than 24 months (GDPR retention)')
+    ->appendOutputTo(storage_path('logs/investor-purge.log'));
+
 // Daily sweep: auto-disable expired reviewer/demo accounts.
 // --allow-production is appended because the scheduled job runs as the system,
 // not a human operator — the production guard is only for manual invocation.

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\ContactController;
 use App\Http\Controllers\GCUController;
 use App\Http\Controllers\StatusController;
+use App\Http\Controllers\Web\InvestorController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -25,6 +26,17 @@ Route::get('/app', function () {
 Route::get('/connect', function () {
     return view('connect');
 })->name('connect');
+
+// Public investor lead-capture page for the FinAegis legal-entity raise.
+// Brand exception: the page itself reads "FinAegis" because investors
+// invest in the entity, not the Zelta product. Header/footer/nav stay
+// Zelta — only the body copy here is FinAegis-branded.
+Route::get('/invest', [InvestorController::class, 'show'])->name('invest.show');
+Route::post('/invest', [InvestorController::class, 'submit'])
+    ->middleware('throttle:5,1440')   // 5 submissions per 24h per IP
+    ->name('invest.submit');
+Route::get('/invest/thanks', [InvestorController::class, 'thanks'])->name('invest.thanks');
+Route::get('/invest/data-room', [InvestorController::class, 'dataRoom'])->name('invest.data-room');
 
 // Privy email-OTP web login (gated by MCP_WEB_PRIVY_LOGIN). The matching
 // GET /login view is registered by Fortify::loginView() in the service

--- a/tests/Feature/Console/InvestorPurgeOldInquiriesCommandTest.php
+++ b/tests/Feature/Console/InvestorPurgeOldInquiriesCommandTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\InvestorInquiry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Build a row with a back-dated created_at. We hit the DB directly because
+ * Eloquent's mass-assign clobbers `created_at` with `now()` even when it's
+ * passed via create().
+ *
+ * @param  array<string, mixed>  $overrides
+ */
+function makeInquiryAt(Carbon $createdAt, array $overrides = []): InvestorInquiry
+{
+    /** @var InvestorInquiry $inquiry */
+    $inquiry = InvestorInquiry::create(array_replace([
+        'name'             => 'Test Investor',
+        'email'            => 'investor@example.com',
+        'linkedin_url'     => 'https://linkedin.com/in/test',
+        'investing_as'     => 'angel',
+        'path_of_interest' => 'licensed',
+        'check_size_range' => '25k_100k',
+        'questions'        => null,
+        'ip_hash'          => str_repeat('a', 64),
+        'user_agent'       => 'Test',
+    ], $overrides));
+
+    // Force the timestamp; the table only has created_at.
+    InvestorInquiry::query()
+        ->where('id', $inquiry->id)
+        ->update(['created_at' => $createdAt]);
+
+    return $inquiry->fresh() ?? $inquiry;
+}
+
+it('deletes inquiries older than 24 months', function (): void {
+    $oldOne = makeInquiryAt(Carbon::now()->subMonths(25));
+    $oldTwo = makeInquiryAt(Carbon::now()->subYears(3));
+
+    expect(InvestorInquiry::query()->count())->toBe(2);
+
+    $exit = Artisan::call('investor:purge-old-inquiries');
+
+    expect($exit)->toBe(0)
+        ->and(InvestorInquiry::query()->count())->toBe(0)
+        ->and(InvestorInquiry::query()->find($oldOne->id))->toBeNull()
+        ->and(InvestorInquiry::query()->find($oldTwo->id))->toBeNull();
+});
+
+it('preserves inquiries that are 23 months old', function (): void {
+    $recent = makeInquiryAt(Carbon::now()->subMonths(23));
+    $brandNew = makeInquiryAt(Carbon::now()->subDay());
+
+    $exit = Artisan::call('investor:purge-old-inquiries');
+
+    expect($exit)->toBe(0)
+        ->and(InvestorInquiry::query()->count())->toBe(2)
+        ->and(InvestorInquiry::query()->find($recent->id))->not->toBeNull()
+        ->and(InvestorInquiry::query()->find($brandNew->id))->not->toBeNull();
+});
+
+it('reports nothing-to-do when the table has no old rows', function (): void {
+    makeInquiryAt(Carbon::now()->subDay());
+
+    $exit = Artisan::call('investor:purge-old-inquiries');
+
+    expect($exit)->toBe(0)
+        ->and(Artisan::output())->toContain('No investor inquiries older than 24 months');
+});
+
+it('does not delete in --dry-run mode', function (): void {
+    makeInquiryAt(Carbon::now()->subYears(3));
+    makeInquiryAt(Carbon::now()->subMonths(25));
+
+    $exit = Artisan::call('investor:purge-old-inquiries', ['--dry-run' => true]);
+
+    expect($exit)->toBe(0)
+        ->and(InvestorInquiry::query()->count())->toBe(2);
+});

--- a/tests/Feature/Web/InvestorInquiryTest.php
+++ b/tests/Feature/Web/InvestorInquiryTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\InvestorInquiry;
+use App\Notifications\InvestorInquirySubmitted;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\RateLimiter;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Build a fresh, valid form submission. Tests can override individual fields
+ * by passing an associative array.
+ *
+ * Email uses gmail.com so the `email:rfc,dns` MX-record check passes — the
+ * default Laravel dns validator hits real DNS even in tests.
+ *
+ * @param  array<string, string|int>  $overrides
+ * @return array<string, string|int>
+ */
+function inquiryPayload(array $overrides = []): array
+{
+    return array_replace([
+        'name'             => 'Jane Investor',
+        'email'            => 'jane@gmail.com',
+        'linkedin_url'     => 'https://linkedin.com/in/jane-investor',
+        'investing_as'     => 'angel',
+        'path_of_interest' => 'licensed',
+        'check_size_range' => '25k_100k',
+        'questions'        => 'How is the licence cycle progressing?',
+        'gdpr_consent'     => '1',
+    ], $overrides);
+}
+
+beforeEach(function (): void {
+    // Clear the throttle counters set by other tests in this file.
+    Cache::flush();
+    RateLimiter::clear('throttle');
+});
+
+it('shows the invest page anonymously', function (): void {
+    $response = $this->get(route('invest.show'));
+
+    $response->assertOk()
+        ->assertSeeText('FinAegis.')
+        ->assertSeeText('Two ways to invest.')
+        ->assertSeeText('Side by side.')
+        ->assertSee('content="noindex,nofollow"', false);
+});
+
+it('requires GDPR consent', function (): void {
+    Notification::fake();
+
+    $response = $this->from(route('invest.show'))
+        ->post(route('invest.submit'), inquiryPayload(['gdpr_consent' => '']));
+
+    $response->assertSessionHasErrors('gdpr_consent');
+    expect(InvestorInquiry::query()->count())->toBe(0);
+    Notification::assertNothingSent();
+});
+
+it('rejects invalid LinkedIn URLs', function (): void {
+    Notification::fake();
+
+    $response = $this->from(route('invest.show'))
+        ->post(route('invest.submit'), inquiryPayload(['linkedin_url' => 'https://example.com/profile']));
+
+    $response->assertSessionHasErrors('linkedin_url');
+    expect(InvestorInquiry::query()->count())->toBe(0);
+});
+
+it('accepts a valid LinkedIn URL', function (): void {
+    Notification::fake();
+
+    $response = $this->post(route('invest.submit'), inquiryPayload([
+        'linkedin_url' => 'https://www.linkedin.com/in/founder-handle',
+    ]));
+
+    $response->assertRedirect(route('invest.thanks'));
+    expect(InvestorInquiry::query()->count())->toBe(1);
+});
+
+it('stores the submission and queues the notification', function (): void {
+    Notification::fake();
+
+    $response = $this->post(route('invest.submit'), inquiryPayload());
+
+    $response->assertRedirect(route('invest.thanks'));
+
+    $inquiry = InvestorInquiry::query()->firstOrFail();
+    expect($inquiry->name)->toBe('Jane Investor')
+        ->and($inquiry->email)->toBe('jane@gmail.com')
+        ->and($inquiry->path_of_interest)->toBe('licensed')
+        ->and($inquiry->check_size_range)->toBe('25k_100k')
+        ->and($inquiry->investing_as)->toBe('angel');
+
+    Notification::assertSentOnDemand(
+        InvestorInquirySubmitted::class,
+        function (InvestorInquirySubmitted $notification, array $channels, object $notifiable) {
+            // The notifiable for an on-demand mail notification carries the
+            // routes; assert the founder address resolved correctly.
+            $routes = (array) $notifiable->routes;
+
+            return ($routes['mail'] ?? null) === config('investor.notification_email');
+        },
+    );
+});
+
+it('silently swallows honeypot submissions', function (): void {
+    Notification::fake();
+
+    $response = $this->post(route('invest.submit'), inquiryPayload(['website' => 'http://spam.example.com']));
+
+    $response->assertRedirect(route('invest.thanks'));
+    expect(InvestorInquiry::query()->count())->toBe(0);
+    Notification::assertNothingSent();
+});
+
+it('hashes the IP rather than storing it raw', function (): void {
+    Notification::fake();
+
+    $this->post(route('invest.submit'), inquiryPayload());
+
+    $inquiry = InvestorInquiry::query()->firstOrFail();
+    expect(strlen($inquiry->ip_hash))->toBe(64)
+        ->and($inquiry->ip_hash)->toMatch('/^[a-f0-9]{64}$/');
+
+    // sha256 of an IP shouldn't equal the IP itself.
+    expect($inquiry->ip_hash)->not->toBe('127.0.0.1');
+});
+
+it('rate-limits beyond 5 submissions in 24h', function (): void {
+    Notification::fake();
+
+    for ($i = 0; $i < 5; $i++) {
+        $response = $this->post(route('invest.submit'), inquiryPayload([
+            'email' => "investor{$i}@gmail.com",
+        ]));
+        $response->assertRedirect(route('invest.thanks'));
+    }
+
+    $sixth = $this->post(route('invest.submit'), inquiryPayload([
+        'email' => 'investor5@gmail.com',
+    ]));
+    $sixth->assertStatus(429);
+
+    expect(InvestorInquiry::query()->count())->toBe(5);
+});
+
+it('returns 403 on the data-room route by default', function (): void {
+    $response = $this->get(route('invest.data-room'));
+
+    $response->assertStatus(403)
+        ->assertSeeText('You need to request access first.')
+        ->assertSeeText('Request access');
+});


### PR DESCRIPTION
## Summary
- `/invest` public landing page: hero with two-path fork CTAs, comparison table, Path A (Licensed €1.0M) + Path B (Non-custodial €300–500k) sections, founder credibility table, engineering rigor section, gated lead form
- `/invest/data-room` returns 403 with request-access CTA (manual approval; not automated)
- `investor_inquiries` table with form-field columns + ip_hash + user_agent
- `InvestorInquirySubmitted` notification (queued) sent to `INVESTOR_NOTIFICATION_EMAIL`
- `investor:purge-old-inquiries` daily at 03:00, deletes >24mo rows
- Honeypot field `website` (silently swallowed); 5/24h rate limit; GDPR consent required
- `noindex` meta until explicit launch; OG card path stubbed (founder to add image at `public/images/og/invest-card.png`)
- Brutalist Zelta design system reused; "FinAegis" in body copy is a deliberate exception to "Zelta in prod" rule for investor materials — header/nav/footer stay Zelta
- Privacy link points to existing `legal.privacy` route (no new privacy page created)

## Design choices (worth flagging)
- Path A CTA + accents use `acid` (#ccff00); Path B uses `lavender` (#c8a8f0) — kept consistent through every Path A/B reference on the page
- Comparison table: full table on desktop, accordion stack on mobile (no horizontal scroll on iPhone 13 mini)
- All financial numbers (€, M-numbers, %) use `font-mono` (JetBrains Mono) per spec
- Cleanup command also accepts `--dry-run` (not in spec, but mirrors `privy:purge-placeholder-users` which it copies the style from)
- Email validation uses `email:rfc,dns` per spec — tests use `gmail.com` so the MX-record check passes

## Files
- Migration: `database/migrations/2026_05_08_221255_create_investor_inquiries_table.php`
- Model: `app/Models/InvestorInquiry.php`
- Controller: `app/Http/Controllers/Web/InvestorController.php`
- Form request: `app/Http/Requests/InvestorInquiryRequest.php`
- Notification: `app/Notifications/InvestorInquirySubmitted.php`
- Cleanup command: `app/Console/Commands/InvestorPurgeOldInquiriesCommand.php`
- Config: `config/investor.php`
- Views: `resources/views/invest.blade.php`, `resources/views/invest/thanks.blade.php`, `resources/views/invest/data-room-gated.blade.php`
- Tests: `tests/Feature/Web/InvestorInquiryTest.php` (9 cases), `tests/Feature/Console/InvestorPurgeOldInquiriesCommandTest.php` (4 cases)
- Modified: `routes/web.php` (4 new routes), `routes/console.php` (1 schedule entry), `.env.example` (`INVESTOR_NOTIFICATION_EMAIL`)

## Test plan
- [x] `./vendor/bin/php-cs-fixer` passes (no further changes needed)
- [x] PHPStan Level 8 clean on all new files
- [x] Pest: 13/13 tests pass (9 web + 4 console)
- [x] No regression in `ConnectPageTest` and `ScheduleNoDuplicatesTest`
- [ ] CI green
- [ ] Manual smoke on staging: form submits, founder gets email, honeypot blocked, rate limit enforced, data-room route returns 403
- [ ] Founder reviews copy before unsetting `noindex`
- [ ] Founder adds OG card image at `public/images/og/invest-card.png` before launch
- [ ] Founder sets `INVESTOR_NOTIFICATION_EMAIL` in production env (defaults to `investors@finaegis.com`)

## Brand exception note
Per CLAUDE.md, production UI says "Zelta" everywhere. This page is the documented exception: the H1 + body copy say "FinAegis" because investors fund the legal entity. Header logo, nav, and footer stay "Zelta" so visitors landing on `/invest` from elsewhere on `zelta.app` see a consistent brand chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)