### PR TITLE
docs(v7.13.0): public changelog + version badge bumps for the v7.13.0 release

### DIFF
--- a/resources/views/changelog.blade.php
+++ b/resources/views/changelog.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'Changelog | ' . config('brand.name', 'Zelta'),
-        'description' => 'Release history for the Zelta core banking platform. Track every feature shipped, bug fixed, and improvement made — v7.0 through v7.11.0.',
+        'description' => 'Release history for the Zelta core banking platform. Track every feature shipped, bug fixed, and improvement made — v7.0 through v7.13.0.',
         'keywords' => 'changelog, release notes, updates, ' . config('brand.name', 'Zelta') . ', version history, core banking',
     ])
 
@@ -43,6 +43,39 @@
 
             @php
                 $releases = [
+                    [
+                        'version' => 'v7.13.0',
+                        'date' => 'May 15, 2026',
+                        'label' => 'Mobile-Driven IAP Subscriptions + Auth Hardening',
+                        'label_color' => 'purple',
+                        'badge_color' => 'bg-purple-100 text-purple-700 border-purple-200',
+                        'dot_color' => 'bg-purple-500',
+                        'items' => [
+                            'In-App Purchase verification — <code>POST /api/v1/subscriptions/iap/verify</code> exchanges an Apple StoreKit 2 JWS or Google Play subscription token for a Zelta subscription record. Idempotent via <code>(provider, original_transaction_id)</code> unique index; Family-Sharing / stale-receipt / cross-account conflicts surface as HTTP 409 with the mobile-aligned <code>ERR_SUB_002 { kind, attemptedSource, existingSubscription }</code> envelope.',
+                            'Apple JWS chain validation — fail-closed verifier pins the trust anchor to Apple Root CA G3 (fingerprint <code>63343ABF…E9179</code>) and performs an ES256 signature check with x5c chain validation, no new vendor deps. Staging-only <code>APPLE_JWS_VERIFICATION_BYPASS</code> is hard-rejected in production.',
+                            'Google Play RTDN ingestion — Cloud Pub/Sub push subscription delivers subscription state transitions through the same <code>processed_webhook_events</code> idempotency path as Apple App Store Server Notifications V2. Receipts are HMAC-pseudonymised by <code>IapReceiptPseudonymiser</code> before persistence or logging.',
+                            'Revenue outbox + event ledger — <code>revenue_outbox_events</code> queues downstream cue grants and analytics; <code>revenue_events</code> is the append-only ledger that survives reconciliation reruns. Trial-card-fingerprint anti-abuse rejects repeat free-trial attempts before they reach the store. GDPR consent payload captured per-purchase via <code>subscription_consent_log</code>.',
+                            'Privy web <code>/login</code> Origin header — <code>PrivyEmailOtpClient</code> now sends <code>Origin: &lt;web origin&gt;</code> (config: <code>privy.web_origin</code>, env: <code>PRIVY_WEB_ORIGIN</code>, falls back to <code>app.url</code>) so Privy\'s REST allowlist accepts server-to-server <code>/passwordless/{init,authenticate}</code> requests. Mobile JWT path is unaffected.',
+                            'Device-takeover guard contract fix — <code>DeviceTakeoverAttemptException</code> declared <code>getHttpStatusCode(): 409</code> since the v2.2.0 security hardening (#348) but had no <code>render()</code> method and no <code>HttpException</code> parent, so the guard fell through to Laravel\'s default handler and emitted a generic 500. <code>POST /api/v1/notifications/register-device</code> now returns <code>{ error: "DEVICE_REGISTERED_TO_DIFFERENT_USER" }</code> with HTTP 409 so mobile can distinguish a takeover-blocked registration from a transient outage.',
+                            'Rewards quest-completion lockdown — the public <code>POST /api/v1/rewards/quests/{id}/complete</code> endpoint and the GraphQL <code>completeQuest</code> mutation are removed. Both credited XP from <code>RewardsService::completeQuest</code> without checking the underlying domain action; any authenticated caller could one-shot ~290 XP + 590 points from the seeded quests. Completion is now reachable only via domain-event listeners. New <code>TriggerQuestOnProfileUpdated</code> listener closes the <code>complete-profile</code> quest gap; new <code>QuestCompleted</code> broadcast fires on <code>private-user.{userId}</code> after successful auto-completion so mobile can show the celebration modal in real time.',
+                        ],
+                    ],
+                    [
+                        'version' => 'v7.12.0',
+                        'date' => 'May 5, 2026',
+                        'label' => 'Non-Custodial Wallet Send (Privy Embedded Wallets)',
+                        'label_color' => 'teal',
+                        'badge_color' => 'bg-teal-100 text-teal-700 border-teal-200',
+                        'dot_color' => 'bg-teal-500',
+                        'items' => [
+                            'Privy passkey login — <code>POST /api/v1/auth/privy-login</code> exchanges a Privy JWT (verified via JWKS with <code>iss</code> / <code>aud</code> / <code>exp</code> checks) for a Sanctum token. Auto-creates the user on first login via <code>privy_user_id</code> lookup; cross-client account merging works for the same Privy DID across mobile and web.',
+                            'Non-custodial address registration — <code>POST /api/v1/wallet/addresses</code> registers Privy-derived addresses. EVM smart-account address mirrors across polygon / base / arbitrum / ethereum, plus one Solana ed25519 row in <code>blockchain_addresses</code> so existing webhook sync, balance lookups, and tx indexers continue unchanged.',
+                            'Two-step send flow — <code>POST /api/v1/wallet/transactions/prepare</code> returns an unsigned payload (Solana legacy tx message bytes; EVM ERC-4337 v0.6 UserOperation with Pimlico paymaster sponsorship), persists a <code>wallet_send_records</code> row in <code>pending</code> state, honors the <code>Idempotency-Key</code> HTTP header. <code>POST /api/v1/wallet/transactions/submit</code> accepts the device-signed payload and broadcasts via Helius (Solana) or Pimlico bundler (EVM). Wire contract is camelCase end-to-end (<code>quoteId</code>, <code>intentId</code>, <code>evm.ownerPasskeyCredentialId</code>) to match mobile RN/TS request types.',
+                            'Confirmation tracking — <code>HeliusTransactionProcessor</code> flips Solana records to <code>confirmed</code> from the existing webhook. <code>PollEvmWalletSendConfirmations</code> polls the Pimlico bundler for in-flight EVM UserOps every minute.',
+                            'Stripped surface (hard cutover, project not yet live) — the custodial signing endpoint <code>POST /api/v1/auth/sign-userop</code>, the custodial dispatch endpoint <code>POST /api/v1/wallet/transactions/send</code>, and all <code>/api/v1/wallet/recovery-shard-backup/*</code> Shamir endpoints are removed. Privy holds the keys; the device signs every transaction; the backend never sees private key material.',
+                            'Operator commands — <code>php artisan privy:verify-jwt &lt;token&gt;</code> verifies a Privy JWT against the live issuer and dumps claims; <code>php artisan wallet:inspect-user &lt;email&gt;</code> shows Privy linkage + addresses + recent send records read-only.',
+                        ],
+                    ],
                     [
                         'version' => 'v7.11.0',
                         'date' => 'April 30, 2026',

--- a/resources/views/developers/index.blade.php
+++ b/resources/views/developers/index.blade.php
@@ -137,7 +137,7 @@
                 <div class="text-center">
                     <div class="inline-flex items-center px-4 py-2 bg-white/10 backdrop-blur-sm rounded-full text-sm mb-6">
                         <span class="w-2 h-2 bg-green-400 rounded-full mr-2 animate-pulse"></span>
-                        <span>v7.11.0 Documentation — 61 Domains, 1,400+ Routes, GraphQL + REST + MCP + x402</span>
+                        <span>v7.13.0 Documentation — 61 Domains, 1,400+ Routes, GraphQL + REST + MCP + x402</span>
                     </div>
                     <h1 class="text-5xl md:text-7xl font-bold mb-6 bg-clip-text text-transparent bg-gradient-to-r from-white to-blue-200">
                         Build with 1,400+ API Routes
@@ -177,8 +177,8 @@
                     <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                     </svg>
-                    <span class="font-medium">v7.11.0 Released:</span>
-                    <span class="ml-2">Public MCP server at <code class="code-font">mcp.zelta.app</code> — 12 OAuth-protected banking tools for Claude Desktop, Cursor, and any spec-compliant AI agent. <code class="code-font">@finaegis/mcp</code> on npm. 61 DDD domains, 1,400+ API routes, GraphQL (45 domains), ISO 20022, ISO 8583, x402 Protocol.</span>
+                    <span class="font-medium">v7.13.0 Released:</span>
+                    <span class="ml-2">Mobile-driven IAP subscriptions (Apple StoreKit 2 + Google Play RTDN) with the <code class="code-font">ERR_SUB_002</code> mobile error contract and Apple Root CA G3 pinned JWS verification. Non-custodial wallet send via Privy passkey-controlled smart accounts (v7.12.0) is live. 61 DDD domains, 1,400+ API routes, GraphQL (45 domains), ISO 20022, ISO 8583, x402 Protocol, public MCP server.</span>
                 </div>
             </div>
         </section>

--- a/resources/views/features/agent-protocol.blade.php
+++ b/resources/views/features/agent-protocol.blade.php
@@ -38,7 +38,7 @@
                 ]])
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-cyan-400 rounded-full mr-2"></span>
-                    v7.11.0 &middot; Autonomous Agent Commerce
+                    v7.13.0 &middot; Autonomous Agent Commerce
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">
                     Agent Protocol

