### PR TITLE
docs: release v7.14.1 — Privy login hotfix

### DIFF
--- a/docs/VERSION_ROADMAP.md
+++ b/docs/VERSION_ROADMAP.md
@@ -3272,6 +3272,15 @@ Findings #1-2 fixed in v7.1.1, findings #3-15 fixed in this release:
 
 ---
 
+## Version 7.14.1 — Privy Login Hotfix (May 2026)
+
+**Theme**: A one-bug patch — new users could not sign in on the web.
+
+### Delivered Features
+- Privy personal-team provisioning (#1088). Signing in at `/login` with a previously-unused email passed the email-OTP step, then returned a 500 the moment the freshly-created account hit the dashboard. Privy email-OTP signups — web `PrivyWebAuthController` and mobile `POST /api/v1/auth/privy-login` — created the user with a bare `User::create()`, skipping the Jetstream personal-team creation that password signups inherit from `CreateNewUser::createTeam()`. Team features are enabled, so every team-aware Blade view dereferences `Auth::user()->currentTeam`; a team-less user threw `Attempt to read property "name" on null` in `navigation-menu.blade.php`. The new `App\Http\Controllers\Concerns\ProvisionsPersonalTeam` trait provisions the personal team via an idempotent `ensurePersonalTeam()` called on every Privy login — not just signup — so users left team-less by the earlier code path (mobile accounts, and web users whose pre-fix signup 500'd after the row was already inserted) are healed on their next sign-in. Returning-user reproduction tests were added for both transports.
+
+---
+
 ## Version 7.14.0 — Wallet Transaction Mirror & Admin Visibility (May 2026)
 
 **Theme**: Close the wallet transaction-history gaps surfaced by a comprehensive architecture review — mirror inbound EVM deposits the way Solana already is, give support a per-user wallet view in the admin panel, make the receipt endpoint serve a real page + PDF, and stop address-poisoning dust from spamming the activity feed.
@@ -3395,5 +3404,5 @@ Embeddable JS widget that renders Zelta's 402 payment flow inside the partner's 
 
 ---
 
-*Document Version: 7.14.0*
-*Updated: May 18, 2026 (v7.14.0 wallet transaction mirror — EVM inbound deposits, admin wallet visibility, hosted receipts, Solana dust filter)*
+*Document Version: 7.14.1*
+*Updated: May 19, 2026 (v7.14.1 Privy login hotfix — personal-team provisioning for email-OTP signups)*

--- a/resources/views/changelog.blade.php
+++ b/resources/views/changelog.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'Changelog | ' . config('brand.name', 'Zelta'),
-        'description' => 'Release history for the Zelta core banking platform. Track every feature shipped, bug fixed, and improvement made — v7.0 through v7.14.0.',
+        'description' => 'Release history for the Zelta core banking platform. Track every feature shipped, bug fixed, and improvement made — v7.0 through v7.14.1.',
         'keywords' => 'changelog, release notes, updates, ' . config('brand.name', 'Zelta') . ', version history, core banking',
     ])
 
