### PR TITLE
fix(api): add DELETE /api/v1/notifications/register-device/{deviceId} alias

### DIFF
--- a/app/Domain/Mobile/Routes/api.php
+++ b/app/Domain/Mobile/Routes/api.php
@@ -114,6 +114,8 @@ Route::prefix('v1/notifications')->name('api.v1.notifications.device.')
     ->group(function () {
         Route::post('/register-device', [MobileController::class, 'registerDevice'])->name('register');
         Route::delete('/unregister-device', [MobileController::class, 'unregisterDevice'])->name('unregister');
+        // Alias: mobile sign-out calls DELETE /api/v1/notifications/register-device/{deviceId} (v7.12.1)
+        Route::delete('/register-device/{id}', [MobileController::class, 'unregisterDevice'])->name('unregister-alias');
     });
 
 // User preferences (v3.3.4) + data export alias (v5.6.0)

--- a/tests/Feature/Api/V1/NotificationsDeviceDeleteAliasTest.php
+++ b/tests/Feature/Api/V1/NotificationsDeviceDeleteAliasTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Domain\Mobile\Models\MobileDevice;
+use App\Models\User;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+/**
+ * Tests for the DELETE /api/v1/notifications/register-device/{deviceId} alias.
+ *
+ * Mobile sign-out flow calls this URL pattern to drop the device's push
+ * notification routing token. The existing endpoint was /unregister-device
+ * (no path param) which broke the controller — this alias wires the correct
+ * {id} segment to MobileController::unregisterDevice.
+ *
+ * @see app/Domain/Mobile/Routes/api.php  (api.v1.notifications.device.unregister-alias)
+ */
+class NotificationsDeviceDeleteAliasTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+    }
+
+    public function test_unauthenticated_request_returns_401(): void
+    {
+        $this->deleteJson('/api/v1/notifications/register-device/some-device-id')
+            ->assertUnauthorized();
+    }
+
+    public function test_authenticated_user_can_delete_own_device(): void
+    {
+        Sanctum::actingAs($this->user, ['read', 'write', 'delete']);
+
+        $device = MobileDevice::create([
+            'user_id'     => $this->user->id,
+            'device_id'   => 'sign-out-device-123',
+            'platform'    => 'android',
+            'app_version' => '2.0.0',
+            'push_token'  => 'fcm-token-abc',
+        ]);
+
+        $this->deleteJson("/api/v1/notifications/register-device/{$device->id}")
+            ->assertOk()
+            ->assertJsonPath('message', 'Device unregistered successfully');
+
+        $this->assertDatabaseMissing('mobile_devices', ['id' => $device->id]);
+    }
+
+    public function test_deleting_another_users_device_returns_404(): void
+    {
+        Sanctum::actingAs($this->user, ['read', 'write', 'delete']);
+
+        $otherUser = User::factory()->create();
+        $device = MobileDevice::create([
+            'user_id'     => $otherUser->id,
+            'device_id'   => 'other-user-device',
+            'platform'    => 'ios',
+            'app_version' => '1.5.0',
+        ]);
+
+        $this->deleteJson("/api/v1/notifications/register-device/{$device->id}")
+            ->assertNotFound()
+            ->assertJsonPath('error.code', 'NOT_FOUND');
+    }
+
+    public function test_deleting_non_existent_device_returns_404(): void
+    {
+        Sanctum::actingAs($this->user, ['read', 'write', 'delete']);
+
+        $this->deleteJson('/api/v1/notifications/register-device/99999999')
+            ->assertNotFound()
+            ->assertJsonPath('error.code', 'NOT_FOUND');
+    }
+
+    public function test_route_is_named_unregister_alias(): void
+    {
+        $this->assertTrue(
+            \Illuminate\Support\Facades\Route::has('api.v1.notifications.device.unregister-alias'),
+            'Route api.v1.notifications.device.unregister-alias must be registered'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `DELETE /api/v1/notifications/register-device/{id}` route alias in the `v1/notifications` group, mapping to `MobileController::unregisterDevice`
- Mobile sign-out flow calls this URL pattern (with the device UUID as a path segment) but the existing route was `/unregister-device` (no `{id}` segment), resulting in a 404 that silently dropped the deregistration — leaving signed-out devices still receiving push notifications (privacy concern)
- Existing routes preserved unchanged; new route named `api.v1.notifications.device.unregister-alias`

## Test plan

- [x] `test_unauthenticated_request_returns_401` — confirms `auth:sanctum` guard is applied
- [x] `test_authenticated_user_can_delete_own_device` — confirms the alias calls `unregisterDevice`, returns 200, and removes the DB row
- [x] `test_deleting_another_users_device_returns_404` — confirms ownership check in `MobileDeviceService::findByIdForUser`
- [x] `test_deleting_non_existent_device_returns_404` — confirms NOT_FOUND handling
- [x] `test_route_is_named_unregister_alias` — asserts the named route exists
- [x] All 787 existing `tests/Feature/Api/` tests pass (no regressions)
- [x] PHPStan Level 8 — no new errors
- [x] php-cs-fixer — no changes required
- [x] phpcs — no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)