### PR TITLE
docs: release v7.14.0 — wallet transaction mirror & admin visibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,10 @@ Plan B mobile-driven subscriptions (Apple App Store + Google Play). Entry point:
 - Solana constants: `SolanaTokens::KNOWN_MINTS` and `SolanaCacheKeys::balance()` in `app/Domain/Wallet/Constants/`
 - Solana webhook: always uses Helius (`HeliusWebhookSyncService`), Alchemy handles EVM only
 - Solana tx processor: `HeliusTransactionProcessor` handles all Solana transaction parsing
-- Webhook controllers: Helius handles Solana, Alchemy handles EVM — both send FCM push via `PushNotificationService`
+- EVM tx processor: `EvmTransactionProcessor` mirrors inbound EVM transfers to `blockchain_address_transactions` + `activity_feed_items` (counterpart of `HeliusTransactionProcessor`); `evm:backfill-transactions` seeds pre-mirror history via the Alchemy Transfers API
+- Webhook controllers: Helius handles Solana, Alchemy handles EVM — both send FCM push via `PushNotificationService` and mirror transactions via their respective processors
+- Inbound Solana dust: native-SOL transfers below `WALLET_SOLANA_DUST_MIN_INBOUND_SOL` (default 0.001 SOL) are recorded for audit but kept out of the activity feed + push (address-poisoning spam). Token transfers are never filtered
+- Admin wallet visibility: `UserResource` has read-only relation managers for wallet addresses, blockchain transactions, and wallet sends — support opens a user to see their crypto activity
 - Alchemy webhook signing keys: stored in `webhook_endpoints` table (managed by `AlchemyWebhookManager`), not env vars
 - Test tables: use `Tests\Traits\CreatesSolanaTestTables` trait for in-memory SQLite schema in webhook/wallet tests
 - Multi-connection tests: `tests/MultiConnection/` — runs against real MySQL with `database.force_real_tenant_connection=true` so models with `UsesTenantConnection` use a separate MySQL session. Required check on PRs. See `docs/superpowers/specs/2026-04-26-multi-connection-test-infrastructure-design.md`.

--- a/docs/VERSION_ROADMAP.md
+++ b/docs/VERSION_ROADMAP.md
@@ -3272,6 +3272,22 @@ Findings #1-2 fixed in v7.1.1, findings #3-15 fixed in this release:
 
 ---
 
