### PR TITLE
fix(wallet): align prepare network validator with PaymentNetwork enum so SOLANA uppercase is accepted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,7 @@ Non-custodial flow. Privy holds the keys (passkey-controlled smart accounts on E
 | Idempotency key on the wrong field | It's an HTTP header (`Idempotency-Key`), not a body field — matches `/pay`/`/pay/card` |
 | `quote_id` vs `quoteId` | Wire contract is camelCase across the board (matches mobile RN/TS request types) |
 | Adding a new send/receive asset | Add the case to `App\Domain\MobilePayment\Enums\PaymentAsset` (decimals + label) AND make sure `EvmTokens` / `SolanaTokens` have the contract / mint. The receive QR builder uses `SolanaTokens::mintFor()` per Solana Pay spec — `spl-token` must be the mint, not the symbol. v7.13.1 added USDT this way |
+| Network casing on quote vs prepare | Both endpoints validate against `PaymentNetwork::values()` — case-sensitive: `SOLANA`/`TRON` uppercase, `polygon`/`base`/`arbitrum`/`ethereum` lowercase. Pre-existing enum inconsistency; quote response is `{ success, data: { quote_id, network, ... } }` (snake_case keys inside `data`), but request bodies on prepare/submit are camelCase (`quoteId`, `intentId`). Mobile must send the exact enum value (no normalisation) and the exact field name |
 
 ## IAP / Subscriptions (v7.13.0+)
 

--- a/app/Http/Controllers/Api/Wallet/MobileWalletController.php
+++ b/app/Http/Controllers/Api/Wallet/MobileWalletController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers\Api\Wallet;
 
 use App\Domain\Account\Models\BlockchainAddress;
 use App\Domain\MobilePayment\Enums\PaymentIntentStatus;
+use App\Domain\MobilePayment\Enums\PaymentNetwork;
 use App\Domain\MobilePayment\Models\PaymentIntent;
 use App\Domain\MobilePayment\Services\ActivityFeedService;
 use App\Domain\MobilePayment\Services\TransactionDetailService;
@@ -33,6 +34,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\Rule;
 use InvalidArgumentException;
 use OpenApi\Attributes as OA;
 use Throwable;
@@ -603,7 +605,7 @@ class MobileWalletController extends Controller
         new OA\Property(property: 'to', type: 'string', example: '0x1234...abcd or base58 Solana pubkey'),
         new OA\Property(property: 'token', type: 'string', enum: ['USDC', 'USDT'], example: 'USDC'),
         new OA\Property(property: 'amount', type: 'string', example: '1.50', description: 'Decimal major units. Send "1" or "1.5"; not "1000000".'),
-        new OA\Property(property: 'network', type: 'string', example: 'polygon', description: 'solana | polygon | base | arbitrum | ethereum'),
+        new OA\Property(property: 'network', type: 'string', example: 'SOLANA', description: 'SOLANA | TRON | polygon | base | arbitrum | ethereum (case-sensitive — must match the exact PaymentNetwork enum value, same as the value returned in quote response)'),
         new OA\Property(property: 'quoteId', type: 'string', example: 'q_abc123'),
         ]))
     )]
@@ -617,7 +619,7 @@ class MobileWalletController extends Controller
             'to'      => ['required', 'string', 'min:26', 'max:128'],
             'token'   => ['required', 'string', 'in:USDC,USDT'],
             'amount'  => ['required', 'string'],
-            'network' => ['required', 'string', 'in:solana,polygon,base,arbitrum,ethereum'],
+            'network' => ['required', 'string', Rule::enum(PaymentNetwork::class)],
             'quoteId' => ['required', 'string', 'max:64'],
         ]);
 

