### PR TITLE
feat: serve a hosted receipt page and downloadable PDF

### DIFF
--- a/app/Domain/MobilePayment/Models/PaymentReceipt.php
+++ b/app/Domain/MobilePayment/Models/PaymentReceipt.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Storage;
 
 /**
  * Payment receipt for completed transactions.
@@ -78,9 +79,25 @@ class PaymentReceipt extends Model
         return $this->belongsTo(PaymentIntent::class);
     }
 
+    /**
+     * Public, no-auth URL of the hosted receipt page. Keyed on the unguessable
+     * `share_token` rather than `public_id` so the link can be shared freely.
+     */
     public function getShareUrl(): string
     {
-        return config('app.url') . '/receipt/' . $this->public_id;
+        return route('receipt.show', ['shareToken' => $this->share_token]);
+    }
+
+    /**
+     * Public URL of the generated receipt PDF, or null if one was not produced.
+     */
+    public function getPdfUrl(): ?string
+    {
+        if ($this->pdf_path === null || $this->pdf_path === '') {
+            return null;
+        }
+
+        return Storage::disk('public')->url($this->pdf_path);
     }
 
     /**
@@ -96,7 +113,7 @@ class PaymentReceipt extends Model
             'dateTime'     => $this->transaction_at->toIso8601String(),
             'networkFee'   => $this->network_fee,
             'sharePayload' => $this->getShareUrl(),
-            'pdfUrl'       => $this->pdf_path,
+            'pdfUrl'       => $this->getPdfUrl(),
         ];
     }
 }

--- a/app/Domain/MobilePayment/Services/ReceiptService.php
+++ b/app/Domain/MobilePayment/Services/ReceiptService.php
@@ -8,8 +8,12 @@ use App\Domain\MobilePayment\Enums\ActivityItemType;
 use App\Domain\MobilePayment\Models\ActivityFeedItem;
 use App\Domain\MobilePayment\Models\PaymentIntent;
 use App\Domain\MobilePayment\Models\PaymentReceipt;
+use Barryvdh\DomPDF\Facade\Pdf;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Throwable;
 
 /**
  * Service for generating and retrieving payment receipts.
@@ -176,17 +180,53 @@ class ReceiptService
     }
 
     /**
-     * Cache the receipt's API representation if it was just persisted.
+     * Generate the receipt PDF then cache its API representation — but only
+     * when the receipt was just persisted, so repeat lookups stay cheap and
+     * idempotent.
      */
     private function cacheIfNew(PaymentReceipt $receipt): void
     {
-        if ($receipt->wasRecentlyCreated) {
-            $cacheHours = (int) config('mobile_payment.receipt_cache_hours', 24);
-            Cache::put(
-                "receipt:{$receipt->public_id}",
-                $receipt->toApiResponse(),
-                now()->addHours($cacheHours)
-            );
+        if (! $receipt->wasRecentlyCreated) {
+            return;
+        }
+
+        $this->generatePdf($receipt);
+
+        $cacheHours = (int) config('mobile_payment.receipt_cache_hours', 24);
+        Cache::put(
+            "receipt:{$receipt->public_id}",
+            $receipt->toApiResponse(),
+            now()->addHours($cacheHours)
+        );
+    }
+
+    /**
+     * Render the receipt to a PDF and store it on the public disk.
+     *
+     * Failures are logged but never bubble up: a missing PDF degrades to
+     * `pdfUrl: null` (mobile falls back to the hosted share page) rather
+     * than failing receipt generation outright.
+     */
+    private function generatePdf(PaymentReceipt $receipt): void
+    {
+        try {
+            /** @var \Barryvdh\DomPDF\PDF $pdf */
+            $pdf = Pdf::loadView('receipts.show', [
+                'receipt' => $receipt,
+                'forPdf'  => true,
+            ]);
+            $pdf->setPaper('a4', 'portrait');
+
+            $path = 'receipts/' . $receipt->share_token . '.pdf';
+            Storage::disk('public')->put($path, $pdf->output());
+
+            $receipt->pdf_path = $path;
+            $receipt->save();
+        } catch (Throwable $e) {
+            Log::error('Receipt PDF generation failed', [
+                'receipt_id' => $receipt->public_id,
+                'error'      => $e->getMessage(),
+            ]);
         }
     }
 

--- a/app/Http/Controllers/Api/MobilePayment/ReceiptController.php
+++ b/app/Http/Controllers/Api/MobilePayment/ReceiptController.php
@@ -40,14 +40,13 @@ class ReceiptController extends Controller
         new OA\Property(property: 'success', type: 'boolean', example: true),
         new OA\Property(property: 'data', type: 'object', properties: [
         new OA\Property(property: 'receiptId', type: 'string', example: 'rcpt_abc123'),
-        new OA\Property(property: 'transactionId', type: 'string', example: 'tx_abc123'),
-        new OA\Property(property: 'amount', type: 'number', example: 25.50),
+        new OA\Property(property: 'merchantName', type: 'string', example: 'Coffee Shop'),
+        new OA\Property(property: 'amount', type: 'string', example: '25.50'),
         new OA\Property(property: 'asset', type: 'string', example: 'USDC'),
-        new OA\Property(property: 'merchant', type: 'object', properties: [
-        new OA\Property(property: 'displayName', type: 'string', example: 'Coffee Shop'),
-        ]),
-        new OA\Property(property: 'timestamp', type: 'string', format: 'date-time'),
-        new OA\Property(property: 'hash', type: 'string', description: 'On-chain transaction hash'),
+        new OA\Property(property: 'dateTime', type: 'string', format: 'date-time'),
+        new OA\Property(property: 'networkFee', type: 'string', example: '0.01 USD'),
+        new OA\Property(property: 'sharePayload', type: 'string', description: 'Public URL of the hosted receipt page', example: 'https://app.zelta.app/receipt/abc...'),
+        new OA\Property(property: 'pdfUrl', type: 'string', nullable: true, description: 'Public URL of the downloadable receipt PDF (null if generation failed)', example: 'https://app.zelta.app/storage/receipts/abc....pdf'),
         ]),
         ])
     )]

