### PR TITLE
feat: mirror inbound EVM transfers into the transaction history

### DIFF
--- a/app/Console/Commands/EvmTransactionBackfillCommand.php
+++ b/app/Console/Commands/EvmTransactionBackfillCommand.php
@@ -128,14 +128,16 @@ class EvmTransactionBackfillCommand extends Command
                         continue;
                     }
 
-                    if ($processor->processActivity(
+                    $created = $processor->processActivity(
                         $address,
                         $blockchainAddress,
                         $user->id,
                         $chain,
                         $activity,
                         $this->blockTimestamp($transfer),
-                    )) {
+                    );
+
+                    if ($created) {
                         $stored++;
                     }
                 }
@@ -154,8 +156,13 @@ class EvmTransactionBackfillCommand extends Command
      *
      * @return array<int, mixed>
      */
-    private function fetchTransfers(string $apiKey, string $chain, string $address, string $direction, int $limit): array
-    {
+    private function fetchTransfers(
+        string $apiKey,
+        string $chain,
+        string $address,
+        string $direction,
+        int $limit
+    ): array {
         $subdomain = self::NETWORK_SUBDOMAINS[$chain] ?? null;
         $contracts = $this->contractsFor($chain);
 

--- a/app/Console/Commands/EvmTransactionBackfillCommand.php
+++ b/app/Console/Commands/EvmTransactionBackfillCommand.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Account\Models\BlockchainAddress;
+use App\Domain\Wallet\Constants\EvmTokens;
+use App\Domain\Wallet\Services\EvmTransactionProcessor;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Backfill EVM transaction history from the Alchemy Transfers API.
+ *
+ * Fetches historical USDC/USDT transfers for every registered EVM address
+ * (Polygon/Base/Arbitrum/Ethereum) and stores them via
+ * {@see EvmTransactionProcessor} into `blockchain_address_transactions` and
+ * `activity_feed_items` — the EVM counterpart of `solana:backfill-transactions`.
+ *
+ * Use it to seed history that predates the live Alchemy webhook mirror.
+ */
+class EvmTransactionBackfillCommand extends Command
+{
+    protected $signature = 'evm:backfill-transactions
+        {--address= : Backfill only this specific address}
+        {--network= : Backfill only this network (polygon|base|arbitrum|ethereum)}
+        {--limit=50 : Maximum transfers per address per direction}
+        {--dry-run : Show counts without storing}';
+
+    protected $description = 'Backfill EVM USDC/USDT transaction history from the Alchemy Transfers API';
+
+    /**
+     * Network key → Alchemy RPC subdomain.
+     */
+    private const array NETWORK_SUBDOMAINS = [
+        'polygon'  => 'polygon-mainnet',
+        'base'     => 'base-mainnet',
+        'arbitrum' => 'arb-mainnet',
+        'ethereum' => 'eth-mainnet',
+    ];
+
+    public function handle(EvmTransactionProcessor $processor): int
+    {
+        $apiKey = (string) config('relayer.balance_checking.alchemy_api_key');
+
+        if ($apiKey === '') {
+            $this->error('ALCHEMY_API_KEY is not set.');
+
+            return self::FAILURE;
+        }
+
+        $limit = max(1, (int) $this->option('limit'));
+        $dryRun = (bool) $this->option('dry-run');
+
+        $networkOption = $this->option('network');
+        $networkFilter = is_string($networkOption) && $networkOption !== '' ? strtolower($networkOption) : null;
+
+        if ($networkFilter !== null && ! isset(self::NETWORK_SUBDOMAINS[$networkFilter])) {
+            $this->error("Unknown network: {$networkFilter}");
+
+            return self::FAILURE;
+        }
+
+        $query = BlockchainAddress::query()
+            ->whereIn('chain', array_keys(self::NETWORK_SUBDOMAINS))
+            ->where('is_active', true)
+            ->with('user');
+
+        if ($networkFilter !== null) {
+            $query->where('chain', $networkFilter);
+        }
+
+        $addressOption = $this->option('address');
+        if (is_string($addressOption) && $addressOption !== '') {
+            $query->where('address', strtolower($addressOption));
+        }
+
+        $addresses = $query->get();
+
+        if ($addresses->isEmpty()) {
+            $this->warn('No matching active EVM addresses to backfill.');
+
+            return self::SUCCESS;
+        }
+
+        $stored = 0;
+        $scanned = 0;
+
+        foreach ($addresses as $blockchainAddress) {
+            $user = $blockchainAddress->user;
+
+            if ($user === null) {
+                continue;
+            }
+
+            $chain = $blockchainAddress->chain;
+            $address = strtolower($blockchainAddress->address);
+
+            // Two directions: inbound deposits (toAddress) and outbound sends (fromAddress).
+            foreach (['toAddress', 'fromAddress'] as $direction) {
+                try {
+                    $transfers = $this->fetchTransfers($apiKey, $chain, $address, $direction, $limit);
+                } catch (Throwable $e) {
+                    $this->error("  {$chain} {$address} ({$direction}): {$e->getMessage()}");
+                    Log::warning('EVM backfill: transfer fetch failed', [
+                        'chain'   => $chain,
+                        'address' => $address,
+                        'error'   => $e->getMessage(),
+                    ]);
+
+                    continue;
+                }
+
+                foreach ($transfers as $transfer) {
+                    $scanned++;
+
+                    $activity = $this->normalizeTransfer($transfer);
+
+                    if ($activity === null) {
+                        continue;
+                    }
+
+                    if ($dryRun) {
+                        continue;
+                    }
+
+                    if ($processor->processActivity(
+                        $address,
+                        $blockchainAddress,
+                        $user->id,
+                        $chain,
+                        $activity,
+                        $this->blockTimestamp($transfer),
+                    )) {
+                        $stored++;
+                    }
+                }
+            }
+        }
+
+        $this->info($dryRun
+            ? "Dry run: {$scanned} transfers found across {$addresses->count()} address rows."
+            : "Backfill complete: {$stored} new transactions stored ({$scanned} transfers scanned).");
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Fetch USDC/USDT transfers for one address in one direction from Alchemy.
+     *
+     * @return array<int, mixed>
+     */
+    private function fetchTransfers(string $apiKey, string $chain, string $address, string $direction, int $limit): array
+    {
+        $subdomain = self::NETWORK_SUBDOMAINS[$chain] ?? null;
+        $contracts = $this->contractsFor($chain);
+
+        if ($subdomain === null || $contracts === []) {
+            return [];
+        }
+
+        $response = Http::timeout(30)->post("https://{$subdomain}.g.alchemy.com/v2/{$apiKey}", [
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'method'  => 'alchemy_getAssetTransfers',
+            'params'  => [[
+                'fromBlock'         => '0x0',
+                'toBlock'           => 'latest',
+                'category'          => ['erc20'],
+                'contractAddresses' => $contracts,
+                'withMetadata'      => true,
+                'excludeZeroValue'  => true,
+                'order'             => 'desc',
+                'maxCount'          => '0x' . dechex($limit),
+                $direction          => $address,
+            ]],
+        ]);
+
+        if ($response->failed()) {
+            throw new RuntimeException("Alchemy API returned HTTP {$response->status()}");
+        }
+
+        $transfers = $response->json('result.transfers');
+
+        return is_array($transfers) ? $transfers : [];
+    }
+
+    /**
+     * Monitored USDC/USDT contract addresses for a chain.
+     *
+     * @return array<int, string>
+     */
+    private function contractsFor(string $chain): array
+    {
+        return array_values(array_filter([
+            EvmTokens::USDC[$chain] ?? null,
+            EvmTokens::USDT[$chain] ?? null,
+        ]));
+    }
+
+    /**
+     * Adapt an Alchemy `getAssetTransfers` transfer to the address-activity
+     * shape {@see EvmTransactionProcessor::processActivity()} expects.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function normalizeTransfer(mixed $transfer): ?array
+    {
+        if (! is_array($transfer)) {
+            return null;
+        }
+
+        $hash = $transfer['hash'] ?? null;
+
+        if (! is_string($hash) || $hash === '') {
+            return null;
+        }
+
+        $rawContract = is_array($transfer['rawContract'] ?? null) ? $transfer['rawContract'] : [];
+
+        return [
+            'hash'        => $hash,
+            'fromAddress' => $transfer['from'] ?? '',
+            'toAddress'   => $transfer['to'] ?? '',
+            'value'       => $transfer['value'] ?? null,
+            'asset'       => $transfer['asset'] ?? '',
+            'category'    => $transfer['category'] ?? 'erc20',
+            'blockNum'    => $transfer['blockNum'] ?? null,
+            'rawContract' => [
+                // getAssetTransfers names it `value`; the webhook names it `rawValue`.
+                'rawValue' => $rawContract['value'] ?? null,
+                'address'  => $rawContract['address'] ?? null,
+            ],
+        ];
+    }
+
+    /**
+     * Pull the ISO block timestamp from a transfer's metadata, if present.
+     */
+    private function blockTimestamp(mixed $transfer): ?string
+    {
+        if (! is_array($transfer)) {
+            return null;
+        }
+
+        $metadata = $transfer['metadata'] ?? null;
+        $timestamp = is_array($metadata) ? ($metadata['blockTimestamp'] ?? null) : null;
+
+        return is_string($timestamp) && $timestamp !== '' ? $timestamp : null;
+    }
+}

--- a/app/Domain/Wallet/Services/EvmTransactionProcessor.php
+++ b/app/Domain/Wallet/Services/EvmTransactionProcessor.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Wallet\Services;
+
+use App\Domain\Account\Models\BlockchainAddress;
+use App\Domain\Account\Models\BlockchainTransaction;
+use App\Domain\MobilePayment\Enums\ActivityItemType;
+use App\Domain\MobilePayment\Models\ActivityFeedItem;
+use App\Domain\Wallet\Constants\EvmTokens;
+use App\Domain\Wallet\Models\WalletSendRecord;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Mirrors EVM (Polygon/Base/Arbitrum/Ethereum) ERC-20 transfers into our
+ * database — the EVM counterpart of {@see HeliusTransactionProcessor}.
+ *
+ * Alchemy's Address Activity webhook fires for every USDC/USDT transfer that
+ * touches a monitored token contract; {@see \App\Jobs\ProcessAlchemyWebhookJob}
+ * matches the from/to address to a user and hands the activity here. We persist:
+ *  - `blockchain_address_transactions` — per-chain raw transaction audit row
+ *  - `activity_feed_items`             — the mobile transaction-history read model
+ *
+ * Before this, inbound EVM deposits triggered only a balance broadcast + push
+ * and were never stored, so they never appeared in the in-app history. This
+ * closes that gap and keeps EVM symmetric with Solana.
+ */
+class EvmTransactionProcessor
+{
+    /**
+     * Activity keys persisted alongside the transaction. Alchemy payloads may
+     * carry debug fields we have no reason to store.
+     */
+    private const array METADATA_WHITELIST = [
+        'hash',
+        'fromAddress',
+        'toAddress',
+        'value',
+        'asset',
+        'category',
+        'blockNum',
+        'rawContract',
+    ];
+
+    /**
+     * Process a single Alchemy address-activity entry for one matched address.
+     *
+     * @param array<string, mixed> $activity   Alchemy address-activity item
+     * @param string|null          $occurredAt ISO datetime (null = now; set by backfill)
+     *
+     * @return bool true if a new BlockchainTransaction row was created
+     */
+    public function processActivity(
+        string $matchedAddress,
+        BlockchainAddress $blockchainAddress,
+        int $userId,
+        string $chain,
+        array $activity,
+        ?string $occurredAt = null,
+    ): bool {
+        $hash = strtolower((string) ($activity['hash'] ?? ''));
+
+        if ($hash === '') {
+            return false;
+        }
+
+        $fromAddr = strtolower((string) ($activity['fromAddress'] ?? ''));
+        $toAddr = strtolower((string) ($activity['toAddress'] ?? ''));
+        $isIncoming = strtolower($matchedAddress) === $toAddr;
+
+        $asset = strtoupper((string) ($activity['asset'] ?? ''));
+        $amount = $this->resolveAmount($activity, $asset);
+
+        $metadata = array_intersect_key($activity, array_flip(self::METADATA_WHITELIST));
+
+        // An outbound send that originated from our prepare/submit flow already
+        // has a `wallet_send` activity-feed item (projected by
+        // WalletSendRecordObserver). Skip the duplicate feed row for those —
+        // but still record the audit transaction.
+        $walletSend = $isIncoming
+            ? null
+            : WalletSendRecord::where('tx_hash', $hash)
+                ->where('network', $chain)
+                ->first();
+
+        $wasCreated = false;
+
+        DB::transaction(function () use (
+            $hash,
+            $blockchainAddress,
+            $isIncoming,
+            $amount,
+            $fromAddr,
+            $toAddr,
+            $metadata,
+            $userId,
+            $asset,
+            $chain,
+            $occurredAt,
+            $walletSend,
+            &$wasCreated,
+        ): void {
+            try {
+                $btx = BlockchainTransaction::firstOrCreate(
+                    ['tx_hash' => $hash, 'chain' => $chain],
+                    [
+                        'address_uuid' => $blockchainAddress->uuid,
+                        'type'         => $isIncoming ? 'receive' : 'send',
+                        'amount'       => $amount,
+                        'fee'          => '0',
+                        'from_address' => $fromAddr,
+                        'to_address'   => $toAddr,
+                        'status'       => 'confirmed',
+                        'metadata'     => $metadata,
+                    ]
+                );
+            } catch (QueryException $e) {
+                if ($e->getCode() === '23000') {
+                    // Concurrent webhook retry lost the (tx_hash, chain) race —
+                    // the transaction is already persisted, nothing more to do.
+                    return;
+                }
+
+                throw $e;
+            }
+
+            if ($walletSend === null) {
+                ActivityFeedItem::firstOrCreate(
+                    ['reference_type' => 'evm_tx', 'reference_id' => self::txHashToReferenceId($chain, $hash)],
+                    [
+                        'user_id'       => $userId,
+                        'activity_type' => $isIncoming ? ActivityItemType::TRANSFER_IN : ActivityItemType::TRANSFER_OUT,
+                        'amount'        => $isIncoming ? $amount : '-' . $amount,
+                        'asset'         => $asset,
+                        'network'       => $chain,
+                        'status'        => 'confirmed',
+                        'protected'     => false,
+                        'from_address'  => $fromAddr,
+                        'to_address'    => $toAddr,
+                        'occurred_at'   => $occurredAt ?? now(),
+                        'metadata'      => ['tx_hash' => $hash],
+                    ]
+                );
+            }
+
+            $wasCreated = $btx->wasRecentlyCreated;
+        });
+
+        return $wasCreated;
+    }
+
+    /**
+     * Resolve the human-readable token amount from an Alchemy activity entry.
+     *
+     * The integer `rawContract.rawValue` is preferred: the decimal `value`
+     * field arrives as a JSON float and loses precision (or renders in
+     * scientific notation) for small amounts.
+     *
+     * @param array<string, mixed> $activity
+     */
+    private function resolveAmount(array $activity, string $asset): string
+    {
+        $decimals = EvmTokens::DECIMALS[$asset] ?? 6;
+
+        $rawContract = $activity['rawContract'] ?? null;
+        $rawValue = is_array($rawContract) ? ($rawContract['rawValue'] ?? null) : null;
+
+        if (is_string($rawValue) && $rawValue !== '') {
+            $units = $this->hexToDecimalString($rawValue);
+
+            return bcdiv($units, bcpow('10', (string) $decimals), 8);
+        }
+
+        $value = $activity['value'] ?? null;
+
+        if (is_int($value) || is_float($value) || (is_string($value) && is_numeric($value))) {
+            // sprintf expands any scientific notation to a plain decimal string.
+            return bcadd(sprintf('%.8f', (float) $value), '0', 8);
+        }
+
+        return '0';
+    }
+
+    /**
+     * Convert a hex quantity (`0x…`) to a base-10 string without precision loss.
+     */
+    private function hexToDecimalString(string $hex): string
+    {
+        $hex = (string) preg_replace('/^0x/i', '', trim($hex));
+
+        if ($hex === '' || ! ctype_xdigit($hex)) {
+            return '0';
+        }
+
+        $decimal = '0';
+
+        foreach (str_split($hex) as $nibble) {
+            $decimal = bcadd(bcmul($decimal, '16'), (string) hexdec($nibble));
+        }
+
+        return $decimal;
+    }
+
+    /**
+     * Derive a deterministic RFC 4122 UUID for an EVM transaction's feed item.
+     *
+     * `activity_feed_items.reference_id` is a UUID column, but EVM tx hashes are
+     * 66-char hex strings. The chain is folded into the hash input so the same
+     * hash on two chains maps to distinct ids.
+     */
+    public static function txHashToReferenceId(string $chain, string $hash): string
+    {
+        $digest = substr(hash('sha256', "evm_tx:{$chain}:" . strtolower($hash)), 0, 32);
+
+        // Force version 4 + variant 10xx so MariaDB accepts it as a valid UUID.
+        $digest[12] = '4';
+        $digest[16] = dechex(0x8 | (hexdec($digest[16]) & 0x3));
+
+        return sprintf(
+            '%s-%s-%s-%s-%s',
+            substr($digest, 0, 8),
+            substr($digest, 8, 4),
+            substr($digest, 12, 4),
+            substr($digest, 16, 4),
+            substr($digest, 20, 12)
+        );
+    }
+}

--- a/app/Jobs/ProcessAlchemyWebhookJob.php
+++ b/app/Jobs/ProcessAlchemyWebhookJob.php
@@ -10,6 +10,7 @@ use App\Domain\Relayer\Contracts\WalletBalanceProviderInterface;
 use App\Domain\Relayer\Enums\SupportedNetwork;
 use App\Domain\Relayer\Models\SmartAccount;
 use App\Domain\Wallet\Events\Broadcast\WalletBalanceUpdated;
+use App\Domain\Wallet\Services\EvmTransactionProcessor;
 use App\Models\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -63,6 +64,7 @@ class ProcessAlchemyWebhookJob implements ShouldQueue
     public function handle(
         WalletBalanceProviderInterface $balanceProvider,
         PushNotificationService $pushService,
+        EvmTransactionProcessor $evmProcessor,
     ): void {
         $network = $this->resolveNetwork((string) ($this->payload['event']['network'] ?? ''));
         $activities = $this->payload['event']['activity'] ?? [];
@@ -71,6 +73,10 @@ class ProcessAlchemyWebhookJob implements ShouldQueue
         $notifiedUsers = [];
 
         foreach ($activities as $activity) {
+            if (! is_array($activity)) {
+                continue;
+            }
+
             // Reorg check: skip removed transactions
             if (($activity['removed'] ?? false) === true) {
                 Log::debug('Alchemy webhook: skipping removed (reorged) activity', [
@@ -119,6 +125,21 @@ class ProcessAlchemyWebhookJob implements ShouldQueue
                     continue;
                 }
                 $notifiedUsers[$userId] = true;
+
+                // Mirror the transfer into our DB so it appears in the in-app
+                // transaction history and the admin wallet view — the EVM
+                // counterpart of HeliusTransactionProcessor. Only Privy/mobile
+                // wallets have a per-chain blockchain_addresses row; legacy
+                // relayer smart accounts (smart_accounts only) are skipped.
+                if ($network !== null) {
+                    $blockchainAddress = BlockchainAddress::where('address', $address)
+                        ->where('chain', $network)
+                        ->first();
+
+                    if ($blockchainAddress !== null) {
+                        $evmProcessor->processActivity($address, $blockchainAddress, $userId, $network, $activity);
+                    }
+                }
 
                 $this->invalidateBalanceCache($address, $network, $balanceProvider);
 

--- a/tests/Feature/Console/EvmTransactionBackfillCommandTest.php
+++ b/tests/Feature/Console/EvmTransactionBackfillCommandTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Account\Models\BlockchainAddress;
+use App\Domain\Account\Models\BlockchainTransaction;
+use App\Domain\MobilePayment\Models\ActivityFeedItem;
+use App\Domain\Wallet\Services\EvmTransactionProcessor;
+use App\Models\User;
+use Illuminate\Support\Facades\Http;
+use Tests\Traits\CreatesSolanaTestTables;
+
+uses(CreatesSolanaTestTables::class);
+
+beforeEach(function (): void {
+    $this->createSolanaTestTables();
+    config(['relayer.balance_checking.alchemy_api_key' => 'test-alchemy-key']);
+});
+
+afterEach(function (): void {
+    $this->dropSolanaTestTables();
+});
+
+/**
+ * @param array<int, array<string, mixed>> $transfers
+ */
+function fakeAlchemyTransfers(array $transfers): void
+{
+    Http::fake([
+        '*.g.alchemy.com/*' => Http::response([
+            'jsonrpc' => '2.0',
+            'id'      => 1,
+            'result'  => ['transfers' => $transfers],
+        ]),
+    ]);
+}
+
+it('fails when the Alchemy API key is not configured', function (): void {
+    config(['relayer.balance_checking.alchemy_api_key' => '']);
+
+    $this->artisan('evm:backfill-transactions')->assertFailed();
+});
+
+it('backfills an inbound EVM transfer from the Alchemy Transfers API', function (): void {
+    $wallet = '0x1111111111111111111111111111111111111111';
+    $user = User::factory()->create();
+    BlockchainAddress::create([
+        'user_uuid'  => $user->uuid,
+        'chain'      => 'polygon',
+        'address'    => $wallet,
+        'public_key' => $wallet,
+        'is_active'  => true,
+    ]);
+
+    // 50 USDC = 50_000_000 base units = 0x2faf080.
+    fakeAlchemyTransfers([[
+        'blockNum'    => '0x1234',
+        'hash'        => '0xbackfill01',
+        'from'        => '0x9999999999999999999999999999999999999999',
+        'to'          => $wallet,
+        'value'       => 50.0,
+        'asset'       => 'USDC',
+        'category'    => 'erc20',
+        'rawContract' => ['value' => '0x2faf080', 'address' => '0xtoken', 'decimal' => '0x6'],
+        'metadata'    => ['blockTimestamp' => '2026-05-01T12:00:00.000Z'],
+    ]]);
+
+    $this->artisan('evm:backfill-transactions', ['--network' => 'polygon', '--limit' => 10])
+        ->assertSuccessful();
+
+    $btx = BlockchainTransaction::where('tx_hash', '0xbackfill01')->where('chain', 'polygon')->first();
+    expect($btx)->not->toBeNull();
+    assert($btx instanceof BlockchainTransaction);
+    expect($btx->type)->toBe('receive')
+        ->and((float) $btx->amount)->toBe(50.0);
+
+    $feedItem = ActivityFeedItem::where('reference_id', EvmTransactionProcessor::txHashToReferenceId('polygon', '0xbackfill01'))
+        ->first();
+    expect($feedItem)->not->toBeNull();
+    assert($feedItem instanceof ActivityFeedItem);
+    expect($feedItem->network)->toBe('polygon')
+        // occurred_at is taken from the transfer's block timestamp, not "now".
+        ->and($feedItem->occurred_at->format('Y-m-d'))->toBe('2026-05-01');
+});
+
+it('stores nothing on a dry run', function (): void {
+    $wallet = '0x2222222222222222222222222222222222222222';
+    $user = User::factory()->create();
+    BlockchainAddress::create([
+        'user_uuid'  => $user->uuid,
+        'chain'      => 'arbitrum',
+        'address'    => $wallet,
+        'public_key' => $wallet,
+        'is_active'  => true,
+    ]);
+
+    fakeAlchemyTransfers([[
+        'blockNum'    => '0x1',
+        'hash'        => '0xdryrun01',
+        'from'        => '0x9999999999999999999999999999999999999999',
+        'to'          => $wallet,
+        'value'       => 5.0,
+        'asset'       => 'USDC',
+        'category'    => 'erc20',
+        'rawContract' => ['value' => '0x4c4b40', 'address' => '0xtoken', 'decimal' => '0x6'],
+    ]]);
+
+    $this->artisan('evm:backfill-transactions', ['--network' => 'arbitrum', '--dry-run' => true])
+        ->assertSuccessful();
+
+    expect(BlockchainTransaction::where('tx_hash', '0xdryrun01')->exists())->toBeFalse();
+});

--- a/tests/Feature/Domain/Wallet/EvmTransactionProcessorTest.php
+++ b/tests/Feature/Domain/Wallet/EvmTransactionProcessorTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Account\Models\BlockchainAddress;
+use App\Domain\Account\Models\BlockchainTransaction;
+use App\Domain\MobilePayment\Models\ActivityFeedItem;
+use App\Domain\Wallet\Models\WalletSendRecord;
+use App\Domain\Wallet\Services\EvmTransactionProcessor;
+use App\Models\User;
+use Illuminate\Support\Facades\Schema;
+use Tests\Traits\CreatesSolanaTestTables;
+
+uses(CreatesSolanaTestTables::class);
+
+const EVM_WALLET = '0x1111111111111111111111111111111111111111';
+const EVM_COUNTERPARTY = '0x9999999999999999999999999999999999999999';
+
+beforeEach(function (): void {
+    $this->createSolanaTestTables();
+
+    $this->user = User::factory()->create();
+    $this->bcAddress = BlockchainAddress::create([
+        'user_uuid'  => $this->user->uuid,
+        'chain'      => 'polygon',
+        'address'    => EVM_WALLET,
+        'public_key' => EVM_WALLET,
+        'is_active'  => true,
+    ]);
+});
+
+afterEach(function (): void {
+    $this->dropSolanaTestTables();
+    Schema::dropIfExists('wallet_send_records');
+});
+
+/**
+ * Build an Alchemy address-activity entry (rawContract.rawValue is the
+ * integer token quantity, exactly as the live webhook delivers it).
+ *
+ * @return array<string, mixed>
+ */
+function evmActivity(string $hash, string $from, string $to, string $rawValueHex, string $asset = 'USDC'): array
+{
+    return [
+        'hash'        => $hash,
+        'fromAddress' => $from,
+        'toAddress'   => $to,
+        'asset'       => $asset,
+        'category'    => 'erc20',
+        'blockNum'    => '0x1234',
+        'value'       => null,
+        'rawContract' => ['rawValue' => $rawValueHex, 'address' => '0xtoken'],
+    ];
+}
+
+function createWalletSendRecordsTable(): void
+{
+    Schema::dropIfExists('wallet_send_records');
+    Schema::create('wallet_send_records', function ($table): void {
+        $table->uuid('id')->primary();
+        $table->string('public_id', 64)->unique();
+        $table->unsignedBigInteger('user_id');
+        $table->string('network', 20);
+        $table->string('asset', 10);
+        $table->decimal('amount', 30, 8);
+        $table->string('sender_address', 128);
+        $table->string('recipient_address', 128);
+        $table->string('status', 20)->default('pending');
+        $table->string('tx_hash', 128)->nullable();
+        $table->string('user_op_hash', 128)->nullable();
+        $table->string('idempotency_key', 128)->nullable()->unique();
+        $table->string('quote_id', 64)->nullable();
+        $table->string('error_code', 50)->nullable();
+        $table->text('error_message')->nullable();
+        $table->json('metadata')->nullable();
+        $table->dateTime('submitted_at')->nullable();
+        $table->dateTime('confirmed_at')->nullable();
+        $table->dateTime('failed_at')->nullable();
+        $table->timestamps();
+    });
+}
+
+it('mirrors an inbound EVM transfer into both tables', function (): void {
+    // 100 USDC = 100_000_000 base units (6 decimals) = 0x5f5e100.
+    $activity = evmActivity('0xa1a1a1', EVM_COUNTERPARTY, EVM_WALLET, '0x5f5e100');
+
+    $created = (new EvmTransactionProcessor())->processActivity(
+        EVM_WALLET,
+        $this->bcAddress,
+        $this->user->id,
+        'polygon',
+        $activity,
+    );
+
+    expect($created)->toBeTrue();
+
+    $btx = BlockchainTransaction::where('tx_hash', '0xa1a1a1')->where('chain', 'polygon')->first();
+    expect($btx)->not->toBeNull();
+    assert($btx instanceof BlockchainTransaction);
+    expect($btx->type)->toBe('receive')
+        ->and($btx->status)->toBe('confirmed')
+        ->and($btx->address_uuid)->toBe($this->bcAddress->uuid)
+        ->and((float) $btx->amount)->toBe(100.0);
+
+    $feedItem = ActivityFeedItem::where('reference_type', 'evm_tx')
+        ->where('reference_id', EvmTransactionProcessor::txHashToReferenceId('polygon', '0xa1a1a1'))
+        ->first();
+    expect($feedItem)->not->toBeNull();
+    assert($feedItem instanceof ActivityFeedItem);
+    expect($feedItem->activity_type->value)->toBe('transfer_in')
+        ->and($feedItem->asset)->toBe('USDC')
+        ->and($feedItem->network)->toBe('polygon')
+        ->and((float) $feedItem->amount)->toBe(100.0)
+        ->and((int) $feedItem->user_id)->toBe($this->user->id);
+});
+
+it('records an outbound EVM transfer as a negative-amount send', function (): void {
+    createWalletSendRecordsTable();
+
+    // 25 USDC = 25_000_000 = 0x17d7840.
+    $activity = evmActivity('0xb2b2b2', EVM_WALLET, EVM_COUNTERPARTY, '0x17d7840');
+
+    (new EvmTransactionProcessor())->processActivity(
+        EVM_WALLET,
+        $this->bcAddress,
+        $this->user->id,
+        'polygon',
+        $activity,
+    );
+
+    $btx = BlockchainTransaction::where('tx_hash', '0xb2b2b2')->first();
+    assert($btx instanceof BlockchainTransaction);
+    expect($btx->type)->toBe('send');
+
+    $feedItem = ActivityFeedItem::where('reference_type', 'evm_tx')->first();
+    assert($feedItem instanceof ActivityFeedItem);
+    expect($feedItem->activity_type->value)->toBe('transfer_out')
+        ->and((float) $feedItem->amount)->toBe(-25.0);
+});
+
+it('resolves tiny amounts precisely from the hex raw value', function (): void {
+    // 1 base unit = 0.000001 USDC — float `value` would lose this.
+    $activity = evmActivity('0xc3c3c3', EVM_COUNTERPARTY, EVM_WALLET, '0x1');
+
+    (new EvmTransactionProcessor())->processActivity(
+        EVM_WALLET,
+        $this->bcAddress,
+        $this->user->id,
+        'polygon',
+        $activity,
+    );
+
+    $btx = BlockchainTransaction::where('tx_hash', '0xc3c3c3')->first();
+    assert($btx instanceof BlockchainTransaction);
+    expect((float) $btx->amount)->toBe(0.000001);
+});
+
+it('is idempotent — processing the same transfer twice creates one row', function (): void {
+    $activity = evmActivity('0xd4d4d4', EVM_COUNTERPARTY, EVM_WALLET, '0xf4240');
+    $processor = new EvmTransactionProcessor();
+
+    expect($processor->processActivity(EVM_WALLET, $this->bcAddress, $this->user->id, 'polygon', $activity))->toBeTrue()
+        ->and($processor->processActivity(EVM_WALLET, $this->bcAddress, $this->user->id, 'polygon', $activity))->toBeFalse();
+
+    expect(BlockchainTransaction::where('tx_hash', '0xd4d4d4')->count())->toBe(1)
+        ->and(ActivityFeedItem::where('reference_type', 'evm_tx')->count())->toBe(1);
+});
+
+it('skips the duplicate feed item when a wallet send already owns the outbound tx', function (): void {
+    createWalletSendRecordsTable();
+
+    // A send initiated through our prepare/submit flow already owns a feed item.
+    WalletSendRecord::create([
+        'public_id'         => 'pi_send_evmtest',
+        'user_id'           => $this->user->id,
+        'network'           => 'polygon',
+        'asset'             => 'USDC',
+        'amount'            => '10.00000000',
+        'sender_address'    => EVM_WALLET,
+        'recipient_address' => EVM_COUNTERPARTY,
+        'status'            => 'submitted',
+        'tx_hash'           => '0xe5e5e5',
+        'submitted_at'      => now(),
+    ]);
+
+    $activity = evmActivity('0xe5e5e5', EVM_WALLET, EVM_COUNTERPARTY, '0x989680');
+
+    (new EvmTransactionProcessor())->processActivity(
+        EVM_WALLET,
+        $this->bcAddress,
+        $this->user->id,
+        'polygon',
+        $activity,
+    );
+
+    // Audit row is still written...
+    expect(BlockchainTransaction::where('tx_hash', '0xe5e5e5')->exists())->toBeTrue()
+        // ...but no duplicate `evm_tx` feed item — the wallet send owns the feed entry.
+        ->and(ActivityFeedItem::where('reference_type', 'evm_tx')->count())->toBe(0);
+});

--- a/tests/Unit/Jobs/ProcessAlchemyWebhookJobTest.php
+++ b/tests/Unit/Jobs/ProcessAlchemyWebhookJobTest.php
@@ -3,10 +3,13 @@
 declare(strict_types=1);
 
 use App\Domain\Account\Models\BlockchainAddress;
+use App\Domain\Account\Models\BlockchainTransaction;
 use App\Domain\Mobile\Services\PushNotificationService;
+use App\Domain\MobilePayment\Models\ActivityFeedItem;
 use App\Domain\Relayer\Contracts\WalletBalanceProviderInterface;
 use App\Domain\Relayer\Models\SmartAccount;
 use App\Domain\Wallet\Events\Broadcast\WalletBalanceUpdated;
+use App\Domain\Wallet\Services\EvmTransactionProcessor;
 use App\Jobs\ProcessAlchemyWebhookJob;
 use App\Models\User;
 use Illuminate\Support\Facades\Event;
@@ -93,11 +96,29 @@ it('processes USDC token transfer for known blockchain address', function (): vo
     $pushService->shouldReceive('sendTransactionReceived')->once();
 
     $job = new ProcessAlchemyWebhookJob($payload);
-    $job->handle($balanceProvider, $pushService);
+    $job->handle($balanceProvider, $pushService, new EvmTransactionProcessor());
 
     Event::assertDispatched(WalletBalanceUpdated::class, function (WalletBalanceUpdated $event) use ($user): bool {
         return $event->userId === $user->id && $event->chainId === 'ethereum';
     });
+
+    // The transfer is now mirrored into our DB (audit row + activity feed).
+    $btx = BlockchainTransaction::where('tx_hash', '0xabc123')->where('chain', 'ethereum')->first();
+    expect($btx)->not->toBeNull();
+    assert($btx instanceof BlockchainTransaction);
+    expect($btx->type)->toBe('receive')
+        ->and($btx->status)->toBe('confirmed')
+        ->and((float) $btx->amount)->toBe(100.0);
+
+    $feedItem = ActivityFeedItem::where('reference_type', 'evm_tx')
+        ->where('reference_id', EvmTransactionProcessor::txHashToReferenceId('ethereum', '0xabc123'))
+        ->first();
+    expect($feedItem)->not->toBeNull();
+    assert($feedItem instanceof ActivityFeedItem);
+    expect($feedItem->activity_type->value)->toBe('transfer_in')
+        ->and($feedItem->asset)->toBe('USDC')
+        ->and($feedItem->network)->toBe('ethereum')
+        ->and((int) $feedItem->user_id)->toBe($user->id);
 });
 
 it('resolves user from smart_accounts table', function (): void {
@@ -132,7 +153,7 @@ it('resolves user from smart_accounts table', function (): void {
     $pushService->shouldReceive('sendTransactionReceived')->once();
 
     $job = new ProcessAlchemyWebhookJob($payload);
-    $job->handle($balanceProvider, $pushService);
+    $job->handle($balanceProvider, $pushService, new EvmTransactionProcessor());
 
     Event::assertDispatched(WalletBalanceUpdated::class, function (WalletBalanceUpdated $event) use ($user): bool {
         return $event->userId === $user->id && $event->chainId === 'polygon';
@@ -170,7 +191,7 @@ it('filters out spam tokens (non-USDC/USDT)', function (): void {
     $pushService->shouldNotReceive('sendTransactionSent');
 
     $job = new ProcessAlchemyWebhookJob($payload);
-    $job->handle($balanceProvider, $pushService);
+    $job->handle($balanceProvider, $pushService, new EvmTransactionProcessor());
 
     Event::assertNotDispatched(WalletBalanceUpdated::class);
 });
@@ -206,7 +227,7 @@ it('skips activities with removed flag (block reorg)', function (): void {
     $pushService->shouldNotReceive('sendTransactionReceived');
 
     $job = new ProcessAlchemyWebhookJob($payload);
-    $job->handle($balanceProvider, $pushService);
+    $job->handle($balanceProvider, $pushService, new EvmTransactionProcessor());
 
     Event::assertNotDispatched(WalletBalanceUpdated::class);
 });
@@ -249,7 +270,7 @@ it('deduplicates notifications per user within batch', function (): void {
     $pushService->shouldReceive('sendTransactionReceived')->once();
 
     $job = new ProcessAlchemyWebhookJob($payload);
-    $job->handle($balanceProvider, $pushService);
+    $job->handle($balanceProvider, $pushService, new EvmTransactionProcessor());
 
     // Only one broadcast despite two activities for same user
     Event::assertDispatched(WalletBalanceUpdated::class, 1);


### PR DESCRIPTION
## Context

Phase 1 of the wallet transaction-mirror work (architectural review delivered separately). A deep review found that **EVM inbound deposits were silently discarded**:

- `ProcessAlchemyWebhookJob` fired a balance broadcast + push notification on an inbound USDC/USDT transfer, then **threw the transaction away** — nothing written to `blockchain_address_transactions` or `activity_feed_items`.
- Solana mirrors *every* transfer (`HeliusTransactionProcessor`); EVM only tracked **outbound** sends (`WalletSendRecord`).

This was not just an admin-visibility gap — it's a **product bug**: a received EVM deposit never appeared in the client's own in-app history (`GET /api/v1/wallet/transactions`). Balance went up, no matching transaction.

## Change

- **`EvmTransactionProcessor`** — the EVM counterpart of `HeliusTransactionProcessor`. Persists each transfer to:
  - `blockchain_address_transactions` — per-chain raw audit row (`firstOrCreate` on the `(tx_hash, chain)` unique index, race-safe)
  - `activity_feed_items` — the mobile transaction-history read model
  Outbound sends that already own a feed item via `WalletSendRecordObserver` keep their audit row but skip the duplicate feed entry (same dedup pattern as the Solana side).
- **Amounts** resolve from the integer `rawContract.rawValue` (hex), not the JSON float `value` — avoids precision loss / scientific-notation on small amounts.
- **`ProcessAlchemyWebhookJob`** hands matched activity to the processor for any address with a per-chain `blockchain_addresses` row (Privy/mobile wallets — `PrivyAddressRegistrar` writes one row per EVM chain). Legacy relayer smart-accounts without such a row are skipped (broadcast/push unchanged).
- **`evm:backfill-transactions`** — seeds history that predates the live mirror, via the Alchemy `getAssetTransfers` API. The EVM counterpart of `solana:backfill-transactions`. Supports `--network`, `--address`, `--limit`, `--dry-run`.

## Mobile / contract impact

No API contract change. EVM inbound deposits now appear in `GET /api/v1/wallet/transactions` like Solana ones already do.

## Known limitation (pre-existing, not in scope)

An EVM transfer between two Zelta users mirrors to only one side's feed — same as the existing Solana behaviour. Tracked for a later pass.

## Tests

- `EvmTransactionProcessorTest` — inbound/outbound mirroring, precise hex amount resolution, idempotency, wallet-send dedup
- `EvmTransactionBackfillCommandTest` — `Http::fake`d Alchemy API: backfill, dry-run, missing-key
- `ProcessAlchemyWebhookJobTest` — updated; asserts the webhook path now writes the mirror

PHPStan level 8 + php-cs-fixer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)