### PR TITLE
fix(iap): align ERR_SUB_002 contract with mobile — drop ERR_SUB_008/009

### DIFF
--- a/app/Domain/Basket/Console/Commands/RebalanceBasketsCommand.php
+++ b/app/Domain/Basket/Console/Commands/RebalanceBasketsCommand.php
@@ -32,7 +32,10 @@ class RebalanceBasketsCommand extends Command
     {
         /** @var BasketAsset|null $basket */
         $basket = null;
-        $basketCode = $this->option('basket');
+        // Symfony Console's option() return type is wide for PHPStan; --basket
+        // is a value option so the runtime value is string|null.
+        $basketCodeOpt = $this->option('basket');
+        $basketCode = is_string($basketCodeOpt) ? $basketCodeOpt : null;
         $force = $this->option('force');
         $dryRun = $this->option('dry-run');
 

--- a/app/Domain/Subscription/Iap/AppleReceiptVerifier.php
+++ b/app/Domain/Subscription/Iap/AppleReceiptVerifier.php
@@ -90,7 +90,7 @@ final class AppleReceiptVerifier
         $expiresDate = $this->parseAppleEpochMillis($payload['expiresDate'] ?? null);
 
         // Apple sets `inAppOwnershipType` = `FAMILY_SHARED` for sharing-derived
-        // receipts (we reject these at the verify endpoint with ERR_SUB_008).
+        // receipts (we reject these at the verify endpoint with ERR_SUB_002 kind=family_sharing_unsupported).
         $ownershipType = (string) ($payload['inAppOwnershipType'] ?? 'PURCHASED');
         $isFamilyShared = $ownershipType === 'FAMILY_SHARED';
 

--- a/app/Domain/Subscription/Iap/IapSubscriptionService.php
+++ b/app/Domain/Subscription/Iap/IapSubscriptionService.php
@@ -116,13 +116,39 @@ final class IapSubscriptionService
         }
 
         // 4. Family Sharing rejection (Apple only — Google has no equivalent).
+        // Emitted as ERR_SUB_002 + kind=family_sharing_unsupported per mobile
+        // contract (subscriptionConflict.ts:14 enum). Existing-subscription
+        // payload is derived from the receipt itself because there's no row
+        // on file yet — mobile hard-requires a non-null existingSubscription
+        // object (subscriptionConflict.ts:21–25).
         if ($verified instanceof AppleVerifiedTransaction && $verified->isFamilyShared) {
-            return ['code' => 'ERR_SUB_008'];
+            return [
+                'code'    => 'ERR_SUB_002',
+                'context' => [
+                    'conflict' => [
+                        'kind'                 => 'family_sharing_unsupported',
+                        'attemptedSource'      => $platform,
+                        'existingSubscription' => $this->existingSubscriptionFromVerified($verified, $platform),
+                    ],
+                ],
+            ];
         }
 
         // 5. appAccountToken / obfuscatedAccountId binding check.
+        // Receipt's account token doesn't match the authenticated user — the
+        // transaction was bound to someone else's account. Mobile maps this
+        // to kind=different_zelta_user.
         if (! $this->matchesAuthenticatedUser($verified, $user)) {
-            return ['code' => 'ERR_SUB_008'];
+            return [
+                'code'    => 'ERR_SUB_002',
+                'context' => [
+                    'conflict' => [
+                        'kind'                 => 'different_zelta_user',
+                        'attemptedSource'      => $platform,
+                        'existingSubscription' => $this->existingSubscriptionFromVerified($verified, $platform),
+                    ],
+                ],
+            ];
         }
 
         // 6. Multi-store conflict gate (deltas Q6).
@@ -272,8 +298,13 @@ final class IapSubscriptionService
                     'code'    => 'ERR_SUB_002',
                     'context' => [
                         'conflict' => [
-                            'kind'            => 'different_zelta_user',
-                            'attemptedSource' => 'apple_iap',
+                            'kind'                 => 'different_zelta_user',
+                            'attemptedSource'      => 'apple_iap',
+                            'existingSubscription' => [
+                                'source'              => 'apple_iap',
+                                'currentPeriodEndsAt' => $existing->current_period_ends_at?->toIso8601String()
+                                    ?? $verified->expiresDate?->toIso8601String(),
+                            ],
                         ],
                     ],
                 ];