+## Version 7.14.0 — Wallet Transaction Mirror & Admin Visibility (May 2026)
+
+**Theme**: Close the wallet transaction-history gaps surfaced by a comprehensive architecture review — mirror inbound EVM deposits the way Solana already is, give support a per-user wallet view in the admin panel, make the receipt endpoint serve a real page + PDF, and stop address-poisoning dust from spamming the activity feed.
+
+### Delivered Features
+- EVM inbound transaction mirror (#1078). Inbound USDC/USDT deposits on Polygon/Base/Arbitrum/Ethereum were discarded — `ProcessAlchemyWebhookJob` fired a balance broadcast + push, then threw the transaction away, so the deposit never appeared in `GET /api/v1/wallet/transactions` (balance moved, no entry). Solana mirrors every transfer via `HeliusTransactionProcessor`; EVM only tracked outbound sends. The new `EvmTransactionProcessor` persists each transfer to `blockchain_address_transactions` (audit row) and `activity_feed_items` (mobile read model), `firstOrCreate` on the `(tx_hash, chain)` unique index. Amounts resolve from the integer `rawContract.rawValue` to avoid float-precision loss. Outbound sends already owning a feed item via `WalletSendRecordObserver` keep the audit row but skip the duplicate. New `php artisan evm:backfill-transactions` seeds pre-mirror history via the Alchemy `getAssetTransfers` API — the EVM counterpart of `solana:backfill-transactions`.
+- Per-user wallet visibility in the admin panel (#1079). Support had no screen for a customer's crypto activity: `/admin/accounts` is the fiat ledger, and no resource surfaced `BlockchainTransaction` / `BlockchainAddress` / `WalletSendRecord`. Three read-only relation managers were added to `UserResource` — Wallet Addresses, Blockchain Transactions (cross-chain, unfiltered — including dust hidden from the customer feed), and Wallet Sends (full lifecycle with `error_code` / `error_message`). Backed by three new `User` relations: `blockchainAddresses` (HasMany), `blockchainTransactions` (HasManyThrough `BlockchainAddress`), `walletSendRecords` (HasMany). On-chain data stays plain-Eloquent — the chain is the system of record, the mirror is a rebuildable projection; event sourcing would duplicate a log we do not own.
+- Hosted receipt page + downloadable PDF (#1076). `POST /api/v1/transactions/{txId}/receipt` returned a `sharePayload` link to an unregistered `/receipt/{id}` route (every share link 404'd) and a null `pdfUrl` (no PDF was ever generated). New public `GET /receipt/{shareToken}` renders a branded `noindex` receipt page keyed on an unguessable 64-char token; `ReceiptService` renders the same Blade view to a PDF via dompdf on the public disk, so `pdfUrl` is now a real downloadable file.
+- Solana inbound dust filter (#1077). A wallet was hit by address-poisoning spam — six unsolicited 0.00001 SOL transfers, each one becoming an activity-feed entry and a push notification. Inbound native-SOL transfers below `WALLET_SOLANA_DUST_MIN_INBOUND_SOL` (default 0.001 SOL) are now recorded as a `BlockchainTransaction` for audit but kept out of `activity_feed_items`, and `ProcessHeliusWebhookJob` suppresses the push. Token transfers (USDC/USDT) are never filtered.
+
+### Environment
+- `WALLET_SOLANA_DUST_MIN_INBOUND_SOL` (default `0.001`) — inbound native-SOL dust threshold. Added to `.env.production.example` and `.env.zelta.example`.
+- The EVM backfill command reuses the existing `ALCHEMY_API_KEY`; no new variable.
+
+---
+
 ## Version 7.13.2 — Mobile Wallet Bug-Fix Patch (May 2026)
 
 **Theme**: Three small, independent server-side fixes surfaced by mobile Build #8 — Solana send unblocked, receipts work for non-intent transactions, privacy merkle-root gives a clean 4xx/5xx instead of a 500.
@@ -3379,5 +3395,5 @@ Embeddable JS widget that renders Zelta's 402 payment flow inside the partner's 
 
 ---
 
-*Document Version: 7.13.2*
-*Updated: May 15, 2026 (v7.13.2 mobile wallet bug-fix patch — Solana send + receipts + privacy gating)*
+*Document Version: 7.14.0*
+*Updated: May 18, 2026 (v7.14.0 wallet transaction mirror — EVM inbound deposits, admin wallet visibility, hosted receipts, Solana dust filter)*

--- a/resources/views/changelog.blade.php
+++ b/resources/views/changelog.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'Changelog | ' . config('brand.name', 'Zelta'),
-        'description' => 'Release history for the Zelta core banking platform. Track every feature shipped, bug fixed, and improvement made — v7.0 through v7.13.2.',
+        'description' => 'Release history for the Zelta core banking platform. Track every feature shipped, bug fixed, and improvement made — v7.0 through v7.14.0.',
         'keywords' => 'changelog, release notes, updates, ' . config('brand.name', 'Zelta') . ', version history, core banking',
     ])
 
@@ -43,6 +43,20 @@
 
             @php
                 $releases = [
+                    [
+                        'version' => 'v7.14.0',
+                        'date' => 'May 18, 2026',
+                        'label' => 'Wallet Transaction Mirror — EVM Deposits, Admin Visibility, Receipts &amp; Dust Filtering',
+                        'label_color' => 'blue',
+                        'badge_color' => 'bg-blue-100 text-blue-700 border-blue-200',
+                        'dot_color' => 'bg-blue-500',
+                        'items' => [
+                            'EVM inbound deposits are now mirrored into transaction history. Previously the Alchemy webhook fired a balance update and a push notification for an inbound USDC/USDT transfer on Polygon, Base, Arbitrum, or Ethereum — then discarded the transaction. The deposit never appeared in <code>GET /api/v1/wallet/transactions</code>: the balance moved but no matching entry was shown. The new <code>EvmTransactionProcessor</code> (the EVM counterpart of <code>HeliusTransactionProcessor</code>) persists every transfer to <code>blockchain_address_transactions</code> and <code>activity_feed_items</code>, bringing EVM to parity with Solana. Outbound sends that already own a feed item via <code>WalletSendRecordObserver</code> keep their audit row but skip the duplicate. A new <code>php artisan evm:backfill-transactions</code> command seeds history that predates the live mirror via the Alchemy Transfers API.',
+                            'Per-user wallet visibility in the admin panel. Support staff had no screen for a customer\'s crypto activity — <code>/admin/accounts</code> is the fiat ledger, and no resource surfaced blockchain data. Opening a user in the admin panel now shows three read-only tabs: <strong>Wallet Addresses</strong> (registered addresses per chain), <strong>Blockchain Transactions</strong> (the cross-chain mirror of on-chain activity, including dust hidden from the customer feed), and <strong>Wallet Sends</strong> (the full send lifecycle with <code>error_code</code> / <code>error_message</code>, so support can see exactly why a transfer failed).',
+                            'Hosted receipt page and downloadable PDF. <code>POST /api/v1/transactions/{txId}/receipt</code> returned a <code>sharePayload</code> link pointing at an unregistered <code>/receipt/{id}</code> route — every share link 404\'d — and <code>pdfUrl</code> was always null because no PDF was ever generated. A new public <code>GET /receipt/{shareToken}</code> renders a branded, <code>noindex</code> receipt page keyed on an unguessable token; <code>ReceiptService</code> renders the same view to a PDF (dompdf) stored on the public disk, so <code>pdfUrl</code> is now a real downloadable file.',
+                            'Solana inbound dust filter. A wallet was hit by address-poisoning spam — six unsolicited 0.00001 SOL transfers — and each one became an activity-feed entry <em>and</em> a push notification. Inbound native-SOL transfers below <code>WALLET_SOLANA_DUST_MIN_INBOUND_SOL</code> (default 0.001 SOL) are now recorded as a <code>BlockchainTransaction</code> for audit but kept out of the activity feed, and the push is suppressed. Token transfers (USDC/USDT) are never filtered.',
+                        ],
+                    ],
                     [
                         'version' => 'v7.13.2',
                         'date' => 'May 15, 2026',

--- a/resources/views/developers/index.blade.php
+++ b/resources/views/developers/index.blade.php
@@ -137,7 +137,7 @@
                 <div class="text-center">
                     <div class="inline-flex items-center px-4 py-2 bg-white/10 backdrop-blur-sm rounded-full text-sm mb-6">
                         <span class="w-2 h-2 bg-green-400 rounded-full mr-2 animate-pulse"></span>
-                        <span>v7.13.2 Documentation — 61 Domains, 1,400+ Routes, GraphQL + REST + MCP + x402</span>
+                        <span>v7.14.0 Documentation — 61 Domains, 1,400+ Routes, GraphQL + REST + MCP + x402</span>
                     </div>
                     <h1 class="text-5xl md:text-7xl font-bold mb-6 bg-clip-text text-transparent bg-gradient-to-r from-white to-blue-200">
                         Build with 1,400+ API Routes
@@ -177,8 +177,8 @@
                     <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                     </svg>
-                    <span class="font-medium">v7.13.2 Released:</span>
-                    <span class="ml-2">Mobile wallet bug-fix patch — Solana send unblocked (<code class="code-font">PaymentNetwork</code> enum casing aligned across quote and prepare), receipts work for Solana inbound and any non-intent activity (routed through <code class="code-font">ActivityFeedItem</code>), and privacy merkle-root returns <code class="code-font">503 ERR_PRIVACY_310</code> instead of an uncaught 500. USDT (v7.13.1), mobile-driven IAP subscriptions (v7.13.0), and non-custodial wallet send via Privy (v7.12.0) all live. 61 DDD domains, 1,400+ API routes, GraphQL (45 domains), ISO 20022, ISO 8583, x402 Protocol, public MCP server.</span>
+                    <span class="font-medium">v7.14.0 Released:</span>
+                    <span class="ml-2">Wallet transaction mirror — inbound EVM deposits (Polygon/Base/Arbitrum/Ethereum) are now mirrored into transaction history at parity with Solana, per-user wallet activity is visible in the admin panel, the receipt endpoint serves a hosted page and a downloadable PDF, and Solana address-poisoning dust is filtered out of the feed. USDT (v7.13.1), mobile-driven IAP subscriptions (v7.13.0), and non-custodial wallet send via Privy (v7.12.0) all live. 61 DDD domains, 1,400+ API routes, GraphQL (45 domains), ISO 20022, ISO 8583, x402 Protocol, public MCP server.</span>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## v7.14.0 — Wallet Transaction Mirror & Admin Visibility

Release docs for the four PRs that closed the wallet transaction-history gaps surfaced by a comprehensive architecture review:

| PR | What |
|----|------|
| #1078 | EVM inbound transaction mirror — Polygon/Base/Arbitrum/Ethereum deposits now persisted at parity with Solana; `evm:backfill-transactions` command |
| #1079 | Per-user wallet visibility in the admin panel — three read-only relation managers on `UserResource` |
| #1076 | Hosted receipt page (`GET /receipt/{token}`) + downloadable PDF |
| #1077 | Solana inbound dust filter — address-poisoning spam kept out of the feed + push |

## Changes

- **`resources/views/changelog.blade.php`** — new v7.14.0 entry; SEO description bumped to "v7.0 through v7.14.0"
- **`docs/VERSION_ROADMAP.md`** — v7.14.0 section (theme, delivered features, environment) + document-version footer
- **`resources/views/developers/index.blade.php`** — v7.13.2 → v7.14.0 in the hero banner and the status alert
- **`CLAUDE.md`** — engineering notes: `EvmTransactionProcessor`, the Solana dust threshold env var, and the admin wallet-visibility relation managers

## Notes

- Docs-only release PR — no code changes; the feature PRs are already merged.
- `CHANGELOG.md` (the markdown file) was intentionally left untouched — it has been stale since 7.10.10; the maintained changelog is the website `changelog.blade.php`.
- Domain count (61) and `features/index.blade.php` unchanged — no new domains or public feature pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)