### PR TITLE
fix: snake_case field names on wallet send + flat aliases on notifications list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,7 @@ Non-custodial flow. Privy holds the keys (passkey-controlled smart accounts on E
 - Web `/login` Privy email-OTP (gated by `MCP_WEB_PRIVY_LOGIN=true`): server-side REST proxy to `POST /api/v1/passwordless/{init,authenticate}` on `auth.privy.io`. Issues a Laravel session via `Auth::login()` and redirects to `intended()`. Replaces legacy Jetstream email+password when the flag is on. Same `User` table + `firstOrCreate(privy_user_id)` lookup as mobile, so cross-client account merging Just Works. See `app/Http/Controllers/Web/PrivyWebAuthController.php`
 - Address registration: `POST /api/v1/wallet/addresses` — mirrors EVM smart-account address across polygon/base/arbitrum/ethereum, plus one Solana ed25519 row in `blockchain_addresses`
 - Send: `POST /api/v1/wallet/transactions/prepare` returns unsigned payload, `POST /api/v1/wallet/transactions/submit` accepts the signed blob
-- Wire contract is camelCase: `quoteId`, `intentId`, `evm.ownerPasskeyCredentialId`. `Idempotency-Key` is an HTTP header, not a body field.
+- Wire contract: prepare/submit accept snake_case (canonical: `quote_id`, `intent_id`) and still accept legacy camelCase (`quoteId`, `intentId`). `evm.ownerPasskeyCredentialId` stays camelCase. `Idempotency-Key` is an HTTP header, not a body field.
 - Confirmation: `HeliusTransactionProcessor` for Solana (existing webhook), `PollEvmWalletSendConfirmations` for EVM (cron, every minute)
 - Operator commands: `php artisan privy:verify-jwt <token>`, `php artisan wallet:inspect-user <email>`
 - Spec: `docs/superpowers/specs/2026-05-05-wallet-privy-noncustodial-design.md` (if present); see PR #1017
@@ -160,9 +160,9 @@ Non-custodial flow. Privy holds the keys (passkey-controlled smart accounts on E
 | EVM address case | Always `strtolower()` for storage (matches our existing EVM convention) — Solana stays case-sensitive |
 | Float-money amounts | Preparers validate `amount` against numeric-string + bcmath; never `(float)` for money |
 | Idempotency key on the wrong field | It's an HTTP header (`Idempotency-Key`), not a body field — matches `/pay`/`/pay/card` |
-| `quote_id` vs `quoteId` | Wire contract is camelCase across the board (matches mobile RN/TS request types) |
+| `quote_id` vs `quoteId` | prepare/submit normalise both spellings (`$request->merge` before `validate`) — snake_case is canonical, camelCase kept for older builds. Validation errors are keyed `quote_id`/`intent_id` |
 | Adding a new send/receive asset | Add the case to `App\Domain\MobilePayment\Enums\PaymentAsset` (decimals + label) AND make sure `EvmTokens` / `SolanaTokens` have the contract / mint. The receive QR builder uses `SolanaTokens::mintFor()` per Solana Pay spec — `spl-token` must be the mint, not the symbol. v7.13.1 added USDT this way |
-| Network casing on quote vs prepare | Both endpoints validate against `PaymentNetwork::values()` — case-sensitive: `SOLANA`/`TRON` uppercase, `polygon`/`base`/`arbitrum`/`ethereum` lowercase. Pre-existing enum inconsistency; quote response is `{ success, data: { quote_id, network, ... } }` (snake_case keys inside `data`), but request bodies on prepare/submit are camelCase (`quoteId`, `intentId`). Mobile must send the exact enum value (no normalisation) and the exact field name |
+| Network casing on quote vs prepare | Both endpoints validate against `PaymentNetwork::values()` — case-sensitive: `SOLANA`/`TRON` uppercase, `polygon`/`base`/`arbitrum`/`ethereum` lowercase. Pre-existing enum inconsistency; quote response is `{ success, data: { quote_id, network, ... } }` (snake_case keys inside `data`). Request bodies on prepare/submit accept snake_case (canonical) or camelCase for the id field, but the `network` value itself is not normalised — mobile must send the exact enum value |
 
 ## IAP / Subscriptions (v7.13.0+)
 

--- a/app/Http/Controllers/Api/V1/NotificationController.php
+++ b/app/Http/Controllers/Api/V1/NotificationController.php
@@ -64,6 +64,9 @@ class NotificationController extends Controller
                     new OA\Property(property: 'limit', type: 'integer'),
                     new OA\Property(property: 'unread_count', type: 'integer'),
                 ]),
+                new OA\Property(property: 'notifications', type: 'array', description: 'Flat alias of `data` for the mobile client.', items: new OA\Items(type: 'object')),
+                new OA\Property(property: 'total', type: 'integer', description: 'Flat alias of `meta.total`.'),
+                new OA\Property(property: 'unread', type: 'integer', description: 'Flat alias of `meta.unread_count`.'),
             ]
         )
     )]
