### PR TITLE
feat: per-user wallet visibility in the admin panel

### DIFF
--- a/app/Filament/Admin/Resources/UserResource.php
+++ b/app/Filament/Admin/Resources/UserResource.php
@@ -132,7 +132,9 @@ class UserResource extends Resource
     public static function getRelations(): array
     {
         return [
-            //
+            UserResource\RelationManagers\BlockchainAddressesRelationManager::class,
+            UserResource\RelationManagers\BlockchainTransactionsRelationManager::class,
+            UserResource\RelationManagers\WalletSendRecordsRelationManager::class,
         ];
     }
 

--- a/app/Filament/Admin/Resources/UserResource/RelationManagers/BlockchainAddressesRelationManager.php
+++ b/app/Filament/Admin/Resources/UserResource/RelationManagers/BlockchainAddressesRelationManager.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\UserResource\RelationManagers;
+
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+/**
+ * Per-user non-custodial wallet addresses. Read-only.
+ *
+ * Privy registers one row per chain for the same EVM smart-account address,
+ * plus one Solana row — so a support agent can confirm exactly which address
+ * a customer is operating on each network.
+ */
+class BlockchainAddressesRelationManager extends RelationManager
+{
+    protected static string $relationship = 'blockchainAddresses';
+
+    protected static ?string $recordTitleAttribute = 'address';
+
+    protected static ?string $title = 'Wallet Addresses';
+
+    protected static ?string $icon = 'heroicon-o-wallet';
+
+    public function isReadOnly(): bool
+    {
+        return true;
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('chain')
+                    ->badge()
+                    ->color('gray'),
+                Tables\Columns\TextColumn::make('address')
+                    ->limit(24)
+                    ->copyable()
+                    ->tooltip(fn ($record): string => (string) $record->address)
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('label')
+                    ->placeholder('—')
+                    ->toggleable(),
+                Tables\Columns\IconColumn::make('is_active')
+                    ->label('Active')
+                    ->boolean(),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Registered')
+                    ->dateTime('M j, Y g:i A')
+                    ->sortable()
+                    ->toggleable(),
+            ])
+            ->defaultSort('chain')
+            ->filters([
+                Tables\Filters\SelectFilter::make('chain')
+                    ->options([
+                        'solana'   => 'Solana',
+                        'polygon'  => 'Polygon',
+                        'base'     => 'Base',
+                        'arbitrum' => 'Arbitrum',
+                        'ethereum' => 'Ethereum',
+                    ]),
+                Tables\Filters\TernaryFilter::make('is_active')
+                    ->label('Active'),
+            ])
+            ->headerActions([])
+            ->actions([])
+            ->bulkActions([]);
+    }
+}

--- a/app/Filament/Admin/Resources/UserResource/RelationManagers/BlockchainTransactionsRelationManager.php
+++ b/app/Filament/Admin/Resources/UserResource/RelationManagers/BlockchainTransactionsRelationManager.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\UserResource\RelationManagers;
+
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+/**
+ * Per-user on-chain transaction history, across every wallet address and
+ * chain. Read-only — this is the support-facing mirror of what actually
+ * settled on-chain (Solana via Helius, EVM via Alchemy), including dust
+ * that is hidden from the customer's in-app feed.
+ */
+class BlockchainTransactionsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'blockchainTransactions';
+
+    protected static ?string $recordTitleAttribute = 'tx_hash';
+
+    protected static ?string $title = 'Blockchain Transactions';
+
+    protected static ?string $icon = 'heroicon-o-arrows-right-left';
+
+    public function isReadOnly(): bool
+    {
+        return true;
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Date')
+                    ->dateTime('M j, Y g:i A')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('chain')
+                    ->badge()
+                    ->color('gray'),
+                Tables\Columns\TextColumn::make('type')
+                    ->badge()
+                    ->color(fn (string $state): string => $state === 'receive' ? 'success' : 'warning'),
+                Tables\Columns\TextColumn::make('amount')
+                    ->numeric(decimalPlaces: 6)
+                    ->weight('bold')
+                    ->color(fn ($record): string => $record->type === 'receive' ? 'success' : 'danger'),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'confirmed' => 'success',
+                        'failed'    => 'danger',
+                        default     => 'warning',
+                    }),
+                Tables\Columns\TextColumn::make('from_address')
+                    ->label('From')
+                    ->limit(16)
+                    ->copyable()
+                    ->tooltip(fn ($record): string => (string) $record->from_address)
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('to_address')
+                    ->label('To')
+                    ->limit(16)
+                    ->copyable()
+                    ->tooltip(fn ($record): string => (string) $record->to_address)
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('tx_hash')
+                    ->label('Tx Hash')
+                    ->limit(18)
+                    ->copyable()
+                    ->tooltip(fn ($record): string => (string) $record->tx_hash)
+                    ->searchable(),
+            ])
+            ->defaultSort('created_at', 'desc')
+            ->filters([
+                Tables\Filters\SelectFilter::make('chain')
+                    ->options([
+                        'solana'   => 'Solana',
+                        'polygon'  => 'Polygon',
+                        'base'     => 'Base',
+                        'arbitrum' => 'Arbitrum',
+                        'ethereum' => 'Ethereum',
+                    ]),
+                Tables\Filters\SelectFilter::make('type')
+                    ->options([
+                        'receive' => 'Receive',
+                        'send'    => 'Send',
+                    ]),
+                Tables\Filters\SelectFilter::make('status')
+                    ->options([
+                        'pending'   => 'Pending',
+                        'confirmed' => 'Confirmed',
+                        'failed'    => 'Failed',
+                    ]),
+            ])
+            ->headerActions([])
+            ->actions([])
+            ->bulkActions([]);
+    }
+}

