### PR TITLE
feat(payment-asset): enable USDT (Solana + EVM) — fixes mobile quote 400

### DIFF
--- a/app/Domain/MobilePayment/Enums/PaymentAsset.php
+++ b/app/Domain/MobilePayment/Enums/PaymentAsset.php
@@ -5,23 +5,29 @@ declare(strict_types=1);
 namespace App\Domain\MobilePayment\Enums;
 
 /**
- * Supported assets for mobile payments (v1: USDC only).
+ * Supported assets for mobile payments.
+ *
+ * USDC and USDT — both 6-decimal stablecoins on every chain we support
+ * (USDT is absent on Base mainnet; {@see \App\Domain\Wallet\Constants\EvmTokens::contractFor()}
+ * returns null and the preparer rejects with InvalidAssetException).
  */
 enum PaymentAsset: string
 {
     case USDC = 'USDC';
+    case USDT = 'USDT';
 
     public function label(): string
     {
         return match ($this) {
             self::USDC => 'USD Coin',
+            self::USDT => 'Tether USD',
         };
     }
 
     public function decimals(): int
     {
         return match ($this) {
-            self::USDC => 6,
+            self::USDC, self::USDT => 6,
         };
     }
 

--- a/app/Domain/MobilePayment/Services/ReceiveAddressService.php
+++ b/app/Domain/MobilePayment/Services/ReceiveAddressService.php
@@ -6,6 +6,7 @@ namespace App\Domain\MobilePayment\Services;
 
 use App\Domain\MobilePayment\Enums\PaymentAsset;
 use App\Domain\MobilePayment\Enums\PaymentNetwork;
+use App\Domain\Wallet\Constants\SolanaTokens;
 use App\Domain\Wallet\Factories\BlockchainConnectorFactory;
 use App\Domain\Wallet\Helpers\SolanaAddressHelper;
 
@@ -76,11 +77,16 @@ class ReceiveAddressService
 
     /**
      * Build a QR-encodable value for the address.
+     *
+     * Solana Pay (https://docs.solanapay.com/spec) requires `spl-token` to be
+     * the mint address, not the symbol. We resolve the asset → mint via
+     * {@see SolanaTokens::mintFor()} so USDC and USDT scan correctly in
+     * spec-compliant wallets.
      */
     private function buildQrValue(string $address, PaymentNetwork $network, PaymentAsset $asset): string
     {
         return match ($network) {
-            PaymentNetwork::SOLANA                                                                            => "solana:{$address}?spl-token=USDC",
+            PaymentNetwork::SOLANA                                                                            => "solana:{$address}?spl-token=" . SolanaTokens::mintFor($asset->value),
             PaymentNetwork::TRON                                                                              => $address,
             PaymentNetwork::POLYGON, PaymentNetwork::BASE, PaymentNetwork::ARBITRUM, PaymentNetwork::ETHEREUM => "ethereum:{$address}",
         };

--- a/app/Domain/Wallet/Constants/SolanaTokens.php
+++ b/app/Domain/Wallet/Constants/SolanaTokens.php
@@ -16,4 +16,20 @@ final class SolanaTokens
     {
         return self::KNOWN_MINTS[$mint]['symbol'] ?? 'SPL';
     }
+
+    /**
+     * Resolve a symbol (USDC, USDT, …) to its canonical Solana mint address.
+     * Falls back to the input string when the symbol isn't a known SPL token
+     * so the caller's QR/URL doesn't end up empty.
+     */
+    public static function mintFor(string $symbol): string
+    {
+        foreach (self::KNOWN_MINTS as $mint => $meta) {
+            if ($meta['symbol'] === $symbol) {
+                return $mint;
+            }
+        }
+
+        return $symbol;
+    }
 }

--- a/app/Http/Controllers/Api/MobilePayment/WalletReceiveController.php
+++ b/app/Http/Controllers/Api/MobilePayment/WalletReceiveController.php
@@ -32,7 +32,7 @@ class WalletReceiveController extends Controller
         tags: ['Mobile Payments'],
         security: [['sanctum' => []]],
         parameters: [
-        new OA\Parameter(name: 'asset', in: 'query', required: true, description: 'Payment asset (currently only USDC supported)', schema: new OA\Schema(type: 'string', enum: ['USDC'], example: 'USDC')),
+        new OA\Parameter(name: 'asset', in: 'query', required: true, description: 'Payment asset (USDC or USDT)', schema: new OA\Schema(type: 'string', enum: ['USDC', 'USDT'], example: 'USDC')),
         new OA\Parameter(name: 'network', in: 'query', required: true, description: 'Payment network', schema: new OA\Schema(type: 'string', enum: ['SOLANA', 'TRON'], example: 'SOLANA')),
         ]
     )]
