### PR TITLE
feat: gate KYC verification fees behind a flag — free verification by default

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -389,6 +389,12 @@ STRIPE_KYC_WEBHOOK_SECRET=
 # from the legacy CGO/KYC secrets). Endpoint: POST /webhooks/stripe/subscriptions.
 STRIPE_SUBSCRIPTION_WEBHOOK_SECRET=
 
+# KYC / TrustCert verification fees. OFF by default — verification is free
+# and the pay endpoints (wallet/card/IAP) are closed. Only enable once the
+# Play Billing IAP rail is production-ready (charging for a digital service
+# outside Play Billing risks Android store rejection).
+TRUSTCERT_VERIFICATION_FEES_ENABLED=false
+
 # Plan B Slice 5 — Stripe Cards (waitlist deposit) webhook secret. Distinct
 # from STRIPE_SUBSCRIPTION_WEBHOOK_SECRET so it can rotate independently.
 # Endpoint: POST /webhooks/stripe/cards.

--- a/.env.zelta.example
+++ b/.env.zelta.example
@@ -161,6 +161,12 @@ STRIPE_KYC_WEBHOOK_SECRET=
 # from the legacy CGO/KYC secrets). Endpoint: POST /webhooks/stripe/subscriptions.
 STRIPE_SUBSCRIPTION_WEBHOOK_SECRET=
 
+# KYC / TrustCert verification fees. OFF by default — verification is free
+# and the pay endpoints (wallet/card/IAP) are closed. Only enable once the
+# Play Billing IAP rail is production-ready (charging for a digital service
+# outside Play Billing risks Android store rejection).
+TRUSTCERT_VERIFICATION_FEES_ENABLED=false
+
 # Plan B Slice 5 — Stripe Cards (waitlist deposit) webhook secret. Distinct
 # from STRIPE_SUBSCRIPTION_WEBHOOK_SECRET so it can rotate independently.
 # Endpoint: POST /webhooks/stripe/cards.

--- a/app/Http/Controllers/Api/V1/TrustCertPaymentController.php
+++ b/app/Http/Controllers/Api/V1/TrustCertPaymentController.php
@@ -17,29 +17,6 @@ use Illuminate\Support\Str;
 class TrustCertPaymentController extends Controller
 {
     /**
-     * Verification fee schedule by trust level (numeric).
-     *
-     * @var array<int, numeric-string>
-     */
-    private const LEVEL_FEES = [
-        1 => '4.99',
-        2 => '4.99',
-        3 => '9.99',
-        4 => '9.99',
-    ];
-
-    /**
-     * IAP product IDs for each level.
-     *
-     * @var array<int, string>
-     */
-    public const IAP_PRODUCT_IDS = [
-        1 => 'kyc_verification_level_1',
-        2 => 'kyc_verification_level_2',
-        3 => 'kyc_verification_level_3',
-    ];
-
-    /**
      * Method 1: Pay with wallet balance (USDC internal ledger deduction).
      */
     public function payWallet(string $applicationId, Request $request): JsonResponse
@@ -47,6 +24,10 @@ class TrustCertPaymentController extends Controller
         $user = $request->user();
         if (! $user instanceof \App\Models\User) {
             return response()->json(['error' => 'Unauthenticated'], 401);
+        }
+
+        if ($disabled = $this->feesDisabledResponse()) {
+            return $disabled;
         }
 
         $application = $this->findApplication($user->id, $applicationId);
@@ -111,6 +92,10 @@ class TrustCertPaymentController extends Controller
         $user = $request->user();
         if (! $user instanceof \App\Models\User) {
             return response()->json(['error' => 'Unauthenticated'], 401);
+        }
+
+        if ($disabled = $this->feesDisabledResponse()) {
+            return $disabled;
         }
 
         $application = $this->findApplication($user->id, $applicationId);
@@ -202,6 +187,10 @@ class TrustCertPaymentController extends Controller
             return response()->json(['error' => 'Unauthenticated'], 401);
         }
 