@@ -93,15 +96,24 @@ class NotificationController extends Controller
 
         $total = $query->count();
         $notifications = $query->skip($offset)->take($limit)->get();
+        $items = NotificationResource::collection($notifications);
+        $unread = $this->pushService->getUnreadCount($user);
 
         return response()->json([
-            'data' => NotificationResource::collection($notifications),
+            'data' => $items,
             'meta' => [
                 'total'        => $total,
                 'offset'       => $offset,
                 'limit'        => $limit,
-                'unread_count' => $this->pushService->getUnreadCount($user),
+                'unread_count' => $unread,
             ],
+            // Flat aliases for the mobile notifications screen, which reads a
+            // top-level `notifications` array plus `total`/`unread` scalars.
+            // Kept alongside the canonical `data`/`meta` envelope so neither
+            // contract breaks.
+            'notifications' => $items,
+            'total'         => $total,
+            'unread'        => $unread,
         ]);
     }
 

--- a/app/Http/Controllers/Api/Wallet/MobileWalletController.php
+++ b/app/Http/Controllers/Api/Wallet/MobileWalletController.php
@@ -601,12 +601,12 @@ class MobileWalletController extends Controller
         description: 'Builds the unsigned Solana legacy-tx message bytes (ed25519) or ERC-4337 v0.6 UserOp hash (with Pimlico paymaster sponsorship) for the device to sign via Privy. Persists a `pending` wallet_send_record. Mobile signs and POSTs the signature to /transactions/submit.',
         tags: ['Mobile Wallet'],
         security: [['sanctum' => []]],
-        requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(required: ['to', 'token', 'amount', 'network', 'quoteId'], properties: [
+        requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(required: ['to', 'token', 'amount', 'network', 'quote_id'], properties: [
         new OA\Property(property: 'to', type: 'string', example: '0x1234...abcd or base58 Solana pubkey'),
         new OA\Property(property: 'token', type: 'string', enum: ['USDC', 'USDT'], example: 'USDC'),
         new OA\Property(property: 'amount', type: 'string', example: '1.50', description: 'Decimal major units. Send "1" or "1.5"; not "1000000".'),
         new OA\Property(property: 'network', type: 'string', example: 'SOLANA', description: 'SOLANA | TRON | polygon | base | arbitrum | ethereum (case-sensitive — must match the exact PaymentNetwork enum value, same as the value returned in quote response)'),
-        new OA\Property(property: 'quoteId', type: 'string', example: 'q_abc123'),
+        new OA\Property(property: 'quote_id', type: 'string', example: 'q_abc123', description: 'Canonical snake_case. The legacy camelCase `quoteId` is also accepted.'),
         ]))
     )]
     #[OA\Response(response: 201, description: 'Unsigned payload ready')]