--- a/app/Http/Controllers/Web/ReceiptController.php
+++ b/app/Http/Controllers/Web/ReceiptController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Web;
+
+use App\Domain\MobilePayment\Models\PaymentReceipt;
+use App\Http\Controllers\Controller;
+use Illuminate\Contracts\View\View;
+
+/**
+ * Public, shareable payment-receipt page.
+ *
+ * The URL embeds the receipt's unguessable `share_token` (64 random chars),
+ * so the page needs no authentication — it is the target of the
+ * `sharePayload` link returned by the mobile receipt endpoint.
+ */
+class ReceiptController extends Controller
+{
+    public function show(string $shareToken): View
+    {
+        $receipt = PaymentReceipt::where('share_token', $shareToken)->first();
+
+        if ($receipt === null) {
+            abort(404);
+        }
+
+        return view('receipts.show', [
+            'receipt' => $receipt,
+            'forPdf'  => false,
+        ]);
+    }
+}

--- a/resources/views/receipts/show.blade.php
+++ b/resources/views/receipts/show.blade.php
@@ -1,0 +1,136 @@
+@php
+    /** @var \App\Domain\MobilePayment\Models\PaymentReceipt $receipt */
+    $brand = config('brand.name', 'Zelta');
+    $forPdf = $forPdf ?? false;
+
+    $amount = (string) $receipt->amount;
+    if (str_contains($amount, '.')) {
+        $amount = rtrim(rtrim($amount, '0'), '.');
+    }
+
+    $txHash = is_string($receipt->tx_hash) ? $receipt->tx_hash : '';
+    $network = is_string($receipt->network) ? $receipt->network : '';
+
+    $pdfUrl = $receipt->pdf_path ? \Illuminate\Support\Facades\Storage::disk('public')->url($receipt->pdf_path) : null;
+@endphp
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex, nofollow">
+    <title>Payment Receipt — {{ $brand }}</title>
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            font-family: 'Helvetica', 'Arial', sans-serif;
+            color: #1a1a2e;
+            background: #f4f5f7;
+            font-size: 14px;
+            line-height: 1.5;
+        }
+        .page { width: 100%; padding: 32px 16px; }
+        .card {
+            width: 480px;
+            max-width: 100%;
+            margin: 0 auto;
+            background: #ffffff;
+            border: 1px solid #e6e8eb;
+            border-radius: 12px;
+        }
+        .header {
+            background: #0b0b23;
+            color: #ffffff;
+            padding: 28px 32px;
+            border-radius: 12px 12px 0 0;
+            text-align: center;
+        }
+        .brand { font-size: 16px; font-weight: bold; letter-spacing: 1px; }
+        .title { font-size: 12px; color: #9aa0b4; margin-top: 4px; text-transform: uppercase; letter-spacing: 2px; }
+        .amount-box { text-align: center; padding: 28px 32px 8px; }
+        .amount { font-size: 34px; font-weight: bold; color: #0b0b23; }
+        .amount-asset { font-size: 18px; color: #6b7280; }
+        .merchant { text-align: center; padding: 0 32px 24px; color: #6b7280; font-size: 15px; }
+        .rows { padding: 8px 32px 24px; }
+        table { width: 100%; border-collapse: collapse; }
+        td { padding: 10px 0; border-bottom: 1px solid #f0f1f3; vertical-align: top; }
+        td.label { color: #9aa0b4; font-size: 13px; width: 40%; }
+        td.value { color: #1a1a2e; font-size: 13px; text-align: right; font-weight: bold; }
+        td.value.mono { font-family: 'Courier New', monospace; font-weight: normal; word-break: break-all; }
+        tr:last-child td { border-bottom: none; }
+        .footer {
+            padding: 20px 32px 28px;
+            border-top: 1px solid #f0f1f3;
+            color: #9aa0b4;
+            font-size: 11px;
+            text-align: center;
+        }
+        .download {
+            display: block;
+            margin: 0 32px 24px;
+            padding: 12px;
+            background: #0b0b23;
+            color: #ffffff;
+            text-decoration: none;
+            text-align: center;
+            border-radius: 8px;
+            font-weight: bold;
+            font-size: 14px;
+        }
+    </style>
+</head>
+<body>
+    <div class="page">
+        <div class="card">
+            <div class="header">
+                <div class="brand">{{ $brand }}</div>
+                <div class="title">Payment Receipt</div>
+            </div>
+
+            <div class="amount-box">
+                <span class="amount">{{ $amount }}</span>
+                <span class="amount-asset">{{ $receipt->asset }}</span>
+            </div>
+            <div class="merchant">{{ $receipt->merchant_name }}</div>
+
+            <div class="rows">
+                <table>
+                    <tr>
+                        <td class="label">Date</td>
+                        <td class="value">{{ $receipt->transaction_at->format('M j, Y · g:i A') }}</td>
+                    </tr>
+                    @if ($network !== '')
+                        <tr>
+                            <td class="label">Network</td>
+                            <td class="value">{{ $network }}</td>
+                        </tr>
+                    @endif
+                    <tr>
+                        <td class="label">Network fee</td>
+                        <td class="value">{{ $receipt->network_fee }}</td>
+                    </tr>
+                    @if ($txHash !== '')
+                        <tr>
+                            <td class="label">Transaction</td>
+                            <td class="value mono">{{ $txHash }}</td>
+                        </tr>
+                    @endif
+                    <tr>
+                        <td class="label">Receipt ID</td>
+                        <td class="value mono">{{ $receipt->public_id }}</td>
+                    </tr>
+                </table>
+            </div>
+
+            @if (! $forPdf && $pdfUrl)
+                <a class="download" href="{{ $pdfUrl }}">Download PDF</a>
+            @endif
+
+            <div class="footer">
+                This receipt confirms a transaction settled on-chain.<br>
+                Generated by {{ $brand }}.
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -889,6 +889,13 @@ Route::prefix('foodo')->group(function () {
     Route::post('/dish/{id}/verify', [App\Http\Controllers\Foodo\FoodoDishAnalysisController::class, 'verify'])->name('foodo.dish.verify');
 });
 
+// Public payment receipt page — shareable, no auth (keyed on an unguessable
+// 64-char share_token). This is the target of the `sharePayload` link
+// returned by POST /api/v1/transactions/{txId}/receipt.
+Route::get('/receipt/{shareToken}', [App\Http\Controllers\Web\ReceiptController::class, 'show'])
+    ->middleware('throttle:60,1')
+    ->name('receipt.show');
+
 // SEO routes - Sitemap and Robots.txt
 Route::get('/sitemap.xml', [App\Http\Controllers\SitemapController::class, 'index'])->name('sitemap');
 Route::get('/robots.txt', [App\Http\Controllers\SitemapController::class, 'robots'])->name('robots');

--- a/tests/Feature/Api/MobilePayment/ReceiptControllerTest.php
+++ b/tests/Feature/Api/MobilePayment/ReceiptControllerTest.php
@@ -12,6 +12,7 @@ use App\Domain\MobilePayment\Models\ActivityFeedItem;
 use App\Domain\MobilePayment\Models\PaymentIntent;
 use App\Models\User;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
@@ -25,6 +26,7 @@ class ReceiptControllerTest extends TestCase
     {
         parent::setUp();
         Cache::flush();
+        Storage::fake('public');
 
         $this->user = User::factory()->create();
         $this->token = $this->user->createToken('test-token', ['read', 'write', 'delete'])->plainTextToken;
@@ -65,6 +67,7 @@ class ReceiptControllerTest extends TestCase
                     'dateTime',
                     'networkFee',
                     'sharePayload',
+                    'pdfUrl',
                 ],
             ])
             ->assertJsonPath('data.merchantName', 'Received')
@@ -72,6 +75,11 @@ class ReceiptControllerTest extends TestCase
             ->assertJsonPath('data.networkFee', '0.0003 USD');
 
         $this->assertSame('1.5', (string) (float) $response->json('data.amount'));
+
+        // The share link points at the hosted receipt page, and a PDF was generated.
+        $this->assertStringContainsString('/receipt/', (string) $response->json('data.sharePayload'));
+        $this->assertNotNull($response->json('data.pdfUrl'));
+        $this->assertStringContainsString('receipts/', (string) $response->json('data.pdfUrl'));
     }
 
     public function test_returns_422_for_pending_activity_feed_item(): void

--- a/tests/Feature/Web/ReceiptPageTest.php
+++ b/tests/Feature/Web/ReceiptPageTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Web;
+
+use App\Domain\MobilePayment\Models\PaymentReceipt;
+use App\Models\User;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class ReceiptPageTest extends TestCase
+{
+    /**
+     * @param array<string, mixed> $overrides
+     */
+    private function makeReceipt(array $overrides = []): PaymentReceipt
+    {
+        $user = User::factory()->create();
+
+        return PaymentReceipt::create(array_merge([
+            'public_id'      => 'rcpt_' . Str::random(24),
+            'user_id'        => $user->id,
+            'merchant_name'  => 'Coffee Shop',
+            'amount'         => '12.50000000',
+            'asset'          => 'USDC',
+            'network'        => 'SOLANA',
+            'tx_hash'        => '5xVgGJzqFVmLqnRkLGJpKfMoNu3ssKYfQYz4XbUmSqJxHfrx7c2yBz8tNvMwQs9X',
+            'network_fee'    => '0.0003 USD',
+            'share_token'    => Str::random(64),
+            'transaction_at' => now()->subMinutes(3),
+        ], $overrides));
+    }
+
+    public function test_renders_the_hosted_receipt_page_for_a_valid_share_token(): void
+    {
+        $receipt = $this->makeReceipt();
+
+        $response = $this->get('/receipt/' . $receipt->share_token);
+
+        $response->assertOk()
+            ->assertSee('Payment Receipt')
+            ->assertSee('Coffee Shop')
+            ->assertSee('12.5')
+            ->assertSee('USDC')
+            ->assertSee($receipt->public_id);
+    }
+
+    public function test_returns_404_for_an_unknown_share_token(): void
+    {
+        $this->get('/receipt/' . Str::random(64))->assertNotFound();
+    }
+
+    public function test_shows_the_download_button_only_when_a_pdf_exists(): void
+    {
+        $withPdf = $this->makeReceipt(['pdf_path' => 'receipts/example.pdf']);
+        $this->get('/receipt/' . $withPdf->share_token)->assertSee('Download PDF');
+
+        $withoutPdf = $this->makeReceipt(['pdf_path' => null]);
+        $this->get('/receipt/' . $withoutPdf->share_token)->assertDontSee('Download PDF');
+    }
+}


### PR DESCRIPTION
## Problem

Mobile reported that the receipt link 404s and there is no downloadable PDF. Tracing `POST /api/v1/transactions/{txId}/receipt` end to end confirmed it:

- `sharePayload` was `config('app.url') . '/receipt/' . $public_id` — a route **never registered anywhere** → every share link 404'd.
- `pdfUrl` returned `PaymentReceipt.pdf_path`, a column **nothing ever wrote** → always `null`. No PDF generation existed in the MobilePayment domain.
- `getReceipt()` / `getReceiptByShareToken()` and the `share_token` column were half-built scaffolding, wired to nothing.

## Fix

- **Hosted receipt page** — new public `GET /receipt/{shareToken}` web route (`App\Http\Controllers\Web\ReceiptController`), no auth, keyed on the unguessable 64-char `share_token`, throttled. Renders a branded Blade receipt.
- **PDF generation** — `ReceiptService` renders the same Blade view to a PDF via dompdf (already a dependency, same pattern as `CertificateExportService`), stores it on the public disk at `receipts/{share_token}.pdf`, and populates `pdf_path`. Generation failures are logged and degrade gracefully to `pdfUrl: null`.
- `PaymentReceipt::getShareUrl()` now points at the real hosted page; `getPdfUrl()` resolves the stored PDF's public URL.
- Corrected the stale OpenAPI 200-response schema (it described `transactionId`/`merchant`/`hash` fields that `toApiResponse()` has never returned).

## Mobile contract

The `POST /receipt` response shape is unchanged. `sharePayload` now opens a real page; `pdfUrl` is now a real downloadable PDF (or `null` only if generation failed). Canonical PDF key is **`pdfUrl`** (camelCase).

## Tests

- `ReceiptPageTest` — hosted page renders for a valid token, 404s for unknown, download button gated on PDF presence.
- `ReceiptControllerTest` — asserts `sharePayload` is a real `/receipt/` URL and `pdfUrl` is populated; `Storage::fake('public')` added.
- PHPStan level 8 + php-cs-fixer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)