### PR TITLE
chore(ci): align release workflows to repo-wide action versions

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -56,7 +56,7 @@ jobs:
         run: php builds/zelta.phar list
 
       - name: Upload PHAR artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: zelta-phar
           path: packages/zelta-cli/builds/zelta.phar
@@ -103,7 +103,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Download PHAR artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: zelta-phar
           path: packages/zelta-cli/npm-package

--- a/.github/workflows/sdk-python-release.yml
+++ b/.github/workflows/sdk-python-release.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 


### PR DESCRIPTION
## Summary
- `cli-release.yml` still pinned `actions/upload-artifact@v4` + `download-artifact@v4` while every other workflow already runs `@v7` / `@v8`. Bumped both together so the artifact backend version is consistent.
- `sdk-python-release.yml` lagged at `actions/setup-python@v5` → bumped to `@v6`.

Supersedes Dependabot PRs #950, #951, #952 — consolidated so the upload/download pair changes atomically (a v4↔v8 mismatch would break the CLI release).

## Risk
Low. These versions are already proven across `deploy.yml`, `03-test-suite.yml`, `05-performance.yml`, `06-build.yml`, `behat-tests.yml`, and `database-operations.yml` on every CI run. Both touched workflows are tag-triggered (`cli-v*`, `py-sdk-v*`), exercised at the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)