@@ -615,12 +615,19 @@ class MobileWalletController extends Controller
     #[OA\Response(response: 401, description: 'Unauthorized')]
     public function prepareTransaction(Request $request): JsonResponse
     {
+        // Canonical field name is snake_case (`quote_id`) to match the rest of
+        // the API. camelCase (`quoteId`) is still accepted for compatibility
+        // with older mobile builds — see /transactions/submit.
+        $request->merge([
+            'quote_id' => $request->input('quote_id', $request->input('quoteId')),
+        ]);
+
         $validated = $request->validate([
-            'to'      => ['required', 'string', 'min:26', 'max:128'],
-            'token'   => ['required', 'string', 'in:USDC,USDT'],
-            'amount'  => ['required', 'string'],
-            'network' => ['required', 'string', Rule::enum(PaymentNetwork::class)],
-            'quoteId' => ['required', 'string', 'max:64'],
+            'to'       => ['required', 'string', 'min:26', 'max:128'],
+            'token'    => ['required', 'string', 'in:USDC,USDT'],
+            'amount'   => ['required', 'string'],
+            'network'  => ['required', 'string', Rule::enum(PaymentNetwork::class)],
+            'quote_id' => ['required', 'string', 'max:64'],
         ]);
 
         $user = $request->user();
@@ -635,7 +642,7 @@ class MobileWalletController extends Controller
         $assetSymbol = strtoupper((string) $validated['token']);
         $recipient = (string) $validated['to'];
         $amount = (string) $validated['amount'];
-        $quoteId = (string) $validated['quoteId'];
+        $quoteId = (string) $validated['quote_id'];
 
         $sender = $this->resolveSenderAddress($user, $networkKey);
         if ($sender === null) {
@@ -708,8 +715,8 @@ class MobileWalletController extends Controller
         description: 'Attaches a Privy-produced signature (ed25519 for Solana, smart-wallet signature blob for EVM) to the matching prepared record and broadcasts via Helius / Pimlico.',
         tags: ['Mobile Wallet'],
         security: [['sanctum' => []]],
-        requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(required: ['intentId', 'signature'], properties: [
-        new OA\Property(property: 'intentId', type: 'string', example: 'pi_send_abc123'),
+        requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(required: ['intent_id', 'signature'], properties: [
+        new OA\Property(property: 'intent_id', type: 'string', example: 'pi_send_abc123', description: 'Canonical snake_case. The legacy camelCase `intentId` is also accepted.'),
         new OA\Property(property: 'signature', type: 'string', example: '0x... or base64 ed25519', description: 'For Solana: 64-byte ed25519 signature, base64-encoded. For EVM: 0x-prefixed hex signature blob from Privy smart wallet.'),
         ]))
     )]
@@ -719,8 +726,14 @@ class MobileWalletController extends Controller
     #[OA\Response(response: 401, description: 'Unauthorized')]
     public function submitTransaction(Request $request): JsonResponse
     {
+        // Canonical field name is snake_case (`intent_id`). camelCase
+        // (`intentId`) is still accepted for compatibility with older builds.
+        $request->merge([
+            'intent_id' => $request->input('intent_id', $request->input('intentId')),
+        ]);
+
         $validated = $request->validate([
-            'intentId'  => ['required', 'string', 'max:64'],
+            'intent_id' => ['required', 'string', 'max:64'],
             'signature' => ['required', 'string', 'min:1', 'max:8192'],
         ]);
 
@@ -731,7 +744,7 @@ class MobileWalletController extends Controller
 
         $record = WalletSendRecord::query()
             ->where('user_id', $user->id)
-            ->where('public_id', (string) $validated['intentId'])
+            ->where('public_id', (string) $validated['intent_id'])
             ->first();
 
         if (! $record instanceof WalletSendRecord) {

--- a/tests/Feature/Api/V1/NotificationControllerTest.php
+++ b/tests/Feature/Api/V1/NotificationControllerTest.php
@@ -166,6 +166,47 @@ class NotificationControllerTest extends TestCase
             ->assertJsonPath('data.unread_count', 2);
     }
 
+    public function test_list_notifications_includes_flat_mobile_aliases(): void
+    {
+        Sanctum::actingAs($this->user, ['read']);
+
+        $this->createNotification();
+        $this->createNotification(['read_at' => now(), 'status' => 'read']);
+
+        $response = $this->getJson('/api/v1/notifications')
+            ->assertOk()
+            ->assertJsonStructure([
+                'data',
+                'meta',
+                'notifications' => [
+                    '*' => ['id', 'type', 'title', 'body', 'data', 'read', 'created_at'],
+                ],
+                'total',
+                'unread',
+            ]);
+
+        $data = $response->json();
+        $this->assertCount(2, $data['notifications']);
+        $this->assertEquals(2, $data['total']);
+        $this->assertEquals(1, $data['unread']);
+        // Flat aliases must stay consistent with the canonical envelope.
+        $this->assertEquals($data['meta']['total'], $data['total']);
+        $this->assertEquals($data['meta']['unread_count'], $data['unread']);
+    }
+
+    public function test_list_notifications_returns_empty_array_when_none_exist(): void
+    {
+        Sanctum::actingAs($this->user, ['read']);
+
+        $response = $this->getJson('/api/v1/notifications')
+            ->assertOk()
+            ->assertJsonStructure(['notifications', 'total', 'unread']);
+
+        $this->assertSame([], $response->json('notifications'));
+        $this->assertSame(0, $response->json('total'));
+        $this->assertSame(0, $response->json('unread'));
+    }
+
     public function test_list_notifications_default_limit_is_20(): void
     {
         Sanctum::actingAs($this->user, ['read']);

--- a/tests/Feature/Api/Wallet/WalletTransactionPrepareTest.php
+++ b/tests/Feature/Api/Wallet/WalletTransactionPrepareTest.php
@@ -112,4 +112,46 @@ class WalletTransactionPrepareTest extends TestCase
         $response->assertUnprocessable()
             ->assertJsonValidationErrors(['network']);
     }
+
+    public function test_prepare_accepts_quote_id_snake_case(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/wallet/transactions/prepare', [
+                'to'       => '0x742d35cc6634c0532925a3b844bc454e4438f44e',
+                'token'    => 'USDC',
+                'amount'   => '1.50',
+                'network'  => 'polygon',
+                'quote_id' => 'q_test_snake',
+            ]);
+
+        $response->assertJsonMissingValidationErrors(['quote_id', 'quoteId']);
+    }
+
+    public function test_prepare_accepts_quote_id_camel_case(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/wallet/transactions/prepare', [
+                'to'      => '0x742d35cc6634c0532925a3b844bc454e4438f44e',
+                'token'   => 'USDC',
+                'amount'  => '1.50',
+                'network' => 'polygon',
+                'quoteId' => 'q_test_camel',
+            ]);
+
+        $response->assertJsonMissingValidationErrors(['quote_id', 'quoteId']);
+    }
+
+    public function test_prepare_rejects_missing_quote_id_with_snake_case_key(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/wallet/transactions/prepare', [
+                'to'      => '0x742d35cc6634c0532925a3b844bc454e4438f44e',
+                'token'   => 'USDC',
+                'amount'  => '1.50',
+                'network' => 'polygon',
+            ]);
+
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors(['quote_id']);
+    }
 }

