### PR TITLE
fix: persist notification feed rows for users with no registered device

### DIFF
--- a/app/Domain/Mobile/Services/PushNotificationService.php
+++ b/app/Domain/Mobile/Services/PushNotificationService.php
@@ -50,6 +50,25 @@ class PushNotificationService
 
         $results = [];
 
+        if ($devices->isEmpty()) {
+            // No push-capable device registered (e.g. after a Privy account
+            // switch the device row is still bound to the previous user).
+            // Persist the in-app notification record anyway so the notification
+            // feed and unread count stay consistent — push delivery resumes
+            // once a device is registered.
+            $notification = $this->createNotification(
+                $user,
+                null,
+                $type,
+                $title,
+                $body,
+                $data,
+                $scheduledAt
+            );
+
+            $results['no_device'] = ['status' => 'recorded', 'notification_id' => $notification->id];
+        }
+
         foreach ($devices as $device) {
             $notification = $this->createNotification(
                 $user,
@@ -121,7 +140,7 @@ class PushNotificationService
      */
     private function createNotification(
         User $user,
-        MobileDevice $device,
+        ?MobileDevice $device,
         string $type,
         string $title,
         string $body,
@@ -130,7 +149,7 @@ class PushNotificationService
     ): MobilePushNotification {
         return MobilePushNotification::create([
             'user_id'           => $user->id,
-            'mobile_device_id'  => $device->id,
+            'mobile_device_id'  => $device?->id,
             'notification_type' => $type,
             'title'             => $title,
             'body'              => $body,

--- a/tests/Unit/Domain/Mobile/Services/PushNotificationServiceTest.php
+++ b/tests/Unit/Domain/Mobile/Services/PushNotificationServiceTest.php
@@ -207,6 +207,52 @@ describe('PushNotificationService', function () {
         expect($result['status'])->toBe('sent');
     });
 
+    it('persists a device-less notification record when the user has no registered device', function () {
+        $service = new PushNotificationService(null);
+        $user = App\Models\User::factory()->create();
+
+        expect(MobilePushNotification::where('user_id', $user->id)->count())->toBe(0);
+
+        $service->sendToUser(
+            $user,
+            MobilePushNotification::TYPE_TRANSACTION_RECEIVED,
+            'Payment Received',
+            'You received 5 USDC',
+        );
+
+        $notifications = MobilePushNotification::where('user_id', $user->id)->get();
+        expect($notifications)->toHaveCount(1);
+        expect($notifications->first()->mobile_device_id)->toBeNull();
+        expect($notifications->first()->notification_type)->toBe(MobilePushNotification::TYPE_TRANSACTION_RECEIVED);
+    });
+
+    it('keeps unread count consistent with the feed for device-less users', function () {
+        $service = new PushNotificationService(null);
+        $user = App\Models\User::factory()->create();
+
+        $service->sendToUser($user, MobilePushNotification::TYPE_TRANSACTION_RECEIVED, 'T', 'B');
+
+        expect($service->getUnreadCount($user))->toBe(1);
+        expect(MobilePushNotification::where('user_id', $user->id)->count())->toBe(1);
+    });
+
+    it('does not create a device-less duplicate when the user has a push-capable device', function () {
+        $service = new PushNotificationService(null);
+        $user = App\Models\User::factory()->create();
+        MobileDevice::factory()->create([
+            'user_id'    => $user->id,
+            'push_token' => 'fcm-token',
+            'platform'   => 'android',
+            'is_blocked' => false,
+        ]);
+
+        $service->sendToUser($user, MobilePushNotification::TYPE_TRANSACTION_RECEIVED, 'T', 'B');
+
+        $notifications = MobilePushNotification::where('user_id', $user->id)->get();
+        expect($notifications)->toHaveCount(1);
+        expect($notifications->first()->mobile_device_id)->not->toBeNull();
+    });
+
     it('returns error when device has no push token', function () {
         $user = App\Models\User::factory()->create();
         $device = MobileDevice::factory()->create([


### PR DESCRIPTION
## Summary
- Inbound transfers produced no `/api/v1/notifications` row when the user had no push-capable device. `MobilePushNotification` records were only created inside the per-device send loop, so a user whose device row is still bound to a previous identity (Privy account switch, see #1059) got zero feed entries — the in-app feed and unread count diverged from real on-chain activity.
- `PushNotificationService::sendToUser` now persists a device-independent notification record when the user has no registered device. The notification feed and unread count stay consistent; push delivery simply resumes once a device is registered.

## Context
Reported from mobile Build #8 (issue #4) and again in Build #9: confirmed inbound USDC/USDT on Solana appear in the tx list within seconds but produce no `/notifications` row. Push delivery itself remains gated on #1059 (device re-registration), but the in-app feed should never have depended on a registered device — that coupling is the bug fixed here.

## Test plan
- [x] `PushNotificationServiceTest` — new cases: device-less user gets a persisted record (`mobile_device_id` null), unread count stays consistent with the feed, no duplicate device-less row when a push-capable device exists
- [x] `ProcessHeliusWebhookJobTest` + `MobileListenersTest` regression — green
- [x] php-cs-fixer + PHPStan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)