### PR TITLE
docs(adr): 0001/0002/0003 — fee collectors, revenue projection, pricing

### DIFF
--- a/docs/adr/0001-fee-collector-wallets.md
+++ b/docs/adr/0001-fee-collector-wallets.md
@@ -1,0 +1,204 @@
+# ADR-0001 — Fee collector wallets: KMS-custodied EOAs with daily sweep
+
+**Status:** Accepted
+**Date:** 2026-05-09
+**Decision-maker:** Backend engineer
+**Related:** Backend-Q2 in `docs/BACKEND_HANDOVER_PLAN_B_REVIEW_DELTAS.md`; original handover §2.4 (Collection mechanism per fee type); ADR-0004 (Money on the wire — fee transfers carry Money in this format)
+
+---
+
+## Context
+
+Plan B Commercial v1.3.0 introduces service fees on user-initiated on-chain transfers. The mechanism (locked in deltas Q2 as Architecture A) is a **sibling fee transfer in the userOp batch**: when the user signs a userOp to send 100 USDC to Alice, the same userOp also transfers €0.20-equivalent USDC (e.g. 200000 micro-USDC) to a Zelta-controlled fee-collector address on the same chain.
+
+The original handover and deltas committed to Architecture A but did not specify **where the fee-collector address actually lives** — i.e., who custodies the key, how it's protected, how the accumulated balance is swept off-chain to operating accounts. That question is the load-bearing operational decision behind A and warrants its own architectural commitment.
+
+The decision must hold for five chains in v1.3.0: Polygon, Base, Arbitrum, Ethereum, Solana. Each chain needs at least one collector address. The total fee inflow per chain at year-1 plateau (~16k MAU per Path A break-even forecast, free-tier sends at €0.20 each) is roughly **€100/day/chain**, sweep daily, on-chain balance at any moment ~€100 per chain.
+
+---
+
+## Decision
+
+**One fee-collector EOA per chain, KMS-backed signing key, swept daily into operating accounts.**
+
+Five collector addresses total:
+
+- `fee_collector_polygon`
+- `fee_collector_base`
+- `fee_collector_arbitrum`
+- `fee_collector_ethereum`
+- `fee_collector_solana`
+
+Configured in `config/fees.php` keyed by chain, env-driven (`FEE_COLLECTOR_POLYGON_ADDRESS`, `FEE_COLLECTOR_POLYGON_KMS_ARN`, etc.). Public addresses are not secrets — they appear in every quoted userOp's calldata and on-chain. The KMS ARN binding the address to a signing key is the secret.
+
+Production signing path: AWS KMS asymmetric secp256k1 keys for EVM, ed25519 for Solana. Key never leaves the HSM. Application calls `kms:Sign` to produce sweep-transaction signatures. Local/staging uses env-stored private keys for the same addresses (different addresses per environment).
+
+---
+
+## Alternatives considered
+
+### (α) One fee-collector EOA per chain, KMS-backed — **chosen**
+
+Five EOAs, one per chain. Daily cron sweeps each into an off-ramp connected account (Coinbase Prime, Circle Mint, or Stripe Connect application_fee_amount where applicable).
+
+**Pros:** operationally simplest at v1.3.0 traffic; minimal infrastructure cost; matches existing patterns for similar low-throughput operational wallets at peer companies; key custody handled by AWS KMS (operationally bulletproof, audit-trailed, key never leaves HSM); revoke / rotate available via KMS without contract redeploys.
+
+**Cons:** custodial surface. We hold platform-revenue USDC for ~24h per chain between sweeps. Concentrated risk per chain (one EOA = one private key = one theft target). Acceptable at €100/day/chain inflow; less acceptable at €25k+/month per chain (escalation trigger documented below).
+
+### (β) One Pimlico/Privy smart-account per chain
+
+Account-abstraction wallets for Zelta itself (not user wallets). Multi-sig + social recovery. Paymaster-sponsored gas (collector wallets pay no gas).
+
+**Pros:** reduces single-key blast radius via multi-sig; recovery paths exist if a key is lost; gas-free sweep transactions (paymaster covers).
+
+**Cons:** higher upfront ops complexity (deploy + configure account contracts on each chain); ongoing Pimlico/Privy costs; v1.3.0 traffic doesn't justify the operational tax.
+
+**Migration trigger:** revisit (β) when sustained fee inflow exceeds **€100-150k/mo per chain** for 90+ days. The original Backend-Q2 grilling proposed €25k/mo as the trigger; the orchestrator pushed back that €25k/mo is small money even after absorbing some smart-account ops cost. €100-150k/mo per chain (≈ 4-6× current Year-1 forecast) is the right threshold — at that point, on-chain collector balance is meaningful enough that the multi-sig insurance pays off.
+
+### (γ) MPC-custodied wallets via Fireblocks / Copper / similar
+
+Treasure-grade MPC custody. Reads as institutional-quality to investors and to a future EMI auditor.
+
+**Pros:** strongest custody story; right answer if we ever hold material balances on-chain longer than a sweep cycle; aligns with the Path A licensed-banking narrative if we go that direction.
+
+**Cons:** material monthly cost (Fireblocks min ~€2-3k/mo; Copper similar). Overengineered for a fee collector under €100k/mo.
+
+**Migration trigger:** consider only if Path A licensed-banking is pursued, where on-chain custody becomes part of regulatory reporting. Path B SaaS doesn't warrant it.
+
+---
+
+## Consequences
+
+### Positive
+
+- **Operationally simple at launch.** Five EOAs, one config block, one sweep cron, one variance audit.
+- **KMS handles the hardest part.** Key never in our application code; key never in our env files (only the ARN); KMS provides audit log of every signing operation; key revocation via KMS does not require contract redeploys.
+- **Reuses existing infrastructure** for chain-event monitoring (Helius for Solana, Alchemy for EVM — both already integrated). The collector addresses become additional subscriptions, not new providers.
+- **Migration paths are open.** If/when we cross the €100-150k/mo threshold per chain, we can deploy smart-account contracts under the same address scheme and rotate.
+
+### Negative
+
+- **Custodial activity, briefly.** Holding platform-revenue USDC for ~24h per chain is custody of platform earnings, not customer funds, but it requires explicit legal framing (see §0.1 Prerequisites in the deltas). Plan B's "software vendor, not payment service" positioning relies on the framing line: *"Service fees are platform revenue; customers do not have a claim against held balances. We hold them transiently before settling to our operating account."* Legal owner: founder.
+- **Concentration risk per chain.** A compromise of the Polygon KMS key drains the Polygon collector. Sweep frequency limits the blast radius (max ~€100 per chain at any moment under Year-1 traffic), but a sophisticated attacker who watches the sweep cadence could time an exploit. Mitigation: anomaly detection on outbound transfers from collector addresses (any non-sweep outbound triggers an alert).
+- **Native asset sends do not collect a fee.** ETH/MATIC/SOL transfers cannot piggyback a stablecoin fee (no USDC balance precondition; adding a separate native-asset call complicates the userOp). Native sends are free at all tiers in v1.3.0. Loss is negligible (native sends are rare for consumer use cases).
+- **Native gas top-up pattern required.** The collector EOAs need gas (ETH on EVM chains, SOL on Solana) to execute sweep transactions. Sweep cron either: (a) uses a gas paymaster where the chain supports it, or (b) tops up collector EOAs from an operations gas wallet on a separate cron. Option (b) is the v1.3.0 default — simpler, no paymaster integration on the collector path.
+
+### Neutral
+
+- **Per-chain isolation.** A failure mode on one chain (Polygon RPC outage; Helius webhook delay) does not cascade. Sweep cron retries per chain independently.
+- **Sweep destination per chain.** Polygon/Base/Arbitrum/Ethereum sweep to a Coinbase Prime or Circle Mint deposit address; Solana sweeps to a Coinbase Prime Solana deposit. Sweep targets are configured per chain.
+
+---
+
+## Implementation notes
+
+### Configuration
+
+```php
+// config/fees.php
+return [
+    'collectors' => [
+        'polygon' => [
+            'address' => env('FEE_COLLECTOR_POLYGON_ADDRESS'),
+            'kms_arn' => env('FEE_COLLECTOR_POLYGON_KMS_ARN'),
+            'sweep_destination' => env('SWEEP_DESTINATION_POLYGON'),
+            'sweep_provider' => 'coinbase_prime',  // or 'circle_mint'
+        ],
+        'base' => [...],
+        'arbitrum' => [...],
+        'ethereum' => [...],
+        'solana' => [
+            'address' => env('FEE_COLLECTOR_SOLANA_ADDRESS'),
+            'kms_arn' => env('FEE_COLLECTOR_SOLANA_KMS_ARN'),  // ed25519
+            'sweep_destination' => env('SWEEP_DESTINATION_SOLANA'),
+            'sweep_provider' => 'coinbase_prime',
+        ],
+    ],
+    'tiers' => [
+        // unchanged from the original §10.2 spec; tier definitions move to config/pricing.php
+        // per ADR-0003.
+    ],
+];
+```
+
+### Sweep cron
+
+`php artisan revenue:sweep-fee-collectors` runs daily at 02:30 UTC. Per chain:
+
+1. Read collector balance via Helius (Solana) / Alchemy (EVM).
+2. If balance > minimum sweep threshold (configurable per chain, default ~€10 worth of USDC):
+   - Build a transfer transaction (USDC → sweep destination address).
+   - Sign via KMS (`kms:Sign` against the collector's ARN).
+   - Submit to chain.
+   - Wait for finality (32 confirmations on EVM, 32 slots on Solana — same finality thresholds as ADR-0002's chain-event-sourced ingestor).
+3. Record the sweep in `revenue_sweeps`:
+   - `chain`, `swept_amount_asset`, `swept_to`, `tx_hash`, `expected_eur_cents`, `actual_eur_cents` (set after off-ramp settlement), `settled_at`.
+4. Match the sweep against the sum of `revenue_events` rows where `collector_address = collector_X AND occurred_at < sweep_window_end`. If `|variance| > €10` OR `>1%`: write `variance_reason` and page ops via the existing PagerDuty hook.
+
+### Native gas top-up pattern
+
+Separate `php artisan revenue:top-up-collector-gas` cron runs daily at 02:00 UTC (before sweep). Reads native balance of each collector. If below threshold (default 0.05 ETH / 0.5 SOL), transfers from operations gas wallet to collector. Operations gas wallet is a separate KMS-keyed EOA, funded manually quarterly.
+
+### `revenue_sweeps` schema
+
+```sql
+CREATE TABLE revenue_sweeps (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    chain VARCHAR(32) NOT NULL,
+    collector_address VARCHAR(128) NOT NULL,
+    sweep_window_start TIMESTAMP NOT NULL,
+    sweep_window_end TIMESTAMP NOT NULL,
+    swept_amount_asset BIGINT UNSIGNED NOT NULL,        -- smallest-unit per ADR-0004
+    swept_amount_decimals TINYINT UNSIGNED NOT NULL,
+    swept_amount_denomination VARCHAR(16) NOT NULL,     -- 'USDC' typically
+    swept_to VARCHAR(128) NOT NULL,
+    sweep_tx_hash VARCHAR(128) NOT NULL,
+    expected_eur_cents BIGINT NOT NULL,                  -- sum of revenue_events for this window
+    actual_eur_cents BIGINT NULL,                        -- populated after off-ramp settlement
+    variance_eur_cents BIGINT NULL,
+    variance_reason VARCHAR(64) NULL,                    -- 'unmatched_inflow' | 'fx_drift' | etc.
+    settled_at TIMESTAMP NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    KEY idx_sweeps_chain_window (chain, sweep_window_start),
+    KEY idx_sweeps_unsettled (settled_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+### Extended `ServiceFeeCharged` event
+
+Per Backend-Q2 refinement, the event carries the source quote ID and the EUR rate at quote time, so revenue analytics and reconciliation can join back to the originating commitment:
+
+```
+ServiceFeeCharged {
+  user_id,
+  source: tx | swap | ramp,
+  reference_id,                            -- tx_hash | swap_id | ramp_session_id
+  reference_quote_id,                      -- price_quote_id (links to Domain/Pricing)
+  asset_amount_smallest_unit,
+  asset_decimals,
+  asset: 'USDC',
+  collector_address,
+  chain,
+  eur_rate_at_quote: { rate, decimals, source_id },  -- frozen from the consumed quote
+  gross_eur_cents,
+  user_tier_at_time,
+  occurred_at,
+}
+```
+
+### Legal §0.1 prerequisite
+
+Add to the deltas §0.1 (Prerequisites — business) under "Engineering pre-launch":
+
+> **Legal sign-off on fee-collector custody framing.** Single-line ToS addition: *"Service fees are platform revenue; customers do not have a claim against amounts held in fee-collector wallets. Zelta holds these balances transiently (typically <24h) before settling to operating accounts."* Founder + counsel review before week 1 of v1.3.0 build.
+
+---
+
+## References
+
+- `docs/BACKEND_HANDOVER_PLAN_B_REVIEW_DELTAS.md` — Backend-Q2 section, source material
+- `docs/BACKEND_HANDOVER_PLAN_B_COMMERCIAL.md` §2.4 (Collection mechanism per fee type)
+- `docs/adr/0002-revenue-projection-dual-upstream.md` — sibling ADR; chain-event-sourced ingestor projects from these collector addresses into `revenue_events`
+- `docs/adr/0004-money-on-the-wire.md` — fee transfers carry Money in the (amount, decimals, denomination) shape
+- AWS KMS asymmetric signing — operational pattern for production keys
+- `app/Domain/Wallet/Helpers/SolanaAddressHelper` — existing pattern for ed25519 derivation that the operations gas wallet's Solana key can mirror

--- a/docs/adr/0002-revenue-projection-dual-upstream.md
+++ b/docs/adr/0002-revenue-projection-dual-upstream.md
@@ -1,0 +1,191 @@
+# ADR-0002 — Revenue projection: chain-event-sourced for on-chain, outbox saga for off-chain
+
+**Status:** Accepted
+**Date:** 2026-05-09
+**Decision-maker:** Backend engineer
+**Related:** Backend-Q3 in `docs/BACKEND_HANDOVER_PLAN_B_REVIEW_DELTAS.md`; original handover §0.2 (Multi-tenancy / saga pattern), §4 (Revenue attribution); ADR-0001 (Fee collector wallets); ADR-0003 (Pricing bounded context)
+
+---
+
+## Context
+
+Plan B Commercial v1.3.0 records revenue events from two structurally different upstreams:
+
+- **On-chain fees** (`tx_fee`, `swap_margin`): collected via sibling transfers in user-signed userOps to the fee-collector wallets defined in ADR-0001. The chain itself is the durable log of which fee was collected when.
+- **Off-chain fees** (`subscription_initial`, `subscription_renewal`, `refund`, `ramp_margin`, `baas`, `kyc_margin`): sourced from PSP webhooks (Stripe, Apple App Store, Google Play, Stripe Bridge). The PSP is the source of truth.
+
+Original §0.2 specified a single mechanism for both — a multi-connection saga where the tenant-side wallet write commits, then a queued job records the revenue event on the global connection. That pattern was written for the deprecated custodial Shamir-shard wallet flow. Under v7.12.0+ non-custodial Privy, **there is no tenant-side wallet write in the user's transaction path** — the user's funds move on-chain, signed by their Privy keys, never touching a Zelta-tenant DB connection. The saga's premise doesn't apply.
+
+The deeper issue surfaced by Backend-Q3: under the saga pattern, a queued job that permanently fails (Redis loses the message; worker dies; DB hiccups during dispatch) means the on-chain fee transfer succeeded but no `revenue_events` row was written. Money is in the collector wallet without an audit trail back to user/tx. PSP-side reconciliation in §4.4 doesn't catch this — it's not a Stripe payout issue.
+
+We need a projection mechanism that's at least as durable as the upstream, for both upstream classes.
+
+---
+
+## Decision
+
+**Dual upstream — chain-event-sourced ingestor for on-chain fees; outbox saga for off-chain fees.** Both project into the same `revenue_events` read model.
+
+- **On-chain path:** Helius / Alchemy webhook subscriptions on the fee-collector addresses (one per chain per ADR-0001). Webhook arrives → ingestor verifies finality → looks up the source userOp / Solana tx via `quotes.user_op_hash` → writes the `revenue_events` row. The chain is the durable log; we project from it.
+- **Off-chain path:** PSP webhook arrives → handler writes a `revenue_outbox_events` row in the SAME transaction as the webhook-dedup row in `processed_webhook_events` (deltas Q7.3). A worker reads outbox rows, writes `revenue_events`, marks delivered. Idempotent on `(source_type, source_event_id)`.
+
+Same `revenue_events` table; two distinct projection paths.
+
+---
+
+## Alternatives considered
+
+### (α) Saga via queued job for everything (original §0.2)
+
+The single-mechanism approach the spec started with.
+
+**Rejected because:**
+- Saga premise (tenant-connection wallet write) doesn't apply to Privy non-custodial flow — there's no tenant wallet write in the user's transaction path.
+- Queued-job dispatch can drop messages between dispatch and worker pickup (Redis crash; worker death). On-chain fees succeed regardless; revenue events go missing.
+- PSP-side reconciliation (§4.4) catches Stripe-side variance but not on-chain variance — chain-side dropped events would only be detected at end-of-day sweep reconciliation, with no way to attribute "money in collector without revenue_event" back to a specific user/tx.
+
+### (β) Outbox saga for everything
+
+Replace queue-dispatch with a transactional outbox table on the global connection. Worker reads outbox, writes `revenue_events`, marks delivered.
+
+**Rejected for on-chain fees:** still has the same failure mode for on-chain — if the controller doesn't write to the outbox after the on-chain transaction succeeds (request times out, container dies between on-chain success and outbox write), revenue is still lost. The chain *did* succeed; we just didn't observe it.
+
+**Accepted for off-chain fees:** it's the right shape. PSP webhook handler writes outbox + dedup row in one transaction; worker is the only thing that can drop, and the worker can retry indefinitely against a durable row.
+
+### (γ) Chain-event-sourced ingestor for on-chain fees + (β) outbox for off-chain — **chosen**
+
+Two upstream paths. On-chain treats the chain as the durable log and projects via webhook-driven ingestor with periodic backfill. Off-chain uses the outbox saga.
+
+**Pros:** structurally rules out dropped events on the on-chain side (can't drop what's permanently on-chain); off-chain reuses the proven outbox pattern; reuses already-paid-for infrastructure (Helius for Solana webhooks, Alchemy for EVM webhooks — both already in production for user-balance sync); each path's reconciliation has a natural source-of-truth (chain history vs PSP reports).
+
+**Cons:** two distinct upstream paths to monitor; webhook latency adds ~30s to revenue recognition vs synchronous saga; chain reorgs require finality thresholds; ingestor extends existing processors (not net-new infrastructure but adds code surface).
+
+---
+
+## Consequences
+
+### Positive
+
+- **Structural durability for on-chain fees.** The chain is replayable; we never lose data the chain has. Webhook drops are caught by the periodic chain-history scan against the collector address. The saga's "queued job dropped between dispatch and consume" failure mode is structurally impossible.
+- **Reconciliation is automatic on the chain side.** ADR-0001's daily sweep reads collector balance and matches against `revenue_events` for the window — divergence is detected within 24h with attribution.
+- **Off-chain saga has clean upstream-of-truth.** Stripe `event.id` / Apple `notificationUUID` / Google `messageId` is the dedup key; outbox idempotency is exact; reconciliation matches against PSP reports per §4.4.
+- **Reuses existing infrastructure.** `HeliusTransactionProcessor` and `AlchemyWebhookManager` are in production. Adding fee-collector address subscriptions is config + code-path extension, not new providers.
+
+### Negative
+
+- **Two distinct upstream paths.** A future engineer reading `revenue_events` will need to know which paths feed it. Documented explicitly in this ADR + the deltas Backend-Q3 section.
+- **Latency.** On-chain transfer settles in ~5s (Polygon/Base/Arbitrum), ~12s (Ethereum), ~1s (Solana). Webhook fires within ~30s. Finality wait adds ~3 minutes (Polygon), ~13 minutes (Ethereum), ~13s (Solana). Hourly backfill scan covers any webhook drops. Net: a fee shows up in `revenue_events` within ~1 minute under normal operation, within ~1 hour under degraded webhook conditions. Acceptable for revenue recognition cadence.
+- **Reorg handling required.** Polygon and Ethereum can reorg up to ~12 blocks. The ingestor MUST wait for finality before writing to `revenue_events`. Pre-finality txs are tracked in-memory but not projected; reorg before finality drops the tracked entry silently.
+- **Original §0.2 saga rule is superseded for v1.3.0 fee path.** The rule stays as a guard-rail for FUTURE cross-connection writes that legitimately touch tenant + global tables. Backend-Q3 supersession note explicitly applies only to the fee path.
+
+### Neutral
+
+- **Off-chain fees' outbox lives on the global connection.** No multi-connection issue (PSP webhook handler runs on global; outbox table is global; revenue_events is global). The original §0.2 multi-connection saga concern doesn't apply here either.
+- **Both paths share the same idempotency primitive.** Off-chain via `processed_webhook_events` + outbox `(source_type, source_event_id)` UNIQUE. On-chain via `quotes.user_op_hash` lookup (the userOp hash is unique per quote per ADR-0003 / deltas Q2.2).
+
+---
+
+## Implementation notes
+
+### Per-chain finality thresholds
+
+| Chain | Threshold | Rationale |
+|---|---|---|
+| Polygon | 32 confirmations (~1 min) | Past typical reorg depth (12-16 blocks); industry standard |
+| Base | 32 confirmations (~1 min) | Same as Polygon; OP-stack chain |
+| Arbitrum | 32 confirmations (~7 sec) | Sequencer-confirmed; low reorg risk |
+| Ethereum | Finalized Beacon commitment (~12.8 min) | Strict finality; matches L1 risk profile |
+| Solana | Commitment level `finalized` (~13s) | Native Solana finality semantics |
+
+Pre-finality txs are tracked in an in-memory cache (`Cache::tags(['unconfirmed-fees'])`) but never projected to `revenue_events`. A reorg that drops a pre-finality tx removes the cache entry silently. A finalized tx that reorgs (extremely rare on Ethereum, never on Polygon/Base/Arbitrum/Solana finality) is a P0 incident that pages ops; manual reconciliation required.
+
+### Chain-event-sourced ingestor
+
+Extend `HeliusTransactionProcessor` (Solana) and `AlchemyWebhookManager` (EVM) with a fee-collector code path:
+
+- Webhook subscribes to incoming USDC transfers to each collector address (config from ADR-0001).
+- Inbound webhook: parse the transfer, extract `from_address`, `amount`, `tx_hash`. Wait for finality.
+- Look up `quotes.user_op_hash` matching the source userOp / Solana instruction. The hash is part of the userOp's signed payload per deltas Q2.2.
+- If found: write `revenue_events` row with `(user_id, source, reference_quote_id, gross_eur_cents, asset_amount, asset, collector_address, occurred_at)`. Match the extended `ServiceFeeCharged` event shape from ADR-0001.
+- If not found: write `unmatched_collector_inflows` row, page ops if amount > €10. Never write `revenue_events` without quote attribution.
+
+```sql
+CREATE TABLE unmatched_collector_inflows (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    chain VARCHAR(32) NOT NULL,
+    collector_address VARCHAR(128) NOT NULL,
+    from_address VARCHAR(128) NOT NULL,
+    asset VARCHAR(16) NOT NULL,
+    amount_smallest_unit BIGINT UNSIGNED NOT NULL,
+    amount_decimals TINYINT UNSIGNED NOT NULL,
+    eur_equivalent_cents BIGINT UNSIGNED NULL,
+    tx_hash VARCHAR(128) NOT NULL,
+    detected_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    resolved_at TIMESTAMP NULL,
+    resolution_note TEXT NULL,
+    UNIQUE KEY uniq_unmatched_tx (chain, tx_hash)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+### Hourly chain-history scan
+
+Belt-and-braces against webhook drops. `php artisan revenue:scan-collector-history` runs hourly:
+
+- For each collector address, query the chain for transfers since last_scanned_block.
+- For each transfer not already in `revenue_events`, run the ingestor logic (finality check, quote lookup, write or unmatched).
+- Update `last_scanned_block` for the chain.
+
+This is the durability backstop. Webhooks deliver fast-path; the scan covers gaps.
+
+### Outbox saga for off-chain fees
+
+```sql
+CREATE TABLE revenue_outbox_events (
+    id CHAR(36) PRIMARY KEY,
+    source_type VARCHAR(32) NOT NULL,                    -- 'stripe' | 'apple_iap' | 'google_play' | 'stripe_bridge'
+    source_event_id VARCHAR(255) NOT NULL,                -- Stripe event.id, Apple notificationUUID, etc.
+    payload JSON NOT NULL,                                -- intended revenue_events row body
+    status ENUM('pending','delivered','failed') NOT NULL DEFAULT 'pending',
+    delivered_at TIMESTAMP NULL,
+    error_message TEXT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uniq_outbox_source (source_type, source_event_id),
+    KEY idx_outbox_pending (status, created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+PSP webhook handler writes the outbox row and the `processed_webhook_events` dedup row in the same `DB::transaction()`. `ProjectRevenueOutbox` worker reads pending rows, writes `revenue_events`, marks delivered. Standard Laravel queue retries on transient failure; permanent failures land in `failed` status with `error_message` populated for ops review.
+
+### `revenue_events` is the unified read model
+
+Schema unchanged from original §4.1. Both paths write into it. Reconciliation in §4.4:
+
+- For PSP-sourced rows: diff `revenue_events` sum-by-provider against PSP reports (Stripe Reporting API, Apple settlement reports, Google Play earnings).
+- For chain-sourced rows: diff `revenue_events` sum-by-collector against the daily `revenue_sweeps` reconciliation (ADR-0001).
+
+### Multi-connection regression test scope
+
+Original §0.2 required a regression test for the saga's multi-connection deadlock. With (γ)+(β):
+
+- On-chain projection has no multi-connection issue (chain ingestor and revenue_events are both on global). No test required.
+- Off-chain outbox saga: PSP webhook handler writes to `revenue_outbox_events` AND `processed_webhook_events`, both global. The worker writes to `revenue_events`, also global. No tenant connection involved. No test required.
+
+The original `tests/MultiConnection/FeeDeductionMultiConnectionTest` from §11.3 is replaced by an outbox-delivery integration test under `tests/Feature/Revenue/RevenueOutboxDeliveryTest`.
+
+### §0.2 supersession note
+
+Add to deltas closing — already captured in Backend-Q3:
+
+> The multi-connection saga rule from original §0.2 stays as a guard-rail for future flows that legitimately write across tenant and global connections. It is **superseded specifically for the v1.3.0 fee projection path**, where on-chain fees use the chain-event-sourced ingestor (no cross-connection write) and off-chain fees use the outbox saga (single-connection write).
+
+---
+
+## References
+
+- `docs/BACKEND_HANDOVER_PLAN_B_REVIEW_DELTAS.md` — Backend-Q3 section, source material
+- `docs/BACKEND_HANDOVER_PLAN_B_COMMERCIAL.md` — original §0.2 (Conventions / multi-tenancy), §4 (Revenue attribution)
+- `docs/adr/0001-fee-collector-wallets.md` — collector addresses are the upstream for the on-chain projection path
+- `docs/adr/0003-pricing-bounded-context.md` — `quotes.user_op_hash` is the join key from inbound chain transfer to user/quote
+- `docs/adr/0004-money-on-the-wire.md` — revenue_events stores Money in the smallest-unit-with-decimals shape
+- `app/Domain/Wallet/Helpers/HeliusTransactionProcessor` — existing infrastructure being extended for the on-chain ingestor path
+- `processed_webhook_events` table — existing infrastructure for off-chain webhook dedup; outbox writes alongside it

--- a/docs/adr/0003-pricing-bounded-context.md
+++ b/docs/adr/0003-pricing-bounded-context.md
@@ -1,0 +1,225 @@
+# ADR-0003 — Pricing bounded context: stateful committed pricing, distinct from upstream Quote VOs
+
+**Status:** Accepted
+**Date:** 2026-05-09
+**Decision-maker:** Backend engineer
+**Related:** Backend-Q4 in `docs/BACKEND_HANDOVER_PLAN_B_REVIEW_DELTAS.md`; original handover §3 (Universal quote endpoint); ADR-0001 (fee collectors); ADR-0002 (revenue projection); ADR-0004 (Money on the wire)
+
+---
+
+## Context
+
+Plan B Commercial v1.3.0 originally specified a new bounded context `Domain/Quote` with model `Quote`, aggregate `QuoteAggregate`, table `quotes`, and endpoint `POST /api/v1/quote` for universal user-facing pricing across send/swap/ramp_buy/ramp_sell.
+
+The codebase already has six existing `Quote`-related types across other domains:
+
+| Domain | Class | Type | Purpose |
+|---|---|---|---|
+| `CrossChain` | `BridgeQuote` | VO | Cross-chain bridge price snapshot |
+| `CrossChain` | `CrossChainSwapQuote` | VO | Cross-chain swap snapshot |
+| `DeFi` | `SwapQuote` | VO | Uniswap/Curve quote |
+| `Exchange` | `ExchangeRateQuote` | VO | FX rate snapshot |
+| `Exchange` | `QuotesUpdated` | Event | Spatie event-sourced |
+| `Interledger` | `QuoteService` | Service | ILP cross-currency |
+
+Plus existing routes: `POST /api/v1/defi/swap/quote`, `POST /api/v1/crosschain/bridge/quote`, `POST /api/v1/interledger/quotes`, `POST /api/v1/mobile/wallet/quote`, `GET /api/v1/quotes` (RampController), and others.
+
+A new `Domain/Quote` with namespace-only differentiation would be the seventh `Quote`-anything in the codebase. Every `grep "Quote"` would return 50+ unrelated hits. Every conversation about "the quote service" would need disambiguation. Mobile devs would confuse `POST /api/v1/quote` (the universal endpoint) with `POST /api/v1/defi/swap/quote` (DeFi-specific).
+
+The deeper issue: the existing `Quote`-named VOs are **stateless market snapshots** — sourced from external markets, valid for seconds, no consumer-side state. The new domain represents **stateful committed pricing** — replay-protected (deltas Q2.2's userOp hash binding), tier-aware (free vs Pro), with a `consumed_at` lifecycle that outlives the source market quote (a 5-minute send window encompasses many refreshed upstream Uniswap quotes). Different concept. Different lifecycle. Different responsibility. Different word.
+
+---
+
+## Decision
+
+**`Domain/Pricing` is the new bounded context.** Aggregate `PriceQuote`, table `price_quotes`, internal references `price_quote_id`. The wire format and error codes preserve `quoteId` and `ERR_QUOTE_*` to avoid forcing mobile / SDK consumer changes for zero functional benefit — but the URL path moves to `POST /api/v1/pricing/quote` to lock the bounded-context home for future related endpoints.
+
+**Wire-vs-internal naming asymmetry is intentional and documented.**
+
+- **Internal** (DB columns, PHP foreign keys, aggregate names, namespaces): `price_quote_id`, `App\Domain\Pricing\Aggregates\PriceQuoteAggregate`, `price_quotes` table.
+- **Wire** (JSON request/response payloads, error codes): `quoteId` field, `ERR_QUOTE_001` / `ERR_QUOTE_002` codes.
+
+The wire contract is what mobile / SDK consumers / external integrators see. They already use `quoteId` and `ERR_QUOTE_*` per deltas Q2 mobile review. Renaming forces ~30 mobile-side string changes for zero functional benefit. Internal naming is what backend engineers see; that gets to be precise.
+
+URLs are the load-bearing wire-rename: `POST /api/v1/quote` → `POST /api/v1/pricing/quote`. Locking the namespace prefix now is cheap (no production traffic on the new endpoint yet); locking it after launch is expensive.
+
+---
+
+## Alternatives considered
+
+### (α) Spec-as-written: `Domain/Quote`, `quotes` table, `POST /api/v1/quote`
+
+What the original handover specified.
+
+**Rejected because:** seventh `Quote` namespace in the codebase. Every backend search for "Quote" returns mixed hits. Mobile devs guaranteed to confuse `POST /quote` (universal) with `POST /defi/swap/quote` (DeFi). Singular-vs-plural URL collision (`POST /quote` vs existing `GET /quotes` for RampController). Naming the new domain after the most-overloaded noun in the codebase is a bug-magnet.
+
+### (β) Embed inside an existing domain
+
+Stuff the universal-pricing logic into `Domain/Subscription` (because fee tier is the gating factor) or `Domain/Wallet` (because 2/4 kinds are wallet operations).
+
+**Rejected because:** this isn't subscription-domain logic — it's pricing logic. It isn't wallet-only either — swap and ramp flows aren't wallet-bounded. The bounded context is real; embedding it inside another collapses the abstraction.
+
+### (γ) New bounded context `Domain/Pricing` — **chosen**
+
+Aggregate `PriceQuote`, internal naming precise, wire naming preserves `quoteId` and `ERR_QUOTE_*` for mobile contract stability.
+
+**Pros:**
+- Zero name collision with any existing `Quote` type.
+- Semantically accurate: this domain wraps upstream quote services and adds Zelta's tier-aware service fee. Existing domains are about UPSTREAM quotes; this domain is about USER-FACING pricing.
+- The wire path `POST /api/v1/pricing/quote` is unambiguously distinct from `POST /api/v1/exchange/swap/quote` etc., signaling to mobile that this is the universal entry point.
+- `PriceQuote` aggregate name avoids conflict with all six existing types.
+- Wire-vs-internal asymmetry preserves mobile contracts without making backend code use the overloaded "quote" noun internally.
+
+**Cons:** ~30 string-replacements across the spec docs (already done in the deltas Backend-Q4 section). One-line URL change required from mobile (`/api/v1/quote` → `/api/v1/pricing/quote`).
+
+---
+
+## Consequences
+
+### Positive
+
+- **No name collision.** Backend engineers searching for "Pricing" find Pricing-domain code; searching for "Quote" finds the existing market-snapshot VOs. Each noun has a clear home.
+- **Wire stability for mobile.** Mobile already uses `quoteId` on submission contracts, replay protection, refresh logic, error responses, and telemetry events per deltas Q2/Q3. Preserving this avoids ~30 mobile-side string changes for zero functional benefit.
+- **URL prefix locks future home.** `/api/v1/pricing/*` becomes the canonical home for related endpoints — `/pricing/fee-tiers` for admin, `/pricing/savings-with-pro` if that ever surfaces directly, `/pricing/quotes/{id}` for read-back. Locking the prefix pre-shipment is cheap; locking it post-shipment is expensive.
+- **Dependency direction is clear.** `Pricing` calls into `Domain/Exchange/QuoteService`, `Domain/DeFi/SwapQuoteService`, `Domain/Ramp/SessionFactory`, etc. — never the other way. Existing domains are downstream of `Pricing` from the user's perspective.
+
+### Negative
+
+- **Wire-vs-internal asymmetry is a real cognitive cost.** A future engineer reading `quoteId` on the wire and `price_quote_id` in DB columns has to know they're the same thing. Mitigated by this ADR being discoverable via grep + the deltas Backend-Q4 section being explicit about the convention.
+- **Existing `GET /api/v1/quotes` (RampController) is left in production.** Renaming it is a mobile-breaking change. v1.3.0 keeps both endpoints; v1.3.1 deprecates the old one with an alias.
+- **One-time mobile coordination.** Mobile changes `idempotentPost('/api/v1/quote', ...)` to `idempotentPost('/api/v1/pricing/quote', ...)`. One-line change, but requires coordination with the mobile week-0 spike.
+
+### Neutral
+
+- **Error code prefix.** `ERR_QUOTE_*` stays despite the domain being named `Pricing`. The QUOTE prefix on the wire refers to the `PriceQuote` user-facing concept, not the upstream market-snapshot Quote VOs. Future error codes for Pricing-domain features (e.g., savings calculator, fee-tier admin) use new prefixes (`ERR_SAVINGS_*`, `ERR_FEE_*`).
+- **`config/fees.php` → `config/pricing.php`.** Fee-tier definitions belong in the domain that owns pricing logic. `Domain/Subscription` reads via the `ResolveFeeTier` query handler from the original §2 spec — no logic change, just config-key namespace move.
+
+---
+
+## Implementation notes
+
+### Naming convention summary
+
+| Surface | Convention |
+|---|---|
+| Bounded context | `App\Domain\Pricing\` |
+| Aggregate | `PriceQuoteAggregate` |
+| Models | `PriceQuote`, `PriceTier` (the §10.2 fee-tier struct moves here) |
+| Events | `PriceQuoteIssued`, `PriceQuoteConsumed`, `PriceQuoteSuperseded` (deltas Q2.3 refresh path) |
+| DB tables | `price_quotes`, `price_quote_events` |
+| FK columns | `price_quote_id` |
+| Config | `config/pricing.php` (replaces `config/fees.php`) |
+| HTTP routes | `POST /api/v1/pricing/quote`; future endpoints under `/api/v1/pricing/*` |
+| HTTP request/response field | `quoteId` (preserved from deltas Q2; backend translates to `price_quote_id` at the controller boundary) |
+| Error codes | `ERR_QUOTE_001` (expired), `ERR_QUOTE_002` (signature mismatch) — preserved per deltas Q2 |
+
+### Wire ↔ internal translation at the controller boundary
+
+Form Requests and API resources translate between the two:
+
+```php
+// Form Request — mobile sends quoteId
+public function rules(): array
+{
+    return [
+        'quoteId' => ['required', 'string', 'uuid'],
+        // ...
+    ];
+}
+
+public function priceQuoteId(): string
+{
+    return (string) $this->validated('quoteId');
+}
+
+// Controller
+public function submit(SubmitWalletSendRequest $request, PriceQuoteRepository $repo): JsonResponse
+{
+    $priceQuote = $repo->findOrFail($request->priceQuoteId());
+    // ... internal logic uses $priceQuote and price_quote_id
+}
+
+// API Resource — backend emits quoteId
+public function toArray(Request $request): array
+{
+    return [
+        'quoteId' => $this->price_quote_id,
+        // ...
+    ];
+}
+```
+
+### Dependency direction
+
+`Pricing` consumes upstream quote VOs; never the other way:
+
+```
+PricingController::quote()
+  → PriceQuoteIssuer::issue($request)
+    → match $request->kind:
+        'send'      → EvmUserOpPreparer / SolanaSendPreparer + tier fee
+        'swap'      → Domain\DeFi\SwapQuoteService + tier margin
+        'ramp_buy'  → Domain\Ramp\SessionFactory + tier margin
+        'ramp_sell' → Domain\Ramp\SessionFactory + tier margin
+```
+
+Existing upstream `Quote` VOs (`BridgeQuote`, `SwapQuote`, `ExchangeRateQuote`) stay in their domains. `Pricing` consumes them and produces `PriceQuote` rows.
+
+### `price_quotes` schema
+
+Per deltas Q2.2 / Q2.3 additions:
+
+```sql
+CREATE TABLE price_quotes (
+    id                CHAR(36) PRIMARY KEY,
+    user_id           CHAR(36) NOT NULL,
+    user_tier         VARCHAR(32) NOT NULL,
+    kind              VARCHAR(16) NOT NULL,        -- send | swap | ramp_buy | ramp_sell
+    request_payload   JSON NOT NULL,
+    response_payload  JSON NOT NULL,
+    entity_key        CHAR(64) NOT NULL,           -- SHA256 of intent (sender, kind, amount, recipient, currency, route)
+    user_op_hash      CHAR(66) NULL,                -- 0x + 32 bytes; null for ramp
+    user_op_payload   JSON NULL,                    -- full userOp; null for ramp
+    superseded_by     CHAR(36) NULL,                -- self-FK on refresh
+    terms_changed     BOOLEAN NOT NULL DEFAULT FALSE,
+    expires_at        TIMESTAMP NOT NULL,
+    consumed_at       TIMESTAMP NULL,
+    consumed_by       VARCHAR(255) NULL,            -- tx_hash | swap_id | ramp_session_id
+    created_at        TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    KEY idx_price_quotes_user_expires (user_id, expires_at),
+    KEY idx_price_quotes_consumed (consumed_at),
+    KEY idx_price_quotes_entity_live (entity_key, expires_at, consumed_at),
+    UNIQUE KEY uniq_price_quotes_user_op_hash (user_op_hash)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+### Rename pass coverage
+
+The deltas Backend-Q4 section already captures the spec rename:
+
+- §3 endpoint definitions: `POST /api/v1/quote` → `POST /api/v1/pricing/quote`
+- §3.2 schema name: `quotes` → `price_quotes`
+- §3.3 submission contracts: `{ quoteId, ... }` (wire stays `quoteId`); FK columns become `price_quote_id`
+- §10.2 config: `config/fees.php` → `config/pricing.php`
+- All references to `Domain/Quote` → `Domain/Pricing`; aggregate `Quote` → `PriceQuote`
+
+### Deprecation plan for `GET /api/v1/quotes` (RampController)
+
+The existing endpoint stays for v1.3.0. v1.3.1 adds an alias `GET /api/v1/pricing/ramp-quotes` that dual-serves. Once mobile has migrated, the old route returns 410 with a `deprecated_path` field pointing to the new one. Document in deltas closing as v1.3.1 follow-up.
+
+### What this ADR does NOT change
+
+- The `Domain/Subscription` boundary (Backend-Q1 γ): subscription state lives in `Domain/Subscription`; pricing-tier reads happen via `ResolveFeeTier` query handler against `config/pricing.php`. The two domains are clean.
+- Existing upstream `Quote` VOs: `BridgeQuote`, `SwapQuote`, `ExchangeRateQuote`, `QuotesUpdated` event, `Interledger\QuoteService`, `AI\MCP\Tools\Exchange\QuoteTool` — all stay where they are. `Pricing` calls into them but doesn't replace them.
+- Existing `/api/v1/exchange/*` and `/api/v1/defi/*` and `/api/v1/crosschain/*` routes — all stay. They serve their domain-specific purposes; `Pricing` is additive, not replacement.
+
+---
+
+## References
+
+- `docs/BACKEND_HANDOVER_PLAN_B_REVIEW_DELTAS.md` — Backend-Q4 section, source material
+- `docs/BACKEND_HANDOVER_PLAN_B_COMMERCIAL.md` §3 (Universal quote endpoint), §10.2 (fee tier config)
+- `docs/adr/0001-fee-collector-wallets.md` — fee-collector address is referenced in the userOp's calldata at quote-issuance time
+- `docs/adr/0002-revenue-projection-dual-upstream.md` — `quotes.user_op_hash` is the join key for chain-event-sourced ingestion
+- `docs/adr/0004-money-on-the-wire.md` — `PriceQuote` serializes Money fields in the smallest-unit-with-decimals shape
+- Existing `app/Domain/Exchange/ValueObjects/ExchangeRateQuote.php`, `app/Domain/DeFi/ValueObjects/SwapQuote.php`, `app/Domain/CrossChain/ValueObjects/BridgeQuote.php` — upstream stateless market-snapshot Quote VOs that `Pricing` consumes


### PR DESCRIPTION
## Summary
Three sibling ADRs locking the Backend-Q2/Q3/Q4 decisions from the Plan B v1.3.0 architectural review. Companions to ADR-0004 (already merged).

- **ADR-0001 fee collector wallets** — KMS-custodied EOAs (α) per chain, daily sweep with variance audit, native gas top-up pattern, migration thresholds at €100-150k/mo per chain for smart-account custody (β), legal framing for §0.1 prereq.
- **ADR-0002 revenue projection dual-upstream** — chain-event-sourced ingestor (γ) for on-chain fees + outbox saga (β) for off-chain fees. Per-chain finality thresholds, `unmatched_collector_inflows` audit, hourly backfill scan, `revenue_outbox_events` schema. §0.2 multi-connection saga rule superseded for v1.3.0 fee path; preserved as guardrail for future cross-connection writes.
- **ADR-0003 Pricing bounded context** — `Domain/Pricing` rename with wire-vs-internal naming asymmetry. Wire stays \`quoteId\` + \`ERR_QUOTE_*\` to preserve mobile contracts; internal becomes \`price_quote_id\` + \`Domain/Pricing\`. URL prefix \`/api/v1/pricing/*\` locks future endpoint home.

## Why these belong in git
Future engineers reading the codebase need to find the architectural decisions where they expect them — in `docs/adr/`. The deltas doc captures the grilling history; ADRs capture the durable decision rationale.

## Test plan
- [x] Pure documentation; no code changes
- [x] CI passes (no implementation impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)