### PR TITLE
docs(v7.13.1): public changelog entry for USDT enablement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,7 @@ Non-custodial flow. Privy holds the keys (passkey-controlled smart accounts on E
 | Float-money amounts | Preparers validate `amount` against numeric-string + bcmath; never `(float)` for money |
 | Idempotency key on the wrong field | It's an HTTP header (`Idempotency-Key`), not a body field — matches `/pay`/`/pay/card` |
 | `quote_id` vs `quoteId` | Wire contract is camelCase across the board (matches mobile RN/TS request types) |
+| Adding a new send/receive asset | Add the case to `App\Domain\MobilePayment\Enums\PaymentAsset` (decimals + label) AND make sure `EvmTokens` / `SolanaTokens` have the contract / mint. The receive QR builder uses `SolanaTokens::mintFor()` per Solana Pay spec — `spl-token` must be the mint, not the symbol. v7.13.1 added USDT this way |
 
 ## IAP / Subscriptions (v7.13.0+)
 

--- a/docs/BACKEND_HANDOVER.md
+++ b/docs/BACKEND_HANDOVER.md
@@ -515,7 +515,7 @@ All errors should follow this format:
 ### Network constraints:
 - v1 supports **Solana + Tron only**. The `preferredNetwork` field in payment intents should only accept `SOLANA` and `TRON`.
 - The network status endpoint should return only these two networks (plus others marked as `coming_soon` if desired).
-- Asset constraint: **USDC only** for v1. The `asset` field should only accept `USDC`.
+- Asset constraint (as of v7.13.1): the `asset` field accepts `USDC` and `USDT`. Both are 6-decimal stablecoins. Asset support is enum-driven via `App\Domain\MobilePayment\Enums\PaymentAsset` — future additions auto-extend the validators.
 
 ---
 

--- a/docs/VERSION_ROADMAP.md
+++ b/docs/VERSION_ROADMAP.md
@@ -3257,6 +3257,21 @@ Findings #1-2 fixed in v7.1.1, findings #3-15 fixed in this release:
 
 ---
 
+## Version 7.13.1 — USDT Enablement + Solana Pay QR Spec Fix (May 2026)
+
+**Theme**: Small follow-up to v7.13.0 — surface a stablecoin that was already wired in the token registries but gated by an enum, and bring Solana receive QRs in line with the Solana Pay spec.
+
+### Delivered Features
+- USDT is now a first-class send/receive asset alongside USDC. `App\Domain\MobilePayment\Enums\PaymentAsset` gains a `USDT` case (decimals=6, label "Tether USD"). The `WalletQuoteRequest` and `CreatePaymentIntentRequest` validators reference `PaymentAsset::values()` so the enum addition auto-extends every endpoint they protect. `WalletReceiveController`'s previously hard-coded `'in:USDC'` validator is replaced with the same enum reference.
+- `EvmTokens::USDT` and `SolanaTokens::KNOWN_MINTS` already carried the USDT contract addresses (polygon `0xc213…58e8f`, arbitrum `0xfd08…fcbb9`, ethereum `0xdac1…31ec7`) and the Solana mint (`Es9v…NYB`) from the v7.12.0 non-custodial Wallet Send work, so the call-encoding and webhook-reconciliation paths needed no change.
+- Solana Pay spec compliance — `ReceiveAddressService::buildQrValue` previously emitted `solana:<addr>?spl-token=USDC`, but [solanapay.com/spec](https://docs.solanapay.com/spec) requires the `spl-token` parameter to be the SPL mint address, not the symbol. A new `SolanaTokens::mintFor()` helper resolves the canonical mint per asset (`USDC` → `EPjF…Dt1v`, `USDT` → `Es9v…NYB`). Old QRs were technically spec-noncompliant even for USDC; strict wallets (Phantom, Solflare) now scan correctly.
+- `CreatePaymentIntentRequest` validation messages dropped the misleading "Only USDC is supported for v1" / "Only SOLANA and TRON networks are supported for v1" strings (both stale post-v7.12.0 / v7.13.1).
+
+### Operational Follow-Up
+- Pimlico's sponsorship policy needs USDT contract addresses added on polygon, arbitrum, and ethereum mainnets, otherwise `pm_sponsorUserOperation` will decline to sponsor USDT transfers. Solana USDT is unaffected (no paymaster on Solana — fees paid in SOL from the user's account). Tracked outside the repo.
+
+---
+
 ## Version 7.13.0 — Plan B Subscriptions / In-App Purchases (May 2026)
 
 **Theme**: Mobile-driven IAP subscriptions (Apple App Store + Google Play) with a hardened revenue path — webhook-replay-safe ingestion, trial-card-fingerprint anti-abuse, GDPR consent log, and ERR_SUB_002 mobile-error contract.
@@ -3350,5 +3365,5 @@ Embeddable JS widget that renders Zelta's 402 payment flow inside the partner's 
 
 ---
 
-*Document Version: 7.13.0*
-*Updated: May 14, 2026 (v7.13.0 Plan B IAP subscriptions + ERR_SUB_002 mobile contract + Privy web `/login` Origin fix)*
+*Document Version: 7.13.1*
+*Updated: May 15, 2026 (v7.13.1 USDT enablement + Solana Pay QR spec fix)*

--- a/resources/views/changelog.blade.php
+++ b/resources/views/changelog.blade.php
@@ -44,6 +44,19 @@
             @php
                 $releases = [
                     [
+                        'version' => 'v7.13.1',
+                        'date' => 'May 15, 2026',
+                        'label' => 'USDT Enablement + Solana Pay QR Spec Fix',
+                        'label_color' => 'slate',
+                        'badge_color' => 'bg-slate-100 text-slate-700 border-slate-200',
+                        'dot_color' => 'bg-slate-500',
+                        'items' => [
+                            'USDT added to the mobile-wallet send and receive surfaces. The <code>PaymentAsset</code> enum gains a USDT case (decimals=6, label "Tether USD"); <code>POST /api/v1/wallet/transactions/quote</code> and <code>GET /api/v1/wallet/receive</code> now accept <code>asset=USDT</code> alongside USDC. The EVM and Solana token registries (<code>EvmTokens</code>, <code>SolanaTokens::KNOWN_MINTS</code>) already had USDT contract addresses and mint wired in since the non-custodial Wallet Send work — only the enum-backed validators were gating it. The hard-coded <code>"in:USDC"</code> validator + "currently only USDC supported" OpenAPI annotation on <code>WalletReceiveController</code> are removed; both validators now reference <code>PaymentAsset::values()</code> so future asset additions auto-track.',
+                            'Solana Pay QR spec compliance. <code>ReceiveAddressService::buildQrValue</code> previously emitted <code>solana:{address}?spl-token=USDC</code> — the <code>spl-token</code> parameter per <a href="https://docs.solanapay.com/spec" target="_blank" rel="noopener" class="underline">solanapay.com/spec</a> must be the SPL mint address, not the symbol. Now resolves <code>USDC</code> → <code>EPjF…Dt1v</code> and <code>USDT</code> → <code>Es9v…NYB</code> via a new <code>SolanaTokens::mintFor()</code> helper. Strict Solana Pay wallets (Phantom, Solflare) will now scan USDC and USDT QRs correctly.',
+                            'Operational follow-up for full USDT enablement on EVM: Pimlico\'s sponsorship policy needs the USDT contract addresses added on polygon, arbitrum, and ethereum mainnets (Polygon <code>0xc213…58e8f</code>, Arbitrum <code>0xfd08…fcbb9</code>, Ethereum <code>0xdac1…31ec7</code>). Without this, <code>pm_sponsorUserOperation</code> will decline to sponsor USDT transfers on EVM. Tracked outside the repo.',
+                        ],
+                    ],
+                    [
                         'version' => 'v7.13.0',
                         'date' => 'May 15, 2026',
                         'label' => 'Mobile-Driven IAP Subscriptions + Auth Hardening',

--- a/resources/views/developers/index.blade.php
+++ b/resources/views/developers/index.blade.php
@@ -137,7 +137,7 @@
                 <div class="text-center">
                     <div class="inline-flex items-center px-4 py-2 bg-white/10 backdrop-blur-sm rounded-full text-sm mb-6">
                         <span class="w-2 h-2 bg-green-400 rounded-full mr-2 animate-pulse"></span>
-                        <span>v7.13.0 Documentation — 61 Domains, 1,400+ Routes, GraphQL + REST + MCP + x402</span>
+                        <span>v7.13.1 Documentation — 61 Domains, 1,400+ Routes, GraphQL + REST + MCP + x402</span>
                     </div>
                     <h1 class="text-5xl md:text-7xl font-bold mb-6 bg-clip-text text-transparent bg-gradient-to-r from-white to-blue-200">
                         Build with 1,400+ API Routes
@@ -177,7 +177,7 @@
                     <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                     </svg>
-                    <span class="font-medium">v7.13.0 Released:</span>
+                    <span class="font-medium">v7.13.1 Released:</span>
                     <span class="ml-2">Mobile-driven IAP subscriptions (Apple StoreKit 2 + Google Play RTDN) with the <code class="code-font">ERR_SUB_002</code> mobile error contract and Apple Root CA G3 pinned JWS verification. Non-custodial wallet send via Privy passkey-controlled smart accounts (v7.12.0) is live. 61 DDD domains, 1,400+ API routes, GraphQL (45 domains), ISO 20022, ISO 8583, x402 Protocol, public MCP server.</span>
                 </div>
             </div>

--- a/resources/views/features/agent-protocol.blade.php
+++ b/resources/views/features/agent-protocol.blade.php
@@ -38,7 +38,7 @@
                 ]])
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-cyan-400 rounded-full mr-2"></span>
-                    v7.13.0 &middot; Autonomous Agent Commerce
+                    v7.13.1 &middot; Autonomous Agent Commerce
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">
                     Agent Protocol