--- a/app/Filament/Admin/Resources/UserResource/RelationManagers/WalletSendRecordsRelationManager.php
+++ b/app/Filament/Admin/Resources/UserResource/RelationManagers/WalletSendRecordsRelationManager.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\UserResource\RelationManagers;
+
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+/**
+ * Per-user outbound wallet sends (the prepare/submit flow). Read-only.
+ *
+ * Surfaces the full send lifecycle — pending → submitted → confirmed/failed —
+ * with the failure `error_code` / `error_message`, so a support agent can see
+ * exactly why a customer's transfer did not go through.
+ */
+class WalletSendRecordsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'walletSendRecords';
+
+    protected static ?string $recordTitleAttribute = 'public_id';
+
+    protected static ?string $title = 'Wallet Sends';
+
+    protected static ?string $icon = 'heroicon-o-paper-airplane';
+
+    public function isReadOnly(): bool
+    {
+        return true;
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label('Date')
+                    ->dateTime('M j, Y g:i A')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('network')
+                    ->badge()
+                    ->color('gray'),
+                Tables\Columns\TextColumn::make('asset'),
+                Tables\Columns\TextColumn::make('amount')
+                    ->numeric(decimalPlaces: 6)
+                    ->weight('bold'),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'confirmed'            => 'success',
+                        'failed'               => 'danger',
+                        'pending', 'submitted' => 'warning',
+                        default                => 'gray',
+                    }),
+                Tables\Columns\TextColumn::make('recipient_address')
+                    ->label('Recipient')
+                    ->limit(16)
+                    ->copyable()
+                    ->tooltip(fn ($record): string => (string) $record->recipient_address),
+                Tables\Columns\TextColumn::make('tx_hash')
+                    ->label('Tx Hash')
+                    ->limit(18)
+                    ->copyable()
+                    ->placeholder('—')
+                    ->tooltip(fn ($record): ?string => $record->tx_hash)
+                    ->searchable()
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('error_code')
+                    ->label('Error')
+                    ->badge()
+                    ->color('danger')
+                    ->placeholder('—')
+                    ->tooltip(fn ($record): ?string => $record->error_message)
+                    ->toggleable(),
+            ])
+            ->defaultSort('created_at', 'desc')
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')
+                    ->options([
+                        'pending'   => 'Pending',
+                        'submitted' => 'Submitted',
+                        'confirmed' => 'Confirmed',
+                        'failed'    => 'Failed',
+                    ]),
+                Tables\Filters\SelectFilter::make('network')
+                    ->options([
+                        'solana'   => 'Solana',
+                        'polygon'  => 'Polygon',
+                        'base'     => 'Base',
+                        'arbitrum' => 'Arbitrum',
+                        'ethereum' => 'Ethereum',
+                    ]),
+            ])
+            ->headerActions([])
+            ->actions([])
+            ->bulkActions([]);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,12 +4,15 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use App\Domain\Account\Models\Account;
+use App\Domain\Account\Models\BlockchainAddress;
+use App\Domain\Account\Models\BlockchainTransaction;
 use App\Domain\Account\Models\Transaction;
 use App\Domain\Banking\Models\BankAccountModel;
 use App\Domain\Banking\Models\UserBankPreference;
 use App\Domain\Cgo\Models\CgoInvestment;
 use App\Domain\Compliance\Models\KycDocument;
 use App\Domain\User\Values\UserRoles;
