### PR TITLE
fix(privacy): catch RuntimeException in getMerkleRoot and return 503 instead of 500

### DIFF
--- a/app/Http/Controllers/Api/Privacy/PrivacyController.php
+++ b/app/Http/Controllers/Api/Privacy/PrivacyController.php
@@ -19,6 +19,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use InvalidArgumentException;
 use OpenApi\Attributes as OA;
+use RuntimeException;
 
 /**
  * Privacy API Controller.
@@ -88,6 +89,10 @@ class PrivacyController extends Controller
         response: 401,
         description: 'Unauthenticated'
     )]
+    #[OA\Response(
+        response: 503,
+        description: 'Privacy pool not available'
+    )]
     public function getMerkleRoot(Request $request): JsonResponse
     {
         // Accept both ?network= and ?chain_id= for mobile compatibility
@@ -116,6 +121,13 @@ class PrivacyController extends Controller
                     'supported_networks' => $this->merkleService->getSupportedNetworks(),
                 ],
             ], 400);
+        } catch (RuntimeException $e) {
+            return response()->json([
+                'error' => [
+                    'code'    => 'ERR_PRIVACY_310',
+                    'message' => 'Privacy pool is not available on this deployment.',
+                ],
+            ], 503);
         }
     }
 

--- a/tests/Feature/Api/Privacy/MerkleRootEndpointTest.php
+++ b/tests/Feature/Api/Privacy/MerkleRootEndpointTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\Privacy;
+
+use App\Domain\Privacy\Contracts\MerkleTreeServiceInterface;
+use App\Domain\Privacy\Services\DemoMerkleTreeService;
+use App\Domain\Privacy\ValueObjects\MerklePath;
+use App\Domain\Privacy\ValueObjects\MerkleRoot;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Laravel\Sanctum\Sanctum;
+use RuntimeException;
+use Tests\TestCase;
+
+/**
+ * Covers the /api/v1/privacy/merkle-root endpoint behaviour for both demo
+ * (happy path) and production (provider-disabled) bindings, including the
+ * mobile-friendly ?chain_id= alias.
+ */
+class MerkleRootEndpointTest extends TestCase
+{
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+
+        $this->user = User::factory()->create();
+    }
+
+    public function test_it_returns_200_with_the_merkle_root_in_demo_mode(): void
+    {
+        $this->app->bind(MerkleTreeServiceInterface::class, DemoMerkleTreeService::class);
+
+        Sanctum::actingAs($this->user, ['read', 'write', 'delete']);
+
+        $response = $this->getJson('/api/v1/privacy/merkle-root?network=polygon');
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'data' => [
+                    'root',
+                    'network',
+                    'leaf_count',
+                    'tree_depth',
+                    'block_number',
+                    'synced_at',
+                ],
+            ])
+            ->assertJsonPath('data.network', 'polygon');
+    }
+
+    public function test_it_returns_503_err_privacy_310_when_the_production_provider_throws(): void
+    {
+        $this->app->bind(
+            MerkleTreeServiceInterface::class,
+            fn () => new ThrowingMerkleTreeService(),
+        );
+
+        Sanctum::actingAs($this->user, ['read', 'write', 'delete']);
+
+        $response = $this->getJson('/api/v1/privacy/merkle-root?network=polygon');
+
+        $response->assertStatus(503)
+            ->assertExactJson([
+                'error' => [
+                    'code'    => 'ERR_PRIVACY_310',
+                    'message' => 'Privacy pool is not available on this deployment.',
+                ],
+            ]);
+
+        // No stack trace, file path, or implementation detail leaks.
+        $payload = $response->getContent();
+        $this->assertIsString($payload);
+        $this->assertStringNotContainsString('not implemented', $payload);
+        $this->assertStringNotContainsString('Trace', $payload);
+        $this->assertStringNotContainsString('MerkleTreeService', $payload);
+    }
+
+    public function test_it_accepts_chain_id_as_well_as_network_and_gives_the_same_503_when_the_provider_is_disabled(): void
+    {
+        $this->app->bind(
+            MerkleTreeServiceInterface::class,
+            fn () => new ThrowingMerkleTreeService(),
+        );
+
+        Sanctum::actingAs($this->user, ['read', 'write', 'delete']);
+
+        $networkResponse = $this->getJson('/api/v1/privacy/merkle-root?network=polygon');
+        $chainIdResponse = $this->getJson('/api/v1/privacy/merkle-root?chain_id=polygon');
+
+        $networkResponse->assertStatus(503)
+            ->assertJsonPath('error.code', 'ERR_PRIVACY_310');
+
+        $chainIdResponse->assertStatus(503)
+            ->assertJsonPath('error.code', 'ERR_PRIVACY_310')
+            ->assertJsonPath(
+                'error.message',
+                'Privacy pool is not available on this deployment.',
+            );
+    }
+
+    public function test_it_returns_400_for_missing_network_param(): void
+    {
+        Sanctum::actingAs($this->user, ['read', 'write', 'delete']);
+
+        $response = $this->getJson('/api/v1/privacy/merkle-root');
+
+        $response->assertStatus(400)
+            ->assertJsonPath('error.code', 'ERR_PRIVACY_306');
+    }
+}
+
+/**
+ * Test double that mimics the production binding by throwing the same
+ * RuntimeException the real MerkleTreeService raises when not configured.
+ */
+final class ThrowingMerkleTreeService implements MerkleTreeServiceInterface
+{
+    public function getMerkleRoot(string $network): MerkleRoot
+    {
+        throw new RuntimeException(
+            'Production Merkle tree sync not implemented. Use DemoMerkleTreeService for development.'
+        );
+    }
+
+    public function getMerklePath(string $commitment, string $network): MerklePath
+    {
+        throw new RuntimeException('Production Merkle path fetch not implemented.');
+    }
+
+    public function verifyCommitment(string $commitment, MerklePath $path): bool
+    {
+        return false;
+    }
+
+    public function supportsNetwork(string $network): bool
+    {
+        return in_array($network, $this->getSupportedNetworks(), true);
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getSupportedNetworks(): array
+    {
+        return ['polygon', 'base', 'arbitrum'];
+    }
+
+    public function syncTree(string $network): MerkleRoot
+    {
+        throw new RuntimeException('Production Merkle tree sync not implemented.');
+    }
+
+    public function getTreeDepth(): int
+    {
+        return 32;
+    }
+
+    public function getProviderName(): string
+    {
+        return 'production';
+    }
+}

--- a/tests/Feature/Api/Privacy/MerkleRootEndpointTest.php
+++ b/tests/Feature/Api/Privacy/MerkleRootEndpointTest.php
@@ -6,11 +6,10 @@ namespace Tests\Feature\Api\Privacy;
 
 use App\Domain\Privacy\Contracts\MerkleTreeServiceInterface;
 use App\Domain\Privacy\Services\DemoMerkleTreeService;
-use App\Domain\Privacy\ValueObjects\MerklePath;
-use App\Domain\Privacy\ValueObjects\MerkleRoot;
 use App\Models\User;
 use Illuminate\Support\Facades\Cache;
 use Laravel\Sanctum\Sanctum;
+use Mockery;
 use RuntimeException;
 use Tests\TestCase;
 
@@ -55,10 +54,7 @@ class MerkleRootEndpointTest extends TestCase
 
     public function test_it_returns_503_err_privacy_310_when_the_production_provider_throws(): void
     {
-        $this->app->bind(
-            MerkleTreeServiceInterface::class,
-            fn () => new ThrowingMerkleTreeService(),
-        );
+        $this->bindThrowingMerkleService();
 
         Sanctum::actingAs($this->user, ['read', 'write', 'delete']);
 
@@ -82,10 +78,7 @@ class MerkleRootEndpointTest extends TestCase
 
     public function test_it_accepts_chain_id_as_well_as_network_and_gives_the_same_503_when_the_provider_is_disabled(): void
     {
-        $this->app->bind(
-            MerkleTreeServiceInterface::class,
-            fn () => new ThrowingMerkleTreeService(),
-        );
+        $this->bindThrowingMerkleService();
 
         Sanctum::actingAs($this->user, ['read', 'write', 'delete']);
 
@@ -112,56 +105,20 @@ class MerkleRootEndpointTest extends TestCase
         $response->assertStatus(400)
             ->assertJsonPath('error.code', 'ERR_PRIVACY_306');
     }
-}
-
-/**
- * Test double that mimics the production binding by throwing the same
- * RuntimeException the real MerkleTreeService raises when not configured.
- */
-final class ThrowingMerkleTreeService implements MerkleTreeServiceInterface
-{
-    public function getMerkleRoot(string $network): MerkleRoot
-    {
-        throw new RuntimeException(
-            'Production Merkle tree sync not implemented. Use DemoMerkleTreeService for development.'
-        );
-    }
-
-    public function getMerklePath(string $commitment, string $network): MerklePath
-    {
-        throw new RuntimeException('Production Merkle path fetch not implemented.');
-    }
-
-    public function verifyCommitment(string $commitment, MerklePath $path): bool
-    {
-        return false;
-    }
-
-    public function supportsNetwork(string $network): bool
-    {
-        return in_array($network, $this->getSupportedNetworks(), true);
-    }
 
     /**
-     * @return array<string>
+     * Binds a Mockery double for MerkleTreeServiceInterface that throws the
+     * same RuntimeException the real production binding raises when the
+     * provider isn't configured for this deployment.
      */
-    public function getSupportedNetworks(): array
+    private function bindThrowingMerkleService(): void
     {
-        return ['polygon', 'base', 'arbitrum'];
-    }
+        $mock = Mockery::mock(MerkleTreeServiceInterface::class);
+        $mock->shouldReceive('getMerkleRoot')
+            ->andThrow(new RuntimeException(
+                'Production Merkle tree sync not implemented. Use DemoMerkleTreeService for development.'
+            ));
 
-    public function syncTree(string $network): MerkleRoot
-    {
-        throw new RuntimeException('Production Merkle tree sync not implemented.');
-    }
-
-    public function getTreeDepth(): int
-    {
-        return 32;
-    }
-
-    public function getProviderName(): string
-    {
-        return 'production';
+        $this->app->instance(MerkleTreeServiceInterface::class, $mock);
     }
 }


### PR DESCRIPTION
## Summary
- `GET /api/v1/privacy/merkle-root` returned 500 when `MERKLE_PROVIDER` resolved to the production binding (whose `fetchMerkleRootFromChain()` throws `RuntimeException`). Mobile shield-feature gating needs a stable 4xx/5xx with a code.
- Controller now catches `RuntimeException` and returns **HTTP 503** with code `ERR_PRIVACY_310` and message `"Privacy pool is not available on this deployment."`
- Service layer unchanged — RuntimeException remains the correct "not configured" signal from the provider.

## Test plan
- [x] Pest: demo provider → 200
- [x] Pest: throwing provider → 503 with `error.code === \"ERR_PRIVACY_310\"`
- [x] Pest: `?chain_id=` query form parity
- [x] Pest: missing network param → existing 400 still works
- [x] PHPStan level 8 clean
- [x] CS Fixer clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)