### PR TITLE
docs(v7.13.2): roadmap entry + public changelog + version badge bumps

### DIFF
--- a/docs/VERSION_ROADMAP.md
+++ b/docs/VERSION_ROADMAP.md
@@ -3272,6 +3272,20 @@ Findings #1-2 fixed in v7.1.1, findings #3-15 fixed in this release:
 
 ---
 
+## Version 7.13.2 — Mobile Wallet Bug-Fix Patch (May 2026)
+
+**Theme**: Three small, independent server-side fixes surfaced by mobile Build #8 — Solana send unblocked, receipts work for non-intent transactions, privacy merkle-root gives a clean 4xx/5xx instead of a 500.
+
+### Delivered Features
+- Wallet prepare network-casing fix (#1064). `POST /api/v1/wallet/transactions/prepare` previously validated `network` against a hard-coded `'in:solana,polygon,base,arbitrum,ethereum'` rule (lowercase-only), while the quote endpoint used `PaymentNetwork::from($network)` which only accepts the canonical enum values — `SOLANA`/`TRON` uppercase, `polygon`/`base`/`arbitrum`/`ethereum` lowercase. Mobile sending `network: "SOLANA"` (as it does for quote) was rejected on prepare with "selected network is invalid", and the lowercase string `"solana"` wasn't a valid enum case at all. Both endpoints now share `Rule::enum(PaymentNetwork::class)`, so the wire contract is identical and `Rule::enum` is the single source of truth. The downstream `$networkKey = strtolower(...)` normalisation inside `prepareTransaction` is unchanged (internal lowercase-string branching keeps working).
+- Receipt endpoint Solana-inbound fallback (#1066). `POST /api/v1/transactions/{txId}/receipt` previously looked up `PaymentIntent::where('public_id', $txId)`, but Solana inbound USDC/USDT lands in `activity_feed_items` + `blockchain_address_transactions` directly via `HeliusTransactionProcessor` — no `PaymentIntent` exists, the lookup returned null, and the controller emitted 422 "Receipt can only be generated for confirmed transactions" even though the activity feed reported the same transaction as `confirmed`. `ReceiptService::generateReceipt` now resolves the `ActivityFeedItem` first (matching the unified ID mobile already gets back from `GET /wallet/transactions` and `GET /transactions/{id}`), then either pulls merchant + fee details from the linked `PaymentIntent` via `reference_type`/`reference_id` (preserving merchant-payment behaviour) or builds the receipt from the activity row + Helius `metadata.tx_hash` / `metadata.fee_usd` when no intent exists. `payment_intent_id` was already nullable in the schema; non-intent receipts use `(user_id, tx_hash)` for idempotency.
+- Privacy merkle-root 503 guard (#1065). `GET /api/v1/privacy/merkle-root?network=…` or `?chain_id=…` previously emitted an uncaught `RuntimeException` from `MerkleTreeService::fetchMerkleRootFromChain` (thrown by the production binding's "not implemented" path) as a generic HTTP 500. The controller now catches `RuntimeException` and returns `HTTP 503 { error: { code: "ERR_PRIVACY_310", message: "Privacy pool is not available on this deployment." } }`, giving mobile's shield-feature gating a stable code to branch on. The service layer is unchanged — `RuntimeException` remains the correct "not configured" signal from the provider; only the controller translation is new.
+
+### CLAUDE.md
+- Wallet Send pitfall table gains a "Network casing on quote vs prepare" row pinning the contract: both endpoints validate against `PaymentNetwork::values()` (case-sensitive); response is `{ success, data: { quote_id, network, ... } }` (snake_case keys inside `data`); request bodies on prepare/submit are camelCase (`quoteId`, `intentId`). Future asset/network additions inherit this convention automatically.
+
+---
+
 ## Version 7.13.0 — Plan B Subscriptions / In-App Purchases (May 2026)
 
 **Theme**: Mobile-driven IAP subscriptions (Apple App Store + Google Play) with a hardened revenue path — webhook-replay-safe ingestion, trial-card-fingerprint anti-abuse, GDPR consent log, and ERR_SUB_002 mobile-error contract.
@@ -3365,5 +3379,5 @@ Embeddable JS widget that renders Zelta's 402 payment flow inside the partner's 
 
 ---
 
-*Document Version: 7.13.1*
-*Updated: May 15, 2026 (v7.13.1 USDT enablement + Solana Pay QR spec fix)*
+*Document Version: 7.13.2*
+*Updated: May 15, 2026 (v7.13.2 mobile wallet bug-fix patch — Solana send + receipts + privacy gating)*

--- a/resources/views/changelog.blade.php
+++ b/resources/views/changelog.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'Changelog | ' . config('brand.name', 'Zelta'),
-        'description' => 'Release history for the Zelta core banking platform. Track every feature shipped, bug fixed, and improvement made — v7.0 through v7.13.0.',
+        'description' => 'Release history for the Zelta core banking platform. Track every feature shipped, bug fixed, and improvement made — v7.0 through v7.13.2.',
         'keywords' => 'changelog, release notes, updates, ' . config('brand.name', 'Zelta') . ', version history, core banking',
     ])
 
@@ -43,6 +43,19 @@
 
             @php
                 $releases = [
+                    [
+                        'version' => 'v7.13.2',
+                        'date' => 'May 15, 2026',
+                        'label' => 'Mobile Wallet Bug-Fix Patch — Solana Send, Receipts, Privacy Gating',
+                        'label_color' => 'slate',
+                        'badge_color' => 'bg-slate-100 text-slate-700 border-slate-200',
+                        'dot_color' => 'bg-slate-500',
+                        'items' => [
+                            'Wallet send network-casing fix. <code>POST /api/v1/wallet/transactions/prepare</code> previously validated <code>network</code> against a hard-coded <code>in:solana,polygon,base,arbitrum,ethereum</code> list (lowercase only) while the <code>quote</code> endpoint accepted the canonical <code>PaymentNetwork</code> enum values (<code>SOLANA</code> / <code>TRON</code> uppercase, <code>polygon</code> / <code>base</code> / <code>arbitrum</code> / <code>ethereum</code> lowercase). Mobile sending <code>network: "SOLANA"</code> to both endpoints (as it does for quote) was rejected with "selected network is invalid" on prepare, and lowercase <code>"solana"</code> wasn\'t a valid enum case at all. Both endpoints now reference <code>Rule::enum(PaymentNetwork::class)</code> so the wire contract is identical end-to-end. CLAUDE.md gains a pitfall row locking the network-casing + snake/camel field-name conventions for future asset additions.',
+                            'Receipt endpoint now works for Solana inbound transfers and any non-intent activity. <code>POST /api/v1/transactions/{txId}/receipt</code> previously looked up <code>PaymentIntent::where(\'public_id\', $txId)</code>, but Solana inbound USDC and USDT are written directly to <code>activity_feed_items</code> + <code>blockchain_address_transactions</code> by <code>HeliusTransactionProcessor</code> with no <code>PaymentIntent</code> in between. The receipt service now resolves the <code>ActivityFeedItem</code> first (matching the unified ID mobile already gets back from <code>GET /wallet/transactions</code> and <code>GET /transactions/{id}</code>), then either pulls merchant + fee details from the linked <code>PaymentIntent</code> (preserving existing merchant-payment behaviour) or builds the receipt from the activity row + Helius <code>metadata.tx_hash</code> / <code>metadata.fee_usd</code> when no intent exists. <code>payment_intent_id</code> was already nullable in the schema; idempotency keys on <code>(user_id, tx_hash)</code> for non-intent receipts.',
+                            'Privacy merkle-root endpoint now returns a clean 503 instead of a generic 500. <code>GET /api/v1/privacy/merkle-root?network=…</code> or <code>?chain_id=…</code> previously surfaced an uncaught <code>RuntimeException</code> from <code>MerkleTreeService::fetchMerkleRootFromChain</code> when the provider binding wasn\'t operational. The controller now catches and returns <code>HTTP 503 { error: { code: "ERR_PRIVACY_310", message: "Privacy pool is not available on this deployment." } }</code> so mobile\'s shield-feature gating has a stable code to branch on without parsing 500s.',
+                        ],
+                    ],
                     [
                         'version' => 'v7.13.1',
                         'date' => 'May 15, 2026',

--- a/resources/views/developers/index.blade.php
+++ b/resources/views/developers/index.blade.php
@@ -137,7 +137,7 @@
                 <div class="text-center">
                     <div class="inline-flex items-center px-4 py-2 bg-white/10 backdrop-blur-sm rounded-full text-sm mb-6">
                         <span class="w-2 h-2 bg-green-400 rounded-full mr-2 animate-pulse"></span>
-                        <span>v7.13.1 Documentation — 61 Domains, 1,400+ Routes, GraphQL + REST + MCP + x402</span>
+                        <span>v7.13.2 Documentation — 61 Domains, 1,400+ Routes, GraphQL + REST + MCP + x402</span>
                     </div>
                     <h1 class="text-5xl md:text-7xl font-bold mb-6 bg-clip-text text-transparent bg-gradient-to-r from-white to-blue-200">
                         Build with 1,400+ API Routes
@@ -177,8 +177,8 @@
                     <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                     </svg>
-                    <span class="font-medium">v7.13.1 Released:</span>
-                    <span class="ml-2">Mobile-driven IAP subscriptions (Apple StoreKit 2 + Google Play RTDN) with the <code class="code-font">ERR_SUB_002</code> mobile error contract and Apple Root CA G3 pinned JWS verification. Non-custodial wallet send via Privy passkey-controlled smart accounts (v7.12.0) is live. 61 DDD domains, 1,400+ API routes, GraphQL (45 domains), ISO 20022, ISO 8583, x402 Protocol, public MCP server.</span>
+                    <span class="font-medium">v7.13.2 Released:</span>
+                    <span class="ml-2">Mobile wallet bug-fix patch — Solana send unblocked (<code class="code-font">PaymentNetwork</code> enum casing aligned across quote and prepare), receipts work for Solana inbound and any non-intent activity (routed through <code class="code-font">ActivityFeedItem</code>), and privacy merkle-root returns <code class="code-font">503 ERR_PRIVACY_310</code> instead of an uncaught 500. USDT (v7.13.1), mobile-driven IAP subscriptions (v7.13.0), and non-custodial wallet send via Privy (v7.12.0) all live. 61 DDD domains, 1,400+ API routes, GraphQL (45 domains), ISO 20022, ISO 8583, x402 Protocol, public MCP server.</span>
                 </div>
             </div>
         </section>

--- a/resources/views/features/agent-protocol.blade.php
+++ b/resources/views/features/agent-protocol.blade.php
@@ -38,7 +38,7 @@
                 ]])
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-cyan-400 rounded-full mr-2"></span>
-                    v7.13.1 &middot; Autonomous Agent Commerce
+                    v7.13.2 &middot; Autonomous Agent Commerce
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">
                     Agent Protocol