+use App\Domain\Wallet\Models\WalletSendRecord;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Panel;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -353,6 +356,43 @@ class User extends Authenticatable implements FilamentUser
             'uuid', // Local key on users table
             'uuid' // Local key on accounts table
         );
+    }
+
+    /**
+     * The user's non-custodial wallet addresses — one row per chain.
+     *
+     * @return HasMany<BlockchainAddress, $this>
+     */
+    public function blockchainAddresses(): HasMany
+    {
+        return $this->hasMany(BlockchainAddress::class, 'user_uuid', 'uuid');
+    }
+
+    /**
+     * Every on-chain transaction mirrored across the user's wallet addresses.
+     *
+     * @return HasManyThrough<BlockchainTransaction, BlockchainAddress, $this>
+     */
+    public function blockchainTransactions(): HasManyThrough
+    {
+        return $this->hasManyThrough(
+            BlockchainTransaction::class,
+            BlockchainAddress::class,
+            'user_uuid',    // Foreign key on blockchain_addresses → users
+            'address_uuid', // Foreign key on blockchain_address_transactions → blockchain_addresses
+            'uuid',         // Local key on users
+            'uuid'          // Local key on blockchain_addresses
+        );
+    }
+
+    /**
+     * The user's outbound wallet sends (prepare/submit flow), all networks.
+     *
+     * @return HasMany<WalletSendRecord, $this>
+     */
+    public function walletSendRecords(): HasMany
+    {
+        return $this->hasMany(WalletSendRecord::class, 'user_id');
     }
 
     /**

--- a/tests/Feature/Filament/UserWalletRelationManagersTest.php
+++ b/tests/Feature/Filament/UserWalletRelationManagersTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Admin\Resources\UserResource;
+use App\Filament\Admin\Resources\UserResource\RelationManagers\BlockchainAddressesRelationManager;
+use App\Filament\Admin\Resources\UserResource\RelationManagers\BlockchainTransactionsRelationManager;
+use App\Filament\Admin\Resources\UserResource\RelationManagers\WalletSendRecordsRelationManager;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Relations\Relation;
+
+it('registers the three wallet relation managers on the User resource', function (): void {
+    expect(UserResource::getRelations())->toBe([
+        BlockchainAddressesRelationManager::class,
+        BlockchainTransactionsRelationManager::class,
+        WalletSendRecordsRelationManager::class,
+    ]);
+});
+
+it('points each wallet relation manager at a real User relation', function (): void {
+    $user = User::factory()->create();
+
+    $managers = [
+        BlockchainAddressesRelationManager::class,
+        BlockchainTransactionsRelationManager::class,
+        WalletSendRecordsRelationManager::class,
+    ];
+
+    foreach ($managers as $manager) {
+        $property = (new ReflectionClass($manager))->getProperty('relationship');
+        $property->setAccessible(true);
+        $relationship = (string) $property->getValue();
+
+        // The configured relationship resolves to a genuine Eloquent relation.
+        expect(method_exists(User::class, $relationship))->toBeTrue()
+            ->and($user->{$relationship}())->toBeInstanceOf(Relation::class);
+    }
+});

--- a/tests/Feature/Models/UserWalletRelationsTest.php
+++ b/tests/Feature/Models/UserWalletRelationsTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Account\Models\BlockchainAddress;
+use App\Domain\Account\Models\BlockchainTransaction;
+use App\Domain\Wallet\Models\WalletSendRecord;
+use App\Models\User;
+use Illuminate\Support\Str;
+
+/**
+ * @param array<string, mixed> $overrides
+ */
+function makeAddress(User $user, string $chain, array $overrides = []): BlockchainAddress
+{
+    $address = $overrides['address'] ?? ('addr_' . Str::random(16));
+
+    return BlockchainAddress::create(array_merge([
+        'user_uuid'  => $user->uuid,
+        'chain'      => $chain,
+        'address'    => $address,
+        'public_key' => $address,
+        'is_active'  => true,
+    ], $overrides));
+}
+
+function makeTx(BlockchainAddress $address, string $hash, string $type = 'receive'): BlockchainTransaction
+{
+    return BlockchainTransaction::create([
+        'address_uuid' => $address->uuid,
+        'tx_hash'      => $hash,
+        'chain'        => $address->chain,
+        'type'         => $type,
+        'amount'       => '1.5',
+        'fee'          => '0',
+        'from_address' => 'from',
+        'to_address'   => 'to',
+        'status'       => 'confirmed',
+    ]);
+}
+
+it('exposes the user wallet addresses, scoped to that user', function (): void {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+
+    makeAddress($user, 'solana');
+    makeAddress($user, 'polygon');
+    makeAddress($other, 'solana');
+
+    expect($user->blockchainAddresses)->toHaveCount(2)
+        ->and($user->blockchainAddresses->pluck('chain')->sort()->values()->all())
+        ->toBe(['polygon', 'solana']);
+});
+
+it('aggregates on-chain transactions across every address the user owns', function (): void {
+    $user = User::factory()->create();
+    $solAddress = makeAddress($user, 'solana');
+    $polyAddress = makeAddress($user, 'polygon');
+    makeTx($solAddress, 'sol-tx-1');
+    makeTx($polyAddress, 'poly-tx-1', 'send');
+
+    // A different user's transaction must not leak through the hasManyThrough.
+    $other = User::factory()->create();
+    makeTx(makeAddress($other, 'solana'), 'other-tx-1');
+
+    expect($user->blockchainTransactions()->pluck('tx_hash')->sort()->values()->all())
+        ->toBe(['poly-tx-1', 'sol-tx-1']);
+});
+
+it('exposes the user outbound wallet send records', function (): void {
+    $user = User::factory()->create();
+    $other = User::factory()->create();
+
+    foreach (['confirmed', 'failed'] as $i => $status) {
+        WalletSendRecord::create([
+            'public_id'         => 'pi_send_' . Str::random(12),
+            'user_id'           => $user->id,
+            'network'           => 'polygon',
+            'asset'             => 'USDC',
+            'amount'            => '10.00000000',
+            'sender_address'    => 'sender',
+            'recipient_address' => 'recipient',
+            'status'            => $status,
+        ]);
+    }
+
+    WalletSendRecord::create([
+        'public_id'         => 'pi_send_' . Str::random(12),
+        'user_id'           => $other->id,
+        'network'           => 'solana',
+        'asset'             => 'USDC',
+        'amount'            => '5.00000000',
+        'sender_address'    => 'sender',
+        'recipient_address' => 'recipient',
+        'status'            => 'confirmed',
+    ]);
+
+    expect($user->walletSendRecords)->toHaveCount(2);
+});


