### PR TITLE
fix: filter inbound Solana dust out of the activity feed and pushes

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -251,6 +251,10 @@ WALLET_SEND_GLOBAL_DAILY_LIMIT=5000
 WALLET_SOLANA_SPONSOR_SECRET_KEY=
 # Alert threshold (lamports) for the hourly sponsor-balance check. 0.1 SOL.
 WALLET_SOLANA_SPONSOR_LOW_BALANCE_LAMPORTS=100000000
+# Inbound native-SOL transfers below this (in SOL) are treated as dusting /
+# address-poisoning spam: recorded for audit but kept out of the activity
+# feed and silenced (no push). Token transfers are never filtered.
+WALLET_SOLANA_DUST_MIN_INBOUND_SOL=0.001
 
 # Network RPC URLs (Alchemy or public endpoints)
 POLYGON_RPC_URL=

--- a/.env.zelta.example
+++ b/.env.zelta.example
@@ -353,6 +353,10 @@ WALLET_SEND_GLOBAL_DAILY_LIMIT=5000
 WALLET_SOLANA_SPONSOR_SECRET_KEY=
 # Alert threshold (lamports) for the hourly sponsor-balance check. 0.1 SOL.
 WALLET_SOLANA_SPONSOR_LOW_BALANCE_LAMPORTS=100000000
+# Inbound native-SOL transfers below this (in SOL) are treated as dusting /
+# address-poisoning spam: recorded for audit but kept out of the activity
+# feed and silenced (no push). Token transfers are never filtered.
+WALLET_SOLANA_DUST_MIN_INBOUND_SOL=0.001
 
 # Network RPC URLs (Alchemy or public endpoints)
 POLYGON_RPC_URL=

--- a/app/Domain/Wallet/Services/HeliusTransactionProcessor.php
+++ b/app/Domain/Wallet/Services/HeliusTransactionProcessor.php
@@ -74,6 +74,12 @@ class HeliusTransactionProcessor
 
         $txFailed = $this->isTransactionFailed($tx);
 
+        // Tiny unsolicited inbound SOL transfers are dusting / address-poisoning
+        // spam. Persist the BlockchainTransaction for audit, but keep the feed
+        // item out of the activity feed (and ProcessHeliusWebhookJob suppresses
+        // the matching push).
+        $isDust = $this->isDust($isIncoming, $token, $amount);
+
         // An outbound send that originated from our prepare/submit flow already
         // has a `wallet_send` activity-feed item (projected by
         // WalletSendRecordObserver). When one exists we skip the duplicate
@@ -102,6 +108,7 @@ class HeliusTransactionProcessor
             $occurredAt,
             $txFailed,
             $walletSend,