--- a/resources/views/features/ai-framework.blade.php
+++ b/resources/views/features/ai-framework.blade.php
@@ -38,7 +38,7 @@
                 ]])
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.13.0 &middot; Multi-Agent Intelligence
+                    v7.13.1 &middot; Multi-Agent Intelligence
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">
                     AI Framework

--- a/resources/views/features/machine-payments.blade.php
+++ b/resources/views/features/machine-payments.blade.php
@@ -34,7 +34,7 @@
                 </div>
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.13.0 &middot; Multi-Rail Payments
+                    v7.13.1 &middot; Multi-Rail Payments
                 </div>
                 <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
                     Machine Payments Protocol

--- a/resources/views/features/x402-protocol.blade.php
+++ b/resources/views/features/x402-protocol.blade.php
@@ -36,7 +36,7 @@
                 </div>
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.13.0 &middot; Production Ready
+                    v7.13.1 &middot; Production Ready
                 </div>
                 <h1 class="font-display text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">x402 Protocol</h1>
                 <p class="text-lg text-slate-400 max-w-3xl mx-auto mb-8">

--- a/resources/views/support/faq.blade.php
+++ b/resources/views/support/faq.blade.php
@@ -13,7 +13,7 @@
     $faqData = [
         [
             'question' => 'What is the current status of ' . config('brand.name', 'Zelta') . '?',
-            'answer' => config('brand.name', 'Zelta') . ' v7.13.0 is a fully-featured open-source core banking platform with 61 domain modules, including a public OAuth-protected MCP server for AI agents. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
+            'answer' => config('brand.name', 'Zelta') . ' v7.13.1 is a fully-featured open-source core banking platform with 61 domain modules, including a public OAuth-protected MCP server for AI agents. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
         ],
         [
             'question' => 'Can I use real money on the platform?',
@@ -127,7 +127,7 @@
                     </button>
                     <div class="faq-answer px-6 py-4 bg-white rounded-b-lg">
                         <p class="text-slate-500">
-                            {{ config('brand.name', 'Zelta') }} is a fully-featured open-source core banking platform at v7.13.0. The sandbox environment lets you:
+                            {{ config('brand.name', 'Zelta') }} is a fully-featured open-source core banking platform at v7.13.1. The sandbox environment lets you:
                         </p>
                         <ul class="list-disc list-inside mt-2 text-slate-500 space-y-1">
                             <li>Explore 61 domain modules including DeFi, cross-chain, privacy, MCP, and rewards</li>


### PR DESCRIPTION
## Summary

Surfaces v7.13.1 — USDT enablement and the Solana Pay QR spec fix — on the public site and in the docs.

Single bundled PR for the patch release:

- **Public /changelog** — new v7.13.1 entry (USDT, Solana Pay QR, Pimlico operational note)
- **docs/VERSION_ROADMAP.md** — full v7.13.1 entry with operational follow-up; footer bumped to 7.13.1 / May 15
- **docs/BACKEND_HANDOVER.md** — drop the "USDC only for v1" line (l. 518); both stablecoins are accepted now
- **CLAUDE.md** — pitfall row under Wallet Send pointing future asset additions at the `PaymentAsset` enum + `SolanaTokens::mintFor()` pattern
- **Public views** — bump v7.13.0 → v7.13.1 on the current-version badges (developers/index, support/faq, and the four feature pages: ai-framework, agent-protocol, machine-payments, x402-protocol)

Tagging v7.13.1 against `main` once this merges.

## Test plan

- [x] Pure Blade + Markdown content
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)