### PR TITLE
fix(auth): send Origin header on Privy OTP REST calls — unblocks prod web /login

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -511,6 +511,12 @@ PRIVY_JWKS_URL=
 # Used for server-to-server email OTP via POST /api/v1/passwordless/{init,authenticate}.
 # PRIVY_API_BASE_URL=https://auth.privy.io
 
+# Optional: web origin sent to Privy as the Origin header on REST calls.
+# Must match a URL added to the Privy dashboard "Allowed Origins" list, or
+# Privy returns 403 "Must specify origin". Defaults to APP_URL when unset —
+# set this explicitly when web /login lives on a different host than the API.
+# PRIVY_WEB_ORIGIN=https://app.your-domain.com
+
 # Web Privy email-OTP login. When true, /login renders Privy email-OTP
 # (replacing legacy email+password Jetstream) and signup happens on first
 # successful OTP.

--- a/.env.zelta.example
+++ b/.env.zelta.example
@@ -578,6 +578,12 @@ PRIVY_JWKS_URL=
 # Used for server-to-server email OTP via POST /api/v1/passwordless/{init,authenticate}.
 # PRIVY_API_BASE_URL=https://auth.privy.io
 
+# Optional: web origin sent to Privy as the Origin header on REST calls.
+# Must match a URL added to the Privy dashboard "Allowed Origins" list, or
+# Privy returns 403 "Must specify origin". Defaults to APP_URL when unset —
+# set this explicitly when web /login lives on a different host than the API.
+# PRIVY_WEB_ORIGIN=https://app.zelta.app
+
 # Web Privy email-OTP login. When true, /login renders Privy email-OTP
 # (replacing legacy email+password Jetstream) and signup happens on first
 # successful OTP.

--- a/app/Domain/Auth/Services/PrivyEmailOtpClient.php
+++ b/app/Domain/Auth/Services/PrivyEmailOtpClient.php
@@ -97,6 +97,13 @@ class PrivyEmailOtpClient
                 'Accept'        => 'application/json',
                 'privy-app-id'  => $appId,
                 'Authorization' => 'Basic ' . base64_encode($appId . ':' . $appSecret),
+                // Privy's REST API rejects requests without an Origin matching
+                // the dashboard allowlist (403 "Must specify origin"). We send
+                // the canonical app origin server-side rather than echoing the
+                // browser's Origin header — the request is server-to-server,
+                // and trusting a client-supplied Origin would defeat the
+                // allowlist's purpose.
+                'Origin' => $this->resolveOrigin(),
             ],
             (string) json_encode($body, JSON_THROW_ON_ERROR),
         );
@@ -153,6 +160,31 @@ class PrivyEmailOtpClient
         }
 
         return $fallback;
+    }
+
+    /**
+     * Privy validates the Origin header against the dashboard allowlist.
+     * Prefer an explicit privy.web_origin (so operators can decouple it from
+     * the API host), fall back to app.url. We strip path/query so we send
+     * only scheme://host[:port], which is what Privy compares against.
+     */
+    private function resolveOrigin(): string
+    {
+        $raw = (string) (config('privy.web_origin') ?: config('app.url', ''));
+        $raw = trim($raw);
+        if ($raw === '') {
+            return '';
+        }
+        $parts = parse_url($raw);
+        if (! is_array($parts) || ! isset($parts['scheme'], $parts['host'])) {
+            return rtrim($raw, '/');
+        }
+        $origin = $parts['scheme'] . '://' . $parts['host'];
+        if (isset($parts['port'])) {
+            $origin .= ':' . $parts['port'];
+        }
+
+        return $origin;
     }
 
     private function extractErrorMessage(string $body): ?string

--- a/config/privy.php
+++ b/config/privy.php
@@ -68,6 +68,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Web Origin (for Privy REST allowlist)
+    |--------------------------------------------------------------------------
+    |
+    | Privy's REST API rejects requests with `403 Must specify origin` unless
+    | an Origin header is sent that matches an entry in the dashboard
+    | allowlist. When the web /login surface lives on a different host than
+    | APP_URL (e.g. APP_URL is api.zelta.app but the web is zelta.app), set
+    | PRIVY_WEB_ORIGIN explicitly. Falls back to APP_URL when unset.
+    |
+    */
+
+    'web_origin' => env('PRIVY_WEB_ORIGIN'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Web login feature flag
     |--------------------------------------------------------------------------
     |

--- a/tests/Unit/Domain/Auth/Services/PrivyEmailOtpClientTest.php
+++ b/tests/Unit/Domain/Auth/Services/PrivyEmailOtpClientTest.php
@@ -16,6 +16,8 @@ beforeEach(function (): void {
         'privy.app_id'       => 'test-app-id',
         'privy.app_secret'   => 'test-app-secret',
         'privy.api_base_url' => 'https://auth.privy.io',
+        'privy.web_origin'   => null,
+        'app.url'            => 'https://app.test',
     ]);
 });
 