--- a/resources/views/features/ai-framework.blade.php
+++ b/resources/views/features/ai-framework.blade.php
@@ -38,7 +38,7 @@
                 ]])
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.13.1 &middot; Multi-Agent Intelligence
+                    v7.13.2 &middot; Multi-Agent Intelligence
                 </div>
                 <h1 class="font-display text-4xl md:text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">
                     AI Framework

--- a/resources/views/features/machine-payments.blade.php
+++ b/resources/views/features/machine-payments.blade.php
@@ -34,7 +34,7 @@
                 </div>
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.13.1 &middot; Multi-Rail Payments
+                    v7.13.2 &middot; Multi-Rail Payments
                 </div>
                 <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
                     Machine Payments Protocol

--- a/resources/views/features/x402-protocol.blade.php
+++ b/resources/views/features/x402-protocol.blade.php
@@ -36,7 +36,7 @@
                 </div>
                 <div class="inline-flex items-center px-3 py-1 bg-white/10 backdrop-blur-sm rounded-full text-sm text-slate-300 mb-6">
                     <span class="w-2 h-2 bg-emerald-400 rounded-full mr-2"></span>
-                    v7.13.1 &middot; Production Ready
+                    v7.13.2 &middot; Production Ready
                 </div>
                 <h1 class="font-display text-5xl lg:text-6xl font-extrabold text-white tracking-tight mb-6">x402 Protocol</h1>
                 <p class="text-lg text-slate-400 max-w-3xl mx-auto mb-8">

