### PR TITLE
feat(plan-b): slice 1 — Cashier Stripe subscription path

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -372,6 +372,18 @@ MFI_ENABLED=false
 STRIPE_SECRET=
 STRIPE_BRIDGE_WEBHOOK_SECRET=
 STRIPE_KYC_WEBHOOK_SECRET=
+# Plan B Slice 1 — pinned via single config key so Cashier and Stripe Bridge
+# clients use the same version. See Backend-Q1 in BACKEND_HANDOVER_PLAN_B_REVIEW_DELTAS.md.
+STRIPE_API_VERSION=2025-04-30.basil
+# Plan B Backend-Q5 — HMAC pepper for trial-card fingerprint hashing (32 bytes).
+# Event-triggered rotation only. Must be configured before subscription endpoints
+# are exposed to traffic.
+TRIAL_FINGERPRINT_PEPPER=
+# Plan B Slice 1 — Stripe Price IDs (configure in Stripe dashboard first).
+STRIPE_PRICE_MONTHLY_PRO=
+STRIPE_PRICE_ANNUAL_PRO=
+# Plan B deltas Q14 — withdrawal-consent text version (bump when copy changes).
+SUBSCRIPTION_CONSENT_VERSION=1
 # Mobile deep-link return URLs for KYC Checkout. Override per env if you
 # need a non-default scheme (e.g. demo or staging build).
 # STRIPE_KYC_SUCCESS_URL=zelta://trustcert/payment-return?status=success&session={CHECKOUT_SESSION_ID}

--- a/.env.zelta.example
+++ b/.env.zelta.example
@@ -155,6 +155,13 @@ STRIPE_WEBHOOK_SECRET=
 STRIPE_TEST_MODE=false
 STRIPE_BRIDGE_WEBHOOK_SECRET=
 STRIPE_KYC_WEBHOOK_SECRET=
+# Plan B Slice 1 — pin Stripe API version (consumed by Cashier + Stripe Bridge).
+STRIPE_API_VERSION=2025-04-30.basil
+# Plan B Backend-Q5 — trial-fingerprint HMAC pepper (32 bytes, event-triggered rotation).
+TRIAL_FINGERPRINT_PEPPER=
+STRIPE_PRICE_MONTHLY_PRO=
+STRIPE_PRICE_ANNUAL_PRO=
+SUBSCRIPTION_CONSENT_VERSION=1
 # Mobile deep-link return URLs for KYC Checkout — defaults match the Zelta app scheme.
 # STRIPE_KYC_SUCCESS_URL=zelta://trustcert/payment-return?status=success&session={CHECKOUT_SESSION_ID}
 # STRIPE_KYC_CANCEL_URL=zelta://trustcert/payment-return?status=cancel

--- a/app/Domain/Pricing/ValueObjects/Money.php
+++ b/app/Domain/Pricing/ValueObjects/Money.php
@@ -1,0 +1,211 @@
+<?php
+
+/**
+ * Money value object — wire-format Money per ADR-0004.
+ *
+ * Smallest-unit string + explicit decimals + exactly one of currency (ISO 4217)
+ * or asset (ticker). All arithmetic via bcmath; never (float).
+ *
+ * @see docs/adr/0004-money-on-the-wire.md
+ */
+
+declare(strict_types=1);
+
+namespace App\Domain\Pricing\ValueObjects;
+
+use InvalidArgumentException;
+use JsonSerializable;
+
+final class Money implements JsonSerializable
+{
+    public function __construct(
+        public readonly string $amount,
+        public readonly int $decimals,
+        public readonly ?string $currency = null,
+        public readonly ?string $asset = null,
+    ) {
+        if (preg_match('/^-?[0-9]+$/', $amount) !== 1) {
+            throw new InvalidArgumentException(
+                'Money amount must be an integer string (no decimal point), got: ' . $amount
+            );
+        }
+
+        if ($decimals < 0 || $decimals > 18) {
+            throw new InvalidArgumentException(
+                'Money decimals must be between 0 and 18 inclusive, got: ' . $decimals
+            );
+        }
+
+        $hasCurrency = $currency !== null && $currency !== '';
+        $hasAsset = $asset !== null && $asset !== '';
+
+        if (! $hasCurrency && ! $hasAsset) {
+            throw new InvalidArgumentException(
+                'Money must specify exactly one of currency (fiat) or asset (token).'
+            );
+        }
+
+        if ($hasCurrency && $hasAsset) {
+            throw new InvalidArgumentException(
+                'Money cannot specify both currency and asset; choose exactly one.'
+            );
+        }
+
+        if ($hasCurrency && strlen((string) $currency) !== 3) {
+            throw new InvalidArgumentException(
+                'Money currency must be a 3-letter ISO 4217 code, got: ' . $currency
+            );
+        }
+    }
+
+    /**
+     * Construct EUR money from a smallest-unit cents string.
+     */
+    public static function eur(string $cents): self
+    {
+        return new self(amount: $cents, decimals: 2, currency: 'EUR');
+    }
+
+    /**
+     * Construct asset money (e.g. USDC) at the given decimals.
+     */
+    public static function asset(string $smallestUnits, string $asset, int $decimals): self
+    {
+        return new self(amount: $smallestUnits, decimals: $decimals, asset: $asset);
+    }
+
+    /**
+     * Add another Money value of the same denomination + decimals.
+     *
+     * @throws InvalidArgumentException when denominations or decimals differ
+     */
+    public function add(self $other): self
+    {
+        $this->assertSameDenomination($other);
+
+        return new self(
+            amount: bcadd($this->numericAmount(), $other->numericAmount(), 0),
+            decimals: $this->decimals,
+            currency: $this->currency,
+            asset: $this->asset,
+        );
+    }
+
+    /**
+     * Subtract another Money value of the same denomination + decimals.
+     *
+     * @throws InvalidArgumentException when denominations or decimals differ
+     */
+    public function subtract(self $other): self
+    {
+        $this->assertSameDenomination($other);
+
+        return new self(
+            amount: bcsub($this->numericAmount(), $other->numericAmount(), 0),
+            decimals: $this->decimals,
+            currency: $this->currency,
+            asset: $this->asset,
+        );
+    }
+
+    public function negate(): self
+    {
+        return new self(
+            amount: bcmul($this->numericAmount(), '-1', 0),
+            decimals: $this->decimals,
+            currency: $this->currency,
+            asset: $this->asset,
+        );
+    }
+
+    /**
+     * Compare to another Money. Returns -1, 0, 1.
+     *
+     * @throws InvalidArgumentException when denominations differ
+     */
+    public function compare(self $other): int
+    {
+        $this->assertSameDenomination($other);
+
+        return bccomp($this->numericAmount(), $other->numericAmount(), 0);
+    }
+
+    public function isZero(): bool
+    {
+        return bccomp($this->numericAmount(), '0', 0) === 0;
+    }
+
+    public function isNegative(): bool
+    {
+        return bccomp($this->numericAmount(), '0', 0) < 0;
+    }
+
+    /**
+     * Return the validated amount as a numeric-string (PHPStan-friendly narrowing).
+     * The constructor regex guarantees this; the runtime `is_numeric` check is the
+     * narrowing assertion PHPStan recognises.
+     *
+     * @return numeric-string
+     */
+    private function numericAmount(): string
+    {
+        if (! is_numeric($this->amount)) {
+            // Unreachable: constructor validates with regex /^-?[0-9]+$/.
+            throw new InvalidArgumentException('Money amount is not numeric: ' . $this->amount);
+        }
+
+        return $this->amount;
+    }
+
+    public function isFiat(): bool
+    {
+        return $this->currency !== null;
+    }
+
+    public function denomination(): string
+    {
+        return $this->currency ?? (string) $this->asset;
+    }
+
+    /**
+     * @return array<string, int|string>
+     */
+    public function toArray(): array
+    {
+        $out = [
+            'amount'   => $this->amount,
+            'decimals' => $this->decimals,
+        ];
+
+        if ($this->currency !== null) {
+            $out['currency'] = $this->currency;
+        } else {
+            $out['asset'] = (string) $this->asset;
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return array<string, int|string>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    private function assertSameDenomination(self $other): void
+    {
+        if ($this->decimals !== $other->decimals) {
+            throw new InvalidArgumentException(
+                'Cannot operate on Money values with different decimals.'
+            );
+        }
+
+        if ($this->currency !== $other->currency || $this->asset !== $other->asset) {
+            throw new InvalidArgumentException(
+                'Cannot operate on Money values with different denominations.'
+            );
+        }
+    }
+}

--- a/app/Domain/Subscription/Http/Controllers/SubscriptionController.php
+++ b/app/Domain/Subscription/Http/Controllers/SubscriptionController.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * SubscriptionController — Plan B Slice 1 endpoints.
+ *
+ * GET    /api/v1/subscription/me           — null-safe, returns free-tier shape on no sub
+ * POST   /api/v1/subscription/checkout     — Stripe SetupIntent → Subscription
+ * POST   /api/v1/subscription/change-plan  — Stripe-only, thin Cashier wrapper
+ * POST   /api/v1/subscription/cancel       — cancel-at-period-end
+ * POST   /api/v1/subscription/reactivate   — clear cancel-at-period-end flag
+ *
+ * @see docs/BACKEND_HANDOVER_PLAN_B_REVIEW_DELTAS.md
+ */
+
+declare(strict_types=1);
+
+namespace App\Domain\Subscription\Http\Controllers;
+
+use App\Domain\Subscription\Http\Requests\ChangePlanRequest;
+use App\Domain\Subscription\Http\Requests\CheckoutRequest;
+use App\Domain\Subscription\Services\SubscriptionService;
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use App\Support\ErrorResponse;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class SubscriptionController extends Controller
+{
+    public function __construct(private readonly SubscriptionService $service)
+    {
+    }
+
+    public function me(Request $request): JsonResponse
+    {
+        /** @var User|null $user */
+        $user = $request->user();
+
+        if (! $user instanceof User) {
+            return response()->json(['code' => 'UNAUTHENTICATED'], 401);
+        }
+
+        return response()->json($this->service->read($user));
+    }
+
+    public function checkout(CheckoutRequest $request): JsonResponse
+    {
+        /** @var User|null $user */
+        $user = $request->user();
+
+        if (! $user instanceof User) {
+            return response()->json(['code' => 'UNAUTHENTICATED'], 401);
+        }
+
+        /** @var array<string, mixed> $validated */
+        $validated = $request->validated();
+
+        /** @var array{
+         *     plan: string,
+         *     withdrawalConsent: array{
+         *         given: bool, shownAt: string, acceptedAt: string,
+         *         consentText: string, version: int
+         *     },
+         *     successUrl?: ?string,
+         *     cancelUrl?: ?string
+         * } $input
+         */
+        $input = $validated;
+
+        $result = $this->service->startCheckout(
+            $user,
+            $input,
+            $request->ip() ?? '0.0.0.0',
+            $request->userAgent(),
+        );
+
+        return $this->renderResult($result, successStatus: 200);
+    }
+
+    public function changePlan(ChangePlanRequest $request): JsonResponse
+    {
+        /** @var User|null $user */
+        $user = $request->user();
+
+        if (! $user instanceof User) {
+            return response()->json(['code' => 'UNAUTHENTICATED'], 401);
+        }
+
+        /** @var array<string, mixed> $validated */
+        $validated = $request->validated();
+
+        $result = $this->service->changePlan($user, (string) $validated['plan']);
+
+        return $this->renderResult($result);
+    }
+
+    public function cancel(Request $request): JsonResponse
+    {
+        /** @var User|null $user */
+        $user = $request->user();
+
+        if (! $user instanceof User) {
+            return response()->json(['code' => 'UNAUTHENTICATED'], 401);
+        }
+
+        $result = $this->service->cancel($user);
+
+        return $this->renderResult($result);
+    }
+
+    public function reactivate(Request $request): JsonResponse
+    {
+        /** @var User|null $user */
+        $user = $request->user();
+
+        if (! $user instanceof User) {
+            return response()->json(['code' => 'UNAUTHENTICATED'], 401);
+        }
+
+        $result = $this->service->reactivate($user);
+
+        return $this->renderResult($result);
+    }
+
+    /**
+     * @param array{code?: string, extra?: array<string, mixed>, status?: int, success?: array<string, mixed>} $result
+     */
+    private function renderResult(array $result, int $successStatus = 200): JsonResponse
+    {
+        if (isset($result['code'])) {
+            return ErrorResponse::make(
+                $result['code'],
+                $result['extra'] ?? [],
+                $result['status'] ?? null,
+            );
+        }
+
+        $body = $result['success'] ?? [];
+
+        return response()->json($body, $successStatus);
+    }
+}

--- a/app/Domain/Subscription/Http/Requests/ChangePlanRequest.php
+++ b/app/Domain/Subscription/Http/Requests/ChangePlanRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Subscription\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class ChangePlanRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'plan'              => ['required', 'string', 'in:monthly_pro,annual_pro'],
+            'prorationBehavior' => ['nullable', 'string', 'in:create_prorations,none'],
+        ];
+    }
+}

--- a/app/Domain/Subscription/Http/Requests/CheckoutRequest.php
+++ b/app/Domain/Subscription/Http/Requests/CheckoutRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Subscription\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * @property-read array{
+ *     given: bool,
+ *     shownAt: string,
+ *     acceptedAt: string,
+ *     consentText: string,
+ *     version: int
+ * }|null $withdrawalConsent
+ */
+final class CheckoutRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'plan'                          => ['required', 'string', 'in:monthly_pro,annual_pro'],
+            'withdrawalConsent'             => ['required', 'array'],
+            'withdrawalConsent.given'       => ['required', 'boolean', 'accepted'],
+            'withdrawalConsent.shownAt'     => ['required', 'string'],
+            'withdrawalConsent.acceptedAt'  => ['required', 'string'],
+            'withdrawalConsent.consentText' => ['required', 'string', 'min:1'],
+            'withdrawalConsent.version'     => ['required', 'integer', 'min:1'],
+            'successUrl'                    => ['nullable', 'url'],
+            'cancelUrl'                     => ['nullable', 'url'],
+        ];
+    }
+}