--- a/tests/Feature/Api/Wallet/WalletTransactionSubmitTest.php
+++ b/tests/Feature/Api/Wallet/WalletTransactionSubmitTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\Wallet;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+/**
+ * Regression coverage for the submit endpoint's `intent_id` field name.
+ *
+ * The whole API is snake_case, but submit used to validate `intentId` only.
+ * These tests lock in the post-fix contract: the canonical key is snake_case
+ * (`intent_id`) and the legacy camelCase (`intentId`) is still accepted.
+ *
+ * We only assert the *validator*. When the field is present and valid the
+ * request gets past validation and 404s on INTENT_NOT_FOUND (no record) —
+ * `assertJsonMissingValidationErrors` is enough to prove acceptance.
+ */
+class WalletTransactionSubmitTest extends TestCase
+{
+    protected User $user;
+
+    protected string $token;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+
+        $this->user = User::factory()->create();
+        $this->token = $this->user->createToken('test-token', ['read', 'write', 'delete'])->plainTextToken;
+    }
+
+    public function test_submit_accepts_intent_id_snake_case(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/wallet/transactions/submit', [
+                'intent_id' => 'pi_send_unknown',
+                'signature' => '0xdeadbeef',
+            ]);
+
+        $response->assertJsonMissingValidationErrors(['intent_id', 'intentId']);
+    }
+
+    public function test_submit_accepts_intent_id_camel_case(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/wallet/transactions/submit', [
+                'intentId'  => 'pi_send_unknown',
+                'signature' => '0xdeadbeef',
+            ]);
+
+        $response->assertJsonMissingValidationErrors(['intent_id', 'intentId']);
+    }
+
+    public function test_submit_rejects_missing_intent_id_with_snake_case_key(): void
+    {
+        $response = $this->withToken($this->token)
+            ->postJson('/api/v1/wallet/transactions/submit', [
+                'signature' => '0xdeadbeef',
+            ]);
+
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors(['intent_id']);
+    }
+}


### PR DESCRIPTION
## Summary

Two API contract gaps surfaced by mobile on-device testing (Builds #9–#11, Samsung S918B, Privy/prod). The other reported issues were already fixed in recent merges — see the triage table below.

### 1. Money-path endpoints validated camelCase field names

`POST /wallet/transactions/prepare` and `/submit` validated `quoteId`/`intentId` while the rest of the API is snake_case. Mobile snake-cases all request bodies, so the ids never matched → 422.

Both endpoints now `$request->merge()` the id from either spelling before validation. **snake_case (`quote_id`, `intent_id`) is canonical**; camelCase is still accepted so older builds and the mobile dual-spelling workaround keep working. Validation errors are keyed snake_case.

The legacy `/transactions/send` endpoint was already removed (PR #1017), so it needs nothing.

### 2. `GET /api/v1/notifications` shape mismatch

The endpoint returned only the canonical `{ data, meta }` envelope; the mobile notifications screen reads a top-level `notifications` array plus `total`/`unread` scalars and crashed without them. Added those flat aliases **alongside** the existing envelope — neither contract breaks.

## Triage of the full mobile report

| Issue | Status |
|---|---|
| 1. camelCase validators on prepare/submit | **Fixed here** |
| 2. `/notifications` missing `notifications` array | **Fixed here** |
| 3. Notification count drifts / inbound transfers no row | Already fixed — PR #1068 (notification feed device-independence) |
| 4. register-device 409 / device rebind (#1059) | Already fixed — PR #1069 (device-takeover guard scoped to credential-bound devices) |
| Build #8: receipt 422 on confirmed tx | Already fixed — PR #1066 (receipt routed through `ActivityFeedItem`) |
| Build #8: `/privacy/merkle-root` 500 | Already fixed — PR #1065 (catches `RuntimeException`, returns 503) |

## Tests

- `WalletTransactionPrepareTest` — `quote_id` and `quoteId` both accepted; missing id errors on `quote_id`
- `WalletTransactionSubmitTest` (new) — same coverage for `intent_id`/`intentId`
- `NotificationControllerTest` — flat aliases present and consistent with the envelope, including the empty case

All 23 affected tests pass. php-cs-fixer + PHPStan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)