### PR TITLE
fix(mobile): surface device-takeover guard as HTTP 409, not 500

### DIFF
--- a/app/Domain/Mobile/Exceptions/DeviceTakeoverAttemptException.php
+++ b/app/Domain/Mobile/Exceptions/DeviceTakeoverAttemptException.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Domain\Mobile\Exceptions;
 
 use Exception;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 
 /**
  * Exception thrown when an attempt is made to register a device that belongs to another user.
@@ -29,6 +31,22 @@ class DeviceTakeoverAttemptException extends Exception
     public function getHttpStatusCode(): int
     {
         return 409; // Conflict
+    }
+
+    /**
+     * Render the exception as an HTTP response.
+     *
+     * Returns 409 so mobile clients can distinguish a takeover-blocked
+     * registration from a generic 500. Existing user identifiers are
+     * deliberately NOT echoed in the response body — that information stays
+     * in the server log via the `context()` array.
+     */
+    public function render(Request $request): JsonResponse
+    {
+        return new JsonResponse([
+            'message' => $this->getMessage(),
+            'error'   => 'DEVICE_REGISTERED_TO_DIFFERENT_USER',
+        ], $this->getHttpStatusCode());
     }
 
     /**

--- a/tests/Feature/Api/V1/RegisterDeviceTakeoverHttpStatusTest.php
+++ b/tests/Feature/Api/V1/RegisterDeviceTakeoverHttpStatusTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Domain\Mobile\Models\MobileDevice;
+use App\Models\User;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+/**
+ * Tests that the device-takeover security guard surfaces as HTTP 409
+ * (DeviceTakeoverAttemptException::render).
+ *
+ * Before the render() method was added, this case fell through to Laravel's
+ * default exception handler and emitted a generic 500 — masking the security
+ * signal from mobile and triggering opaque "Server Error" reports.
+ *
+ * @see app/Domain/Mobile/Exceptions/DeviceTakeoverAttemptException.php
+ * @see app/Domain/Mobile/Services/MobileDeviceService.php (registerDevice guard)
+ */
+class RegisterDeviceTakeoverHttpStatusTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    public function test_takeover_attempt_returns_409_with_structured_error_code(): void
+    {
+        $owner = User::factory()->create();
+        $attacker = User::factory()->create();
+
+        MobileDevice::create([
+            'user_id'     => $owner->id,
+            'device_id'   => 'shared-device-uuid',
+            'platform'    => 'android',
+            'app_version' => '1.0.0',
+            'push_token'  => 'fcm-original-token',
+        ]);
+
+        Sanctum::actingAs($attacker, ['read', 'write', 'delete']);
+
+        $response = $this->postJson('/api/v1/notifications/register-device', [
+            'device_id'   => 'shared-device-uuid',
+            'platform'    => 'android',
+            'app_version' => '1.0.0',
+            'push_token'  => 'fcm-attacker-token',
+        ]);
+
+        $response->assertStatus(409)
+            ->assertJsonPath('error', 'DEVICE_REGISTERED_TO_DIFFERENT_USER');
+
+        // Body must not leak the owner's identity. Render() returns only
+        // message + error; the standardize-error-responses callback adds
+        // request_id. None of the takeover context fields belong on the wire.
+        $response->assertJsonMissingPath('existing_user_id')
+            ->assertJsonMissingPath('attempted_user_id')
+            ->assertJsonMissingPath('user_id');
+
+        // Existing device row is untouched — no push_token rotation, no user_id swap.
+        $this->assertDatabaseHas('mobile_devices', [
+            'device_id'  => 'shared-device-uuid',
+            'user_id'    => $owner->id,
+            'push_token' => 'fcm-original-token',
+        ]);
+    }
+
+    public function test_same_user_re_registering_existing_device_returns_201_and_updates_push_token(): void
+    {
+        $user = User::factory()->create();
+
+        MobileDevice::create([
+            'user_id'     => $user->id,
+            'device_id'   => 'self-owned-device',
+            'platform'    => 'ios',
+            'app_version' => '1.0.0',
+            'push_token'  => 'apns-old-token',
+        ]);
+
+        Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+        $this->postJson('/api/v1/notifications/register-device', [
+            'device_id'   => 'self-owned-device',
+            'platform'    => 'ios',
+            'app_version' => '1.1.0',
+            'push_token'  => 'apns-new-token',
+        ])->assertStatus(201);
+
+        $this->assertDatabaseHas('mobile_devices', [
+            'device_id'  => 'self-owned-device',
+            'user_id'    => $user->id,
+            'push_token' => 'apns-new-token',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

`DeviceTakeoverAttemptException` declares `getHttpStatusCode(): int { return 409; }` and has done since #348 (Jan 31, v2.2.0 security hardening) — but Laravel only honors `HttpExceptionInterface::getStatusCode()`. The custom method has been dead code. With no `render()` and no parent `HttpException`, the takeover guard at `MobileDeviceService::registerDevice:53` fell through to Laravel's default exception handler and emitted `{"message":"Server Error","error":"SERVER_ERROR"}` with status 500.

That broke the security contract in both directions:
- mobile clients can't distinguish a takeover-blocked registration from a transient outage (Vertex hit exactly this trap in prod today — push-token registration started 500'ing after a Privy account switch repointed `device_id` to a new `user_id`)
- operators get opaque "Server Error" alerts that mask a security event

This adds `render(Request $request): JsonResponse` returning **409** with a structured error code `DEVICE_REGISTERED_TO_DIFFERENT_USER`. Existing-user identifiers stay in the `context()` array (used by the critical-log line in `MobileDeviceService:45`), they don't go on the wire.

## Test plan

- [x] `./vendor/bin/php-cs-fixer fix` clean
- [x] PHPStan L8 clean on touched files
- [x] `tests/Unit/Domain/Mobile/Services/MobileSecurityTest.php` still green (unit-level exception throw)
- [x] New `tests/Feature/Api/V1/RegisterDeviceTakeoverHttpStatusTest.php` covers:
  - attacker registering an owner's `device_id` → **409 + `DEVICE_REGISTERED_TO_DIFFERENT_USER`**, no leak of owner identifiers, original row untouched (push_token, user_id)
  - same user re-registering own device → **201**, push_token rotated through the update path
- [ ] CI green

## Follow-up

Filing a separate issue to revisit the guard's scope — currently it rejects any `device_id` reassignment regardless of whether the device has biometric or passkey credentials bound. For credential-less rows the guarantee is weaker than the cost (operator-only recovery), and the dev/test re-Privy flow gets locked out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)