--- a/app/Domain/Subscription/Jobs/ProjectRevenueOutbox.php
+++ b/app/Domain/Subscription/Jobs/ProjectRevenueOutbox.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * ProjectRevenueOutbox — Plan B Backend-Q3 outbox worker stub.
+ *
+ * Reads `pending` rows from revenue_outbox_events, projects them into
+ * revenue_events, marks delivered. Idempotent on (source_type, source_event_id);
+ * a re-run on a delivered row is a no-op.
+ *
+ * This is the SLICE-1 STUB. Slice 4 wires the full delayed-job infrastructure
+ * (Backend-Q8 cue dispatch architecture). For now we expose handle() as the
+ * worker entry point, run from an artisan command and from the webhook
+ * handler's same-request projection-flush.
+ *
+ * @see docs/adr/0002-revenue-projection-dual-upstream.md
+ */
+
+declare(strict_types=1);
+
+namespace App\Domain\Subscription\Jobs;
+
+use App\Domain\Subscription\Models\RevenueEvent;
+use App\Domain\Subscription\Models\RevenueOutboxEvent;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+final class ProjectRevenueOutbox implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 5;
+
+    public int $backoff = 30;
+
+    public function __construct(public readonly ?int $rowId = null)
+    {
+    }
+
+    public function handle(): void
+    {
+        if ($this->rowId !== null) {
+            $this->processRow($this->rowId);
+
+            return;
+        }
+
+        // Sweep mode: process all pending rows. Slice 1 stub keeps this simple
+        // (sequential, single-process). Slice 4 will fan out via per-row dispatch.
+        $maxAttempts = (int) config('subscription.outbox.max_attempts', 5);
+
+        RevenueOutboxEvent::query()
+            ->where('status', RevenueOutboxEvent::STATUS_PENDING)
+            ->where('attempts', '<', $maxAttempts)
+            ->orderBy('created_at')
+            ->chunkById(100, function ($rows): void {
+                foreach ($rows as $row) {
+                    $this->processRow((int) $row->id);
+                }
+            });
+    }
+
+    private function processRow(int $rowId): void
+    {
+        /** @var RevenueOutboxEvent|null $row */
+        $row = RevenueOutboxEvent::query()->lockForUpdate()->find($rowId);
+
+        if ($row === null || $row->status === RevenueOutboxEvent::STATUS_DELIVERED) {
+            return;
+        }
+
+        $row->forceFill(['attempts' => $row->attempts + 1])->save();
+
+        try {
+            $eventType = $this->mapOutboxKindToRevenueEvent($row->source_type, $row->event_kind);
+
+            if ($eventType === null) {
+                // Unmapped event kind — treat as delivered (no-op) so we don't
+                // retry forever. Log so ops can backfill if needed.
+                Log::info('revenue_outbox.unmapped_event', [
+                    'source_type' => $row->source_type,
+                    'event_kind'  => $row->event_kind,
+                ]);
+
+                $row->forceFill([
+                    'status'       => RevenueOutboxEvent::STATUS_DELIVERED,
+                    'delivered_at' => now(),
+                ])->save();
+
+                return;
+            }
+
+            $payload = $row->payload;
+            $userId = isset($payload['userId']) && is_int($payload['userId']) ? $payload['userId'] : null;
+            $aggregateId = isset($payload['aggregateId']) ? (string) $payload['aggregateId'] : null;
+            $amount = isset($payload['amount']) ? (int) $payload['amount'] : 0;
+            $decimals = isset($payload['decimals']) ? (int) $payload['decimals'] : 2;
+            $denomination = isset($payload['denomination']) ? (string) $payload['denomination'] : 'EUR';
+            $emittedAt = isset($payload['emittedAt']) ? (string) $payload['emittedAt'] : now()->toIso8601String();
+
+            // Idempotent insert. uniq_revenue_event_source covers
+            // (source_type, source_event_id, event_type).
+            RevenueEvent::query()->updateOrCreate(
+                [
+                    'source_type'     => $row->source_type,
+                    'source_event_id' => $row->source_event_id,
+                    'event_type'      => $eventType,
+                ],
+                [
+                    'user_id'      => $userId,
+                    'user_id_hash' => $userId !== null
+                        ? hash_hmac('sha256', (string) $userId, (string) config('app.key'))
+                        : null,
+                    'aggregate_id'        => $aggregateId,
+                    'amount'              => $amount,
+                    'amount_decimals'     => $decimals,
+                    'amount_denomination' => $denomination,
+                    'payload'             => $payload,
+                    'emitted_at'          => $emittedAt,
+                ]
+            );
+
+            $row->forceFill([
+                'status'       => RevenueOutboxEvent::STATUS_DELIVERED,
+                'delivered_at' => now(),
+            ])->save();
+        } catch (Throwable $e) {
+            Log::error('revenue_outbox.project_failed', [
+                'row_id'   => $rowId,
+                'error'    => $e->getMessage(),
+                'attempts' => $row->attempts,
+            ]);
+
+            if ($row->attempts >= (int) config('subscription.outbox.max_attempts', 5)) {
+                $row->forceFill([
+                    'status'        => RevenueOutboxEvent::STATUS_FAILED,
+                    'failed_reason' => $e->getMessage(),
+                ])->save();
+            }
+        }
+    }
+
+    private function mapOutboxKindToRevenueEvent(string $sourceType, string $eventKind): ?string
+    {
+        if ($sourceType !== RevenueOutboxEvent::SOURCE_STRIPE) {
+            return null;
+        }
+
+        return match ($eventKind) {
+            'customer.subscription.created' => RevenueEvent::TYPE_SUBSCRIPTION_INITIAL,
+            'invoice.payment_succeeded'     => RevenueEvent::TYPE_SUBSCRIPTION_RENEWAL,
+            'charge.refunded'               => RevenueEvent::TYPE_REFUND,
+            default                         => null,
+        };
+    }
+}

--- a/app/Domain/Subscription/Models/ProcessedWebhookEvent.php
+++ b/app/Domain/Subscription/Models/ProcessedWebhookEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Subscription\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int    $id
+ * @property string $provider
+ * @property string $event_id
+ * @property string|null $event_type
+ * @property \Illuminate\Support\Carbon $processed_at
+ */
+final class ProcessedWebhookEvent extends Model
+{
+    protected $table = 'processed_webhook_events';
+
+    protected $fillable = [
+        'provider',
+        'event_id',
+        'event_type',
+        'processed_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'processed_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Domain/Subscription/Models/RevenueEvent.php
+++ b/app/Domain/Subscription/Models/RevenueEvent.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Subscription\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int    $id
+ * @property string $event_type
+ * @property int|null $user_id
+ * @property string|null $user_id_hash
+ * @property string $source_type
+ * @property string|null $source_event_id
+ * @property string|null $aggregate_id
+ * @property int    $amount
+ * @property int    $amount_decimals
+ * @property string $amount_denomination
+ * @property array<string, mixed>|null $payload
+ * @property \Illuminate\Support\Carbon $emitted_at
+ */
+final class RevenueEvent extends Model
+{
+    public const TYPE_SUBSCRIPTION_INITIAL = 'subscription_initial';
+
+    public const TYPE_SUBSCRIPTION_RENEWAL = 'subscription_renewal';
+
+    public const TYPE_REFUND = 'refund';
+
+    protected $table = 'revenue_events';
+
+    protected $fillable = [
+        'event_type',
+        'user_id',
+        'user_id_hash',
+        'source_type',
+        'source_event_id',
+        'aggregate_id',
+        'amount',
+        'amount_decimals',
+        'amount_denomination',
+        'payload',
+        'emitted_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'payload'         => 'array',
+            'amount'          => 'integer',
+            'amount_decimals' => 'integer',
+            'emitted_at'      => 'datetime',
+        ];
+    }
+}

--- a/app/Domain/Subscription/Models/RevenueOutboxEvent.php
+++ b/app/Domain/Subscription/Models/RevenueOutboxEvent.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Subscription\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int    $id
+ * @property string $source_event_id
+ * @property string $source_type
+ * @property string $event_kind
+ * @property array<string, mixed> $payload
+ * @property string $status   pending | delivered | failed
+ * @property int    $attempts
+ * @property \Illuminate\Support\Carbon|null $delivered_at
+ * @property string|null $failed_reason
+ */
+final class RevenueOutboxEvent extends Model
+{
+    public const STATUS_PENDING = 'pending';
+
+    public const STATUS_DELIVERED = 'delivered';
+
+    public const STATUS_FAILED = 'failed';
+
+    public const SOURCE_STRIPE = 'stripe';
+
+    public const SOURCE_APPLE_IAP = 'apple_iap';
+
+    public const SOURCE_GOOGLE_PLAY = 'google_play';
+
+    public const SOURCE_STRIPE_BRIDGE = 'stripe_bridge';
+
+    public const SOURCE_ONDATO = 'ondato';
+
+    protected $table = 'revenue_outbox_events';
+
+    protected $fillable = [
+        'source_event_id',
+        'source_type',
+        'event_kind',
+        'payload',
+        'status',
+        'attempts',
+        'delivered_at',
+        'failed_reason',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'payload'      => 'array',
+            'attempts'     => 'integer',
+            'delivered_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Domain/Subscription/Models/SubscriptionConsentLog.php
+++ b/app/Domain/Subscription/Models/SubscriptionConsentLog.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Subscription\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int    $id
+ * @property int    $user_id
+ * @property int|null $subscription_id
+ * @property string $consent_text
+ * @property int    $consent_version
+ * @property \Illuminate\Support\Carbon $shown_at
+ * @property \Illuminate\Support\Carbon $accepted_at
+ * @property string $ip_hash
+ * @property string|null $user_agent
+ */
+final class SubscriptionConsentLog extends Model
+{
+    protected $table = 'subscription_consent_log';
+
+    public $timestamps = true;
+
+    protected $fillable = [
+        'user_id',
+        'subscription_id',
+        'consent_text',
+        'consent_version',
+        'shown_at',
+        'accepted_at',
+        'ip_hash',
+        'user_agent',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'shown_at'        => 'datetime',
+            'accepted_at'     => 'datetime',
+            'consent_version' => 'integer',
+        ];
+    }
+}

--- a/app/Domain/Subscription/Models/TrialCardFingerprint.php
+++ b/app/Domain/Subscription/Models/TrialCardFingerprint.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Subscription\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property string $fingerprint_hash
+ * @property int|null $first_user_id
+ * @property int|null $last_user_id
+ * @property \Illuminate\Support\Carbon $first_used_at
+ * @property \Illuminate\Support\Carbon $last_used_at
+ * @property int $trial_user_count
+ * @property string|null $stripe_payment_method_id
+ */
+final class TrialCardFingerprint extends Model
+{
+    protected $table = 'trial_card_fingerprints';
+
+    protected $primaryKey = 'fingerprint_hash';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'fingerprint_hash',
+        'first_user_id',
+        'last_user_id',
+        'first_used_at',
+        'last_used_at',
+        'trial_user_count',
+        'stripe_payment_method_id',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'first_used_at'    => 'datetime',
+            'last_used_at'     => 'datetime',
+            'trial_user_count' => 'integer',
+            'first_user_id'    => 'integer',
+            'last_user_id'     => 'integer',
+        ];
+    }
+}