+        if ($disabled = $this->feesDisabledResponse()) {
+            return $disabled;
+        }
+
         $request->validate([
             'receipt'  => ['required', 'string'],
             'platform' => ['required', 'string', 'in:ios,android'],
@@ -283,7 +272,32 @@ class TrustCertPaymentController extends Controller
 
         $numericLevel = $levelMap[$targetLevel] ?? 1;
 
-        return self::LEVEL_FEES[$numericLevel] ?? '4.99';
+        return self::getVerificationFee($numericLevel) ?? '0.00';
+    }
+
+    /**
+     * Whether paid verification is currently enabled. When false, verification
+     * is free and the pay endpoints are closed.
+     */
+    public static function feesEnabled(): bool
+    {
+        return (bool) config('trustcert.verification_fees.enabled', false);
+    }
+
+    /**
+     * Guard for the pay endpoints: a 403 response when verification fees are
+     * disabled (verification is free — there is nothing to pay), else null.
+     */
+    private function feesDisabledResponse(): ?JsonResponse
+    {
+        if (self::feesEnabled()) {
+            return null;
+        }
+
+        return response()->json([
+            'error'   => 'ERR_CERT_403',
+            'message' => 'Verification is currently free — no payment is required.',
+        ], 403);
     }
 
     /**
@@ -394,12 +408,25 @@ class TrustCertPaymentController extends Controller
     }
 
     /**
-     * Get verification fee for a given numeric trust level.
+     * Get the verification fee for a numeric trust level.
      *
-     * Used by MobileTrustCertController to add verificationFee to requirements response.
+     * Used by MobileTrustCertController to add verificationFee to the
+     * requirements response. Returns '0.00' for every chargeable level when
+     * verification fees are disabled (the launch default), so the mobile
+     * "fee = 0 -> no payment step" path applies. Returns null for levels
+     * with no fee-schedule entry (e.g. unknown).
+     *
+     * @return numeric-string|null
      */
     public static function getVerificationFee(int $numericLevel): ?string
     {
-        return self::LEVEL_FEES[$numericLevel] ?? null;
+        /** @var array<int, numeric-string> $schedule */
+        $schedule = (array) config('trustcert.verification_fees.level_fees', []);
+
+        if (! isset($schedule[$numericLevel])) {
+            return null;
+        }
+
+        return self::feesEnabled() ? $schedule[$numericLevel] : '0.00';
     }
 }

