### PR TITLE
feat(web): /invest references Aegis Brightsmark Ltd. as legal entity

### DIFF
--- a/resources/views/invest.blade.php
+++ b/resources/views/invest.blade.php
@@ -177,7 +177,7 @@
             <section class="text-center mb-16 mt-4">
                 <div class="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-acid bru-border text-sm font-bold mb-6" style="transform: rotate(-1deg);">
                     <span class="w-2 h-2 rounded-full bg-obsidian"></span>
-                    INVESTOR PAGE &middot; FINAEGIS LTD.
+                    INVESTOR PAGE &middot; AEGIS BRIGHTSMARK LTD.
                 </div>
                 <h1 class="text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-black mb-6 font-heading max-w-5xl mx-auto" style="line-height: 0.95;">
                     FinAegis. <span class="block sm:inline">Two ways to invest.</span> <span class="block">One <span class="bg-z-purple px-2 inline-block" style="box-decoration-break: clone; -webkit-box-decoration-break: clone;">operator</span> who&rsquo;s done this before.</span>
@@ -671,7 +671,7 @@
                         <div class="md:col-span-2 flex items-start gap-3 bg-white p-4 bru-border">
                             <input type="checkbox" id="f-gdpr" name="gdpr_consent" value="1" required class="mt-1 flex-none w-5 h-5">
                             <label for="f-gdpr" class="text-obsidian text-sm font-medium">
-                                I consent to FinAegis storing this submission to contact me about this investment opportunity.
+                                I consent to Aegis Brightsmark Ltd. (operator of FinAegis) storing this submission to contact me about this investment opportunity.
                                 <a href="{{ route('legal.privacy') }}" target="_blank" rel="noopener" class="font-bold underline hover:no-underline">Privacy Policy</a>.
                             </label>
                         </div>
@@ -696,8 +696,11 @@
         <div class="mx-auto max-w-6xl bg-white bru-card p-6 md:p-8">
             <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
                 <div>
-                    <div class="font-black font-heading text-base mb-2">FinAegis Ltd.</div>
-                    <p class="text-sm text-text-sec font-medium">Legal entity behind {{ $brand }}. Registered in Lithuania.</p>
+                    <div class="font-black font-heading text-base mb-2">Aegis Brightsmark Ltd.</div>
+                    <p class="text-sm text-text-sec font-medium">
+                        Legal entity behind FinAegis &middot; {{ $brand }}. Registered in Lithuania.
+                        <a href="https://aegisbrightsmark.com/about" target="_blank" rel="noopener" class="font-bold underline hover:no-underline">Company info &rarr;</a>
+                    </p>
                 </div>
                 <div>
                     <div class="font-black font-heading text-base mb-2">Contact</div>
@@ -717,9 +720,9 @@
             <div class="border-t-2 border-obsidian/10 pt-4 text-xs text-text-muted leading-relaxed">
                 <p class="mb-2">
                     <strong class="text-text-sec">For accredited investors only.</strong>
-                    This page is provided for informational purposes and does not constitute an offer to sell or a solicitation to buy any securities. Any investment in FinAegis Ltd. requires a separately executed subscription agreement and is subject to applicable securities laws in your jurisdiction. Past performance is not indicative of future results.
+                    This page is provided for informational purposes and does not constitute an offer to sell or a solicitation to buy any securities. Any investment in Aegis Brightsmark Ltd. (operator of FinAegis &middot; {{ $brand }}) requires a separately executed subscription agreement and is subject to applicable securities laws in your jurisdiction. Past performance is not indicative of future results.
                 </p>
-                <p class="font-mono">© {{ date('Y') }} FinAegis Ltd. All rights reserved.</p>
+                <p class="font-mono">© {{ date('Y') }} Aegis Brightsmark Ltd. All rights reserved.</p>
             </div>
         </div>
     </footer>


### PR DESCRIPTION
## Summary
FinAegis is the trading name; Aegis Brightsmark Ltd. is the actual registered legal entity. The investor page needs to be honest about who the investor would be contracting with.

### Changed
- Hero pill tag → \"AEGIS BRIGHTSMARK LTD.\"
- Footer entity column → \"Aegis Brightsmark Ltd. — Legal entity behind FinAegis · Zelta. Registered in Lithuania.\" + link to [aegisbrightsmark.com/about](https://aegisbrightsmark.com/about)
- Securities disclaimer → references Aegis Brightsmark Ltd. as the entity any investment is in
- Copyright → © Aegis Brightsmark Ltd.
- GDPR consent in form → names Aegis Brightsmark Ltd. as data controller (Art 13/14 transparency)

### Preserved (deliberate)
- Hero H1 \"FinAegis. Two ways to invest.\" — trading-name brand investors recognise from deck
- Contact email `invest@finaegis.com` — trading-name surface
- Header logo + nav (\"Zelta\") — production brand convention

## Test plan
- [x] All 9 InvestorInquiryTest cases pass
- [ ] Manual smoke after deploy: hero pill, footer link, GDPR consent text all show new entity

🤖 Generated with [Claude Code](https://claude.com/claude-code)