@@ -43,6 +43,17 @@
 
             @php
                 $releases = [
+                    [
+                        'version' => 'v7.14.1',
+                        'date' => 'May 19, 2026',
+                        'label' => 'Privy Login Hotfix — Personal Team Provisioning',
+                        'label_color' => 'slate',
+                        'badge_color' => 'bg-slate-100 text-slate-700 border-slate-200',
+                        'dot_color' => 'bg-slate-500',
+                        'items' => [
+                            'Fixed a 500 error when signing in with a new email. Signing in at <code>/login</code> with a previously-unused email cleared the email-OTP step, then returned a &ldquo;500 Server Error&rdquo; the instant the freshly-created account reached the dashboard. Privy email-OTP signups — both the web flow and the mobile <code>POST /api/v1/auth/privy-login</code> flow — created the user with a bare <code>User::create()</code> and skipped the Jetstream personal-team provisioning that password signups inherit from <code>CreateNewUser</code>. Team features are enabled, so every team-aware view dereferences <code>currentTeam</code> — a team-less user crashed rendering <code>navigation-menu.blade.php</code>. A new <code>ProvisionsPersonalTeam</code> trait provisions the personal team idempotently on every Privy login (not just signup), which also heals users left team-less by the earlier code path on their next sign-in. (#1088)',
+                        ],
+                    ],
                     [
                         'version' => 'v7.14.0',
                         'date' => 'May 18, 2026',

--- a/resources/views/developers/index.blade.php
+++ b/resources/views/developers/index.blade.php
@@ -137,7 +137,7 @@
                 <div class="text-center">
                     <div class="inline-flex items-center px-4 py-2 bg-white/10 backdrop-blur-sm rounded-full text-sm mb-6">
                         <span class="w-2 h-2 bg-green-400 rounded-full mr-2 animate-pulse"></span>
-                        <span>v7.14.0 Documentation — 61 Domains, 1,400+ Routes, GraphQL + REST + MCP + x402</span>
+                        <span>v7.14.1 Documentation — 61 Domains, 1,400+ Routes, GraphQL + REST + MCP + x402</span>
                     </div>
                     <h1 class="text-5xl md:text-7xl font-bold mb-6 bg-clip-text text-transparent bg-gradient-to-r from-white to-blue-200">
                         Build with 1,400+ API Routes
@@ -177,8 +177,8 @@
                     <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                     </svg>
-                    <span class="font-medium">v7.14.0 Released:</span>
-                    <span class="ml-2">Wallet transaction mirror — inbound EVM deposits (Polygon/Base/Arbitrum/Ethereum) are now mirrored into transaction history at parity with Solana, per-user wallet activity is visible in the admin panel, the receipt endpoint serves a hosted page and a downloadable PDF, and Solana address-poisoning dust is filtered out of the feed. USDT (v7.13.1), mobile-driven IAP subscriptions (v7.13.0), and non-custodial wallet send via Privy (v7.12.0) all live. 61 DDD domains, 1,400+ API routes, GraphQL (45 domains), ISO 20022, ISO 8583, x402 Protocol, public MCP server.</span>
+                    <span class="font-medium">v7.14.1 Released:</span>
+                    <span class="ml-2">Hotfix — Privy email-OTP signups now provision a Jetstream personal team, fixing a 500 on first web login. v7.14.0 shipped the wallet transaction mirror — inbound EVM deposits (Polygon/Base/Arbitrum/Ethereum) mirrored into transaction history at parity with Solana, per-user wallet activity in the admin panel, the receipt endpoint serving a hosted page and a downloadable PDF, and Solana address-poisoning dust filtered out of the feed. USDT (v7.13.1), mobile-driven IAP subscriptions (v7.13.0), and non-custodial wallet send via Privy (v7.12.0) all live. 61 DDD domains, 1,400+ API routes, GraphQL (45 domains), ISO 20022, ISO 8583, x402 Protocol, public MCP server.</span>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## v7.14.1 — Privy Login Hotfix

Patch release documenting the personal-team provisioning fix shipped in #1088.

**The bug:** signing in at `/login` with a previously-unused email cleared the email-OTP step, then returned a 500 the moment the new account reached the dashboard — Privy email-OTP signups skipped the Jetstream personal-team provisioning that password signups get from `CreateNewUser`.

**The fix (#1088, already merged to `main`):** a `ProvisionsPersonalTeam` trait provisions the personal team idempotently on every Privy login (web + mobile), healing previously-affected users too.

### Doc changes
- `changelog.blade.php` — v7.14.1 entry (slate, the established patch-release color); SEO description bumped to `v7.14.1`
- `docs/VERSION_ROADMAP.md` — v7.14.1 section + footer
- `developers/index.blade.php` — version badge + status alert

`post-phase-review` run — no critical/important findings; blade templates compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)