--- a/config/trustcert.php
+++ b/config/trustcert.php
@@ -121,6 +121,41 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Verification Fees
+    |--------------------------------------------------------------------------
+    |
+    | KYC / verification fee schedule. `enabled` is the master switch: when
+    | false (the launch default) verification is free — the API reports a
+    | $0 fee for every level so the mobile "fee = 0 -> no payment step" path
+    | applies, and the pay endpoints reject. Paid verification can be turned
+    | back on later without an app release.
+    |
+    | Note: charging for a digital service outside Play Billing risks Android
+    | store rejection — only re-enable once the IAP rail is production-ready.
+    |
+    */
+    'verification_fees' => [
+        'enabled' => (bool) env('TRUSTCERT_VERIFICATION_FEES_ENABLED', false),
+
+        // Fee schedule by numeric trust level (USD). Applied only when enabled.
+        'level_fees' => [
+            1 => '4.99',
+            2 => '4.99',
+            3 => '9.99',
+            4 => '9.99',
+        ],
+
+        // IAP product IDs by numeric level — must exist in App Store Connect
+        // and Play Console before the IAP rail can be used.
+        'iap_product_ids' => [
+            1 => 'kyc_verification_level_1',
+            2 => 'kyc_verification_level_2',
+            3 => 'kyc_verification_level_3',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | W3C Standards Compliance
     |--------------------------------------------------------------------------
     */

--- a/tests/Unit/Http/Controllers/Api/V1/TrustCertPaymentControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/V1/TrustCertPaymentControllerTest.php
@@ -17,6 +17,11 @@ uses(TestCase::class);
 beforeEach(function (): void {
     config(['cache.default' => 'array']);
 
+    // Paid-verification flow is gated behind a flag (default off). The paid
+    // path tests below assume it is on; the "fees disabled" describe block
+    // overrides it back to false per-test.
+    config(['trustcert.verification_fees.enabled' => true]);
+
     // Recreate table without FK to avoid users table dependency in tests
     Schema::dropIfExists('verification_payments');
     Schema::create('verification_payments', function ($table): void {
@@ -438,6 +443,50 @@ describe('TrustCertPaymentController fee schedule', function (): void {
             ->and(TrustCertPaymentController::getVerificationFee(3))->toBe('9.99')
             ->and(TrustCertPaymentController::getVerificationFee(4))->toBe('9.99')
             ->and(TrustCertPaymentController::getVerificationFee(0))->toBeNull();
+    });
+});
+
+// ---------- Free verification (fees disabled) ----------
+
+describe('TrustCertPaymentController with verification fees disabled', function (): void {
+    it('reports a zero fee for every chargeable level', function (): void {
+        config(['trustcert.verification_fees.enabled' => false]);
+
+        expect(TrustCertPaymentController::getVerificationFee(1))->toBe('0.00')
+            ->and(TrustCertPaymentController::getVerificationFee(2))->toBe('0.00')
+            ->and(TrustCertPaymentController::getVerificationFee(3))->toBe('0.00')
+            ->and(TrustCertPaymentController::getVerificationFee(4))->toBe('0.00')
+            ->and(TrustCertPaymentController::getVerificationFee(0))->toBeNull();
+    });
+
+    it('reports fees as enabled/disabled via the flag', function (): void {
+        config(['trustcert.verification_fees.enabled' => false]);
+        expect(TrustCertPaymentController::feesEnabled())->toBeFalse();
+
+        config(['trustcert.verification_fees.enabled' => true]);
+        expect(TrustCertPaymentController::feesEnabled())->toBeTrue();
+    });
+
+    it('closes the wallet pay endpoint with 403', function (): void {
+        config(['trustcert.verification_fees.enabled' => false]);
+        storeTestApplication(1, 'app_free_wallet', 'basic');
+
+        $controller = new TrustCertPaymentController();
+        $response = $controller->payWallet('app_free_wallet', makePaymentRequest('/pay'));
+
+        expect($response->getStatusCode())->toBe(403)
+            ->and($response->getData(true)['error'])->toBe('ERR_CERT_403');
+    });
+
+    it('closes the card pay endpoint with 403', function (): void {
+        config(['trustcert.verification_fees.enabled' => false]);
+        storeTestApplication(1, 'app_free_card', 'basic');
+
+        $controller = new TrustCertPaymentController();
+        $response = $controller->payCard('app_free_card', makePaymentRequest('/pay/card'));
+
+        expect($response->getStatusCode())->toBe(403)
+            ->and($response->getData(true)['error'])->toBe('ERR_CERT_403');
     });
 });
 

--- a/tests/Unit/Http/Middleware/RequireKycVerificationTest.php
+++ b/tests/Unit/Http/Middleware/RequireKycVerificationTest.php
@@ -36,6 +36,13 @@ it('allows verified users through', function () {
 });
 
 it('allows unverified users to access KYC payment endpoints', function () {
+    // Verification fees on, so the pay endpoint runs its normal flow and
+    // returns 404 for a missing application. With fees off it would short
+    // out at 403 "free verification" before that — either way the point is
+    // that the KYC middleware did not intercept (that would be 403
+    // ERR_KYC_REQUIRED).
+    config(['trustcert.verification_fees.enabled' => true]);
+
     $user = User::factory()->create(['kyc_status' => 'not_started']);
     Sanctum::actingAs($user, ['read', 'write', 'delete']);
 


### PR DESCRIPTION
## Summary

KYC / TrustCert verification was charging **$4.99–$9.99 per level** (wallet / card / IAP). For the store launch that's untenable:

- The **IAP rail is stubbed** — `payIap` returns `501 ERR_CERT_501` in production, no real Apple/Google receipt validation.
- The **wallet rail hits a demo cache balance**, not the real non-custodial USDC wallet.
- Charging for a **digital service outside Play Billing** risks Android store rejection.

Per the product decision, verification ships **free at launch**. This PR makes that the authoritative backend behaviour.

## Changes

- New `trustcert.verification_fees.enabled` flag (`TRUSTCERT_VERIFICATION_FEES_ENABLED`, **default `false`**).
- When disabled: `getVerificationFee()` reports `0.00` for every level — the mobile `fee = 0 → no payment step` path applies with no client special-casing — and `payWallet` / `payCard` / `payIap` return **403 `ERR_CERT_403`** ("verification is currently free").
- Paid verification can be re-enabled later **without an app release** by flipping the flag.
- Moved the hardcoded `LEVEL_FEES` / `IAP_PRODUCT_IDS` constants into `config/trustcert.php`.

## Mobile impact

Mobile can keep its `verificationFee = 0 → skip payment` logic — the backend now always sends `0` while the flag is off. Card/wallet/IAP can be gated off on store builds. (Separately: `verificationFeeLocal` is **not implemented** backend-side — mobile is reading a phantom field.)

## Tests

`TrustCertPaymentControllerTest` — existing paid-flow tests pin `enabled => true` in `beforeEach`; 4 new tests cover the disabled path (zero fee for every level, `feesEnabled()` flag, wallet + card endpoints returning 403). All 25 pass; php-cs-fixer + PHPStan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)