@@ -100,6 +102,41 @@ it('throws malformedResponse when login response has no user.id', function (): v
     $client = new PrivyEmailOtpClient($http);
     expect(fn () => $client->loginWithCode('jane@example.com', '123456'))
         ->toThrow(PrivyEmailOtpException::class, 'missing user.id');
+});
+
+it('sends Origin header derived from app.url so Privy allowlist accepts the request', function (): void {
+    /** @var ClientInterface&MockInterface $http */
+    $http = Mockery::mock(ClientInterface::class);
+    /** @var Mockery\Expectation $expect */
+    $expect = $http->shouldReceive('send');
+    $expect->once()->andReturnUsing(function (RequestInterface $request) {
+        expect($request->getHeaderLine('Origin'))->toBe('https://app.test');
+
+        return new PsrResponse(200, [], '{"success":true}');
+    });
+
+    $client = new PrivyEmailOtpClient($http);
+    $client->sendCode('jane@example.com');
+});
+
+it('prefers privy.web_origin over app.url and strips path/query when sending the Origin header', function (): void {
+    config([
+        'privy.web_origin' => 'https://zelta.app/some/path?x=1',
+        'app.url'          => 'https://api.zelta.app',
+    ]);
+
+    /** @var ClientInterface&MockInterface $http */
+    $http = Mockery::mock(ClientInterface::class);
+    /** @var Mockery\Expectation $expect */
+    $expect = $http->shouldReceive('send');
+    $expect->once()->andReturnUsing(function (RequestInterface $request) {
+        expect($request->getHeaderLine('Origin'))->toBe('https://zelta.app');
+
+        return new PsrResponse(200, [], '{"success":true}');
+    });
+
+    $client = new PrivyEmailOtpClient($http);
+    $client->sendCode('jane@example.com');
 });
 
 it('throws misconfigured when app_id or app_secret is empty', function (): void {


### PR DESCRIPTION
## Summary

The web `/login` Privy email-OTP flow was broken in production for any user — clicking **Send Code** flashed _"We could not send the code right now. Please try again."_ Production logs trace this to Privy returning:

```
POST https://auth.privy.io/api/v1/passwordless/init → 403
"Must specify origin"
```

Privy's REST API enforces a per-app dashboard allowlist on the `Origin` header for `/api/v1/passwordless/{init,authenticate}`. Our `PrivyEmailOtpClient` only carried `privy-app-id` + Basic Auth — no `Origin` — so every web OTP attempt was rejected at the edge.

**Mobile is unaffected.** Mobile uses `POST /api/v1/auth/privy-login`, which verifies a JWT minted client-side via `PrivyJwtVerifier` and never hits this REST path.

## What changed

- `PrivyEmailOtpClient::call()` now sends `Origin: <web origin>` on every outbound request.
- New `privy.web_origin` config (env: `PRIVY_WEB_ORIGIN`), defaults to `app.url` when unset. Operators with split API/web hosts (e.g. `api.zelta.app` for the API, `app.zelta.app` for the web `/login`) set this explicitly.
- Origin is normalised to `scheme://host[:port]` before sending — Privy compares against the dashboard list exactly, so path/query would silently fail the match.
- Origin is derived **server-side** from config; we deliberately do not echo the browser's `Origin` header (would defeat the allowlist).
- `.env.production.example` and `.env.zelta.example` document the new var.
- 2 new unit tests cover the default `app.url` path and the explicit override + path stripping.

## Operator action after merge

1. Set `PRIVY_WEB_ORIGIN` in production `.env` if web `/login` lives on a different host than `APP_URL` (otherwise leave unset).
2. **Critical:** add that origin to the Privy dashboard → **Settings → Allowed origins**. Mobile bundle ID origins stay untouched.
3. `php artisan config:clear && php artisan config:cache`
4. Test the flow with a real email — should now show the OTP step.

## Test plan

- [x] `./vendor/bin/pest tests/Unit/Domain/Auth/Services/PrivyEmailOtpClientTest.php` — 8 passed, 24 assertions
- [x] `php-cs-fixer fix` clean on modified files
- [x] `phpstan analyse` clean on modified files
- [ ] After deploy + dashboard allowlist update: confirm `POST /login/privy/send` returns 302 to `?step=verify` (not back with flash error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)