### PR DESCRIPTION
## Context

Phase 2 of the wallet transaction-mirror work (architectural review delivered separately; Phase 1 = #1078).

Admin/support staff had **no way to see a customer's crypto wallet activity**:
- `/admin/accounts` is the **fiat bank ledger** (`Account` model), unrelated to crypto wallets.
- No Filament resource surfaced `BlockchainTransaction`, `BlockchainAddress`, or `WalletSendRecord`.

When a client emailed *"my USDC didn't arrive"*, a support agent had no screen to look at.

## Change

Adds three **read-only relation managers** to the existing `UserResource`. Opening a user in the admin panel (`/admin/users/{id}/edit`) now shows, as tabs:

- **Wallet Addresses** — registered addresses per chain (Solana + the four EVM networks)
- **Blockchain Transactions** — the cross-chain mirror of on-chain activity (Solana via Helius, EVM via Alchemy once #1078 lands), newest first, filterable by chain/type/status. Shows the **unfiltered** truth — including dust that is hidden from the customer's in-app feed — which is exactly what support needs to explain things like the "6× dust SOL" ticket.
- **Wallet Sends** — the full send lifecycle (`pending → submitted → confirmed/failed`) with `error_code` / `error_message`, so support can see exactly *why* a transfer failed.

Backed by three new `User` relations:
- `blockchainAddresses()` — `HasMany`
- `blockchainTransactions()` — `HasManyThrough` `BlockchainAddress`
- `walletSendRecords()` — `HasMany`

All three relation managers are `isReadOnly()` — admin views, never mutates on-chain-derived data.

## Design notes

- **No event sourcing** — on-chain data is a plain-Eloquent projection/cache; the chain is the system of record (consistent with the architecture review and the existing `HeliusTransactionProcessor` pattern).
- **No live balances** — balances are live-RPC only; rendering them in an admin table would mean an RPC call per row. Deferred to a future phase (balance snapshots). The transaction history already shows money in/out.
- Relation managers were chosen over standalone resources: zero new nav groups / module-visibility config, and the per-user edit page *is* the support dashboard.

## Tests

- `UserWalletRelationsTest` — the three new User relations return correct, user-scoped data (incl. the `HasManyThrough` isolation)
- `UserWalletRelationManagersTest` — the relation managers are registered on `UserResource` and each points at a real User relation

PHPStan level 8 + php-cs-fixer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)