+            $isDust,
             &$wasCreated,
         ): void {
             try {
@@ -141,8 +148,9 @@ class HeliusTransactionProcessor
 
             // Skip the solana_tx feed item when the WalletSendRecordObserver
             // already owns a feed item for this outbound send — avoids a
-            // duplicate row for the same transaction.
-            if ($walletSend === null) {
+            // duplicate row for the same transaction — or when the transfer
+            // is inbound dust (recorded above, but not surfaced to the user).
+            if ($walletSend === null && ! $isDust) {
                 ActivityFeedItem::firstOrCreate(
                     ['reference_type' => 'solana_tx', 'reference_id' => $refId],
                     [
@@ -203,6 +211,44 @@ class HeliusTransactionProcessor
         $err = $tx['transactionError'] ?? null;
 
         return $err !== null && $err !== '' && $err !== [];
+    }
+
+    /**
+     * Decide whether an inbound transfer is dust / address-poisoning spam.
+     *
+     * Solana addresses are public, so anyone can send a wallet tiny
+     * unsolicited SOL transfers. Such transfers are still recorded as a
+     * BlockchainTransaction for audit, but are kept out of the activity feed
+     * and suppress the push notification. Only native-SOL transfers are
+     * considered — USDC/USDT token transfers are always real product activity.
+     *
+     * @param array<string, mixed> $tx
+     */
+    public function isInboundDust(string $address, array $tx): bool
+    {
+        return $this->isDust(
+            $this->isIncoming($address, $tx),
+            $this->resolveToken($tx),
+            $this->resolveAmount($tx),
+        );
+    }
+
+    /**
+     * Dust test against already-resolved transaction primitives.
+     */
+    private function isDust(bool $isIncoming, string $token, string $amount): bool
+    {
+        if (! $isIncoming || $token !== 'SOL') {
+            return false;
+        }
+
+        $threshold = (string) config('wallet.solana.dust.min_inbound_sol', '0.001');
+
+        if (! is_numeric($threshold) || ! is_numeric($amount)) {
+            return false;
+        }
+
+        return bccomp($amount, $threshold, 9) < 0;
     }
 
     /**

--- a/app/Jobs/ProcessHeliusWebhookJob.php
+++ b/app/Jobs/ProcessHeliusWebhookJob.php
@@ -224,18 +224,21 @@ class ProcessHeliusWebhookJob implements ShouldQueue
         $fromAddr = $processor->resolveFromAddress($tx);
         $toAddr = $processor->resolveToAddress($tx);
 
-        // Send FCM push notification
-        try {
-            $counterpartyAddr = $isIncoming ? ($fromAddr ?? 'unknown') : ($toAddr ?? 'unknown');
-            $truncatedAddr = substr($counterpartyAddr, 0, 4) . '...' . substr($counterpartyAddr, -4);
+        // Send FCM push notification — but never for inbound dust / address-
+        // poisoning spam, which is recorded for audit yet kept silent.
+        if (! $processor->isInboundDust($address, $tx)) {
+            try {
+                $counterpartyAddr = $isIncoming ? ($fromAddr ?? 'unknown') : ($toAddr ?? 'unknown');
+                $truncatedAddr = substr($counterpartyAddr, 0, 4) . '...' . substr($counterpartyAddr, -4);
 
-            if ($isIncoming) {
-                $pushService->sendTransactionReceived($user, $amount, $token, $truncatedAddr);
-            } else {
-                $pushService->sendTransactionSent($user, $amount, $token, $truncatedAddr);
+                if ($isIncoming) {
+                    $pushService->sendTransactionReceived($user, $amount, $token, $truncatedAddr);
+                } else {
+                    $pushService->sendTransactionSent($user, $amount, $token, $truncatedAddr);
+                }
+            } catch (Throwable $e) {
+                Log::warning('Helius: Push notification failed', ['user_id' => $user->id, 'error' => $e->getMessage()]);
             }
-        } catch (Throwable $e) {
-            Log::warning('Helius: Push notification failed', ['user_id' => $user->id, 'error' => $e->getMessage()]);
         }
 
         Log::info('Helius: Solana transaction stored and balance update broadcast', [

--- a/config/wallet.php
+++ b/config/wallet.php
@@ -45,6 +45,23 @@ return [
             // 1 SOL = 1_000_000_000 lamports; default 0.1 SOL.
             'low_balance_lamports' => (int) env('WALLET_SOLANA_SPONSOR_LOW_BALANCE_LAMPORTS', 100_000_000),
         ],
+
+        /*
+        |----------------------------------------------------------------------
+        | Inbound Dust Filter
+        |----------------------------------------------------------------------
+        |
+        | Solana addresses are public, so anyone can send a wallet tiny
+        | unsolicited SOL transfers ("dusting" / address-poisoning spam).
+        | Inbound native-SOL transfers below this threshold are still
+        | recorded as a BlockchainTransaction for audit, but are kept out of
+        | the activity feed and suppress the push notification — so spam does
+        | not buzz the user. Token transfers (USDC/USDT) are never filtered.
+        |
+        */
+        'dust' => [
+            'min_inbound_sol' => (string) env('WALLET_SOLANA_DUST_MIN_INBOUND_SOL', '0.001'),
+        ],
     ],
 
     /*

--- a/tests/Unit/Jobs/ProcessHeliusWebhookJobTest.php
+++ b/tests/Unit/Jobs/ProcessHeliusWebhookJobTest.php
@@ -209,3 +209,78 @@ it('resolves USDT token correctly', function (): void {
     assert($feedItem instanceof ActivityFeedItem);
     expect($feedItem->asset)->toBe('USDT');
 });
+
+it('records an inbound dust SOL transfer but neither feeds nor pushes it', function (): void {
+    $user = User::factory()->create();
+    BlockchainAddress::create([
+        'user_uuid'  => $user->uuid,
+        'chain'      => 'solana',
+        'address'    => 'DustReceiver',
+        'public_key' => 'DustReceiver',
+        'is_active'  => true,
+    ]);
+
+    // 0.00001 SOL — classic address-poisoning dust, well below the 0.001 threshold.
+    $tx = makeNativeSolJobTx('sig_dust_001', 'SpamSender', 'DustReceiver', 10000);
+
+    /** @var PushNotificationService&Mockery\MockInterface $pushService */
+    $pushService = Mockery::mock(PushNotificationService::class);
+    $pushService->shouldNotReceive('sendTransactionReceived');
+    $pushService->shouldNotReceive('sendTransactionSent');
+
+    $job = new ProcessHeliusWebhookJob([$tx]);
+    $job->handle(app(HeliusTransactionProcessor::class), $pushService);
+
+    // Recorded for audit...
+    expect(BlockchainTransaction::where('tx_hash', 'sig_dust_001')->exists())->toBeTrue()
+        // ...but kept out of the activity feed.
+        ->and(ActivityFeedItem::where('reference_id', HeliusTransactionProcessor::signatureToUuid('sig_dust_001'))->count())->toBe(0);
+});
+
+it('never filters a tiny token transfer — only native SOL is dust-filtered', function (): void {
+    $user = User::factory()->create();
+    BlockchainAddress::create([
+        'user_uuid'  => $user->uuid,
+        'chain'      => 'solana',
+        'address'    => 'TokenReceiver',
+        'public_key' => 'TokenReceiver',
+        'is_active'  => true,
+    ]);
+
+    // A 0.000001 USDC transfer is tiny, but a token transfer is real product activity.
+    $tx = makeHeliusJobTx('sig_tinytoken_001', 'Sender', 'TokenReceiver', '0.000001');
+
+    /** @var PushNotificationService&Mockery\MockInterface $pushService */
+    $pushService = Mockery::mock(PushNotificationService::class);
+    $pushService->shouldReceive('sendTransactionReceived')->once();
+
+    $job = new ProcessHeliusWebhookJob([$tx]);
+    $job->handle(app(HeliusTransactionProcessor::class), $pushService);
+
+    expect(ActivityFeedItem::where('reference_id', HeliusTransactionProcessor::signatureToUuid('sig_tinytoken_001'))->count())->toBe(1);
+});
+
+it('honours a configurable dust threshold', function (): void {
+    config(['wallet.solana.dust.min_inbound_sol' => '0.000001']);
+
+    $user = User::factory()->create();
+    BlockchainAddress::create([
+        'user_uuid'  => $user->uuid,
+        'chain'      => 'solana',
+        'address'    => 'ThresholdReceiver',
+        'public_key' => 'ThresholdReceiver',
+        'is_active'  => true,
+    ]);
+
+    // 0.00001 SOL is now ABOVE the lowered threshold, so it surfaces normally.
+    $tx = makeNativeSolJobTx('sig_threshold_001', 'Sender', 'ThresholdReceiver', 10000);
+
+    /** @var PushNotificationService&Mockery\MockInterface $pushService */
+    $pushService = Mockery::mock(PushNotificationService::class);
+    $pushService->shouldReceive('sendTransactionReceived')->once();
+
+    $job = new ProcessHeliusWebhookJob([$tx]);
+    $job->handle(app(HeliusTransactionProcessor::class), $pushService);
+
+    expect(ActivityFeedItem::where('reference_id', HeliusTransactionProcessor::signatureToUuid('sig_threshold_001'))->count())->toBe(1);
+});


### PR DESCRIPTION
## Context

A client reported receiving **six unsolicited 0.00001 SOL transfers** in one day. Investigation (see the wallet-send code trace):

- **Nothing in our backend sent them.** The wallet-send feature only moves USDC/USDT (`PaymentAsset` has exactly those two cases); `SolanaTransferBuilder` builds only SPL-token transfers — there is no native-SOL send path anywhere. PR #1075 was purely additive and removed no funding mechanism.
- It is textbook **Solana dusting / address-poisoning spam**: any public address can be sent tiny unsolicited transfers, typically from a look-alike vanity address hoping the victim later copies it from their history.
- `0.00001 SOL = 10,000 lamports` = exactly the fee of a 2-signature transaction — a giveaway that it is mechanical spam, not product activity.

## The actual bug on our side

We can't stop dust arriving on a public chain — but `HeliusTransactionProcessor` **amplified** it: each junk transfer became an activity-feed entry **and** a push notification. The client got buzzed six times for $0.00 of dust.

## Fix

Inbound **native-SOL** transfers below `wallet.solana.dust.min_inbound_sol` (default `0.001` SOL, env `WALLET_SOLANA_DUST_MIN_INBOUND_SOL`) are now treated as dust:

- The `BlockchainTransaction` row is **still written** for audit/reconciliation.
- **No `ActivityFeedItem`** is created — kept out of the activity feed.
- `ProcessHeliusWebhookJob` **suppresses the push notification**.
- Balance updates still broadcast (the balance genuinely changed).

**Token transfers (USDC/USDT) are never filtered** — `isInboundDust()` only considers native-SOL transfers, so real product activity always surfaces regardless of amount.

## Tests

Added to `ProcessHeliusWebhookJobTest` — exercises the full job path (feed + push):
- dust SOL → `BlockchainTransaction` recorded, no feed item, no push
- tiny (0.000001) USDC token transfer → still feeds + pushes (not filtered)
- configurable threshold → lowering it surfaces a previously-dust amount

PHPStan level 8 + php-cs-fixer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)