### PR TITLE
fix: surface pending and failed wallet sends in transaction history

### DIFF
--- a/app/Domain/Wallet/Jobs/PollSolanaWalletSendConfirmations.php
+++ b/app/Domain/Wallet/Jobs/PollSolanaWalletSendConfirmations.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Wallet\Jobs;
+
+use App\Domain\Wallet\Models\WalletSendRecord;
+use App\Domain\Wallet\Services\Send\HeliusRpcClient;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Polls Solana RPC for the outcome of submitted Solana wallet sends and flips
+ * matching wallet_send_records to confirmed or failed.
+ *
+ * The Helius webhook ({@see \App\Domain\Wallet\Services\HeliusTransactionProcessor})
+ * is the primary confirmation path, but it does not reliably deliver *failed*
+ * transactions — and a send the RPC accepted that then failed on-chain (e.g.
+ * insufficient SOL for the network fee) would otherwise sit in `submitted`
+ * forever, invisible as a failure to the user. This job is the safety net that
+ * gives every Solana send a terminal state.
+ *
+ * Runs every minute. Only touches rows where status='submitted',
+ * network='solana', within a 2-hour window. The EVM side uses
+ * {@see PollEvmWalletSendConfirmations} instead.
+ */
+class PollSolanaWalletSendConfirmations implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 1;
+
+    public int $timeout = 60;
+
+    /**
+     * A submitted send still unknown to the cluster after this many minutes
+     * can never land — its blockhash validity window (~60-90s) has long since
+     * expired — so it is marked failed.
+     */
+    private const int DROPPED_AFTER_MINUTES = 5;
+
+    public function handle(HeliusRpcClient $rpc): void
+    {
+        $records = WalletSendRecord::query()
+            ->where('status', WalletSendRecord::STATUS_SUBMITTED)
+            ->where('network', 'solana')
+            ->whereNotNull('tx_hash')
+            ->where('submitted_at', '>=', now()->subHours(2))
+            ->limit(100)
+            ->get();
+
+        foreach ($records as $record) {
+            $this->reconcile($rpc, $record);
+        }
+    }
+
+    private function reconcile(HeliusRpcClient $rpc, WalletSendRecord $record): void
+    {
+        $signature = (string) $record->tx_hash;
+        if ($signature === '') {
+            return;
+        }
+
+        try {
+            $statuses = $rpc->getSignatureStatuses([$signature]);
+        } catch (Throwable $e) {
+            Log::warning('PollSolanaWalletSendConfirmations: RPC error', [
+                'record_id' => $record->id,
+                'signature' => $signature,
+                'error'     => $e->getMessage(),
+            ]);
+
+            return;
+        }
+
+        $entry = $statuses[$signature] ?? null;
+
+        if ($entry === null) {
+            // Unknown to the cluster. Once the blockhash-validity window has
+            // long passed, the transaction can never land — mark it failed so
+            // the user sees the send did not go through.
+            if (
+                $record->submitted_at !== null
+                && $record->submitted_at->lt(now()->subMinutes(self::DROPPED_AFTER_MINUTES))
+            ) {
+                $record->update([
+                    'status'        => WalletSendRecord::STATUS_FAILED,
+                    'failed_at'     => now(),
+                    'error_code'    => 'SOLANA_TX_DROPPED',
+                    'error_message' => 'This transfer expired before it was confirmed on the Solana network. No funds were moved.',
+                ]);
+            }
+
+            return;
+        }
+
+        if ($entry['err'] !== null) {
+            $record->update([
+                'status'        => WalletSendRecord::STATUS_FAILED,
+                'failed_at'     => now(),
+                'error_code'    => 'SOLANA_TX_FAILED',
+                'error_message' => 'This transfer could not be completed on the Solana network.',
+            ]);
+
+            return;
+        }
+
+        if (in_array($entry['confirmationStatus'], ['confirmed', 'finalized'], true)) {
+            $record->update([
+                'status'       => WalletSendRecord::STATUS_CONFIRMED,
+                'confirmed_at' => now(),
+            ]);
+        }
+
+        // 'processed' or '' → still in flight; poll again next tick.
+    }
+}

--- a/app/Domain/Wallet/Models/WalletSendRecord.php
+++ b/app/Domain/Wallet/Models/WalletSendRecord.php
@@ -105,6 +105,35 @@ class WalletSendRecord extends Model
         ];
     }
 