@@ -288,7 +319,20 @@ final class IapSubscriptionService
             $isTerminal = in_array($existing->status, $terminalStatuses, true);
             $expiryPast = $verified->expiresDate?->isPast() ?? true;
             if ($isTerminal && $expiryPast) {
-                return ['code' => 'ERR_SUB_009'];
+                return [
+                    'code'    => 'ERR_SUB_002',
+                    'context' => [
+                        'conflict' => [
+                            'kind'                 => 'stale_receipt',
+                            'attemptedSource'      => 'apple_iap',
+                            'existingSubscription' => [
+                                'source'              => 'apple_iap',
+                                'currentPeriodEndsAt' => $existing->current_period_ends_at?->toIso8601String()
+                                    ?? $verified->expiresDate?->toIso8601String(),
+                            ],
+                        ],
+                    ],
+                ];
             }
 
             // Within-grace reactivation (cancel_at_period_end = true, not yet expired).
@@ -412,8 +456,13 @@ final class IapSubscriptionService
                     'code'    => 'ERR_SUB_002',
                     'context' => [
                         'conflict' => [
-                            'kind'            => 'different_zelta_user',
-                            'attemptedSource' => 'google_play',
+                            'kind'                 => 'different_zelta_user',
+                            'attemptedSource'      => 'google_play',
+                            'existingSubscription' => [
+                                'source'              => 'google_play',
+                                'currentPeriodEndsAt' => $existing->current_period_ends_at?->toIso8601String()
+                                    ?? $verified->expiryTime?->toIso8601String(),
+                            ],
                         ],
                     ],
                 ];