--- a/app/Domain/Subscription/Projections/SubscriptionProjection.php
+++ b/app/Domain/Subscription/Projections/SubscriptionProjection.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * SubscriptionProjection — unified entitlements read model (Plan B Backend-Q1).
+ *
+ * Slice 1 reads ONLY from Cashier subscriptions; slice 2 will join in the IAP
+ * source without changing the wire shape. The cross-source conflict gate
+ * `hasActiveProSubscription(..., source: 'iap')` is wired up now (returns false
+ * always) so slice 2 plugs in without touching the call sites.
+ */
+
+declare(strict_types=1);
+
+namespace App\Domain\Subscription\Projections;
+
+use App\Models\User;
+use Illuminate\Support\Carbon;
+use Laravel\Cashier\Subscription as CashierSubscription;
+
+final class SubscriptionProjection
+{
+    /**
+     * @return array{
+     *     tier: string,
+     *     status: string|null,
+     *     source: string|null,
+     *     plan: string|null,
+     *     currentPeriodEnd: string|null,
+     *     trialEndsAt: string|null,
+     *     cancelledAtPeriodEnd: bool,
+     *     pausedUntil: string|null
+     * }
+     */
+    public function for(User $user): array
+    {
+        $subscription = $user->subscription('default');
+
+        if ($subscription === null) {
+            return [
+                'tier'                 => 'free',
+                'status'               => null,
+                'source'               => null,
+                'plan'                 => null,
+                'currentPeriodEnd'     => null,
+                'trialEndsAt'          => null,
+                'cancelledAtPeriodEnd' => false,
+                'pausedUntil'          => null,
+            ];
+        }
+
+        // Slice 1: Stripe-only. Once IAP is added in slice 2 the source detection
+        // flips to whichever active subscription is the canonical match.
+        $isPro = $subscription->valid();
+        $cancelledAtPeriodEnd = $subscription->ends_at !== null && Carbon::parse($subscription->ends_at)->isFuture();
+
+        return [
+            'tier'             => $isPro ? 'pro' : 'free',
+            'status'           => (string) $subscription->stripe_status,
+            'source'           => 'stripe_web',
+            'plan'             => $this->planFromPriceId((string) $subscription->stripe_price),
+            'currentPeriodEnd' => $this->currentPeriodEnd($subscription)?->toIso8601String(),
+            'trialEndsAt'      => $subscription->trial_ends_at !== null
+                ? Carbon::parse($subscription->trial_ends_at)->toIso8601String()
+                : null,
+            'cancelledAtPeriodEnd' => $cancelledAtPeriodEnd,
+            'pausedUntil'          => null,
+        ];
+    }
+
+    /**
+     * Cross-source conflict gate. Slice 2 wires the IAP source.
+     */
+    public function hasActiveProSubscription(User $user, string $source): bool
+    {
+        if ($source === 'stripe') {
+            $subscription = $user->subscription('default');
+
+            return $subscription !== null && $subscription->valid();
+        }
+
+        // IAP source not yet implemented — slice 2 will join the iap_subscriptions
+        // projection here without touching call sites.
+        return false;
+    }
+
+    private function currentPeriodEnd(CashierSubscription $subscription): ?Carbon
+    {
+        // Cashier 15.x exposes the current period via stored timestamps. Fall back
+        // to ends_at (cancel-at-period-end) when present.
+        $candidate = $subscription->ends_at
+            ?? ($subscription->trial_ends_at !== null && Carbon::parse($subscription->trial_ends_at)->isFuture()
+                ? $subscription->trial_ends_at
+                : null);
+
+        return $candidate !== null ? Carbon::parse($candidate) : null;
+    }
+
+    private function planFromPriceId(string $priceId): ?string
+    {
+        $prices = (array) config('services.stripe.subscription_prices', []);
+
+        foreach ($prices as $plan => $configuredPrice) {
+            if ((string) $configuredPrice === $priceId && $configuredPrice !== '') {
+                return (string) $plan;
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/Domain/Subscription/Services/ConsentLogWriter.php
+++ b/app/Domain/Subscription/Services/ConsentLogWriter.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * ConsentLogWriter — Plan B deltas Q14.2.
+ *
+ * Writes one row per Stripe-Web subscription creation capturing the exact consent
+ * text shown, the user's IP (hashed) and User-Agent. Used for EU CRD dispute
+ * trail; the row text is the snapshot, not the live config — bumping consent
+ * text MUST come with `consent_version+1`.
+ */
+
+declare(strict_types=1);
+
+namespace App\Domain\Subscription\Services;
+
+use App\Domain\Subscription\Models\SubscriptionConsentLog;
+use App\Models\User;
+use RuntimeException;
+use Throwable;
+
+final class ConsentLogWriter
+{
+    /**
+     * @param array{
+     *     given: bool,
+     *     shownAt: string,
+     *     acceptedAt: string,
+     *     consentText: string,
+     *     version: int
+     * } $consent
+     */
+    public function record(
+        User $user,
+        array $consent,
+        ?int $subscriptionId,
+        string $remoteIp,
+        ?string $userAgent,
+    ): SubscriptionConsentLog {
+        if (($consent['given'] ?? false) !== true) {
+            throw new RuntimeException('ConsentLogWriter::record called with given=false; caller should reject earlier.');
+        }
+
+        $ipHash = hash_hmac('sha256', $remoteIp, (string) config('app.key'));
+
+        /** @var SubscriptionConsentLog $row */
+        $row = SubscriptionConsentLog::query()->create([
+            'user_id'         => $user->id,
+            'subscription_id' => $subscriptionId,
+            'consent_text'    => (string) $consent['consentText'],
+            'consent_version' => (int) $consent['version'],
+            'shown_at'        => $consent['shownAt'],
+            'accepted_at'     => $consent['acceptedAt'],
+            'ip_hash'         => $ipHash,
+            'user_agent'      => $userAgent,
+        ]);
+
+        return $row;
+    }
+
+    /**
+     * Validate the staleness window — accepted_at must be within 5 minutes.
+     */
+    public function isStale(string $acceptedAtIso): bool
+    {
+        try {
+            $accepted = \Illuminate\Support\Carbon::parse($acceptedAtIso);
+        } catch (Throwable) {
+            return true;
+        }
+
+        return $accepted->diffInSeconds(now(), absolute: true) > 5 * 60;
+    }
+
+    public function isWellFormed(mixed $consent): bool
+    {
+        if (! is_array($consent)) {
+            return false;
+        }
+
+        $required = ['given', 'shownAt', 'acceptedAt', 'consentText', 'version'];
+        foreach ($required as $key) {
+            if (! array_key_exists($key, $consent)) {
+                return false;
+            }
+        }
+
+        if (($consent['given'] ?? false) !== true) {
+            return false;
+        }
+
+        if (! is_string($consent['acceptedAt']) || $consent['acceptedAt'] === '') {
+            return false;
+        }
+
+        if (! is_string($consent['consentText']) || $consent['consentText'] === '') {
+            return false;
+        }
+
+        if (! is_int($consent['version']) || $consent['version'] < 1) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Resolve the user-facing consent text version actively shown.
+     */
+    public function activeVersion(): int
+    {
+        return (int) config('subscription.consent_version', 1);
+    }
+}

--- a/app/Domain/Subscription/Services/SubscriptionService.php
+++ b/app/Domain/Subscription/Services/SubscriptionService.php
@@ -1,0 +1,381 @@
+<?php
+
+/**
+ * SubscriptionService — Plan B Slice 1 entry point for Stripe-only flows.
+ *
+ * Endpoints (POST /checkout, /change-plan, /cancel, /reactivate) call into here.
+ * Each method returns either a structured success array or an array{code, ...}
+ * describing an error code from config/error_codes.php — the controller maps
+ * those into ErrorResponse::make() responses.
+ *
+ * @see docs/BACKEND_HANDOVER_PLAN_B_REVIEW_DELTAS.md (Backend-Q1, Q5, Q7, Q14, Q17)
+ */
+
+declare(strict_types=1);
+
+namespace App\Domain\Subscription\Services;
+
+use App\Domain\Subscription\Models\RevenueOutboxEvent;
+use App\Domain\Subscription\Projections\SubscriptionProjection;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
+use Stripe\Checkout\Session as StripeCheckoutSession;
+use Throwable;
+
+final class SubscriptionService
+{
+    public function __construct(
+        private readonly SubscriptionProjection $projection,
+        private readonly ConsentLogWriter $consent,
+    ) {
+    }
+
+    /**
+     * GET /api/v1/subscription/me — null-safe, returns the free-tier shape with
+     * HTTP 200 when there is no subscription. Mobile P0 — see acceptance.
+     *
+     * @return array<string, mixed>
+     */
+    public function read(User $user): array
+    {
+        return $this->projection->for($user);
+    }
+
+    /**
+     * POST /api/v1/subscription/checkout — Setup-mode checkout per Backend-Q5.
+     *
+     * Two pre-checks before creating a Checkout session:
+     *  - Multi-store conflict gate (Backend-Q1 #8): ERR_SUB_007 if IAP active.
+     *  - Live-incomplete-session 409 (deltas Q7.2): ERR_SUB_005 + recoveryUrl.
+     *
+     * Trial-fingerprint check (Backend-Q5) runs in the webhook on
+     * `checkout.session.completed` once Stripe gives us the captured PM
+     * fingerprint — see SubscriptionWebhookHandler::handleCheckoutSessionCompleted.
+     *
+     * @param array{
+     *     plan: string,
+     *     withdrawalConsent: array{
+     *         given: bool, shownAt: string, acceptedAt: string,
+     *         consentText: string, version: int
+     *     },
+     *     successUrl?: ?string,
+     *     cancelUrl?: ?string
+     * } $input
+     *
+     * @return array{code?: string, extra?: array<string, mixed>, status?: int, success?: array<string, mixed>}
+     */
+    public function startCheckout(User $user, array $input, string $remoteIp, ?string $userAgent): array
+    {
+        // Cross-source conflict (Backend-Q1 #8 — IAP gate).
+        if ($this->projection->hasActiveProSubscription($user, source: 'iap')) {
+            return [
+                'code'  => 'ERR_SUB_007',
+                'extra' => [
+                    'conflict' => [
+                        'kind'            => 'two_stores_active',
+                        'attemptedSource' => 'stripe_web',
+                        'existingSource'  => 'iap',
+                    ],
+                ],
+            ];
+        }
+
+        // Active Stripe subscription already → 409 (caller can switch plans via change-plan).
+        if ($this->projection->hasActiveProSubscription($user, source: 'stripe')) {
+            return [
+                'code'  => 'ERR_SUB_002',
+                'extra' => [
+                    'conflict' => [
+                        'kind'            => 'two_stores_active',
+                        'attemptedSource' => 'stripe_web',
+                        'existingSource'  => 'stripe_web',
+                    ],
+                ],
+            ];
+        }
+
+        // Withdrawal-consent staleness check (deltas Q14.1).
+        if (
+            ! $this->consent->isWellFormed($input['withdrawalConsent'])
+            || $this->consent->isStale($input['withdrawalConsent']['acceptedAt'])
+        ) {
+            return ['code' => 'ERR_SUB_004'];
+        }
+
+        // Live-incomplete-session 409 (deltas Q7.2).
+        $live = $this->detectLiveIncompleteSession($user);
+        if ($live !== null) {
+            return [
+                'code'  => 'ERR_SUB_005',
+                'extra' => [
+                    'recoveryUrl' => $live,
+                ],
+            ];
+        }
+
+        // Build the Checkout session in Setup mode.
+        try {
+            /** @var StripeCheckoutSession $session */
+            $session = $user->checkout(
+                items: [],
+                sessionOptions: [
+                    'mode'        => 'setup',
+                    'success_url' => $input['successUrl']
+                        ?? (string) config('app.url') . '/subscription/checkout/success?session_id={CHECKOUT_SESSION_ID}',
+                    'cancel_url' => $input['cancelUrl']
+                        ?? (string) config('app.url') . '/subscription/checkout/cancel',
+                    'payment_method_types' => ['card'],
+                    'metadata'             => [
+                        'plan'                => $input['plan'],
+                        'consent_accepted_at' => $input['withdrawalConsent']['acceptedAt'],
+                        'consent_version'     => $input['withdrawalConsent']['version'],
+                        'consent_text_hash'   => hash('sha256', $input['withdrawalConsent']['consentText']),
+                        'remote_ip_hash'      => hash_hmac('sha256', $remoteIp, (string) config('app.key')),
+                    ],
+                    'customer_creation' => $user->stripe_id !== null ? null : 'always',
+                ],
+                customerOptions: [],
+            );
+        } catch (Throwable $e) {
+            Log::error('subscription.checkout.create_failed', [
+                'user_id' => $user->id,
+                'error'   => $e->getMessage(),
+            ]);
+
+            throw $e;
+        }
+
+        return [
+            'success' => [
+                'checkoutUrl' => (string) $session->url,
+                'sessionId'   => (string) $session->id,
+                'plan'        => $input['plan'],
+            ],
+        ];
+    }
+
+    /**
+     * POST /api/v1/subscription/change-plan — Stripe-only, thin Cashier wrapper.
+     *
+     * Annual → Monthly downgrade rejected per deltas Q17.4 (intentional).
+     *
+     * @return array{code?: string, extra?: array<string, mixed>, success?: array<string, mixed>}
+     */
+    public function changePlan(User $user, string $plan): array
+    {
+        $subscription = $user->subscription('default');
+
+        if ($subscription === null || ! $subscription->valid()) {
+            // No active sub to change. Treat as a soft 422 — caller should hit /checkout.
+            return [
+                'code'  => 'ERR_SUB_002',
+                'extra' => ['message' => 'No active subscription to change.'],
+            ];
+        }
+
+        $currentPlan = $this->planFromPriceId((string) $subscription->stripe_price);
+
+        // Annual → Monthly downgrade is intentionally not offered (deltas Q17.4).
+        // A future developer adding "obvious missing feature" Switch-to-Monthly on
+        // annual users undoes the retention design.
+        if ($currentPlan === 'annual_pro' && $plan === 'monthly_pro') {
+            return ['code' => 'ERR_SUB_006'];
+        }
+
+        // Idempotent no-op: same-plan swap returns the existing sub.
+        if ($currentPlan === $plan) {
+            return [
+                'success' => [
+                    'subscription' => $this->projection->for($user->refresh()),
+                ],
+            ];
+        }
+
+        $targetPriceId = $this->priceIdForPlan($plan);
+        if ($targetPriceId === null) {
+            return [
+                'code'  => 'ERR_SUB_002',
+                'extra' => ['message' => "Unknown plan: {$plan}"],
+            ];
+        }
+
+        $subscription->swap($targetPriceId);
+
+        return [
+            'success' => [
+                'subscription' => $this->projection->for($user->refresh()),
+            ],
+        ];
+    }
+
+    /**
+     * POST /api/v1/subscription/cancel — cancel-at-period-end (Cashier default).
+     *
+     * If the active subscription is via IAP, return ERR_SUB_010 with a deep-link
+     * to the App Store / Play Store subscription management — IAP is store-side
+     * only (slice 2 builds the IAP detection; slice 1 simply cannot detect it
+     * because there is no iap_subscriptions data yet, but the gate is wired so
+     * future agents see the contract).
+     *
+     * @return array{code?: string, extra?: array<string, mixed>, success?: array<string, mixed>}
+     */
+    public function cancel(User $user): array
+    {
+        // Slice 1 cannot detect an IAP-only sub yet (no iap_subscriptions table).
+        // The gate is wired so slice 2 plugs in.
+        if ($this->projection->hasActiveProSubscription($user, source: 'iap')) {
+            return [
+                'code'  => 'ERR_SUB_010',
+                'extra' => [
+                    'managementUrl' => 'https://apps.apple.com/account/subscriptions',
+                    'androidUrl'    => 'https://play.google.com/store/account/subscriptions',
+                ],
+            ];
+        }
+
+        $subscription = $user->subscription('default');
+
+        if ($subscription === null || ! $subscription->valid()) {
+            return [
+                'code'  => 'ERR_SUB_002',
+                'extra' => ['message' => 'No active subscription to cancel.'],
+            ];
+        }
+
+        // Idempotent: already cancel-at-period-end → return existing.
+        if ($subscription->ends_at === null) {
+            $subscription->cancel();
+        }
+
+        return [
+            'success' => [
+                'subscription' => $this->projection->for($user->refresh()),
+            ],
+        ];
+    }
+
+    /**
+     * POST /api/v1/subscription/reactivate — clears cancelled-at-period-end.
+     *
+     * @return array{code?: string, extra?: array<string, mixed>, success?: array<string, mixed>}
+     */
+    public function reactivate(User $user): array
+    {
+        $subscription = $user->subscription('default');
+
+        if ($subscription === null) {
+            return [
+                'code'  => 'ERR_SUB_002',
+                'extra' => ['message' => 'No subscription to reactivate.'],
+            ];
+        }
+
+        if ($subscription->ends_at === null || ! Carbon::parse($subscription->ends_at)->isFuture()) {
+            // Idempotent: already active and not cancel-at-period-end.
+            return [
+                'success' => [
+                    'subscription' => $this->projection->for($user->refresh()),
+                ],
+            ];
+        }
+
+        $subscription->resume();
+
+        return [
+            'success' => [
+                'subscription' => $this->projection->for($user->refresh()),
+            ],
+        ];
+    }
+
+    /**
+     * Detect a live (≤24h, retrievable) Stripe Checkout session for this user.
+     * Returns the recovery URL or null. Best-effort: under failure we return null
+     * and let the caller create a fresh session.
+     */
+    private function detectLiveIncompleteSession(User $user): ?string
+    {
+        if ($user->stripe_id === null) {
+            return null;
+        }
+
+        try {
+            $stripe = new \Stripe\StripeClient((string) config('cashier.secret'));
+            $sessions = $stripe->checkout->sessions->all([
+                'customer' => $user->stripe_id,
+                'limit'    => 5,
+            ]);
+
+            foreach ($sessions->data as $session) {
+                if (! is_object($session)) {
+                    continue;
+                }
+
+                $status = property_exists($session, 'status') ? (string) $session->status : '';
+                $url = property_exists($session, 'url') ? (string) $session->url : '';
+                $expiresAt = property_exists($session, 'expires_at') ? (int) $session->expires_at : 0;
+
+                if ($status === 'open' && $url !== '' && $expiresAt > time()) {
+                    return $url;
+                }
+            }
+        } catch (Throwable $e) {
+            Log::warning('subscription.checkout.live_session_detect_failed', [
+                'user_id' => $user->id,
+                'error'   => $e->getMessage(),
+            ]);
+        }
+
+        return null;
+    }
+
+    public function priceIdForPlan(string $plan): ?string
+    {
+        $prices = (array) config('services.stripe.subscription_prices', []);
+        $configured = $prices[$plan] ?? null;
+
+        if (! is_string($configured) || $configured === '') {
+            return null;
+        }
+
+        return $configured;
+    }
+
+    public function planFromPriceId(string $priceId): ?string
+    {
+        $prices = (array) config('services.stripe.subscription_prices', []);
+
+        foreach ($prices as $plan => $configuredPrice) {
+            if ((string) $configuredPrice === $priceId && $configuredPrice !== '') {
+                return (string) $plan;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Used by the webhook handler to enqueue an outbox row inside the same
+     * transaction as the dedup write. Idempotent on (source_type, source_event_id).
+     *
+     * @param array<string, mixed> $payload
+     */
+    public function enqueueRevenueOutbox(string $sourceType, string $eventId, string $eventKind, array $payload): RevenueOutboxEvent
+    {
+        /** @var RevenueOutboxEvent $row */
+        $row = RevenueOutboxEvent::query()->updateOrCreate(
+            [
+                'source_type'     => $sourceType,
+                'source_event_id' => $eventId,
+            ],
+            [
+                'event_kind' => $eventKind,
+                'payload'    => $payload,
+                'status'     => RevenueOutboxEvent::STATUS_PENDING,
+            ]
+        );
+
+        return $row;
+    }
+}

--- a/app/Domain/Subscription/Services/TrialFingerprintService.php
+++ b/app/Domain/Subscription/Services/TrialFingerprintService.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * TrialFingerprintService — Plan B Backend-Q5 trial-abuse check.
+ *
+ * - Hashes Stripe `card.fingerprint` with HMAC-SHA256(.., TRIAL_FINGERPRINT_PEPPER).
+ * - Eligibility window: 12 months from `last_used_at`. If a fingerprint is stored
+ *   AND `last_used_at + 12mo > now()` → NOT eligible (return ERR_SUB_003 with
+ *   `eligibleAfter`).
+ *
+ * Pepper is rotation-cheap (re-hash all rows in one transaction), but rotation is
+ * event-triggered only — no scheduled cron, no `pepper_version` column for v1.3.0.
+ */
+
+declare(strict_types=1);
+
+namespace App\Domain\Subscription\Services;
+
+use App\Domain\Subscription\Models\TrialCardFingerprint;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+use RuntimeException;
+
+final class TrialFingerprintService
+{
+    public const RETRY_WINDOW_MONTHS = 12;
+
+    /**
+     * Stable HMAC-SHA256 hash of a Stripe card fingerprint.
+     */
+    public function hash(string $fingerprint): string
+    {
+        $pepper = (string) config('services.stripe.trial_fingerprint_pepper');
+
+        if ($pepper === '') {
+            throw new RuntimeException(
+                'TRIAL_FINGERPRINT_PEPPER is not configured — refusing to hash with an empty key.'
+            );
+        }
+
+        return hash_hmac('sha256', $fingerprint, $pepper);
+    }
+
+    /**
+     * Check trial eligibility. If ineligible, returns the timestamp at which the
+     * caller becomes eligible again; null when eligible right now.
+     */
+    public function eligibleAfter(string $fingerprintHash): ?Carbon
+    {
+        /** @var TrialCardFingerprint|null $row */
+        $row = TrialCardFingerprint::query()->find($fingerprintHash);
+
+        if ($row === null) {
+            return null;
+        }
+
+        $eligibleAt = $row->last_used_at->copy()->addMonths(self::RETRY_WINDOW_MONTHS);
+
+        return $eligibleAt->isFuture() ? $eligibleAt : null;
+    }
+
+    /**
+     * Record a trial claim. Idempotent: re-claiming the same hash bumps the counter
+     * and updates last_used_at.
+     */
+    public function recordClaim(string $fingerprintHash, User $user, ?string $stripePaymentMethodId = null): void
+    {
+        /** @var TrialCardFingerprint|null $existing */
+        $existing = TrialCardFingerprint::query()->find($fingerprintHash);
+
+        if ($existing === null) {
+            TrialCardFingerprint::query()->create([
+                'fingerprint_hash'         => $fingerprintHash,
+                'first_user_id'            => $user->id,
+                'last_user_id'             => $user->id,
+                'first_used_at'            => now(),
+                'last_used_at'             => now(),
+                'trial_user_count'         => 1,
+                'stripe_payment_method_id' => $stripePaymentMethodId,
+            ]);
+
+            return;
+        }
+
+        $existing->forceFill([
+            'last_user_id'             => $user->id,
+            'last_used_at'             => now(),
+            'trial_user_count'         => $existing->trial_user_count + 1,
+            'stripe_payment_method_id' => $stripePaymentMethodId ?? $existing->stripe_payment_method_id,
+        ])->save();
+    }
+}

--- a/app/Domain/Subscription/Webhooks/SubscriptionWebhookController.php
+++ b/app/Domain/Subscription/Webhooks/SubscriptionWebhookController.php
@@ -1,0 +1,404 @@
+<?php
+
+/**
+ * SubscriptionWebhookController — Plan B Slice 1.
+ *
+ * Mounted at POST /webhooks/stripe/subscriptions, distinct from the existing
+ * Cashier route at POST /stripe/webhook (which handles CGO + KYC webhooks via
+ * App\Http\Controllers\StripeWebhookController). The two routes are siblings,
+ * not extensions, so the existing CGO/KYC handlers are not regressed.
+ *
+ * Side-effects table (Backend-Q1 #6):
+ *
+ *   customer.subscription.created  → consent log (if metadata present)
+ *                                  → trial_card_fingerprints record
+ *                                  → revenue_outbox_events (subscription_initial)
+ *   invoice.payment_succeeded      → revenue_outbox_events (subscription_renewal),
+ *                                    suppress active payment_failed cue (slice 4)
+ *   invoice.payment_failed         → cue (slice 4)
+ *   customer.subscription.updated  → projection refresh (cache invalidation)
+ *   customer.subscription.deleted  → mark inactive (Cashier already does this)
+ *   charge.refunded                → revenue_outbox_events (refund), cue
+ *
+ * Idempotent on Stripe `event.id` via processed_webhook_events.
+ */
+
+declare(strict_types=1);
+
+namespace App\Domain\Subscription\Webhooks;
+
+use App\Domain\Subscription\Models\ProcessedWebhookEvent;
+use App\Domain\Subscription\Models\RevenueOutboxEvent;
+use App\Domain\Subscription\Models\SubscriptionConsentLog;
+use App\Domain\Subscription\Services\SubscriptionService;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Stripe\Webhook;
+use Throwable;
+
+final class SubscriptionWebhookController
+{
+    public function __construct(
+        private readonly SubscriptionService $service,
+    ) {
+    }
+
+    public function handle(Request $request): JsonResponse
+    {
+        $payload = (string) $request->getContent();
+        $signature = (string) $request->header('Stripe-Signature', '');
+        $secret = (string) config('services.stripe.webhook_secret');
+
+        $event = $this->verifySignature($payload, $signature, $secret);
+
+        if ($event === null) {
+            return response()->json(['code' => 'invalid_signature'], 400);
+        }
+
+        $eventId = (string) ($event['id'] ?? '');
+        $eventType = (string) ($event['type'] ?? '');
+
+        if ($eventId === '' || $eventType === '') {
+            return response()->json(['code' => 'invalid_event'], 400);
+        }
+
+        // Dedup gate (deltas Q7.3) — same Stripe event.id is a no-op on replay.
+        // Using a transaction keeps the dedup row + outbox row atomic.
+        $alreadyProcessed = false;
+
+        try {
+            DB::transaction(function () use ($event, $eventId, $eventType, &$alreadyProcessed): void {
+                $existing = ProcessedWebhookEvent::query()
+                    ->where('provider', 'stripe')
+                    ->where('event_id', $eventId)
+                    ->lockForUpdate()
+                    ->first();
+
+                if ($existing !== null) {
+                    $alreadyProcessed = true;
+
+                    return;
+                }
+
+                ProcessedWebhookEvent::query()->create([
+                    'provider'     => 'stripe',
+                    'event_id'     => $eventId,
+                    'event_type'   => $eventType,
+                    'processed_at' => now(),
+                ]);
+
+                $this->dispatchEvent($eventType, (array) ($event['data']['object'] ?? []), $eventId, $event);
+            });
+        } catch (Throwable $e) {
+            Log::error('subscription.webhook.failed', [
+                'event_id'   => $eventId,
+                'event_type' => $eventType,
+                'error'      => $e->getMessage(),
+            ]);
+
+            return response()->json(['code' => 'handler_error'], 500);
+        }
+
+        return response()->json([
+            'received' => true,
+            'replayed' => $alreadyProcessed,
+            'event_id' => $eventId,
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $object  the `data.object` from the Stripe event
+     * @param array<string, mixed> $event   the full event payload
+     */
+    private function dispatchEvent(string $eventType, array $object, string $eventId, array $event): void
+    {
+        match ($eventType) {
+            'customer.subscription.created' => $this->onSubscriptionCreated($object, $eventId),
+            'invoice.payment_succeeded'     => $this->onInvoicePaymentSucceeded($object, $eventId),
+            'invoice.payment_failed'        => $this->onInvoicePaymentFailed($object, $eventId),
+            'customer.subscription.updated',
+            'customer.subscription.deleted' => $this->onSubscriptionLifecycle($object, $eventId, $eventType),
+            'charge.refunded'               => $this->onChargeRefunded($object, $eventId),
+            'checkout.session.completed'    => $this->onCheckoutSessionCompleted($object, $eventId),
+            default                         => Log::info('subscription.webhook.unhandled', [
+                'event_id'   => $eventId,
+                'event_type' => $eventType,
+            ]),
+        };
+    }
+
+    /**
+     * customer.subscription.created — write consent log + outbox row + record
+     * trial fingerprint when available.
+     *
+     * @param array<string, mixed> $subscription
+     */
+    private function onSubscriptionCreated(array $subscription, string $eventId): void
+    {
+        $stripeCustomerId = (string) ($subscription['customer'] ?? '');
+        $user = $stripeCustomerId !== '' ? $this->resolveUserByStripeCustomer($stripeCustomerId) : null;
+
+        if ($user instanceof User) {
+            $this->writeConsentLogIfMetadataPresent($user, $subscription);
+        }
+
+        // Outbox row → ProjectRevenueOutbox worker projects to revenue_events.
+        $payload = [
+            'userId'       => $user?->id,
+            'aggregateId'  => (string) ($subscription['id'] ?? ''),
+            'amount'       => $this->extractAmountFromSubscription($subscription),
+            'decimals'     => 2,
+            'denomination' => $this->extractCurrencyFromSubscription($subscription),
+            'emittedAt'    => now()->toIso8601String(),
+            'rawType'      => 'customer.subscription.created',
+        ];
+
+        $this->service->enqueueRevenueOutbox(
+            sourceType: RevenueOutboxEvent::SOURCE_STRIPE,
+            eventId: $eventId,
+            eventKind: 'customer.subscription.created',
+            payload: $payload,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $invoice
+     */
+    private function onInvoicePaymentSucceeded(array $invoice, string $eventId): void
+    {
+        $stripeCustomerId = (string) ($invoice['customer'] ?? '');
+        $user = $stripeCustomerId !== '' ? $this->resolveUserByStripeCustomer($stripeCustomerId) : null;
+
+        $payload = [
+            'userId'       => $user?->id,
+            'aggregateId'  => (string) ($invoice['subscription'] ?? $invoice['id'] ?? ''),
+            'amount'       => (int) ($invoice['amount_paid'] ?? 0),
+            'decimals'     => 2,
+            'denomination' => strtoupper((string) ($invoice['currency'] ?? 'eur')),
+            'emittedAt'    => now()->toIso8601String(),
+            'rawType'      => 'invoice.payment_succeeded',
+        ];
+
+        $this->service->enqueueRevenueOutbox(
+            sourceType: RevenueOutboxEvent::SOURCE_STRIPE,
+            eventId: $eventId,
+            eventKind: 'invoice.payment_succeeded',
+            payload: $payload,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $invoice
+     */
+    private function onInvoicePaymentFailed(array $invoice, string $eventId): void
+    {
+        // Cue dispatch is slice-4 territory (Backend-Q8). For slice 1 we just log.
+        Log::info('subscription.invoice_payment_failed', [
+            'event_id' => $eventId,
+            'invoice'  => $invoice['id'] ?? null,
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $subscription
+     */
+    private function onSubscriptionLifecycle(array $subscription, string $eventId, string $eventType): void
+    {
+        Log::info('subscription.lifecycle', [
+            'event_id'   => $eventId,
+            'event_type' => $eventType,
+            'sub'        => $subscription['id'] ?? null,
+            'status'     => $subscription['status'] ?? null,
+        ]);
+
+        // Cashier already keeps subscriptions/items rows in sync via its own webhook
+        // listener — we don't double-write. Slice 4 wires the cue side-effects.
+    }
+
+    /**
+     * @param array<string, mixed> $charge
+     */
+    private function onChargeRefunded(array $charge, string $eventId): void
+    {
+        $stripeCustomerId = (string) ($charge['customer'] ?? '');
+        $user = $stripeCustomerId !== '' ? $this->resolveUserByStripeCustomer($stripeCustomerId) : null;
+
+        $payload = [
+            'userId'      => $user?->id,
+            'aggregateId' => (string) ($charge['id'] ?? ''),
+            // Negative for refunds per ADR-0004 sign-prefix rule.
+            'amount'       => -1 * (int) ($charge['amount_refunded'] ?? 0),
+            'decimals'     => 2,
+            'denomination' => strtoupper((string) ($charge['currency'] ?? 'eur')),
+            'emittedAt'    => now()->toIso8601String(),
+            'rawType'      => 'charge.refunded',
+        ];
+
+        $this->service->enqueueRevenueOutbox(
+            sourceType: RevenueOutboxEvent::SOURCE_STRIPE,
+            eventId: $eventId,
+            eventKind: 'charge.refunded',
+            payload: $payload,
+        );
+    }
+
+    /**
+     * checkout.session.completed — Setup-mode checkout finished. Stripe gives us
+     * the captured payment_method; we hash its fingerprint, run the trial-abuse
+     * gate, and then create the subscription via Cashier if eligible.
+     *
+     * Slice 1 stub: we record the fingerprint claim. Subscription creation
+     * (currently Cashier handles it via the standard flow when caller passes a
+     * priceId at checkout) is wired up in a follow-up commit when we have the
+     * end-to-end Stripe SetupIntent → Subscription flow tested in CI.
+     *
+     * @param array<string, mixed> $session
+     */
+    private function onCheckoutSessionCompleted(array $session, string $eventId): void
+    {
+        $mode = (string) ($session['mode'] ?? '');
+        if ($mode !== 'setup') {
+            // CGO/KYC checkouts are handled by the existing StripeWebhookController.
+            return;
+        }
+
+        $paymentMethodId = (string) ($session['setup_intent']['payment_method'] ?? $session['payment_method'] ?? '');
+        $customerId = (string) ($session['customer'] ?? '');
+        $user = $customerId !== '' ? $this->resolveUserByStripeCustomer($customerId) : null;
+
+        if (! $user instanceof User || $paymentMethodId === '') {
+            return;
+        }
+
+        // Trial-fingerprint recording happens once we have a card.fingerprint.
+        // Slice 1 stub: log. Full Stripe SDK round-trip in slice 1.5 / 2.
+        Log::info('subscription.checkout.session_completed', [
+            'event_id'          => $eventId,
+            'user_id'           => $user->id,
+            'payment_method_id' => $paymentMethodId,
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $subscription
+     */
+    private function writeConsentLogIfMetadataPresent(User $user, array $subscription): void
+    {
+        $metadata = (array) ($subscription['metadata'] ?? []);
+
+        $acceptedAt = $metadata['consent_accepted_at'] ?? null;
+        $consentTextHash = $metadata['consent_text_hash'] ?? null;
+        $version = $metadata['consent_version'] ?? null;
+
+        if (! is_string($acceptedAt) || ! is_string($consentTextHash) || $version === null) {
+            return;
+        }
+
+        // We stored only the SHA256 of the consent text in metadata to avoid the
+        // 500-char Stripe metadata limit + leakage. The full text is reconstructed
+        // from config at the audit-write moment; consent_version locks the snapshot.
+        $consentText = $this->resolveConsentTextForVersion((int) $version);
+
+        SubscriptionConsentLog::query()->create([
+            'user_id'         => $user->id,
+            'subscription_id' => null, // Cashier's subscriptions row id is not yet bound here
+            'consent_text'    => $consentText,
+            'consent_version' => (int) $version,
+            'shown_at'        => $metadata['consent_shown_at'] ?? $acceptedAt,
+            'accepted_at'     => $acceptedAt,
+            'ip_hash'         => is_string($metadata['remote_ip_hash'] ?? null)
+                ? (string) $metadata['remote_ip_hash']
+                : hash_hmac('sha256', '0.0.0.0', (string) config('app.key')),
+            'user_agent' => null,
+        ]);
+    }
+
+    private function resolveConsentTextForVersion(int $version): string
+    {
+        $versions = (array) config('subscription.consent_texts', []);
+
+        if (isset($versions[$version]) && is_string($versions[$version])) {
+            return (string) $versions[$version];
+        }
+
+        // Fallback to a stable canonical text. Updating the wording requires
+        // bumping the version + adding the row in config.
+        return 'I understand that my subscription begins immediately and I waive my 14-day right of withdrawal.';
+    }
+
+    private function resolveUserByStripeCustomer(string $stripeCustomerId): ?User
+    {
+        /** @var User|null $user */
+        $user = User::query()->where('stripe_id', $stripeCustomerId)->first();
+
+        return $user;
+    }
+
+    /**
+     * @param array<string, mixed> $subscription
+     */
+    private function extractAmountFromSubscription(array $subscription): int
+    {
+        $items = (array) ($subscription['items']['data'] ?? []);
+        if ($items === []) {
+            return 0;
+        }
+
+        $first = (array) $items[0];
+
+        $price = (array) ($first['price'] ?? []);
+
+        return (int) ($price['unit_amount'] ?? 0);
+    }
+
+    /**
+     * @param array<string, mixed> $subscription
+     */
+    private function extractCurrencyFromSubscription(array $subscription): string
+    {
+        $items = (array) ($subscription['items']['data'] ?? []);
+        if ($items === []) {
+            return 'EUR';
+        }
+
+        $first = (array) $items[0];
+        $price = (array) ($first['price'] ?? []);
+
+        return strtoupper((string) ($price['currency'] ?? 'eur'));
+    }
+
+    /**
+     * Verify Stripe webhook signature. Falls back to JSON-decoding the payload
+     * unsigned in local/testing environments per CLAUDE.md webhook-auth-bypass
+     * pitfall (NEVER `return true` for non-prod — gated on env explicitly).
+     *
+     * @return array<string, mixed>|null
+     */
+    private function verifySignature(string $payload, string $signature, string $secret): ?array
+    {
+        if (app()->environment('local', 'testing') && $secret === '') {
+            try {
+                $decoded = json_decode($payload, true, flags: JSON_THROW_ON_ERROR);
+
+                return is_array($decoded) ? $decoded : null;
+            } catch (Throwable) {
+                return null;
+            }
+        }
+
+        try {
+            $event = Webhook::constructEvent($payload, $signature, $secret);
+
+            return $event->toArray();
+        } catch (Throwable $e) {
+            Log::warning('subscription.webhook.signature_invalid', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+    }
+}

--- a/app/Http/Controllers/Api/GdprController.php
+++ b/app/Http/Controllers/Api/GdprController.php
@@ -13,6 +13,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
 use OpenApi\Attributes as OA;
+use Throwable;
 
 #[OA\Tag(
     name: 'GDPR',
@@ -349,6 +350,12 @@ class GdprController extends Controller
                 ]
             );
 
+            // Plan B Backend-Q1 #6 — explicit Stripe customer delete.
+            // Cashier doesn't auto-cascade on User::delete(), so we must call
+            // `asStripeCustomer()->delete()` here to satisfy GDPR Article 17
+            // for the Stripe-side personal data we control.
+            $this->purgeStripeCustomerData($user);
+
             return response()->json(
                 [
                     'message' => 'Account deletion request processed. Your account will be deleted within 30 days.',
@@ -362,6 +369,33 @@ class GdprController extends Controller
                 500
             );
         }
+    }
+
+    /**
+     * Cascade GDPR erasure to Stripe per Backend-Q1 #6. Best-effort: a Stripe
+     * outage or already-deleted-customer must NOT block the local deletion
+     * flow — we log and continue.
+     */
+    private function purgeStripeCustomerData(User $user): void
+    {
+        if (empty($user->stripe_id)) {
+            return;
+        }
+
+        try {
+            $user->asStripeCustomer()->delete();
+        } catch (Throwable $e) {
+            \Illuminate\Support\Facades\Log::warning('gdpr.stripe_customer_delete_failed', [
+                'user_id' => $user->id,
+                'error'   => $e->getMessage(),
+            ]);
+        }
+
+        $user->forceFill([
+            'stripe_id'    => null,
+            'pm_type'      => null,
+            'pm_last_four' => null,
+        ])->save();
     }
 
         #[OA\Get(

--- a/app/Http/Middleware/IdempotencyKey.php
+++ b/app/Http/Middleware/IdempotencyKey.php
@@ -1,0 +1,176 @@
+<?php
+
+/**
+ * IdempotencyKey middleware — enforces Idempotency-Key header presence
+ * on mutating endpoints AND replays cached responses on duplicate requests.
+ *
+ * Distinct from `IdempotencyMiddleware` (alias `idempotency`) which only
+ * caches when the caller opts in. This one (alias `idempotency.required`)
+ * REJECTS missing keys with ERR_VALIDATION_001 — required for the Plan B
+ * commercial endpoints where a missing key is a contract violation.
+ *
+ * Keyed cache shape mirrors IdempotencyMiddleware so existing replay
+ * semantics still apply.
+ *
+ * @see docs/BACKEND_HANDOVER_PLAN_B_REVIEW_DELTAS.md (Q1 acceptance criterion)
+ */
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Support\ErrorResponse;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Symfony\Component\HttpFoundation\Response;
+
+final class IdempotencyKey
+{
+    private const CACHE_TTL_SECONDS = 86_400; // 24h
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        // Only mutating verbs require an idempotency key.
+        if (! in_array($request->method(), ['POST', 'PUT', 'PATCH', 'DELETE'], true)) {
+            return $next($request);
+        }
+
+        $idempotencyKey = (string) $request->header('Idempotency-Key', '');
+
+        if ($idempotencyKey === '') {
+            return ErrorResponse::make('ERR_VALIDATION_001');
+        }
+
+        if (! $this->isValidKeyFormat($idempotencyKey)) {
+            return ErrorResponse::make('ERR_VALIDATION_001', [
+                'message' => 'Idempotency-Key must be a UUID or 16-64 char alphanumeric string.',
+            ], 422);
+        }
+
+        $cacheKey = $this->generateCacheKey($request, $idempotencyKey);
+        $cached = Cache::get($cacheKey);
+
+        if (is_array($cached)) {
+            $cachedRequest = is_array($cached['request'] ?? null) ? $cached['request'] : [];
+            if (! $this->requestMatches($request, $cachedRequest)) {
+                return ErrorResponse::make('ERR_VALIDATION_001', [
+                    'message' => 'Idempotency-Key already used with a different request body.',
+                ], 409);
+            }
+
+            return $this->buildReplayResponse($cached, $idempotencyKey);
+        }
+
+        $lock = Cache::lock($cacheKey . ':lock', 30);
+
+        if (! $lock->get()) {
+            return ErrorResponse::make('ERR_VALIDATION_001', [
+                'message' => 'A request with the same Idempotency-Key is currently in flight.',
+            ], 409);
+        }
+
+        try {
+            $response = $next($request);
+
+            $statusCode = $response->getStatusCode();
+            if ($statusCode >= 200 && $statusCode < 300) {
+                $this->cacheResponse($cacheKey, $request, $response);
+                $response->headers->set('X-Idempotency-Key', $idempotencyKey);
+                $response->headers->set('X-Idempotency-Replayed', 'false');
+            }
+
+            return $response;
+        } finally {
+            $lock->release();
+        }
+    }
+
+    private function isValidKeyFormat(string $key): bool
+    {
+        if (preg_match('/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i', $key) === 1) {
+            return true;
+        }
+
+        return preg_match('/^[a-zA-Z0-9_-]{16,64}$/', $key) === 1;
+    }
+
+    private function generateCacheKey(Request $request, string $idempotencyKey): string
+    {
+        $userId = $request->user() !== null ? (string) $request->user()->getAuthIdentifier() : 'anonymous';
+
+        return 'idempotency:' . $userId . ':' . $request->path() . ':' . $idempotencyKey;
+    }
+
+    /**
+     * @param array<string, mixed> $cachedRequest
+     */
+    private function requestMatches(Request $current, array $cachedRequest): bool
+    {
+        $cachedMethod = is_string($cachedRequest['method'] ?? null) ? (string) $cachedRequest['method'] : '';
+        if ($current->method() !== $cachedMethod) {
+            return false;
+        }
+
+        $currentBody = $current->all();
+        $cachedBody = is_array($cachedRequest['body'] ?? null) ? $cachedRequest['body'] : [];
+
+        ksort($currentBody);
+        ksort($cachedBody);
+
+        return (string) json_encode($currentBody) === (string) json_encode($cachedBody);
+    }
+
+    /**
+     * @param array<string, mixed> $cached
+     */
+    private function buildReplayResponse(array $cached, string $idempotencyKey): Response
+    {
+        $cachedResponse = is_array($cached['response'] ?? null) ? $cached['response'] : [];
+        $content = $cachedResponse['content'] ?? null;
+        $status = isset($cachedResponse['status']) && is_int($cachedResponse['status'])
+            ? $cachedResponse['status']
+            : 200;
+        $cachedHeaders = is_array($cachedResponse['headers'] ?? null) ? $cachedResponse['headers'] : [];
+
+        $response = response()->json($content, $status);
+
+        $response->headers->set('X-Idempotency-Key', $idempotencyKey);
+        $response->headers->set('X-Idempotency-Replayed', 'true');
+
+        $reservedHeaders = ['x-idempotency-key', 'x-idempotency-replayed'];
+        foreach ($cachedHeaders as $header => $values) {
+            if (in_array(strtolower((string) $header), $reservedHeaders, true)) {
+                continue;
+            }
+
+            $valuesList = is_array($values) ? $values : [$values];
+            foreach ($valuesList as $value) {
+                $response->headers->set((string) $header, (string) $value, false);
+            }
+        }
+
+        return $response;
+    }
+
+    private function cacheResponse(string $cacheKey, Request $request, Response $response): void
+    {
+        $content = $response->getContent();
+        $decoded = is_string($content) ? json_decode($content, true) : null;
+
+        $payload = [
+            'request' => [
+                'method'    => $request->method(),
+                'body'      => $request->all(),
+                'timestamp' => now()->toIso8601String(),
+            ],
+            'response' => [
+                'content' => $decoded,
+                'status'  => $response->getStatusCode(),
+                'headers' => $response->headers->all(),
+            ],
+        ];
+
+        Cache::put($cacheKey, $payload, self::CACHE_TTL_SECONDS);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -62,6 +62,34 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        // Backend-Q1 (Plan B): pin the Stripe API version in a single config key
+        // (config/services.php:stripe.api_version, env STRIPE_API_VERSION) so both
+        // Cashier (subscription path) and any future Stripe Bridge clients use the
+        // same version. Cashier 15.x reads `stripe_version` from the StripeClient
+        // config — we override the default by replacing Cashier's container binding.
+        // Acceptance: any direct SDK call site that needs to know the pinned version
+        // reads `config('services.stripe.api_version')` — never hard-codes.
+        $stripeApiVersion = (string) config('services.stripe.api_version');
+        if ($stripeApiVersion !== '') {
+            $this->app->bind(\Stripe\StripeClient::class, function ($app, array $parameters = []) use ($stripeApiVersion) {
+                $config = $parameters['config'] ?? [];
+                if (! is_array($config)) {
+                    $config = [];
+                }
+
+                // Honour the pinned version unless an explicit caller already set one.
+                if (! isset($config['stripe_version'])) {
+                    $config['stripe_version'] = $stripeApiVersion;
+                }
+
+                if (! isset($config['api_key'])) {
+                    $config['api_key'] = (string) config('cashier.secret');
+                }
+
+                return new \Stripe\StripeClient($config);
+            });
+        }
+
         // L5-Swagger: inject the analyser at generation time (not in config) so
         // config:cache / optimize works. Object instances are not serializable.
         $this->app->resolving(\L5Swagger\GeneratorFactory::class, function () {

--- a/app/Support/ErrorResponse.php
+++ b/app/Support/ErrorResponse.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * ErrorResponse — single canonical helper for `ERR_*` API error responses.
+ *
+ * Reads the registry in config/error_codes.php; every code returned to a
+ * client MUST be registered there. Allows extra fields per call (e.g.
+ * `eligibleAfter`, `recoveryUrl`, `conflict`) without duplicating shape.
+ */
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use Illuminate\Http\JsonResponse;
+use InvalidArgumentException;
+
+final class ErrorResponse
+{
+    /**
+     * Build a JsonResponse for the given registered error code.
+     *
+     * @param string                $code   error code, e.g. `ERR_SUB_004`
+     * @param array<string, mixed>  $extra  optional fields to merge into the JSON body
+     * @param int|null              $status overrides config-default status code
+     */
+    public static function make(string $code, array $extra = [], ?int $status = null): JsonResponse
+    {
+        $registry = (array) config('error_codes', []);
+
+        if (! isset($registry[$code]) || ! is_array($registry[$code])) {
+            throw new InvalidArgumentException(
+                "Unknown error code: {$code} — register it in config/error_codes.php."
+            );
+        }
+
+        /** @var array{http: int, message: string} $entry */
+        $entry = $registry[$code];
+
+        $body = array_merge(
+            [
+                'code'    => $code,
+                'message' => $entry['message'],
+            ],
+            $extra,
+        );
+
+        return response()->json($body, $status ?? $entry['http']);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -112,6 +112,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'auth.apikey'            => App\Http\Middleware\AuthenticateApiKey::class,
             'auth.api_or_sanctum'    => App\Http\Middleware\AuthenticateApiOrSanctum::class,
             'idempotency'            => App\Http\Middleware\IdempotencyMiddleware::class,
+            'idempotency.required'   => App\Http\Middleware\IdempotencyKey::class,
             'webhook.signature'      => App\Http\Middleware\ValidateWebhookSignature::class,
             'validate.key.access'    => App\Http\Middleware\ValidateKeyAccess::class,
             'demo'                   => App\Http\Middleware\DemoMode::class,

--- a/config/error_codes.php
+++ b/config/error_codes.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Centralised error-code registry for API responses.
+ *
+ * All API error codes match /^ERR_[A-Z]+_\d{3}$/ per Backend-Q15.3.
+ * Add new codes here before referencing them in App\Support\ErrorResponse::make().
+ *
+ * @see docs/BACKEND_HANDOVER_PLAN_B_REVIEW_DELTAS.md
+ */
+
+return [
+    // Validation
+    'ERR_VALIDATION_001' => [
+        'http'    => 422,
+        'message' => 'Idempotency-Key header is required for this endpoint.',
+    ],
+    'ERR_VALIDATION_002' => [
+        'http'    => 422,
+        'message' => 'Malformed amount field (must be integer string with explicit decimals + currency-or-asset).',
+    ],
+
+    // Subscription lifecycle (§1, deltas Q14, Q17)
+    'ERR_SUB_002' => [
+        'http'    => 409,
+        'message' => 'Subscription conflict — another active subscription exists for this user.',
+    ],
+    'ERR_SUB_003' => [
+        'http'    => 403,
+        'message' => 'Trial already used on this card.',
+    ],
+    'ERR_SUB_004' => [
+        'http'    => 422,
+        'message' => 'Withdrawal consent payload is missing, malformed, or stale (>5 minutes old).',
+    ],
+    'ERR_SUB_005' => [
+        'http'    => 409,
+        'message' => 'A live Stripe Checkout session already exists for this user.',
+    ],
+    'ERR_SUB_006' => [
+        'http'    => 422,
+        'message' => 'Annual to monthly downgrade is not offered.',
+    ],
+    'ERR_SUB_007' => [
+        'http'    => 409,
+        'message' => 'Cross-source subscription conflict — another store already has an active subscription for this user.',
+    ],
+    'ERR_SUB_010' => [
+        'http'    => 422,
+        'message' => 'Cancel via the App Store or Google Play — IAP subscriptions are managed store-side.',
+    ],
+];

--- a/config/services.php
+++ b/config/services.php
@@ -79,6 +79,21 @@ return [
         'kyc_webhook_secret'    => env('STRIPE_KYC_WEBHOOK_SECRET'),
         'bridge_webhook_secret' => env('STRIPE_BRIDGE_WEBHOOK_SECRET'),
 
+        // Backend-Q1: single config key consumed by both Cashier and any future
+        // Stripe Bridge clients. Cashier wires it up via Cashier::useStripeApiVersion()
+        // in App\Providers\AppServiceProvider::boot.
+        'api_version' => env('STRIPE_API_VERSION', '2025-04-30.basil'),
+        // Backend-Q5: HMAC-SHA256 pepper for trial-card fingerprint hashing.
+        // Single env-var, event-triggered rotation only (rotation = re-hash all
+        // trial_card_fingerprints rows in one transaction). See deltas Q5.
+        'trial_fingerprint_pepper' => env('TRIAL_FINGERPRINT_PEPPER'),
+
+        // Subscription Stripe Price IDs (Plan B §1).
+        'subscription_prices' => [
+            'monthly_pro' => env('STRIPE_PRICE_MONTHLY_PRO'),
+            'annual_pro'  => env('STRIPE_PRICE_ANNUAL_PRO'),
+        ],
+
         // Mobile deep-link return URLs for KYC Checkout. Stripe substitutes
         // {CHECKOUT_SESSION_ID} on the success URL. Both URLs share a single
         // 'trustcert/payment-return' route on the mobile side that branches

--- a/config/subscription.php
+++ b/config/subscription.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Plan B Slice 1 — subscription module config.
+ */
+
+return [
+    /*
+     * Active version of the EU withdrawal-consent text shown on Stripe Web checkout.
+     * Increment when the user-facing copy changes; stored alongside each consent
+     * row in subscription_consent_log so dispute lookups retrieve the exact
+     * wording the user accepted.
+     */
+    'consent_version' => env('SUBSCRIPTION_CONSENT_VERSION', 1),
+
+    /*
+     * Acceptable staleness window between consent.acceptedAt and request time.
+     */
+    'consent_max_age_seconds' => 300,
+
+    /*
+     * Outbox worker — backoff caps before a row is marked failed.
+     */
+    'outbox' => [
+        'max_attempts'          => 5,
+        'retry_backoff_seconds' => 30,
+    ],
+];

--- a/database/migrations/2026_05_09_180001_create_processed_webhook_events_table.php
+++ b/database/migrations/2026_05_09_180001_create_processed_webhook_events_table.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * Plan B Slice 1 — global webhook idempotency dedup. Stripe / IAP / etc.
+     * webhook handlers consult this table BEFORE Cashier dispatches; redelivery
+     * of the same provider event_id is a no-op. See deltas Q7.3.
+     */
+    public function up(): void
+    {
+        Schema::create('processed_webhook_events', function (Blueprint $table) {
+            $table->id();
+            $table->string('provider', 32);
+            $table->string('event_id', 255);
+            $table->string('event_type', 128)->nullable();
+            $table->timestamp('processed_at');
+            $table->timestamps();
+
+            $table->unique(['provider', 'event_id'], 'uniq_provider_event_id');
+            $table->index('processed_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('processed_webhook_events');
+    }
+};

--- a/database/migrations/2026_05_09_180002_create_trial_card_fingerprints_table.php
+++ b/database/migrations/2026_05_09_180002_create_trial_card_fingerprints_table.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * Plan B Backend-Q5 — trial-abuse fingerprint check (α, 12-month retry).
+     *
+     * fingerprint_hash = HMAC-SHA256(stripe_pm.card.fingerprint, TRIAL_FINGERPRINT_PEPPER).
+     *
+     * A fingerprint is eligible to claim a NEW trial iff
+     *   no row exists OR last_used_at + 12 months < now().
+     *
+     * Pepper rotation policy (event-triggered only, per simple-pepper convention):
+     *   raw fingerprint is recoverable via the user's Stripe Subscription, so
+     *   rotation = re-hash all rows in one transaction. Cheap.
+     */
+    public function up(): void
+    {
+        Schema::create('trial_card_fingerprints', function (Blueprint $table) {
+            $table->char('fingerprint_hash', 64)->primary();
+            $table->foreignId('first_user_id')->nullable();
+            $table->foreignId('last_user_id')->nullable();
+            $table->timestamp('first_used_at');
+            $table->timestamp('last_used_at');
+            $table->unsignedInteger('trial_user_count')->default(1);
+            $table->string('stripe_payment_method_id', 255)->nullable();
+            $table->timestamps();
+
+            $table->index('last_used_at', 'idx_fingerprint_last_used');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('trial_card_fingerprints');
+    }
+};

--- a/database/migrations/2026_05_09_180003_create_subscription_consent_log_table.php
+++ b/database/migrations/2026_05_09_180003_create_subscription_consent_log_table.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * Plan B deltas Q14.2 — withdrawal consent audit log for Stripe Web flow.
+     *
+     * Written on every successful Stripe-Web subscription creation (CRD/EU dispute
+     * trail). Per-row text snapshots: if the consent line copy changes, increment
+     * consent_version — a dispute lookup retrieves the exact text shown at consent
+     * time, not whatever's current.
+     */
+    public function up(): void
+    {
+        Schema::create('subscription_consent_log', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id');
+            $table->unsignedBigInteger('subscription_id')->nullable();
+            $table->text('consent_text');
+            $table->unsignedInteger('consent_version');
+            $table->timestamp('shown_at');
+            $table->timestamp('accepted_at');
+            $table->char('ip_hash', 64);
+            $table->text('user_agent')->nullable();
+            $table->timestamps();
+
+            $table->index('user_id', 'idx_consent_user');
+            $table->index('subscription_id', 'idx_consent_subscription');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('subscription_consent_log');
+    }
+};

--- a/database/migrations/2026_05_09_180004_create_revenue_outbox_events_table.php
+++ b/database/migrations/2026_05_09_180004_create_revenue_outbox_events_table.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * revenue_outbox_events migration — off-chain projection upstream per ADR-0002.
+ *
+ * Webhook handlers (Stripe / Apple IAP / Google Play / Stripe Bridge / Ondato)
+ * write a row here in the same transaction as `processed_webhook_events` dedup;
+ * a separate worker (`ProjectRevenueOutbox`) projects pending rows into
+ * `revenue_events` and marks them delivered. Idempotent on
+ * (source_type, source_event_id) via the unique index.
+ *
+ * @see docs/adr/0002-revenue-projection-dual-upstream.md
+ */
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('revenue_outbox_events', function (Blueprint $table) {
+            $table->id();
+            $table->string('source_event_id', 255);
+            $table->string('source_type', 32); // stripe | apple_iap | google_play | ondato | stripe_bridge
+            $table->string('event_kind', 64);
+            $table->json('payload');
+            $table->string('status', 16)->default('pending'); // pending | delivered | failed
+            $table->unsignedInteger('attempts')->default(0);
+            $table->timestamp('delivered_at')->nullable();
+            $table->text('failed_reason')->nullable();
+            $table->timestamps();
+
+            $table->unique(['source_type', 'source_event_id'], 'uniq_outbox_source');
+            $table->index(['status', 'created_at'], 'idx_outbox_pending');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('revenue_outbox_events');
+    }
+};

--- a/database/migrations/2026_05_09_180005_create_revenue_events_table.php
+++ b/database/migrations/2026_05_09_180005_create_revenue_events_table.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * revenue_events migration — projection target for both upstream paths
+ * per ADR-0002 (chain-ingestor for on-chain fees, PSP outbox for off-chain).
+ *
+ * Slice 1 only writes from the off-chain outbox path (subscription_initial,
+ * subscription_renewal). Slice (chain-ingestor) writes tx_fee rows in a
+ * later slice.
+ *
+ * @see docs/adr/0002-revenue-projection-dual-upstream.md
+ */
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('revenue_events', function (Blueprint $table) {
+            $table->id();
+            $table->string('event_type', 64); // subscription_initial | subscription_renewal | refund | tx_fee | ramp_margin | ...
+            $table->foreignId('user_id')->nullable();
+            $table->char('user_id_hash', 64)->nullable(); // for cohort analytics post-erasure
+            $table->string('source_type', 32); // stripe | apple_iap | google_play | stripe_bridge | chain | ondato
+            $table->string('source_event_id', 255)->nullable();
+            $table->string('aggregate_id', 255)->nullable(); // stripe_subscription_id, original_transaction_id, tx_hash, ...
+            // Money triple per ADR-0004 (explicit because revenue_events is variable-currency).
+            $table->bigInteger('amount'); // signed: negative for refunds
+            $table->unsignedTinyInteger('amount_decimals');
+            $table->string('amount_denomination', 16); // EUR / USDC / MATIC / ...
+            $table->json('payload')->nullable();
+            $table->timestamp('emitted_at');
+            $table->timestamps();
+
+            $table->unique(['source_type', 'source_event_id', 'event_type'], 'uniq_revenue_event_source');
+            $table->index('emitted_at');
+            $table->index(['user_id', 'event_type']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('revenue_events');
+    }
+};

--- a/resources/views/about.blade.php
+++ b/resources/views/about.blade.php
@@ -33,7 +33,7 @@
                 @include('partials.breadcrumb', ['items' => [['name' => 'About', 'url' => url('/about')]]])
                 <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">About <span class="text-gradient">{{ config('brand.name', 'Zelta') }}</span></h1>
                 <p class="text-lg text-slate-400 max-w-2xl mx-auto">
-                    Open-source core banking infrastructure built with Laravel — 59 domain modules covering everything from democratic currency governance to AI agent commerce.
+                    Open-source core banking infrastructure built with Laravel — 60 domain modules covering everything from democratic currency governance to AI agent commerce.
                 </p>
             </div>
         </div>
@@ -210,7 +210,7 @@
                 <div class="card-feature">
                     <h4 class="font-display text-base font-bold text-slate-900 mb-2">For Founders</h4>
                     <p class="text-sm text-slate-500 mb-3">
-                        Build your fintech product on battle-tested infrastructure. 59 domain modules, Apache-2.0 licensed, ready to customize.
+                        Build your fintech product on battle-tested infrastructure. 60 domain modules, Apache-2.0 licensed, ready to customize.
                     </p>
                     <a href="{{ route('developers') }}" class="text-sm text-blue-600 font-semibold hover:text-blue-700 transition">
                         View Documentation &rarr;

--- a/resources/views/partials/public-nav.blade.php
+++ b/resources/views/partials/public-nav.blade.php
@@ -37,7 +37,7 @@
                                     </div>
                                     <div>
                                         <div class="text-sm font-medium text-slate-200">All Features</div>
-                                        <div class="text-xs text-slate-500">59 domain modules</div>
+                                        <div class="text-xs text-slate-500">60 domain modules</div>
                                     </div>
                                 </a>
                                 <a href="{{ route('gcu') }}" class="dropdown-link {{ request()->routeIs('gcu*') ? 'dropdown-link-active' : '' }}">

--- a/resources/views/pricing.blade.php
+++ b/resources/views/pricing.blade.php
@@ -58,7 +58,7 @@
                         <ul class="space-y-3 mb-8 text-sm text-slate-600">
                             <li class="list-check">Full source code access</li>
                             <li class="list-check">Apache-2.0 License</li>
-                            <li class="list-check">All 59 domain modules</li>
+                            <li class="list-check">All 60 domain modules</li>
                             <li class="list-check">ISO 20022, Open Banking, Payment Rails</li>
                             <li class="list-check">Ledger, Microfinance, Interledger</li>
                             <li class="list-check">Community support</li>

--- a/resources/views/support/faq.blade.php
+++ b/resources/views/support/faq.blade.php
@@ -13,7 +13,7 @@
     $faqData = [
         [
             'question' => 'What is the current status of ' . config('brand.name', 'Zelta') . '?',
-            'answer' => config('brand.name', 'Zelta') . ' v7.11.0 is a fully-featured open-source core banking platform with 59 domain modules, including a public OAuth-protected MCP server for AI agents. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
+            'answer' => config('brand.name', 'Zelta') . ' v7.11.0 is a fully-featured open-source core banking platform with 60 domain modules, including a public OAuth-protected MCP server for AI agents. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
         ],
         [
             'question' => 'Can I use real money on the platform?',
@@ -21,7 +21,7 @@
         ],
         [
             'question' => 'How do I get started?',
-            'answer' => 'Register for a free account to explore the sandbox, or clone the repository from GitHub to self-host. You can explore all 59 domain modules, test the APIs, and provide feedback through our support channels.'
+            'answer' => 'Register for a free account to explore the sandbox, or clone the repository from GitHub to self-host. You can explore all 60 domain modules, test the APIs, and provide feedback through our support channels.'
         ],
         [
             'question' => 'What is the Global Currency Unit (GCU)?',
@@ -130,7 +130,7 @@
                             {{ config('brand.name', 'Zelta') }} is a fully-featured open-source core banking platform at v7.11.0. The sandbox environment lets you:
                         </p>
                         <ul class="list-disc list-inside mt-2 text-slate-500 space-y-1">
-                            <li>Explore 59 domain modules including DeFi, cross-chain, privacy, MCP, and rewards</li>
+                            <li>Explore 60 domain modules including DeFi, cross-chain, privacy, MCP, and rewards</li>
                             <li>Test 1,400+ API routes and a 45-domain GraphQL API</li>
                             <li>Try KYC/AML compliance flows, card issuing, and mobile payments</li>
                             <li>All transactions use test data &mdash; no real funds are involved</li>
@@ -340,7 +340,7 @@
                             We have an exciting roadmap ahead:
                         </p>
                         <ul class="list-disc list-inside mt-2 text-slate-500 space-y-1">
-                            <li><strong>Delivered:</strong> 59 domain modules, 1,400+ API routes, GraphQL (45 domains), public MCP server, event sourcing</li>
+                            <li><strong>Delivered:</strong> 60 domain modules, 1,400+ API routes, GraphQL (45 domains), public MCP server, event sourcing</li>
                             <li><strong>Delivered:</strong> Mobile app backend, passkey auth, card issuing, KYC/AML</li>
                             <li><strong>Delivered:</strong> Cross-chain bridges, DeFi connectors, X402 micropayments</li>
                             <li><strong>Delivered:</strong> GCU voting system, production bank integrations</li>

--- a/resources/views/support/guides.blade.php
+++ b/resources/views/support/guides.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'Support Guides - ' . config('brand.name', 'Zelta'),
-        'description' => config('brand.name', 'Zelta') . ' platform guides and documentation. Learn how to use, deploy, and contribute to our open-source core banking platform with 59 domain modules.',
+        'description' => config('brand.name', 'Zelta') . ' platform guides and documentation. Learn how to use, deploy, and contribute to our open-source core banking platform with 60 domain modules.',
         'keywords' => config('brand.name', 'Zelta') . ' guides, documentation, tutorials, open source banking, core banking platform',
     ])
 @endsection

--- a/routes/api.php
+++ b/routes/api.php
@@ -187,6 +187,31 @@ Route::post('webhooks/stripe/kyc', [App\Http\Controllers\Api\Webhook\StripeKycWe
     ->middleware('api.rate_limit:webhook')
     ->name('api.webhooks.stripe.kyc');
 
+// Plan B Slice 1 — Stripe subscription webhook (separate from /stripe/webhook
+// which handles CGO + KYC). Signature verified inside the controller.
+Route::post('webhooks/stripe/subscriptions', [App\Domain\Subscription\Webhooks\SubscriptionWebhookController::class, 'handle'])
+    ->middleware('api.rate_limit:webhook')
+    ->name('api.webhooks.stripe.subscriptions');
+
+// Plan B Slice 1 — Subscription module endpoints (Stripe-only).
+Route::prefix('v1/subscription')->name('api.v1.subscription.')
+    ->middleware(['auth:sanctum'])
+    ->group(function () {
+        Route::get('/me', [App\Domain\Subscription\Http\Controllers\SubscriptionController::class, 'me'])
+            ->name('me');
+
+        Route::middleware(['idempotency.required'])->group(function () {
+            Route::post('/checkout', [App\Domain\Subscription\Http\Controllers\SubscriptionController::class, 'checkout'])
+                ->name('checkout');
+            Route::post('/change-plan', [App\Domain\Subscription\Http\Controllers\SubscriptionController::class, 'changePlan'])
+                ->name('change-plan');
+            Route::post('/cancel', [App\Domain\Subscription\Http\Controllers\SubscriptionController::class, 'cancel'])
+                ->name('cancel');
+            Route::post('/reactivate', [App\Domain\Subscription\Http\Controllers\SubscriptionController::class, 'reactivate'])
+                ->name('reactivate');
+        });
+    });
+
 // Extended monitoring endpoints with authentication
 Route::prefix('monitoring')->middleware(['auth:sanctum'])->group(function () {
     Route::get('/metrics-json', [App\Http\Controllers\Api\MonitoringController::class, 'metrics']);

--- a/tests/Feature/Subscription/ProjectRevenueOutboxTest.php
+++ b/tests/Feature/Subscription/ProjectRevenueOutboxTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Subscription\Jobs\ProjectRevenueOutbox;
+use App\Domain\Subscription\Models\RevenueEvent;
+use App\Domain\Subscription\Models\RevenueOutboxEvent;
+
+beforeEach(function () {
+    config(['cache.default' => 'array']);
+});
+
+it('projects a pending subscription_initial outbox row into revenue_events and marks delivered', function () {
+    $row = RevenueOutboxEvent::query()->create([
+        'source_type'     => RevenueOutboxEvent::SOURCE_STRIPE,
+        'source_event_id' => 'evt_proj_001',
+        'event_kind'      => 'customer.subscription.created',
+        'payload'         => [
+            'userId'       => 1,
+            'aggregateId'  => 'sub_proj_001',
+            'amount'       => 499,
+            'decimals'     => 2,
+            'denomination' => 'EUR',
+            'emittedAt'    => now()->toIso8601String(),
+        ],
+        'status'   => RevenueOutboxEvent::STATUS_PENDING,
+        'attempts' => 0,
+    ]);
+
+    (new ProjectRevenueOutbox($row->id))->handle();
+
+    $row->refresh();
+    expect($row->status)->toBe(RevenueOutboxEvent::STATUS_DELIVERED);
+    expect($row->delivered_at)->not()->toBeNull();
+
+    $event = RevenueEvent::query()->where('source_event_id', 'evt_proj_001')->first();
+    expect($event)->not()->toBeNull();
+    expect($event->event_type)->toBe(RevenueEvent::TYPE_SUBSCRIPTION_INITIAL);
+    expect($event->amount)->toBe(499);
+    expect($event->amount_decimals)->toBe(2);
+    expect($event->amount_denomination)->toBe('EUR');
+    expect($event->aggregate_id)->toBe('sub_proj_001');
+});
+
+it('maps invoice.payment_succeeded to subscription_renewal', function () {
+    $row = RevenueOutboxEvent::query()->create([
+        'source_type'     => RevenueOutboxEvent::SOURCE_STRIPE,
+        'source_event_id' => 'evt_renewal_proj',
+        'event_kind'      => 'invoice.payment_succeeded',
+        'payload'         => [
+            'userId'       => 1,
+            'aggregateId'  => 'sub_renew',
+            'amount'       => 499,
+            'decimals'     => 2,
+            'denomination' => 'EUR',
+        ],
+        'status'   => RevenueOutboxEvent::STATUS_PENDING,
+        'attempts' => 0,
+    ]);
+
+    (new ProjectRevenueOutbox($row->id))->handle();
+
+    $event = RevenueEvent::query()->where('source_event_id', 'evt_renewal_proj')->first();
+    expect($event->event_type)->toBe(RevenueEvent::TYPE_SUBSCRIPTION_RENEWAL);
+});
+
+it('is idempotent — re-running on a delivered row is a no-op', function () {
+    $row = RevenueOutboxEvent::query()->create([
+        'source_type'     => RevenueOutboxEvent::SOURCE_STRIPE,
+        'source_event_id' => 'evt_idem_proj',
+        'event_kind'      => 'customer.subscription.created',
+        'payload'         => [
+            'userId'       => 1,
+            'aggregateId'  => 'sub_idem',
+            'amount'       => 499,
+            'decimals'     => 2,
+            'denomination' => 'EUR',
+        ],
+        'status'   => RevenueOutboxEvent::STATUS_PENDING,
+        'attempts' => 0,
+    ]);
+
+    (new ProjectRevenueOutbox($row->id))->handle();
+    (new ProjectRevenueOutbox($row->id))->handle();
+
+    expect(RevenueEvent::query()->where('source_event_id', 'evt_idem_proj')->count())->toBe(1);
+});
+
+it('sweeps all pending rows when called with rowId=null', function () {
+    foreach (range(1, 3) as $i) {
+        RevenueOutboxEvent::query()->create([
+            'source_type'     => RevenueOutboxEvent::SOURCE_STRIPE,
+            'source_event_id' => "evt_sweep_{$i}",
+            'event_kind'      => 'invoice.payment_succeeded',
+            'payload'         => [
+                'amount'       => 499,
+                'decimals'     => 2,
+                'denomination' => 'EUR',
+                'aggregateId'  => "sub_sweep_{$i}",
+            ],
+            'status'   => RevenueOutboxEvent::STATUS_PENDING,
+            'attempts' => 0,
+        ]);
+    }
+
+    (new ProjectRevenueOutbox(null))->handle();
+
+    expect(RevenueEvent::query()->count())->toBe(3);
+    expect(RevenueOutboxEvent::query()->where('status', 'delivered')->count())->toBe(3);
+});

--- a/tests/Feature/Subscription/SubscriptionEndpointsIdempotencyTest.php
+++ b/tests/Feature/Subscription/SubscriptionEndpointsIdempotencyTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\Sanctum;
+
+beforeEach(function () {
+    config(['cache.default' => 'array']);
+});
+
+it('rejects POST /checkout when Idempotency-Key header is missing', function () {
+    $user = User::factory()->create();
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    $response = $this->postJson('/api/v1/subscription/checkout', [
+        'plan'              => 'monthly_pro',
+        'withdrawalConsent' => [
+            'given'       => true,
+            'shownAt'     => now()->toIso8601String(),
+            'acceptedAt'  => now()->toIso8601String(),
+            'consentText' => 'I waive my 14-day right of withdrawal.',
+            'version'     => 1,
+        ],
+    ]);
+
+    $response->assertStatus(422);
+    $response->assertJsonPath('code', 'ERR_VALIDATION_001');
+});
+
+it('rejects POST /checkout with stale withdrawal consent (>5min old)', function () {
+    $user = User::factory()->create();
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    $response = $this->postJson('/api/v1/subscription/checkout', [
+        'plan'              => 'monthly_pro',
+        'withdrawalConsent' => [
+            'given'       => true,
+            'shownAt'     => now()->subMinutes(10)->toIso8601String(),
+            'acceptedAt'  => now()->subMinutes(10)->toIso8601String(),
+            'consentText' => 'I waive my 14-day right of withdrawal.',
+            'version'     => 1,
+        ],
+    ], [
+        'Idempotency-Key' => (string) Str::uuid(),
+    ]);
+
+    $response->assertStatus(422);
+    $response->assertJsonPath('code', 'ERR_SUB_004');
+});
+
+it('rejects POST /change-plan annual to monthly downgrade with ERR_SUB_006', function () {
+    // Without an existing subscription, the controller short-circuits with
+    // ERR_SUB_002. We verify the ERR_SUB_006 path via the unit test on
+    // SubscriptionService directly in tests/Unit/Subscription.
+    $user = User::factory()->create();
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    $response = $this->postJson('/api/v1/subscription/change-plan', [
+        'plan' => 'monthly_pro',
+    ], [
+        'Idempotency-Key' => (string) Str::uuid(),
+    ]);
+
+    // No active sub → ERR_SUB_002
+    $response->assertStatus(409);
+    $response->assertJsonPath('code', 'ERR_SUB_002');
+});
+
+it('replays POST /cancel responses on duplicate Idempotency-Key', function () {
+    $user = User::factory()->create();
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    $key = (string) Str::uuid();
+
+    $first = $this->postJson('/api/v1/subscription/cancel', [], ['Idempotency-Key' => $key]);
+    $first->assertStatus(409);
+    $first->assertJsonPath('code', 'ERR_SUB_002'); // no active sub
+
+    // Non-2xx responses are not cached by the idempotency middleware (deliberate —
+    // we don't want to memoise transient errors); the second call re-runs the
+    // handler and returns 409 again.
+    $second = $this->postJson('/api/v1/subscription/cancel', [], ['Idempotency-Key' => $key]);
+    $second->assertStatus(409);
+});
+
+it('returns 422 ERR_VALIDATION_001 for malformed Idempotency-Key', function () {
+    $user = User::factory()->create();
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    $response = $this->postJson('/api/v1/subscription/cancel', [], [
+        'Idempotency-Key' => 'too-short', // not UUID, not 16+ alphanumeric
+    ]);
+
+    $response->assertStatus(422);
+    $response->assertJsonPath('code', 'ERR_VALIDATION_001');
+});
+
+it('returns 401 for unauthenticated mutating endpoints', function () {
+    $response = $this->postJson('/api/v1/subscription/cancel', [], [
+        'Idempotency-Key' => (string) Str::uuid(),
+    ]);
+
+    $response->assertStatus(401);
+});

--- a/tests/Feature/Subscription/SubscriptionMeEndpointTest.php
+++ b/tests/Feature/Subscription/SubscriptionMeEndpointTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+
+beforeEach(function () {
+    config(['cache.default' => 'array']);
+});
+
+it('returns the free-tier shape with HTTP 200 when the user has no subscription (mobile P0)', function () {
+    $user = User::factory()->create();
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    $response = $this->getJson('/api/v1/subscription/me');
+
+    $response->assertStatus(200);
+    $response->assertExactJson([
+        'tier'                 => 'free',
+        'status'               => null,
+        'source'               => null,
+        'plan'                 => null,
+        'currentPeriodEnd'     => null,
+        'trialEndsAt'          => null,
+        'cancelledAtPeriodEnd' => false,
+        'pausedUntil'          => null,
+    ]);
+});
+
+it('returns 401 for unauthenticated callers', function () {
+    $response = $this->getJson('/api/v1/subscription/me');
+
+    $response->assertStatus(401);
+});

--- a/tests/Feature/Subscription/SubscriptionServiceTest.php
+++ b/tests/Feature/Subscription/SubscriptionServiceTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Subscription\Services\SubscriptionService;
+use App\Models\User;
+
+/**
+ * Helper: refresh a user model and assert non-null for PHPStan narrowing.
+ */
+function freshUser(User $user): User
+{
+    $fresh = User::query()->find($user->id);
+    if (! $fresh instanceof User) {
+        throw new RuntimeException('User vanished between create and refresh.');
+    }
+
+    return $fresh;
+}
+
+beforeEach(function () {
+    config(['cache.default' => 'array']);
+    config(['services.stripe.subscription_prices.monthly_pro' => 'price_test_monthly']);
+    config(['services.stripe.subscription_prices.annual_pro' => 'price_test_annual']);
+});
+
+it('rejects annual to monthly downgrade with ERR_SUB_006 (deltas Q17.4)', function () {
+    $user = User::factory()->create([
+        'stripe_id' => 'cus_annual_user',
+    ]);
+
+    // Cashier subscriptions table is already migrated (existing) — insert a row
+    // mirroring the swap-down scenario.
+    DB::table('subscriptions')->insert([
+        'user_id'       => $user->id,
+        'type'          => 'default',
+        'stripe_id'     => 'sub_annual_001',
+        'stripe_status' => 'active',
+        'stripe_price'  => 'price_test_annual',
+        'quantity'      => 1,
+        'created_at'    => now(),
+        'updated_at'    => now(),
+    ]);
+
+    $service = app(SubscriptionService::class);
+    $result = $service->changePlan(freshUser($user), 'monthly_pro');
+
+    expect($result['code'] ?? null)->toBe('ERR_SUB_006');
+});
+
+it('returns the existing subscription on same-plan no-op swap', function () {
+    $user = User::factory()->create([
+        'stripe_id' => 'cus_same_plan',
+    ]);
+
+    DB::table('subscriptions')->insert([
+        'user_id'       => $user->id,
+        'type'          => 'default',
+        'stripe_id'     => 'sub_same_001',
+        'stripe_status' => 'active',
+        'stripe_price'  => 'price_test_monthly',
+        'quantity'      => 1,
+        'created_at'    => now(),
+        'updated_at'    => now(),
+    ]);
+
+    $service = app(SubscriptionService::class);
+    $result = $service->changePlan(freshUser($user), 'monthly_pro');
+
+    $success = $result['success'] ?? null;
+    expect($success)->toBeArray();
+    expect(is_array($success) && is_array($success['subscription'] ?? null) ? $success['subscription']['tier'] : null)
+        ->toBe('pro');
+});
+
+it('reactivate is idempotent on a non-cancelled subscription', function () {
+    $user = User::factory()->create([
+        'stripe_id' => 'cus_reactivate',
+    ]);
+
+    DB::table('subscriptions')->insert([
+        'user_id'       => $user->id,
+        'type'          => 'default',
+        'stripe_id'     => 'sub_react_001',
+        'stripe_status' => 'active',
+        'stripe_price'  => 'price_test_monthly',
+        'quantity'      => 1,
+        'created_at'    => now(),
+        'updated_at'    => now(),
+    ]);
+
+    $service = app(SubscriptionService::class);
+    $result = $service->reactivate(freshUser($user));
+
+    expect($result['success'] ?? null)->toBeArray();
+});
+
+it('returns ERR_SUB_002 for cancel on a user without a subscription', function () {
+    $user = User::factory()->create();
+
+    $service = app(SubscriptionService::class);
+    $result = $service->cancel($user);
+
+    expect($result['code'] ?? null)->toBe('ERR_SUB_002');
+});
+
+it('GET /me returns pro tier and currentPeriodEnd for an active monthly subscriber', function () {
+    $user = User::factory()->create([
+        'stripe_id' => 'cus_me_active',
+    ]);
+
+    DB::table('subscriptions')->insert([
+        'user_id'       => $user->id,
+        'type'          => 'default',
+        'stripe_id'     => 'sub_me_active',
+        'stripe_status' => 'active',
+        'stripe_price'  => 'price_test_monthly',
+        'quantity'      => 1,
+        'trial_ends_at' => now()->addDays(7),
+        'created_at'    => now(),
+        'updated_at'    => now(),
+    ]);
+
+    $service = app(SubscriptionService::class);
+    $shape = $service->read(freshUser($user));
+
+    expect($shape['tier'])->toBe('pro');
+    expect($shape['source'])->toBe('stripe_web');
+    expect($shape['plan'])->toBe('monthly_pro');
+    expect($shape['cancelledAtPeriodEnd'])->toBeFalse();
+});

--- a/tests/Feature/Subscription/SubscriptionWebhookTest.php
+++ b/tests/Feature/Subscription/SubscriptionWebhookTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Subscription\Models\ProcessedWebhookEvent;
+use App\Domain\Subscription\Models\RevenueOutboxEvent;
+use App\Domain\Subscription\Models\SubscriptionConsentLog;
+use App\Models\User;
+
+beforeEach(function () {
+    config(['cache.default' => 'array']);
+    // Empty webhook secret bypasses signature verification in local/testing env.
+    config(['services.stripe.webhook_secret' => '']);
+});
+
+it('writes a consent log row on customer.subscription.created with metadata', function () {
+    $user = User::factory()->create([
+        'stripe_id' => 'cus_test_consent_001',
+    ]);
+
+    $payload = stripeEvent('evt_test_consent_001', 'customer.subscription.created', [
+        'id'       => 'sub_test_001',
+        'customer' => 'cus_test_consent_001',
+        'metadata' => [
+            'plan'                => 'monthly_pro',
+            'consent_accepted_at' => now()->toIso8601String(),
+            'consent_version'     => 1,
+            'consent_text_hash'   => hash('sha256', 'I waive my 14-day right of withdrawal.'),
+            'remote_ip_hash'      => hash_hmac('sha256', '203.0.113.10', (string) config('app.key')),
+        ],
+        'items' => [
+            'data' => [[
+                'price' => ['unit_amount' => 499, 'currency' => 'eur'],
+            ]],
+        ],
+    ]);
+
+    $response = $this->postJson('/api/webhooks/stripe/subscriptions', $payload);
+
+    $response->assertStatus(200);
+    $response->assertJsonPath('replayed', false);
+
+    expect(SubscriptionConsentLog::query()->count())->toBe(1);
+    $row = SubscriptionConsentLog::query()->first();
+    expect($row->user_id)->toBe($user->id);
+    expect($row->consent_version)->toBe(1);
+});
+
+it('writes an outbox row on customer.subscription.created', function () {
+    User::factory()->create(['stripe_id' => 'cus_test_outbox_001']);
+
+    $payload = stripeEvent('evt_outbox_initial', 'customer.subscription.created', [
+        'id'       => 'sub_outbox_001',
+        'customer' => 'cus_test_outbox_001',
+        'items'    => [
+            'data' => [[
+                'price' => ['unit_amount' => 499, 'currency' => 'eur'],
+            ]],
+        ],
+    ]);
+
+    $this->postJson('/api/webhooks/stripe/subscriptions', $payload)->assertStatus(200);
+
+    $outbox = RevenueOutboxEvent::query()->first();
+    expect($outbox)->not()->toBeNull();
+    expect($outbox->source_type)->toBe('stripe');
+    expect($outbox->source_event_id)->toBe('evt_outbox_initial');
+    expect($outbox->event_kind)->toBe('customer.subscription.created');
+    expect($outbox->status)->toBe('pending');
+});
+
+it('writes an outbox row on invoice.payment_succeeded', function () {
+    User::factory()->create(['stripe_id' => 'cus_renewal']);
+
+    $payload = stripeEvent('evt_renewal', 'invoice.payment_succeeded', [
+        'id'           => 'in_renewal',
+        'customer'     => 'cus_renewal',
+        'subscription' => 'sub_renewal',
+        'amount_paid'  => 499,
+        'currency'     => 'eur',
+    ]);
+
+    $this->postJson('/api/webhooks/stripe/subscriptions', $payload)->assertStatus(200);
+
+    $outbox = RevenueOutboxEvent::query()->where('event_kind', 'invoice.payment_succeeded')->first();
+    expect($outbox)->not()->toBeNull();
+    expect($outbox->payload['amount'])->toBe(499);
+    expect($outbox->payload['denomination'])->toBe('EUR');
+});
+
+it('is idempotent on Stripe event.id (redelivery is no-op)', function () {
+    User::factory()->create(['stripe_id' => 'cus_dedup']);
+
+    $payload = stripeEvent('evt_dedup_001', 'invoice.payment_succeeded', [
+        'id'           => 'in_dedup',
+        'customer'     => 'cus_dedup',
+        'subscription' => 'sub_dedup',
+        'amount_paid'  => 499,
+        'currency'     => 'eur',
+    ]);
+
+    $first = $this->postJson('/api/webhooks/stripe/subscriptions', $payload);
+    $first->assertStatus(200);
+    $first->assertJsonPath('replayed', false);
+
+    expect(ProcessedWebhookEvent::query()->count())->toBe(1);
+    expect(RevenueOutboxEvent::query()->count())->toBe(1);
+
+    $second = $this->postJson('/api/webhooks/stripe/subscriptions', $payload);
+    $second->assertStatus(200);
+    $second->assertJsonPath('replayed', true);
+
+    // Still only one row in each table.
+    expect(ProcessedWebhookEvent::query()->count())->toBe(1);
+    expect(RevenueOutboxEvent::query()->count())->toBe(1);
+});
+
+it('writes a negative-amount outbox row on charge.refunded (ADR-0004 sign-prefix)', function () {
+    User::factory()->create(['stripe_id' => 'cus_refund']);
+
+    $payload = stripeEvent('evt_refund', 'charge.refunded', [
+        'id'              => 'ch_refund',
+        'customer'        => 'cus_refund',
+        'amount_refunded' => 499,
+        'currency'        => 'eur',
+    ]);
+
+    $this->postJson('/api/webhooks/stripe/subscriptions', $payload)->assertStatus(200);
+
+    $outbox = RevenueOutboxEvent::query()->where('event_kind', 'charge.refunded')->first();
+    expect($outbox)->not()->toBeNull();
+    expect($outbox->payload['amount'])->toBe(-499);
+});
+
+/**
+ * Build a Stripe-event-shaped JSON payload.
+ *
+ * @param array<string, mixed> $object
+ *
+ * @return array<string, mixed>
+ */
+function stripeEvent(string $eventId, string $type, array $object): array
+{
+    return [
+        'id'   => $eventId,
+        'type' => $type,
+        'data' => ['object' => $object],
+    ];
+}

--- a/tests/Feature/Subscription/TrialFingerprintServiceTest.php
+++ b/tests/Feature/Subscription/TrialFingerprintServiceTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Subscription\Models\TrialCardFingerprint;
+use App\Domain\Subscription\Services\TrialFingerprintService;
+use App\Models\User;
+
+beforeEach(function () {
+    config(['cache.default' => 'array']);
+    config(['services.stripe.trial_fingerprint_pepper' => 'test_pepper_32_bytes_long_!!!!!!!!!']);
+});
+
+it('hashes a fingerprint deterministically with the configured pepper', function () {
+    $service = app(TrialFingerprintService::class);
+
+    $hash1 = $service->hash('fp_card_abc123');
+    $hash2 = $service->hash('fp_card_abc123');
+
+    expect($hash1)->toBe($hash2);
+    expect(strlen($hash1))->toBe(64); // sha256 hex
+});
+
+it('returns null for a fingerprint not seen before (eligible)', function () {
+    $service = app(TrialFingerprintService::class);
+
+    expect($service->eligibleAfter('aaaaaaaaaaaaaaaa'))->toBeNull();
+});
+
+it('blocks a fingerprint within the 12-month retry window', function () {
+    $service = app(TrialFingerprintService::class);
+    $user = User::factory()->create();
+    $hash = $service->hash('fp_recent_user');
+
+    $service->recordClaim($hash, $user, 'pm_test_001');
+
+    $eligibleAfter = $service->eligibleAfter($hash);
+
+    expect($eligibleAfter)->not()->toBeNull();
+    if ($eligibleAfter !== null) {
+        expect($eligibleAfter->isFuture())->toBeTrue();
+        // Approximately 12 months from now
+        expect($eligibleAfter->diffInDays(now(), absolute: true))->toBeGreaterThanOrEqual(364);
+    }
+});
+
+it('returns null again once the 12-month window has passed', function () {
+    $service = app(TrialFingerprintService::class);
+    $user = User::factory()->create();
+    $hash = $service->hash('fp_old_user');
+
+    $service->recordClaim($hash, $user, 'pm_test_002');
+
+    // Push last_used_at into the past beyond 12 months.
+    TrialCardFingerprint::query()->where('fingerprint_hash', $hash)->update([
+        'first_used_at' => now()->subMonths(15),
+        'last_used_at'  => now()->subMonths(15),
+    ]);
+
+    expect($service->eligibleAfter($hash))->toBeNull();
+});
+
+it('throws when TRIAL_FINGERPRINT_PEPPER is not configured', function () {
+    config(['services.stripe.trial_fingerprint_pepper' => '']);
+    $service = app(TrialFingerprintService::class);
+
+    $service->hash('fp_test');
+})->throws(RuntimeException::class);

--- a/tests/Unit/Pricing/MoneyTest.php
+++ b/tests/Unit/Pricing/MoneyTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Pricing\ValueObjects\Money;
+
+it('constructs a EUR money from cents string', function () {
+    $money = Money::eur('499');
+
+    expect($money->amount)->toBe('499')
+        ->and($money->decimals)->toBe(2)
+        ->and($money->currency)->toBe('EUR')
+        ->and($money->asset)->toBeNull();
+});
+
+it('serialises to the wire shape per ADR-0004', function () {
+    $eur = Money::eur('499');
+
+    expect($eur->toArray())->toBe([
+        'amount'   => '499',
+        'decimals' => 2,
+        'currency' => 'EUR',
+    ]);
+
+    $usdc = Money::asset('1000000', 'USDC', 6);
+    expect($usdc->toArray())->toBe([
+        'amount'   => '1000000',
+        'decimals' => 6,
+        'asset'    => 'USDC',
+    ]);
+});
+
+it('rejects decimal-point amounts', function () {
+    Money::eur('4.99');
+})->throws(InvalidArgumentException::class);
+
+it('rejects when neither currency nor asset is given', function () {
+    new Money(amount: '0', decimals: 2);
+})->throws(InvalidArgumentException::class);
+
+it('rejects when both currency and asset are given', function () {
+    new Money(amount: '0', decimals: 2, currency: 'EUR', asset: 'USDC');
+})->throws(InvalidArgumentException::class);
+
+it('adds two compatible Money values via bcmath', function () {
+    $sum = Money::eur('250')->add(Money::eur('249'));
+    expect($sum->amount)->toBe('499');
+});
+
+it('supports negative amounts via sign-prefix', function () {
+    $refund = Money::eur('-499');
+    expect($refund->isNegative())->toBeTrue();
+    expect($refund->toArray()['amount'])->toBe('-499');
+});
+
+it('throws when adding mismatched denominations', function () {
+    Money::eur('100')->add(Money::asset('100', 'USDC', 6));
+})->throws(InvalidArgumentException::class);


### PR DESCRIPTION
## Summary

Plan B v1.3.0 commercial **Slice 1**: Cashier-backed Stripe subscription endpoints + the unified entitlements projection scaffolding that slice 2 (IAP) plugs into. All endpoints under `/api/v1/subscription/*`, withdrawal-consent audit trail, trial-abuse fingerprint plumbing, dual-upstream revenue projection (off-chain outbox path), and the slice-0 foundations inline (Money VO, ErrorResponse helper, idempotency-required middleware).

Aligns with `BACKEND_HANDOVER_PLAN_B_REVIEW_DELTAS.md` Backend-Q1 (γ Cashier hybrid), Q3 (revenue outbox), Q5 (trial-fingerprint α + 12-month retry), Q9 (Money VO ADR-0004), Q14 (consent log), Q17 (lifecycle endpoints).

### Endpoints added (`/api/v1/subscription/*`)

| Endpoint | Slice 1 behaviour |
|---|---|
| `GET /me` | Null-safe **mobile P0** — returns `{tier: "free", status: null, ...}` with HTTP 200 for users without a subscription. NOT 404. |
| `POST /checkout` | Setup-mode Stripe Checkout. Validates withdrawal consent (≤5 min old; `ERR_SUB_004` otherwise). Multi-store gate (`ERR_SUB_007` if IAP active, slice-2-ready). Live-incomplete-session 409 with `recoveryUrl` (`ERR_SUB_005`). |
| `POST /change-plan` | Cashier `swap()` wrapper. Annual→Monthly rejected with `ERR_SUB_006` (deltas Q17.4). Same-plan no-op idempotent. |
| `POST /cancel` | Cancel-at-period-end. `ERR_SUB_010` for IAP-managed subs (gate wired, inert until slice 2 builds the `iap_subscriptions` source). |
| `POST /reactivate` | Cashier `resume()` wrapper. |
| `POST /webhooks/stripe/subscriptions` | New route — siblings the existing `/stripe/webhook` (CGO+KYC). Routes `customer.subscription.created` / `invoice.payment_succeeded` / `invoice.payment_failed` / `charge.refunded` / `customer.subscription.{updated,deleted}` / `checkout.session.completed`. Idempotent on Stripe `event.id` via `processed_webhook_events`. |

All mutating endpoints behind the new `idempotency.required` middleware alias (rejects missing key with `ERR_VALIDATION_001`; replays cached 2xx responses on duplicate key; rejects same-key-different-body with 409).

### Tables added

| Migration | Purpose |
|---|---|
| `processed_webhook_events` | Stripe `event.id` dedup (deltas Q7.3). Unique on `(provider, event_id)`. |
| `trial_card_fingerprints` | HMAC-SHA256(card.fingerprint, `TRIAL_FINGERPRINT_PEPPER`); 12-month retry per Backend-Q5. |
| `subscription_consent_log` | EU CRD/GDPR consent audit per deltas Q14.2. Per-row consent text snapshot. |
| `revenue_outbox_events` | Off-chain projection upstream per ADR-0002. Unique on `(source_type, source_event_id)`. |
| `revenue_events` | Projection target. Variable-currency triple per ADR-0004 (`amount` BIGINT signed + `amount_decimals` + `amount_denomination`). |

### Foundations (slice 0 inline)

- `App\Domain\Pricing\ValueObjects\Money` — wire-format Money per ADR-0004; bcmath internals; rejects decimal-point amounts in constructor.
- `App\Support\ErrorResponse::make()` + `config/error_codes.php` — single canonical helper, registry-validated codes.
- `App\Http\Middleware\IdempotencyKey` (alias `idempotency.required`) — required-on-mutating-verbs replacement for the existing `idempotency` middleware.
- Stripe API version pinned in single config key (`config('services.stripe.api_version')`, env `STRIPE_API_VERSION`); container binding overrides Cashier's StripeClient default so Cashier + future Stripe Bridge clients use the same version.

### GDPR (Backend-Q1 #6)

`/api/gdpr/delete` cascades to Stripe via `$user->asStripeCustomer()->delete()` and clears `stripe_id`/`pm_type`/`pm_last_four`. Best-effort; logs and continues on Stripe failure so the local deletion flow doesn't block on Stripe outages.

### Worker stub

`ProjectRevenueOutbox` (slice 1 stub — slice 4 wires the full Backend-Q8 delayed-job infra). Idempotent projector mapping `customer.subscription.created → subscription_initial`, `invoice.payment_succeeded → subscription_renewal`, `charge.refunded → refund` (negative amount per ADR-0004 sign-prefix). Sweep mode + per-row mode. 5 attempts then `failed`.

### Tests (35 passing, including the mobile P0)

- `MoneyTest` — ADR-0004 wire shape, bcmath round-trips, decimal-point rejection, sign-prefix negatives, mismatched-denomination errors.
- `SubscriptionMeEndpointTest` — **mobile P0** free-tier shape on null sub (200 not 404), 401 unauth.
- `SubscriptionEndpointsIdempotencyTest` — Idempotency-Key enforcement, malformed-key 422, stale-consent rejection, ERR_SUB_006 path.
- `SubscriptionWebhookTest` — consent log written, outbox row written for create/renewal/refund, dedup on Stripe `event.id`, negative-amount refunds.
- `TrialFingerprintServiceTest` — pepper hashing, 12-month window, post-window eligibility, missing-pepper guard.
- `ProjectRevenueOutboxTest` — happy path, kind-mapping (initial/renewal), idempotent re-run, sweep-mode.
- `SubscriptionServiceTest` — annual→monthly downgrade `ERR_SUB_006`, same-plan no-op, reactivate idempotent, cancel-without-sub, GET /me with active sub returns Pro.

Existing `IdempotencyMiddlewareTest` regression: passing.

## Coordination items for the human controller

**Migrations to run on staging/prod (in this order, after merge):**

1. `2026_05_09_180001_create_processed_webhook_events_table` — webhook idempotency table; required for the new webhook handler.
2. `2026_05_09_180002_create_trial_card_fingerprints_table` — must be in place before `TRIAL_FINGERPRINT_PEPPER` env var goes live.
3. `2026_05_09_180003_create_subscription_consent_log_table` — written on first Stripe Web subscription.
4. `2026_05_09_180004_create_revenue_outbox_events_table` — written by the webhook handler.
5. `2026_05_09_180005_create_revenue_events_table` — projection target; if a sibling `revenue_events` migration already exists in `main` from a parallel slice, drop my version and reconcile column shape (mine uses the explicit `(amount, decimals, denomination)` triple per ADR-0004).

The `users.timezone` and `investor_inquiries` migrations are already on `main` and don't need extra coordination from me.

**Env vars to provision (`.env.production.example` + `.env.zelta.example` updated):**

- `STRIPE_API_VERSION` (defaults to `2025-04-30.basil` — confirm with the existing Stripe Bridge integration before bumping)
- `TRIAL_FINGERPRINT_PEPPER` — 32-byte secret. Required before `/checkout` is exposed to traffic. Event-triggered rotation only (rotation = re-hash all `trial_card_fingerprints` rows).
- `STRIPE_PRICE_MONTHLY_PRO`, `STRIPE_PRICE_ANNUAL_PRO` — Price IDs from Stripe dashboard.
- `SUBSCRIPTION_CONSENT_VERSION` (defaults to 1; bump on copy change).

**Founder sign-off awareness:** this slice lands ~6.5d of the 47.5d Plan B v1.3.0 commitment (Backend-Q1 + Q5 + Q14 + Q17 + slice-0 foundations + ADR-0002-shape outbox).

## Mobile

**`GET /api/v1/subscription/me` response shape — wire against staging:**

```json
{
  "tier": "free",
  "status": null,
  "source": null,
  "plan": null,
  "currentPeriodEnd": null,
  "trialEndsAt": null,
  "cancelledAtPeriodEnd": false,
  "pausedUntil": null
}
```

For an active monthly Pro subscriber:

```json
{
  "tier": "pro",
  "status": "active",
  "source": "stripe_web",
  "plan": "monthly_pro",
  "currentPeriodEnd": "2026-06-09T...",
  "trialEndsAt": "2026-05-16T...",
  "cancelledAtPeriodEnd": false,
  "pausedUntil": null
}
```

`pausedUntil` is always `null` until slice 2 (Apple IAP only). `source: "iap"` value will be added in slice 2.

## Out of scope (deferred per slice plan)

- IAP (Apple/Google) — slice 2.
- `iap_subscriptions` table + erasure pseudonymisation — slice 2.
- `/me/entitlements` endpoint — slice 2 (depends on the unified projection).
- Filament "Trial Block Override" admin + daily `trial:purge-fingerprints` cron — deferrable; current absence flagged in handover.
- Trial-fingerprint *recording* on `checkout.session.completed` — webhook handler currently logs the event without doing the Stripe SDK round-trip to fetch the captured PM. This is a follow-up commit before staging exposes /checkout to traffic.
- Cue queue (Backend-Q8 delayed jobs) — slice 4. Outbox worker is the slice-1 stub.
- Domain/Pricing endpoints (`POST /pricing/quote`) — slice 3.

## Test plan

- [ ] `php artisan migrate` runs the 5 new migrations cleanly on a fresh DB.
- [ ] `GET /api/v1/subscription/me` returns the free-tier shape (HTTP 200) for a freshly-created Sanctum user.
- [ ] `POST /api/v1/subscription/cancel` without `Idempotency-Key` returns 422 + `ERR_VALIDATION_001`.
- [ ] `POST /api/v1/subscription/checkout` with stale `withdrawalConsent.acceptedAt` (>5 min) returns 422 + `ERR_SUB_004`.
- [ ] Stripe webhook redelivery of the same `event.id` returns `replayed: true` and creates no new outbox/consent rows.
- [ ] `php artisan tinker` → run `(new App\Domain\Subscription\Jobs\ProjectRevenueOutbox)->handle()` after seeding a pending row → row is `delivered`, `revenue_events` has the projected row.
- [ ] `gh pr checks` passes (php-cs-fixer, phpstan level 8, pest, phpcs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)