--- a/resources/views/support/faq.blade.php
+++ b/resources/views/support/faq.blade.php
@@ -13,7 +13,7 @@
     $faqData = [
         [
             'question' => 'What is the current status of ' . config('brand.name', 'Zelta') . '?',
-            'answer' => config('brand.name', 'Zelta') . ' v7.13.1 is a fully-featured open-source core banking platform with 61 domain modules, including a public OAuth-protected MCP server for AI agents. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
+            'answer' => config('brand.name', 'Zelta') . ' v7.13.2 is a fully-featured open-source core banking platform with 61 domain modules, including a public OAuth-protected MCP server for AI agents. The public instance runs in sandbox mode with test data so you can explore every feature freely. No real money is processed in the sandbox environment.'
         ],
         [
             'question' => 'Can I use real money on the platform?',
@@ -127,7 +127,7 @@
                     </button>
                     <div class="faq-answer px-6 py-4 bg-white rounded-b-lg">
                         <p class="text-slate-500">
-                            {{ config('brand.name', 'Zelta') }} is a fully-featured open-source core banking platform at v7.13.1. The sandbox environment lets you:
+                            {{ config('brand.name', 'Zelta') }} is a fully-featured open-source core banking platform at v7.13.2. The sandbox environment lets you:
                         </p>
                         <ul class="list-disc list-inside mt-2 text-slate-500 space-y-1">
                             <li>Explore 61 domain modules including DeFi, cross-chain, privacy, MCP, and rewards</li>


### PR DESCRIPTION
## Summary
- Surfaces v7.13.2 — the mobile wallet bug-fix patch — on the public site and in the docs. Mirrors the v7.13.1 changelog PR pattern (#1063).
- **VERSION_ROADMAP** — full v7.13.2 entry covering the three merged fixes: #1064 wallet prepare network-casing aligned with \`PaymentNetwork\` enum, #1066 receipt service routed through \`ActivityFeedItem\` so Solana inbound works, #1065 privacy merkle-root returns 503 \`ERR_PRIVACY_310\` instead of 500. Footer bumped to 7.13.2 / May 15.
- **Public /changelog** — new v7.13.2 entry at the top of the timeline; SEO description bumped through v7.13.2.
- **Public version badges** — v7.13.1 → v7.13.2 across the developers/index banner + status alert, support/faq (status + sandbox answers), and the four feature pages (ai-framework, agent-protocol, machine-payments, x402-protocol). The developers/index Released banner now describes the bug-fix scope rather than the v7.13.0 IAP blurb.
- CLAUDE.md is unchanged here — the Wallet Send pitfall row was added in #1064 as part of the network-casing fix.

Tagging v7.13.2 against \`main\` once this merges.

## Test plan
- [x] Pure Blade + Markdown content
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)