--- a/resources/views/features/ai-framework.blade.php
+++ b/resources/views/features/ai-framework.blade.php
@@ -38,7 +38,7 @@
                 ]])
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.11.0 &middot; Multi-Agent Intelligence
+                    v7.13.0 &middot; Multi-Agent Intelligence
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">
                     AI Framework

--- a/resources/views/features/machine-payments.blade.php
+++ b/resources/views/features/machine-payments.blade.php
@@ -34,7 +34,7 @@
                 </div>
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.11.0 &middot; Multi-Rail Payments
+                    v7.13.0 &middot; Multi-Rail Payments
                 </div>
                 <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
                     Machine Payments Protocol

--- a/resources/views/features/x402-protocol.blade.php
+++ b/resources/views/features/x402-protocol.blade.php
@@ -36,7 +36,7 @@
                 </div>
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.11.0 &middot; Production Ready
+                    v7.13.0 &middot; Production Ready
                 </div>
                 <h1 class="font-display text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">x402 Protocol</h1>
                 <p class="text-lg text-slate-400 max-w-3xl mx-auto mb-8">

--- a/resources/views/support/faq.blade.php
+++ b/resources/views/support/faq.blade.php
@@ -13,7 +13,7 @@
     $faqData = [
         [
             'question' => 'What is the current status of ' . config('brand.name', 'Zelta') . '?',
-            'answer' => config('brand.name', 'Zelta') . ' v7.11.0 is a fully-featured open-source core banking platform with 61 domain modules, including a public OAuth-protected MCP server for AI agents. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
+            'answer' => config('brand.name', 'Zelta') . ' v7.13.0 is a fully-featured open-source core banking platform with 61 domain modules, including a public OAuth-protected MCP server for AI agents. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
         ],
         [
             'question' => 'Can I use real money on the platform?',
@@ -127,7 +127,7 @@
                     </button>
                     <div class="faq-answer px-6 py-4 bg-white rounded-b-lg">
                         <p class="text-slate-500">
-                            {{ config('brand.name', 'Zelta') }} is a fully-featured open-source core banking platform at v7.11.0. The sandbox environment lets you:
+                            {{ config('brand.name', 'Zelta') }} is a fully-featured open-source core banking platform at v7.13.0. The sandbox environment lets you:
                         </p>
                         <ul class="list-disc list-inside mt-2 text-slate-500 space-y-1">
                             <li>Explore 61 domain modules including DeFi, cross-chain, privacy, MCP, and rewards</li>


### PR DESCRIPTION
## Summary

Surfaces v7.12.0 + v7.13.0 on the public site for the v7.13.0 tag.

- **Public /changelog** — adds the two missing entries (v7.12.0 Non-Custodial Wallet Send, v7.13.0 Mobile-Driven IAP + Auth Hardening). The page had stopped at v7.11.0 — two releases ago.
- **Version badges** — bumps v7.11.0 → v7.13.0 on `developers/index`, `support/faq`, and the feature pages that show a current-version badge (ai-framework, agent-protocol, machine-payments, x402-protocol). The MCP page's "v7.11.0 · New" badge stays — that one is a ship-version marker, not a current-version indicator.

This is the public-content half of the v7.13.0 release. Once this and PR #1060 (rewards lockdown) merge, I'll cut the `v7.13.0` git tag against the resulting `main`.

## Test plan

- [x] No code changes — Blade content only
- [x] `grep -rn "v7.11" resources/views` reports nothing actionable left (only the deliberate "v7.11.0 · New" badge for MCP and the illustrative `version: "7.10.8"` in a `curl` sample)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)