--- a/tests/Feature/Api/Wallet/WalletTransactionPrepareTest.php
+++ b/tests/Feature/Api/Wallet/WalletTransactionPrepareTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\Wallet;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+/**
+ * Regression coverage for the prepare endpoint's `network` validator.
+ *
+ * The quote endpoint accepts `network=SOLANA` because it validates against
+ * `PaymentNetwork::values()`. Prepare used to be hardcoded
+ * `in:solana,polygon,base,arbitrum,ethereum` which both rejected the
+ * canonical `SOLANA` casing AND accepted strings that aren't valid enum
+ * values. These tests lock in the post-fix contract: both endpoints share
+ * the same case-sensitive `PaymentNetwork` allow-list.
+ *
+ * We only assert the *validator* — the full prepare flow needs a registered
+ * sender address + Pimlico paymaster, etc. `assertJsonMissingValidationErrors`
+ * is enough to prove the network rule accepts/rejects what it should.
+ */
+class WalletTransactionPrepareTest extends TestCase
+{
+    protected User $user;
+
+    protected string $token;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+
+        $this->user = User::factory()->create();
+        $this->token = $this->user->createToken('test-token', ['read', 'write', 'delete'])->plainTextToken;
+    }
+
+    public function test_prepare_accepts_network_solana_uppercase(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/wallet/transactions/prepare', [
+                'to'      => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+                'token'   => 'USDC',
+                'amount'  => '1.50',
+                'network' => 'SOLANA',
+                'quoteId' => 'q_test_solana_upper',
+            ]);
+
+        // Response may be 422 for downstream reasons (no sender address,
+        // missing paymaster, etc.) — we only care that the `network` field
+        // itself is not the reason.
+        $response->assertJsonMissingValidationErrors(['network']);
+    }
+
+    public function test_prepare_accepts_network_polygon_lowercase(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/wallet/transactions/prepare', [
+                'to'      => '0x742d35cc6634c0532925a3b844bc454e4438f44e',
+                'token'   => 'USDC',
+                'amount'  => '1.50',
+                'network' => 'polygon',
+                'quoteId' => 'q_test_polygon_lower',
+            ]);
+
+        $response->assertJsonMissingValidationErrors(['network']);
+    }
+
+    public function test_prepare_rejects_network_solana_lowercase(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/wallet/transactions/prepare', [
+                'to'      => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+                'token'   => 'USDC',
+                'amount'  => '1.50',
+                'network' => 'solana',
+                'quoteId' => 'q_test_solana_lower',
+            ]);
+
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors(['network']);
+    }
+
+    public function test_prepare_rejects_network_ethereum_uppercase(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/wallet/transactions/prepare', [
+                'to'      => '0x742d35cc6634c0532925a3b844bc454e4438f44e',
+                'token'   => 'USDC',
+                'amount'  => '1.50',
+                'network' => 'ETHEREUM',
+                'quoteId' => 'q_test_ethereum_upper',
+            ]);
+
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors(['network']);
+    }
+
+    public function test_prepare_rejects_unknown_network(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/wallet/transactions/prepare', [
+                'to'      => '0x742d35cc6634c0532925a3b844bc454e4438f44e',
+                'token'   => 'USDC',
+                'amount'  => '1.50',
+                'network' => 'FOOBAR',
+                'quoteId' => 'q_test_foobar',
+            ]);
+
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors(['network']);
+    }
+}


### PR DESCRIPTION
## Summary
- Quote endpoint accepts `network=SOLANA` (matching `PaymentNetwork::SOLANA`), but prepare's hardcoded `'in:solana,polygon,base,arbitrum,ethereum'` rule rejected uppercase and accepted strings that aren't valid enum cases. Mobile got 422 "selected network is invalid" sending the same casing it sends to quote.
- Switched prepare's `network` rule to `Rule::enum(PaymentNetwork::class)`. The existing `$networkKey = strtolower(...)` downstream of validation is preserved, so internal lowercase-string branching is unchanged.
- Updated CLAUDE.md Wallet Send pitfall table to lock in the casing contract: `SOLANA`/`TRON` uppercase, `polygon`/`base`/`arbitrum`/`ethereum` lowercase, identical on quote/prepare/submit, plus the canonical quote-response shape (`data.quote_id`) and the prepare/submit request shape (`quoteId`/`intentId` camelCase).

## Test plan
- [x] Pest: `network=SOLANA` on prepare — no network validation error
- [x] Pest: `network=polygon` on prepare — no network validation error
- [x] Pest: `network=solana` (lowercase) — rejected
- [x] Pest: `network=ETHEREUM` (uppercase) — rejected
- [x] Pest: `network=FOOBAR` — rejected
- [x] Pest: existing `WalletTransactionQuoteTest` still passes
- [x] PHPStan level 8 clean
- [x] CS Fixer clean

Generated with Claude Code