@@ -74,7 +74,7 @@ class WalletReceiveController extends Controller
     public function __invoke(Request $request): JsonResponse
     {
         $request->validate([
-            'asset'   => ['required', 'string', 'in:USDC'],
+            'asset'   => ['required', 'string', 'in:' . implode(',', PaymentAsset::values())],
             'network' => ['required', 'string', 'in:SOLANA,TRON'],
         ]);
 

--- a/app/Http/Requests/MobilePayment/CreatePaymentIntentRequest.php
+++ b/app/Http/Requests/MobilePayment/CreatePaymentIntentRequest.php
@@ -37,8 +37,8 @@ class CreatePaymentIntentRequest extends FormRequest
     public function messages(): array
     {
         return [
-            'asset.in'            => 'Only USDC is supported for v1.',
-            'preferredNetwork.in' => 'Only SOLANA and TRON networks are supported for v1.',
+            'asset.in'            => 'Supported assets: ' . implode(', ', PaymentAsset::values()) . '.',
+            'preferredNetwork.in' => 'Supported networks: ' . implode(', ', PaymentNetwork::values()) . '.',
             'amount.gt'           => 'Payment amount must be greater than zero.',
         ];
     }

--- a/tests/Feature/Api/Wallet/WalletTransactionQuoteTest.php
+++ b/tests/Feature/Api/Wallet/WalletTransactionQuoteTest.php
@@ -85,4 +85,39 @@ class WalletTransactionQuoteTest extends TestCase
         $response->assertStatus(400)
             ->assertJsonPath('success', false);
     }
+
+    public function test_transaction_quote_accepts_usdt_on_solana(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/wallet/transactions/quote', [
+                'to'      => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+                'network' => 'SOLANA',
+                'asset'   => 'USDT',
+                'amount'  => 1,
+            ]);
+
+        $response->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.asset', 'USDT')
+            ->assertJsonPath('data.network', 'SOLANA');
+    }
+
+    public function test_transaction_quote_accepts_usdt_on_polygon(): void
+    {
+        // Note: PaymentNetwork uses lowercase enum values for EVM chains
+        // (`polygon`, `base`, `arbitrum`, `ethereum`) while non-EVM chains use
+        // upper-case (`SOLANA`, `TRON`). Inconsistent but pre-existing; mobile
+        // must send the exact enum value.
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/wallet/transactions/quote', [
+                'to'      => '0x742d35cc6634c0532925a3b844bc454e4438f44e',
+                'network' => 'polygon',
+                'asset'   => 'USDT',
+                'amount'  => 5,
+            ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.asset', 'USDT')
+            ->assertJsonPath('data.network', 'polygon');
+    }
 }