+    /**
+     * Flat, snake_case status payload for the per-intent polling endpoint
+     * (GET /api/v1/wallet/transactions/by-intent/{intentId}).
+     *
+     * `status` is the lowercase lifecycle value (pending/submitted/confirmed/
+     * failed). `error_message` is best-effort human-readable text; mobile
+     * should branch on the stable `error_code`.
+     *
+     * @return array<string, mixed>
+     */
+    public function toIntentStatusResponse(): array
+    {
+        return [
+            'intent_id'     => $this->public_id,
+            'status'        => $this->status,
+            'network'       => $this->network,
+            'asset'         => $this->asset,
+            'amount'        => $this->amount,
+            'tx_hash'       => $this->tx_hash,
+            'explorer_url'  => $this->buildExplorerUrl(),
+            'error_code'    => $this->error_code,
+            'error_message' => $this->error_message,
+            'created_at'    => $this->created_at->toIso8601String(),
+            'submitted_at'  => $this->submitted_at?->toIso8601String(),
+            'confirmed_at'  => $this->confirmed_at?->toIso8601String(),
+            'failed_at'     => $this->failed_at?->toIso8601String(),
+        ];
+    }
+
     private function buildExplorerUrl(): ?string
     {
         if ($this->tx_hash === null) {

--- a/app/Domain/Wallet/Observers/WalletSendRecordObserver.php
+++ b/app/Domain/Wallet/Observers/WalletSendRecordObserver.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Wallet\Observers;
+
+use App\Domain\MobilePayment\Enums\ActivityItemType;
+use App\Domain\MobilePayment\Models\ActivityFeedItem;
+use App\Domain\Wallet\Models\WalletSendRecord;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Projects the WalletSendRecord lifecycle into the activity_feed_items read
+ * model so outbound sends are visible in GET /api/v1/wallet/transactions while
+ * they are still pending — and after they fail — not only once confirmed
+ * on-chain.
+ *
+ * Before this observer, an outbound send only reached the feed when the Helius
+ * confirmation webhook fired (always as `confirmed`); pending and failed sends
+ * were invisible to the user. Inbound transfers are projected separately by
+ * {@see \App\Domain\Wallet\Services\HeliusTransactionProcessor}.
+ *
+ * The activity feed is a non-critical read model: a projection failure must
+ * never roll back or break an actual wallet send, so the write is best-effort
+ * and logged on failure. Correctness is covered by WalletSendRecordObserverTest.
+ */
+class WalletSendRecordObserver
+{
+    public function created(WalletSendRecord $record): void
+    {
+        $this->project($record);
+    }
+
+    public function updated(WalletSendRecord $record): void
+    {
+        // Only re-project on the fields the feed actually reflects — avoids a
+        // redundant write when an unrelated column changes.
+        if (! $record->wasChanged(['status', 'tx_hash'])) {
+            return;
+        }
+
+        $this->project($record);
+    }
+
+    private function project(WalletSendRecord $record): void
+    {
+        try {
+            ActivityFeedItem::updateOrCreate(
+                [
+                    'reference_type' => WalletSendRecord::class,
+                    'reference_id'   => $record->id,
+                ],
+                [
+                    'user_id'       => $record->user_id,
+                    'activity_type' => ActivityItemType::TRANSFER_OUT,
+                    'amount'        => '-' . $record->amount,
+                    'asset'         => $record->asset,
+                    'network'       => $record->network,
+                    'status'        => $record->status,
+                    'protected'     => false,
+                    'from_address'  => $record->sender_address,
+                    'to_address'    => $record->recipient_address,
+                    // Pinned to creation time so a status update never reorders
+                    // the item in the cursor-paginated feed.
+                    'occurred_at' => $record->created_at ?? now(),
+                    'metadata'    => [
+                        'intent_id' => $record->public_id,
+                        'tx_hash'   => $record->tx_hash,
+                    ],
+                ],
+            );
+        } catch (Throwable $e) {
+            Log::warning('WalletSendRecordObserver: activity feed projection failed', [
+                'record_id' => $record->id,
+                'public_id' => $record->public_id,
+                'status'    => $record->status,
+                'error'     => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/app/Domain/Wallet/Routes/api.php
+++ b/app/Domain/Wallet/Routes/api.php
@@ -134,6 +134,9 @@ Route::prefix('v1/wallet')->name('mobile.wallet.')
         Route::get('/transactions', [MobileWalletController::class, 'transactions'])
             ->middleware('api.rate_limit:query')
             ->name('transactions');
+        Route::get('/transactions/by-intent/{intentId}', [MobileWalletController::class, 'transactionByIntent'])
+            ->middleware('api.rate_limit:query')
+            ->name('transactions.by-intent');
         Route::get('/transactions/{id}', [MobileWalletController::class, 'transactionDetail'])
             ->middleware('api.rate_limit:query')
             ->name('transactions.detail');

--- a/app/Domain/Wallet/Services/HeliusTransactionProcessor.php
+++ b/app/Domain/Wallet/Services/HeliusTransactionProcessor.php
@@ -9,6 +9,7 @@ use App\Domain\Account\Models\BlockchainTransaction;
 use App\Domain\MobilePayment\Enums\ActivityItemType;
 use App\Domain\MobilePayment\Models\ActivityFeedItem;
 use App\Domain\Wallet\Constants\SolanaTokens;
+use App\Domain\Wallet\Models\WalletSendRecord;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -71,6 +72,19 @@ class HeliusTransactionProcessor
 
         $metadata = array_intersect_key($tx, array_flip(self::METADATA_WHITELIST));
 
+        $txFailed = $this->isTransactionFailed($tx);
+
+        // An outbound send that originated from our prepare/submit flow already
+        // has a `wallet_send` activity-feed item (projected by
+        // WalletSendRecordObserver). When one exists we skip the duplicate
+        // `solana_tx` feed item and instead drive the record's status — its
+        // observer keeps the feed item in sync.
+        $walletSend = $isIncoming
+            ? null
+            : WalletSendRecord::where('tx_hash', $signature)
+                ->where('network', 'solana')
+                ->first();
+
         $wasCreated = false;
 
         DB::transaction(function () use (
@@ -86,6 +100,8 @@ class HeliusTransactionProcessor
             $userId,
             $token,
             $occurredAt,
+            $txFailed,
+            $walletSend,
             &$wasCreated,
         ): void {
             try {
@@ -98,7 +114,7 @@ class HeliusTransactionProcessor
                         'fee'          => $fee,
                         'from_address' => $fromAddr ?? '',
                         'to_address'   => $toAddr ?? '',
-                        'status'       => 'confirmed',
+                        'status'       => $txFailed ? 'failed' : 'confirmed',
                         'metadata'     => $metadata,
                     ]
                 );
@@ -123,42 +139,70 @@ class HeliusTransactionProcessor
                 throw $e;
             }
 
-            ActivityFeedItem::firstOrCreate(
-                ['reference_type' => 'solana_tx', 'reference_id' => $refId],
-                [
-                    'user_id'       => $userId,
-                    'activity_type' => $isIncoming ? ActivityItemType::TRANSFER_IN : ActivityItemType::TRANSFER_OUT,
-                    'amount'        => $isIncoming ? $amount : '-' . $amount,
-                    'asset'         => $token,
-                    'network'       => 'solana',
-                    'status'        => 'confirmed',
-                    'protected'     => false,
-                    'from_address'  => $fromAddr,
-                    'to_address'    => $toAddr,
-                    'occurred_at'   => $occurredAt ?? now(),
-                    'metadata'      => ['signature' => $signature],
-                ]
-            );
+            // Skip the solana_tx feed item when the WalletSendRecordObserver
+            // already owns a feed item for this outbound send — avoids a
+            // duplicate row for the same transaction.
+            if ($walletSend === null) {
+                ActivityFeedItem::firstOrCreate(
+                    ['reference_type' => 'solana_tx', 'reference_id' => $refId],
+                    [
+                        'user_id'       => $userId,
+                        'activity_type' => $isIncoming ? ActivityItemType::TRANSFER_IN : ActivityItemType::TRANSFER_OUT,
+                        'amount'        => $isIncoming ? $amount : '-' . $amount,
+                        'asset'         => $token,
+                        'network'       => 'solana',
+                        'status'        => $txFailed ? 'failed' : 'confirmed',
+                        'protected'     => false,
+                        'from_address'  => $fromAddr,
+                        'to_address'    => $toAddr,
+                        'occurred_at'   => $occurredAt ?? now(),
+                        'metadata'      => ['signature' => $signature],
+                    ]
+                );
+            }
 
-            // Outbound wallet send confirmation: if a wallet_send_records row
-            // is awaiting this signature, flip it to confirmed. This is the
-            // production confirmation path for Solana sends — the EVM side
+            // Outbound wallet send: flip the awaiting record to its terminal
+            // state. Driven through the model (->update, not a bulk query) so
+            // WalletSendRecordObserver re-projects the activity feed. This is
+            // the production confirmation path for Solana sends — the EVM side
             // uses a polling job against bundler getUserOperationByHash.
-            if (! $isIncoming) {
-                \App\Domain\Wallet\Models\WalletSendRecord::query()
-                    ->where('tx_hash', $signature)
-                    ->where('network', 'solana')
-                    ->whereIn('status', ['pending', 'submitted'])
-                    ->update([
+            if ($walletSend !== null && in_array($walletSend->status, ['pending', 'submitted'], true)) {
+                if ($txFailed) {
+                    $walletSend->update([
+                        'status'        => 'failed',
+                        'error_code'    => 'SOLANA_TX_FAILED',
+                        'error_message' => 'This transfer could not be completed on the Solana network.',
+                        'failed_at'     => now(),
+                    ]);
+                } else {
+                    $walletSend->update([
                         'status'       => 'confirmed',
                         'confirmed_at' => now(),
                     ]);
+                }
             }
 
             $wasCreated = $btx->wasRecentlyCreated;
         });
 
         return $wasCreated;
+    }
+
+    /**
+     * Detect a failed Solana transaction from a Helius enhanced payload.
+     *
+     * Helius sets `transactionError` to null on success and to an error
+     * object/string on failure. A failed tx must not be persisted as
+     * `confirmed` — otherwise a doomed send (e.g. insufficient SOL for the
+     * network fee) would look successful in the activity feed.
+     *
+     * @param array<string, mixed> $tx
+     */
+    private function isTransactionFailed(array $tx): bool
+    {
+        $err = $tx['transactionError'] ?? null;
+
+        return $err !== null && $err !== '' && $err !== [];
     }
 
     /**

--- a/app/Http/Controllers/Api/Wallet/MobileWalletController.php
+++ b/app/Http/Controllers/Api/Wallet/MobileWalletController.php
@@ -587,6 +587,69 @@ class MobileWalletController extends Controller
     }
 
     /**
+     * Get live status for a wallet send by its intent id (`pi_send_…`).
+     *
+     * Lets mobile poll a send through to a terminal state from the
+     * send-confirmation screen: `submit` returns immediately, so this is how
+     * the UI learns the final outcome (confirmed vs failed) and the on-chain
+     * tx hash / explorer link once available.
+     */
+    #[OA\Get(
+        path: '/api/v1/wallet/transactions/by-intent/{intentId}',
+        operationId: 'walletTransactionByIntent',
+        summary: 'Get wallet send status by intent id',
+        description: 'Returns the live status of a wallet send identified by its prepare/submit intent id.',
+        tags: ['Mobile Wallet'],
+        security: [['sanctum' => []]],
+        parameters: [
+        new OA\Parameter(name: 'intentId', in: 'path', required: true, description: 'Send intent id (pi_send_…)', schema: new OA\Schema(type: 'string')),
+        ]
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Wallet send status',
+        content: new OA\JsonContent(properties: [
+        new OA\Property(property: 'success', type: 'boolean', example: true),
+        new OA\Property(property: 'data', type: 'object', description: 'Wallet send status object'),
+        ])
+    )]
+    #[OA\Response(
+        response: 404,
+        description: 'Intent not found'
+    )]
+    #[OA\Response(
+        response: 401,
+        description: 'Unauthorized'
+    )]
+    public function transactionByIntent(string $intentId, Request $request): JsonResponse
+    {
+        $user = $request->user();
+        if (! $user instanceof \App\Models\User) {
+            return response()->json([
+                'success' => false,
+                'error'   => ['code' => 'UNAUTHORIZED', 'message' => 'Not authenticated.'],
+            ], 401);
+        }
+
+        $record = WalletSendRecord::query()
+            ->where('user_id', $user->id)
+            ->where('public_id', $intentId)
+            ->first();
+
+        if (! $record instanceof WalletSendRecord) {
+            return response()->json([
+                'success' => false,
+                'error'   => ['code' => 'INTENT_NOT_FOUND', 'message' => 'No send matches this id.'],
+            ], 404);
+        }
+
+        return response()->json([
+            'success' => true,
+            'data'    => $record->toIntentStatusResponse(),
+        ]);
+    }
+
+    /**
      * Step 1 of a non-custodial send: build the unsigned payload for the
      * device to sign.
      *

--- a/app/Providers/WalletServiceProvider.php
+++ b/app/Providers/WalletServiceProvider.php
@@ -53,5 +53,11 @@ class WalletServiceProvider extends ServiceProvider
         \App\Domain\Relayer\Models\SmartAccount::observe(
             \App\Domain\Wallet\Observers\SmartAccountObserver::class,
         );
+
+        // Project outbound wallet sends into the activity feed so pending and
+        // failed sends are visible in GET /api/v1/wallet/transactions.
+        \App\Domain\Wallet\Models\WalletSendRecord::observe(
+            \App\Domain\Wallet\Observers\WalletSendRecordObserver::class,
+        );
     }
 }

--- a/routes/console.php
+++ b/routes/console.php
@@ -216,11 +216,17 @@ Schedule::command('trustcert:check-expired')
     });
 
 // Wallet send (EVM) confirmation polling — every minute.
-// Solana confirmations come via the Helius webhook (HeliusTransactionProcessor),
-// not this job.
 Schedule::job(new App\Domain\Wallet\Jobs\PollEvmWalletSendConfirmations())
     ->everyMinute()
     ->description('Poll bundler for EVM wallet-send confirmations')
+    ->withoutOverlapping();
+
+// Wallet send (Solana) confirmation polling — every minute. The Helius webhook
+// is the primary path, but does not reliably deliver failed transactions; this
+// job is the safety net that gives every Solana send a terminal state.
+Schedule::job(new App\Domain\Wallet\Jobs\PollSolanaWalletSendConfirmations())
+    ->everyMinute()
+    ->description('Poll Solana RPC for Solana wallet-send confirmations')
     ->withoutOverlapping();
 
 // Daily retention sweep for the public investor lead-capture form.

--- a/tests/Feature/Api/Wallet/WalletTransactionByIntentTest.php
+++ b/tests/Feature/Api/Wallet/WalletTransactionByIntentTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\Wallet;
+
+use App\Domain\Wallet\Models\WalletSendRecord;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+/**
+ * Coverage for GET /api/v1/wallet/transactions/by-intent/{intentId} — the
+ * per-intent polling endpoint mobile uses on the send-confirmation screen to
+ * learn a send's terminal outcome (confirmed vs failed).
+ */
+class WalletTransactionByIntentTest extends TestCase
+{
+    protected User $user;
+
+    protected string $token;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+
+        $this->user = User::factory()->create();
+        $this->token = $this->user->createToken('test-token', ['read', 'write', 'delete'])->plainTextToken;
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     */
+    private function makeRecord(array $overrides = []): WalletSendRecord
+    {
+        return WalletSendRecord::create(array_merge([
+            'public_id'         => 'pi_send_' . uniqid(),
+            'user_id'           => $this->user->id,
+            'network'           => 'solana',
+            'asset'             => 'USDT',
+            'amount'            => '1.00000000',
+            'sender_address'    => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+            'recipient_address' => 'BobxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxV',
+            'status'            => WalletSendRecord::STATUS_PENDING,
+        ], $overrides));
+    }
+
+    public function test_returns_live_status_for_own_intent(): void
+    {
+        $record = $this->makeRecord([
+            'status'       => WalletSendRecord::STATUS_SUBMITTED,
+            'tx_hash'      => '5xRealSolanaSignature',
+            'submitted_at' => now(),
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->getJson("/api/v1/wallet/transactions/by-intent/{$record->public_id}");
+
+        $response->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.intent_id', $record->public_id)
+            ->assertJsonPath('data.status', 'submitted')
+            ->assertJsonPath('data.tx_hash', '5xRealSolanaSignature')
+            ->assertJsonPath('data.explorer_url', 'https://solscan.io/tx/5xRealSolanaSignature')
+            ->assertJsonPath('data.error_code', null);
+    }
+
+    public function test_returns_error_details_for_a_failed_send(): void
+    {
+        $record = $this->makeRecord([
+            'status'        => WalletSendRecord::STATUS_FAILED,
+            'error_code'    => 'SOLANA_TX_FAILED',
+            'error_message' => 'This transfer could not be completed on the Solana network.',
+            'failed_at'     => now(),
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->getJson("/api/v1/wallet/transactions/by-intent/{$record->public_id}");
+
+        $response->assertOk()
+            ->assertJsonPath('data.status', 'failed')
+            ->assertJsonPath('data.error_code', 'SOLANA_TX_FAILED')
+            ->assertJsonPath('data.error_message', 'This transfer could not be completed on the Solana network.');
+    }
+
+    public function test_returns_404_for_unknown_intent(): void
+    {
+        $response = $this->withToken($this->token)
+            ->getJson('/api/v1/wallet/transactions/by-intent/pi_send_doesnotexist');
+
+        $response->assertNotFound()
+            ->assertJsonPath('success', false)
+            ->assertJsonPath('error.code', 'INTENT_NOT_FOUND');
+    }
+
+    public function test_does_not_leak_another_users_intent(): void
+    {
+        $other = User::factory()->create();
+        $record = WalletSendRecord::create([
+            'public_id'         => 'pi_send_otheruser',
+            'user_id'           => $other->id,
+            'network'           => 'solana',
+            'asset'             => 'USDT',
+            'amount'            => '1.00000000',
+            'sender_address'    => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+            'recipient_address' => 'BobxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxV',
+            'status'            => WalletSendRecord::STATUS_PENDING,
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->getJson("/api/v1/wallet/transactions/by-intent/{$record->public_id}");
+
+        $response->assertNotFound()
+            ->assertJsonPath('error.code', 'INTENT_NOT_FOUND');
+    }
+
+    public function test_requires_authentication(): void
+    {
+        $this->getJson('/api/v1/wallet/transactions/by-intent/pi_send_x')
+            ->assertUnauthorized();
+    }
+}

--- a/tests/Feature/Domain/Wallet/HeliusTransactionProcessorWalletSendConfirmationTest.php
+++ b/tests/Feature/Domain/Wallet/HeliusTransactionProcessorWalletSendConfirmationTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Domain\Account\Models\BlockchainAddress;
+use App\Domain\MobilePayment\Models\ActivityFeedItem;
 use App\Domain\Wallet\Models\WalletSendRecord;
 use App\Domain\Wallet\Services\HeliusTransactionProcessor;
 use App\Models\User;
@@ -146,4 +147,111 @@ it('does not touch wallet_send_records on incoming (receive) Solana tx', functio
     // Outbound record stays submitted — we don't confirm it from a receive event
     expect($sendRecord->status)->toBe('submitted')
         ->and($sendRecord->confirmed_at)->toBeNull();
+});
+
+it('marks the wallet send failed when the Helius payload reports a transaction error', function (): void {
+    $signature = '7zFailedSignature222222222222222222222222222222222222222222222222';
+
+    $sendRecord = WalletSendRecord::create([
+        'public_id'         => 'pi_send_failedtx',
+        'user_id'           => 42,
+        'network'           => 'solana',
+        'asset'             => 'USDC',
+        'amount'            => '1.00000000',
+        'sender_address'    => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        'recipient_address' => 'BobxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxV',
+        'status'            => 'submitted',
+        'tx_hash'           => $signature,
+        'submitted_at'      => now(),
+    ]);
+
+    $blockchainAddress = BlockchainAddress::create([
+        'uuid'       => '22222222-3333-4444-8555-666666666666',
+        'user_uuid'  => 'user-uuid-42',
+        'address'    => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        'public_key' => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        'chain'      => 'solana',
+        'is_active'  => true,
+    ]);
+
+    // Outbound tx that failed on-chain — Helius reports it via transactionError.
+    $tx = [
+        'signature'        => $signature,
+        'fee'              => 5000,
+        'transactionError' => ['InstructionError' => [0, 'InsufficientFundsForFee']],
+        'tokenTransfers'   => [[
+            'fromUserAccount' => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+            'toUserAccount'   => 'BobxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxV',
+            'mint'            => 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+            'tokenAmount'     => '1.0',
+        ]],
+    ];
+
+    app(HeliusTransactionProcessor::class)->processTransaction(
+        'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        $blockchainAddress,
+        42,
+        $tx,
+    );
+
+    $sendRecord->refresh();
+    expect($sendRecord->status)->toBe('failed')
+        ->and($sendRecord->error_code)->toBe('SOLANA_TX_FAILED')
+        ->and($sendRecord->failed_at)->not->toBeNull();
+
+    // The observer-owned feed item reflects the failure.
+    $item = ActivityFeedItem::where('reference_id', $sendRecord->id)->first();
+    expect($item)->not->toBeNull()
+        ->and($item->status)->toBe('failed');
+});
+
+it('does not create a duplicate feed item for a tracked outbound send', function (): void {
+    $signature = '8xDedupSignature3333333333333333333333333333333333333333333333333';
+
+    // Creating the record projects exactly one wallet_send feed item (observer).
+    $sendRecord = WalletSendRecord::create([
+        'public_id'         => 'pi_send_deduptest',
+        'user_id'           => 42,
+        'network'           => 'solana',
+        'asset'             => 'USDC',
+        'amount'            => '2.00000000',
+        'sender_address'    => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        'recipient_address' => 'BobxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxV',
+        'status'            => 'submitted',
+        'tx_hash'           => $signature,
+        'submitted_at'      => now(),
+    ]);
+
+    $blockchainAddress = BlockchainAddress::create([
+        'uuid'       => '33333333-4444-4555-8666-777777777777',
+        'user_uuid'  => 'user-uuid-42',
+        'address'    => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        'public_key' => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        'chain'      => 'solana',
+        'is_active'  => true,
+    ]);
+
+    $tx = [
+        'signature'      => $signature,
+        'fee'            => 5000,
+        'tokenTransfers' => [[
+            'fromUserAccount' => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+            'toUserAccount'   => 'BobxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxV',
+            'mint'            => 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+            'tokenAmount'     => '2.0',
+        ]],
+    ];
+
+    app(HeliusTransactionProcessor::class)->processTransaction(
+        'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        $blockchainAddress,
+        42,
+        $tx,
+    );
+
+    // Still exactly one feed item — the observer-owned one, now confirmed.
+    expect(ActivityFeedItem::count())->toBe(1);
+    $item = ActivityFeedItem::first();
+    expect($item->reference_type)->toBe(WalletSendRecord::class)
+        ->and($item->status)->toBe('confirmed');
 });

--- a/tests/Feature/Domain/Wallet/WalletSendRecordObserverTest.php
+++ b/tests/Feature/Domain/Wallet/WalletSendRecordObserverTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\MobilePayment\Enums\ActivityItemType;
+use App\Domain\MobilePayment\Models\ActivityFeedItem;
+use App\Domain\Wallet\Models\WalletSendRecord;
+use App\Models\User;
+use Illuminate\Support\Facades\Schema;
+use Tests\Traits\CreatesSolanaTestTables;
+
+uses(CreatesSolanaTestTables::class);
+
+beforeEach(function (): void {
+    $this->createSolanaTestTables();
+
+    Schema::dropIfExists('wallet_send_records');
+    Schema::create('wallet_send_records', function ($table): void {
+        $table->uuid('id')->primary();
+        $table->string('public_id', 64)->unique();
+        $table->unsignedBigInteger('user_id');
+        $table->string('network', 20);
+        $table->string('asset', 10);
+        $table->decimal('amount', 30, 8);
+        $table->string('sender_address', 128);
+        $table->string('recipient_address', 128);
+        $table->string('status', 20)->default('pending');
+        $table->string('tx_hash', 128)->nullable();
+        $table->string('user_op_hash', 128)->nullable();
+        $table->string('idempotency_key', 128)->nullable()->unique();
+        $table->string('quote_id', 64)->nullable();
+        $table->string('error_code', 50)->nullable();
+        $table->text('error_message')->nullable();
+        $table->json('metadata')->nullable();
+        $table->dateTime('submitted_at')->nullable();
+        $table->dateTime('confirmed_at')->nullable();
+        $table->dateTime('failed_at')->nullable();
+        $table->timestamps();
+    });
+});
+
+afterEach(function (): void {
+    Schema::dropIfExists('wallet_send_records');
+    $this->dropSolanaTestTables();
+});
+
+/**
+ * @param array<string, mixed> $overrides
+ */
+function makeSendRecord(array $overrides = []): WalletSendRecord
+{
+    if (! isset($overrides['user_id'])) {
+        $overrides['user_id'] = User::factory()->create()->id;
+    }
+
+    return WalletSendRecord::create(array_merge([
+        'public_id'         => 'pi_send_' . uniqid(),
+        'network'           => 'solana',
+        'asset'             => 'USDT',
+        'amount'            => '1.00000000',
+        'sender_address'    => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        'recipient_address' => 'BobxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxV',
+        'status'            => WalletSendRecord::STATUS_PENDING,
+    ], $overrides));
+}
+
+it('projects a pending send into the activity feed on creation', function (): void {
+    $record = makeSendRecord();
+
+    $item = ActivityFeedItem::where('reference_type', WalletSendRecord::class)
+        ->where('reference_id', $record->id)
+        ->first();
+
+    expect($item)->not->toBeNull()
+        ->and($item->activity_type)->toBe(ActivityItemType::TRANSFER_OUT)
+        ->and($item->status)->toBe('pending')
+        ->and($item->user_id)->toBe($record->user_id)
+        ->and($item->asset)->toBe('USDT')
+        ->and((float) $item->amount)->toBe(-1.0)
+        ->and($item->to_address)->toBe('BobxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxV');
+});
+
+it('updates the feed item status when the send is submitted', function (): void {
+    $record = makeSendRecord();
+
+    $record->update([
+        'status'       => WalletSendRecord::STATUS_SUBMITTED,
+        'tx_hash'      => '5xRealSolanaSignature',
+        'submitted_at' => now(),
+    ]);
+
+    $item = ActivityFeedItem::where('reference_id', $record->id)->first();
+    expect($item->status)->toBe('submitted');
+});
+
+it('updates the feed item status when the send fails', function (): void {
+    $record = makeSendRecord();
+
+    $record->update([
+        'status'        => WalletSendRecord::STATUS_FAILED,
+        'error_code'    => 'SOLANA_TX_FAILED',
+        'error_message' => 'This transfer could not be completed.',
+        'failed_at'     => now(),
+    ]);
+
+    $item = ActivityFeedItem::where('reference_id', $record->id)->first();
+    expect($item->status)->toBe('failed');
+});
+
+it('does not create a duplicate feed item across the full lifecycle', function (): void {
+    $record = makeSendRecord();
+    $record->update(['status' => WalletSendRecord::STATUS_SUBMITTED, 'tx_hash' => 'sig1', 'submitted_at' => now()]);
+    $record->update(['status' => WalletSendRecord::STATUS_CONFIRMED, 'confirmed_at' => now()]);
+
+    $count = ActivityFeedItem::where('reference_id', $record->id)->count();
+    expect($count)->toBe(1);
+
+    $item = ActivityFeedItem::where('reference_id', $record->id)->first();
+    expect($item->status)->toBe('confirmed');
+});
+
+it('keeps occurred_at pinned to creation time across status updates', function (): void {
+    $record = makeSendRecord();
+    $original = ActivityFeedItem::where('reference_id', $record->id)->first()->occurred_at;
+
+    $this->travel(10)->minutes();
+    $record->update(['status' => WalletSendRecord::STATUS_SUBMITTED, 'tx_hash' => 'sig', 'submitted_at' => now()]);
+
+    $item = ActivityFeedItem::where('reference_id', $record->id)->first();
+    expect($item->occurred_at->equalTo($original))->toBeTrue();
+});

--- a/tests/Unit/Domain/Wallet/Jobs/PollSolanaWalletSendConfirmationsTest.php
+++ b/tests/Unit/Domain/Wallet/Jobs/PollSolanaWalletSendConfirmationsTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Wallet\Jobs\PollSolanaWalletSendConfirmations;
+use App\Domain\Wallet\Models\WalletSendRecord;
+use App\Domain\Wallet\Services\Send\HeliusRpcClient;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+beforeEach(function (): void {
+    Schema::dropIfExists('wallet_send_records');
+    Schema::create('wallet_send_records', function ($table): void {
+        $table->uuid('id')->primary();
+        $table->string('public_id', 64)->unique();
+        $table->unsignedBigInteger('user_id');
+        $table->string('network', 20);
+        $table->string('asset', 10);
+        $table->decimal('amount', 30, 8);
+        $table->string('sender_address', 128);
+        $table->string('recipient_address', 128);
+        $table->string('status', 20)->default('pending');
+        $table->string('tx_hash', 128)->nullable();
+        $table->string('user_op_hash', 128)->nullable();
+        $table->string('idempotency_key', 128)->nullable()->unique();
+        $table->string('quote_id', 64)->nullable();
+        $table->string('error_code', 50)->nullable();
+        $table->text('error_message')->nullable();
+        $table->json('metadata')->nullable();
+        $table->dateTime('submitted_at')->nullable();
+        $table->dateTime('confirmed_at')->nullable();
+        $table->dateTime('failed_at')->nullable();
+        $table->timestamps();
+    });
+});
+
+/**
+ * @param array<string, mixed> $overrides
+ */
+function makeSolanaSendRecord(array $overrides = []): WalletSendRecord
+{
+    return WalletSendRecord::create(array_merge([
+        'public_id'         => 'pi_send_' . uniqid(),
+        'user_id'           => 1,
+        'network'           => 'solana',
+        'asset'             => 'USDC',
+        'amount'            => '1.00000000',
+        'sender_address'    => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        'recipient_address' => 'BobxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxV',
+        'status'            => 'submitted',
+        'tx_hash'           => '5xSolanaSig' . uniqid(),
+        'submitted_at'      => now(),
+    ], $overrides));
+}
+
+/**
+ * @param array{confirmationStatus: string, err: array<int|string, mixed>|null}|null $entry
+ */
+function mockHeliusRpc(string $signature, ?array $entry): HeliusRpcClient
+{
+    /** @var HeliusRpcClient&Mockery\MockInterface $rpc */
+    $rpc = Mockery::mock(HeliusRpcClient::class);
+    $rpc->shouldReceive('getSignatureStatuses')
+        ->once()
+        ->with([$signature])
+        ->andReturn([$signature => $entry]);
+
+    return $rpc;
+}
+
+it('flips a submitted Solana send to confirmed when the cluster reports it confirmed', function (): void {
+    $record = makeSolanaSendRecord();
+
+    $rpc = mockHeliusRpc((string) $record->tx_hash, ['confirmationStatus' => 'finalized', 'err' => null]);
+
+    (new PollSolanaWalletSendConfirmations())->handle($rpc);
+
+    $record->refresh();
+    expect($record->status)->toBe('confirmed')
+        ->and($record->confirmed_at)->not->toBeNull();
+});
+
+it('flips a submitted Solana send to failed when the cluster reports an error', function (): void {
+    $record = makeSolanaSendRecord();
+
+    $rpc = mockHeliusRpc((string) $record->tx_hash, [
+        'confirmationStatus' => 'confirmed',
+        'err'                => ['InstructionError' => [0, 'InsufficientFundsForFee']],
+    ]);
+
+    (new PollSolanaWalletSendConfirmations())->handle($rpc);
+
+    $record->refresh();
+    expect($record->status)->toBe('failed')
+        ->and($record->error_code)->toBe('SOLANA_TX_FAILED')
+        ->and($record->error_message)->not->toBeNull()
+        ->and($record->failed_at)->not->toBeNull();
+});
+
+it('marks a stale unknown send as dropped', function (): void {
+    $record = makeSolanaSendRecord(['submitted_at' => now()->subMinutes(10)]);
+
+    $rpc = mockHeliusRpc((string) $record->tx_hash, null);
+
+    (new PollSolanaWalletSendConfirmations())->handle($rpc);
+
+    $record->refresh();
+    expect($record->status)->toBe('failed')
+        ->and($record->error_code)->toBe('SOLANA_TX_DROPPED')
+        ->and($record->failed_at)->not->toBeNull();
+});
+
+it('leaves a recently submitted unknown send alone (still within blockhash window)', function (): void {
+    $record = makeSolanaSendRecord(['submitted_at' => now()->subMinute()]);
+
+    $rpc = mockHeliusRpc((string) $record->tx_hash, null);
+
+    (new PollSolanaWalletSendConfirmations())->handle($rpc);
+
+    $record->refresh();
+    expect($record->status)->toBe('submitted')
+        ->and($record->failed_at)->toBeNull();
+});
+
+it('leaves a send still being processed alone', function (): void {
+    $record = makeSolanaSendRecord();
+
+    $rpc = mockHeliusRpc((string) $record->tx_hash, ['confirmationStatus' => 'processed', 'err' => null]);
+
+    (new PollSolanaWalletSendConfirmations())->handle($rpc);
+
+    $record->refresh();
+    expect($record->status)->toBe('submitted')
+        ->and($record->confirmed_at)->toBeNull()
+        ->and($record->failed_at)->toBeNull();
+});
+
+it('ignores EVM records and non-submitted records', function (): void {
+    $evm = makeSolanaSendRecord(['network' => 'polygon']);
+    $pending = makeSolanaSendRecord(['status' => 'pending']);
+
+    /** @var HeliusRpcClient&Mockery\MockInterface $rpc */
+    $rpc = Mockery::mock(HeliusRpcClient::class);
+    $rpc->shouldNotReceive('getSignatureStatuses');
+
+    (new PollSolanaWalletSendConfirmations())->handle($rpc);
+
+    expect($evm->refresh()->status)->toBe('submitted')
+        ->and($pending->refresh()->status)->toBe('pending');
+});
+
+it('logs and continues when the RPC throws', function (): void {
+    $record = makeSolanaSendRecord();
+
+    /** @var HeliusRpcClient&Mockery\MockInterface $rpc */
+    $rpc = Mockery::mock(HeliusRpcClient::class);
+    $rpc->shouldReceive('getSignatureStatuses')
+        ->once()
+        ->andThrow(new RuntimeException('Helius RPC down'));
+
+    (new PollSolanaWalletSendConfirmations())->handle($rpc);
+
+    $record->refresh();
+    expect($record->status)->toBe('submitted');
+});


### PR DESCRIPTION
## Summary

Reported by the mobile team: a 1 USDT Solana send went through `quote → prepare → submit` (got a `pi_send_…` intent, "pending confirmation"), then **failed** — and never appeared in `GET /api/v1/wallet/transactions`, not as pending, not as failed. The user had zero in-app visibility of an in-flight or failed transfer.

**Root cause:** `/wallet/transactions` reads `activity_feed_items`. Outbound sends only got an `activity_feed_items` row when the Helius confirmation webhook fired — always as `confirmed`. The `prepare`/`submit` flow wrote only to `wallet_send_records`. So pending sends and failed sends never reached the feed. Inbound transfers appear because the webhook writes their feed row directly.

## Changes

- **`WalletSendRecordObserver`** projects every wallet send into `activity_feed_items` — `pending` on prepare, status updated on each transition — so the feed shows `pending`/`submitted`/`confirmed`/`failed`, matching inbound transfers. Projection is best-effort: a feed-write failure never rolls back a money send.
- **`HeliusTransactionProcessor`** skips the duplicate `solana_tx` feed item when a tracked `WalletSendRecord` exists (the observer owns it), and honours the Helius `transactionError` field so a failed Solana tx is recorded `failed` — not `confirmed`. The record update now goes through the model so the observer re-projects.
- **`PollSolanaWalletSendConfirmations`** (scheduled every minute, mirrors the EVM poller) gives every Solana send a terminal state by polling `getSignatureStatuses`. This is the safety net for on-chain failures the Helius webhook does not reliably deliver — e.g. a send doomed by insufficient SOL for the network fee — and for dropped/expired transactions.
- **`GET /api/v1/wallet/transactions/by-intent/{intentId}`** returns live send status (`status`, `error_code`, `error_message`, `tx_hash`, `explorer_url`, timestamps) for the mobile send-confirmation polling screen, since `submit` returns immediately.

WebSocket push for intent transitions is intentionally **not** in this PR — agreed with the mobile team as a fast-follow; polling ships for launch.

## Testing

- New: `WalletSendRecordObserverTest` (5), `PollSolanaWalletSendConfirmationsTest` (7), `WalletTransactionByIntentTest` (5), + 2 cases on `HeliusTransactionProcessorWalletSendConfirmationTest`.
- Regression: `tests/Unit/Domain/Wallet` + `tests/Feature/Domain/Wallet` (244 passed), `tests/Feature/Api/Wallet` + webhook/activity-feed suites (54 passed). PHPStan level 8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)