@@ -426,7 +475,20 @@ final class IapSubscriptionService
                 'SUBSCRIPTION_STATE_CANCELED',
             ], true);
             if ($googleTerminal && ($verified->expiryTime?->isPast() ?? true)) {
-                return ['code' => 'ERR_SUB_009'];
+                return [
+                    'code'    => 'ERR_SUB_002',
+                    'context' => [
+                        'conflict' => [
+                            'kind'                 => 'stale_receipt',
+                            'attemptedSource'      => 'google_play',
+                            'existingSubscription' => [
+                                'source'              => 'google_play',
+                                'currentPeriodEndsAt' => $existing->current_period_ends_at?->toIso8601String()
+                                    ?? $verified->expiryTime?->toIso8601String(),
+                            ],
+                        ],
+                    ],
+                ];
             }
 
             if ($existing->cancel_at_period_end && $verified->expiryTime?->isFuture() === true) {
@@ -547,6 +609,28 @@ final class IapSubscriptionService
         $expected = hash('sha256', (string) $user->uuid);
 
         return hash_equals($expected, $token);
+    }
+
+    /**
+     * Build the `existingSubscription` conflict payload when there's no
+     * matching iap_subscriptions row yet (family sharing, binding mismatch).
+     * Mobile (subscriptionConflict.ts:21–25) hard-requires a non-null object —
+     * the receipt's reported source + expiry is what we have to work with.
+     *
+     * @return array{source: string, currentPeriodEndsAt: string|null}
+     */
+    private function existingSubscriptionFromVerified(
+        AppleVerifiedTransaction|GoogleVerifiedSubscription $verified,
+        string $source,
+    ): array {
+        $endsAt = $verified instanceof AppleVerifiedTransaction
+            ? $verified->expiresDate
+            : $verified->expiryTime;
+
+        return [
+            'source'              => $source,
+            'currentPeriodEndsAt' => $endsAt?->toIso8601String(),
+        ];
     }
 
     /**

--- a/config/error_codes.php
+++ b/config/error_codes.php
@@ -34,9 +34,11 @@ return [
     'ERR_SUB_005' => ['http' => 409, 'description' => 'Live incomplete checkout session for user; recovery URL provided.'],
     'ERR_SUB_006' => ['http' => 422, 'description' => 'Annual to monthly downgrade is not offered.'],
     'ERR_SUB_007' => ['http' => 409, 'description' => 'Cross-source subscription conflict — another store already has an active subscription for this user.'],
-    // Slice 2 — IAP-specific subscription error codes.
-    'ERR_SUB_008' => ['http' => 409, 'description' => 'Family Sharing receipt — purchase was made by a different Apple ID. Manage subscription from the original purchasing account.'],
-    'ERR_SUB_009' => ['http' => 422, 'description' => 'Receipt is expired or subscription has already ended.'],
+    // Slice 2 — IAP family-sharing + stale-receipt cases are emitted as
+    // ERR_SUB_002 with a `conflict.kind` discriminator (family_sharing_unsupported,
+    // stale_receipt) so mobile can switch on a single field. The dedicated
+    // ERR_SUB_008 / ERR_SUB_009 codes were dropped 2026-05-14 after the mobile
+    // contract review (subscriptionConflict.ts:14 enum is the source of truth).
     'ERR_SUB_010' => ['http' => 409, 'description' => 'Cancellation must occur at originating store (Apple/Google).'],
 
     // ─── Quote / Pricing (deltas Q2, Q3 — codes stay ERR_QUOTE_* per Backend-Q4) ──

--- a/tests/Feature/Subscription/IapVerifyEndpointTest.php
+++ b/tests/Feature/Subscription/IapVerifyEndpointTest.php
@@ -167,7 +167,7 @@ it('returns ERR_CUR_001 for a non-EUR currency', function () {
     $response->assertJsonPath('error.code', 'ERR_CUR_001');
 });
 
-it('returns ERR_SUB_008 for an Apple Family Sharing receipt', function () {
+it('returns ERR_SUB_002 kind=family_sharing_unsupported for an Apple Family Sharing receipt', function () {
     $user = User::factory()->create();
     Sanctum::actingAs($user, ['read', 'write', 'delete']);
 
@@ -187,7 +187,11 @@ it('returns ERR_SUB_008 for an Apple Family Sharing receipt', function () {
     ]);
 
     $response->assertStatus(409);
-    $response->assertJsonPath('error.code', 'ERR_SUB_008');
+    $response->assertJsonPath('error.code', 'ERR_SUB_002');
+    $response->assertJsonPath('error.conflict.kind', 'family_sharing_unsupported');
+    $response->assertJsonPath('error.conflict.attemptedSource', 'apple_iap');
+    $response->assertJsonPath('error.conflict.existingSubscription.source', 'apple_iap');
+    expect($response->json('error.conflict.existingSubscription.currentPeriodEndsAt'))->not->toBeNull();
 });
 
 it('returns ERR_SUB_001 when the request bundleId does not match Apple JWS', function () {


### PR DESCRIPTION
## Summary

Mobile confirmed the IAP error contract — they discriminate on `conflict.kind` under a single `ERR_SUB_002` envelope, NOT on dedicated `ERR_SUB_008` / `ERR_SUB_009` codes. The previous backend emitted those dedicated codes which mobile's `subscriptionConflict.ts:52` silently dropped through to the generic error toast.

## Mobile feedback (verbatim)

> Mobile rejects anything not matching ERR_SUB_002 + kind contract:
> - subscriptionConflict.ts:52 — returns null if code !== 'ERR_SUB_002'
> - Line 14 — ConflictKind enum is 'two_stores_active' | 'different_zelta_user' | 'family_sharing_unsupported' | 'stale_receipt'
> - useSubscriptionErrorHandler.test.tsx:82,92 covers FAMILY + STALE both arriving as ERR_SUB_002

> The conflict body shape mobile expects (subscriptionConflict.ts:21-25):
> { kind, attemptedSource, existingSubscription: { source, currentPeriodEndsAt: ISO8601 } }

> For stale-receipt / family-sharing cases where there's no "existing subscription on file," the backend should still populate existingSubscription — the parser hard-requires it.

## Changes

- **`config/error_codes.php`** — drop `ERR_SUB_008` (409 Family Sharing) and `ERR_SUB_009` (422 stale). Replace with a comment pointing future readers to this PR.
- **`IapSubscriptionService.php`** — route 4 emission sites through `ERR_SUB_002` + `conflict.kind`:
  - Apple Family Sharing → `kind=family_sharing_unsupported`
  - appAccountToken / obfuscatedAccountId binding mismatch → `kind=different_zelta_user`
  - Apple terminal-state existing sub + past expiry → `kind=stale_receipt`
  - Google terminal-state existing sub + past expiry → `kind=stale_receipt`
- **All conflict bodies** now include `existingSubscription: { source, currentPeriodEndsAt }`. For family / binding-mismatch cases (no DB row), derived from the verified receipt via new private helper `existingSubscriptionFromVerified()`.
- **Test update**: family-sharing feature test asserts the new shape.

## Test plan

- [ ] CI green
- [ ] Mobile re-tests Family Sharing / stale-receipt flows against staging
- [ ] No other client (web, admin) consumes ERR_SUB_008/009 — grep confirmed only backend + tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)