--- a/tests/Unit/Domain/MobilePayment/Services/ReceiveAddressServiceTest.php
+++ b/tests/Unit/Domain/MobilePayment/Services/ReceiveAddressServiceTest.php
@@ -32,7 +32,7 @@ describe('ReceiveAddressService', function (): void {
 });
 
 describe('ReceiveAddressService QR Value', function (): void {
-    it('builds Solana QR value via reflection', function (): void {
+    it('builds Solana USDC QR value with the USDC mint per Solana Pay spec', function (): void {
         $service = new ReceiveAddressService();
         $reflection = new ReflectionClass($service);
         $method = $reflection->getMethod('buildQrValue');
@@ -40,7 +40,18 @@ describe('ReceiveAddressService QR Value', function (): void {
 
         $qr = $method->invoke($service, 'testAddr123', PaymentNetwork::SOLANA, PaymentAsset::USDC);
 
-        expect($qr)->toBe('solana:testAddr123?spl-token=USDC');
+        expect($qr)->toBe('solana:testAddr123?spl-token=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
+    });
+
+    it('builds Solana USDT QR value with the USDT mint per Solana Pay spec', function (): void {
+        $service = new ReceiveAddressService();
+        $reflection = new ReflectionClass($service);
+        $method = $reflection->getMethod('buildQrValue');
+        $method->setAccessible(true);
+
+        $qr = $method->invoke($service, 'testAddr123', PaymentNetwork::SOLANA, PaymentAsset::USDT);
+
+        expect($qr)->toBe('solana:testAddr123?spl-token=Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB');
     });
 
     it('builds Tron QR value as plain address', function (): void {

--- a/tests/Unit/Domain/Wallet/Services/WalletTransferServiceTest.php
+++ b/tests/Unit/Domain/Wallet/Services/WalletTransferServiceTest.php
@@ -168,8 +168,17 @@ describe('WalletTransferService', function (): void {
         });
 
         it('throws for invalid asset', function (): void {
-            expect(fn () => $this->service->getTransferQuote('SOLANA', 'USDT', '100.00'))
+            // 'BTC' was 'USDT' before USDT was added to PaymentAsset. Pick a
+            // symbol that genuinely isn't in the enum so the cast throws.
+            expect(fn () => $this->service->getTransferQuote('SOLANA', 'BTC', '100.00'))
                 ->toThrow(ValueError::class);
+        });
+
+        it('accepts USDT on Solana now that the enum supports it', function (): void {
+            $result = $this->service->getTransferQuote('SOLANA', 'USDT', '50.00');
+
+            expect($result['network'])->toBe('SOLANA');
+            expect($result['asset'])->toBe('USDT');
         });
     });
 });


### PR DESCRIPTION
## Summary

Mobile is hitting `400 QUOTE_FAILED` with `\"USDT\" is not a valid backing value for enum PaymentAsset` on Solana USDT and Polygon USDT. The EVM (`EvmTokens`) and Solana (`SolanaTokens`) token registries already had USDT addresses and decimals wired — the gate was the **`PaymentAsset` enum** that the quote / payment-intent validators check against. Product scope for launch is USDC + USDT.

## Mobile's analysis vs reality

Mobile flagged 7 files. Verified each — most were already USDT-ready:

| File | Status | What changed |
|---|---|---|
| `PaymentAsset` enum | **Updated** | Added `USDT` case, decimals=6, label \"Tether USD\" |
| `WalletQuoteRequest` | Already USDT-ready | Uses `PaymentAsset::values()` — auto-tracks |
| `CreatePaymentIntentRequest` | **Updated** | Same auto-track; just dropped the misleading \"Only USDC supported for v1\" + \"Only SOLANA/TRON supported\" messages (both wrong now) |
| `WalletReceiveController` | **Updated** | Replaced hard-coded `in:USDC` validator + OpenAPI annotation with the enum |
| `WalletTransferService` | Already USDT-ready | Uses `PaymentAsset::from()` discriminator |
| `FeeEstimationService` | Asset-agnostic | Network-level gas estimate, no asset branching |
| `ReceiptService` | Asset-agnostic | Passes through `\$intent->asset`, doesn't care |

Found one extra issue mobile didn't list:
- **`ReceiveAddressService::buildQrValue`** hard-coded `solana:{addr}?spl-token=USDC`. Solana Pay spec ([docs.solanapay.com/spec](https://docs.solanapay.com/spec)) requires `spl-token` to be the **mint address**, not the symbol. The old QRs were technically spec-noncompliant even for USDC. Now uses the canonical mint via a new `SolanaTokens::mintFor()` helper — USDC → `EPjF…Dt1v`, USDT → `Es9v…NYB`.

## Open questions — answered

1. **Pimlico paymaster contract whitelist** — *yes, this needs an out-of-repo update.* `PimlicoPaymasterService::sponsor()` defers to Pimlico's `pm_sponsorUserOperation`, which checks our dashboard-side sponsorship policy. USDT contracts on polygon / arbitrum / ethereum need to be added there, otherwise the paymaster will refuse to sponsor USDT transfers. **Tracked outside this PR.**
2. **Helius / Alchemy webhook coverage** — *no change needed.*
    - Helius (Solana): `HeliusTransactionProcessor` resolves token symbol via `SolanaTokens::resolveSymbol(\$mint)`, which already maps the USDT mint `Es9v…NYB` → `\"USDT\"`. Inbound USDT deposits flow through the existing reconciler.
    - Alchemy (EVM): `AlchemyWebhookManager` provisions **address-based** Address Activity webhooks, not token-filtered. Any ERC-20 transfer to/from a known user address fires; the reconciler identifies the asset by contract address against `EvmTokens`. **USDT auto-watched.**

## USDT-vs-USDC transfer ABI

Mobile flagged that USDT's `transfer` on Ethereum mainnet historically has a non-standard return type (missing return bool). Verified: not an issue for our call site. `Erc20Transfer` encodes the standard `0xa9059cbb transfer(address,uint256)` selector + args; the ERC-4337 SimpleAccount executes the call and success is read from the tx receipt (not from a decoded return value). The historical USDT quirk only bites integrations that *decode* the return — ours doesn't.

## Test plan

- [x] `php-cs-fixer fix` clean
- [x] PHPStan L8 clean on touched files
- [x] `tests/Feature/Api/Wallet/WalletTransactionQuoteTest` — new cases for **USDT on Solana** and **USDT on Polygon** (both 200 + `data.asset = USDT`)
- [x] `tests/Unit/Domain/MobilePayment/Services/ReceiveAddressServiceTest` — old assertion `solana:…?spl-token=USDC` replaced with mint-address assertions for both USDC + USDT
- [ ] CI green

## Note for mobile

Once this merges, both **POST /wallet/transactions/quote** and **GET /wallet/receive** accept `asset=USDT`. The `network` enum quirk pre-exists: EVM chain values are lowercase (`polygon`, `base`, `arbitrum`, `ethereum`) while non-EVM are upper-case (`SOLANA`, `TRON`). Send the exact enum value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)