### PR TITLE
feat: Bridge.xyz HTTP integration (handover §3.1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -249,7 +249,7 @@ FLUTTERWAVE_SETTLEMENT_NGN=FLUTTERWAVE_SETTLEMENT_NGN_ACCOUNT
 FLUTTERWAVE_SETTLEMENT_USD=FLUTTERWAVE_SETTLEMENT_USD_ACCOUNT
 FLUTTERWAVE_SETTLEMENT_KES=FLUTTERWAVE_SETTLEMENT_KES_ACCOUNT
 
-# Ramp (Fiat on/off-ramp — providers: mock, onramper, stripe_crypto_onramp [legacy: stripe_bridge])
+# Ramp (Fiat on/off-ramp — providers: mock, onramper, bridge, stripe_crypto_onramp [legacy: stripe_bridge])
 RAMP_PROVIDER=mock
 RAMP_MIN_AMOUNT=10
 RAMP_MAX_AMOUNT=10000
@@ -269,6 +269,15 @@ ONRAMPER_FAILURE_REDIRECT_URL=
 # STRIPE_BRIDGE_WEBHOOK_SECRET is the deprecated alias; STRIPE_CRYPTO_ONRAMP_WEBHOOK_SECRET wins if both are set.
 STRIPE_CRYPTO_ONRAMP_WEBHOOK_SECRET=
 STRIPE_BRIDGE_WEBHOOK_SECRET=
+
+# Bridge.xyz (https://apidocs.bridge.xyz/) — primary v1 ramp + KYC provider.
+# Webhook URL: POST /api/v1/webhooks/bridge. KYC_RAMP_PROVIDER and
+# KYC_CARDS_PROVIDER in config/kyc.php both default to 'bridge'.
+BRIDGE_API_KEY=
+BRIDGE_WEBHOOK_SECRET=
+BRIDGE_API_BASE_URL=https://api.bridge.xyz
+BRIDGE_DEFAULT_DEV_FEE_BPS=75
+BRIDGE_ENABLED=true
 
 # =============================================================================
 # CGO (Continuous Growth Offering)

--- a/.env.production.example
+++ b/.env.production.example
@@ -480,10 +480,16 @@ IAP_RECEIPT_PEPPER=
 # STRIPE_KYC_SUCCESS_URL=zelta://trustcert/payment-return?status=success&session={CHECKOUT_SESSION_ID}
 # STRIPE_KYC_CANCEL_URL=zelta://trustcert/payment-return?status=cancel
 # Provider selection is via RAMP_PROVIDER below — no separate enable flag.
-# In v1, switch to RAMP_PROVIDER=bridge once the Bridge.xyz integration ships
-# (see docs/BACKEND_HANDOVER_BRIDGE_RAMP.md). The legacy `stripe_bridge` value
-# is still accepted with a deprecation warning and maps to stripe_crypto_onramp.
-RAMP_PROVIDER=stripe_crypto_onramp
+# v1 default: Bridge.xyz bank-rail integration (ACH + SEPA + SEPA Instant).
+# The legacy `stripe_bridge` value is still accepted with a deprecation
+# warning and maps to stripe_crypto_onramp (card-payment fallback).
+RAMP_PROVIDER=bridge
+
+# Bridge.xyz credentials
+BRIDGE_API_KEY=
+BRIDGE_WEBHOOK_SECRET=
+BRIDGE_API_BASE_URL=https://api.bridge.xyz
+BRIDGE_DEFAULT_DEV_FEE_BPS=75
 
 # Onramper (legacy ramp provider, prefer stripe_crypto_onramp or bridge for production)
 ONRAMPER_API_KEY=

--- a/.env.zelta.example
+++ b/.env.zelta.example
@@ -221,10 +221,16 @@ IAP_RECEIPT_PEPPER=
 # STRIPE_KYC_SUCCESS_URL=zelta://trustcert/payment-return?status=success&session={CHECKOUT_SESSION_ID}
 # STRIPE_KYC_CANCEL_URL=zelta://trustcert/payment-return?status=cancel
 # Provider selection is via RAMP_PROVIDER below — no separate enable flag.
-# In v1, switch to RAMP_PROVIDER=bridge once the Bridge.xyz integration ships
-# (see docs/BACKEND_HANDOVER_BRIDGE_RAMP.md). The legacy `stripe_bridge` value
-# is still accepted with a deprecation warning and maps to stripe_crypto_onramp.
-RAMP_PROVIDER=stripe_crypto_onramp
+# v1 default: Bridge.xyz bank-rail integration. The legacy `stripe_bridge`
+# value is still accepted with a deprecation warning and maps to
+# stripe_crypto_onramp (card-payment fallback, disabled by default).
+RAMP_PROVIDER=bridge
+
+# Bridge.xyz credentials — see https://apidocs.bridge.xyz/
+BRIDGE_API_KEY=
+BRIDGE_WEBHOOK_SECRET=
+BRIDGE_API_BASE_URL=https://api.bridge.xyz
+BRIDGE_DEFAULT_DEV_FEE_BPS=75
 CASHIER_CURRENCY=eur
 CASHIER_CURRENCY_LOCALE=en
 

--- a/app/Domain/Compliance/Kyc/Providers/BridgeKycProvider.php
+++ b/app/Domain/Compliance/Kyc/Providers/BridgeKycProvider.php
@@ -6,25 +6,24 @@ namespace App\Domain\Compliance\Kyc\Providers;
 
 use App\Domain\Compliance\Kyc\Contracts\KycProviderInterface;
 use App\Domain\Compliance\Kyc\Enums\KycPurpose;
+use App\Domain\Compliance\Kyc\Exceptions\UnsupportedKycPurposeException;
 use App\Domain\Compliance\Kyc\Models\BridgeCustomer;
+use App\Infrastructure\Bridge\BridgeClient;
+use App\Infrastructure\Bridge\BridgeWebhookVerifier;
+use App\Models\User;
+use Carbon\Carbon;
 use RuntimeException;
 
 /**
- * Bridge.xyz adapter — skeleton.
+ * Bridge.xyz adapter.
  *
- * getName(), getStatus(), and getWebhookSignatureHeader() are real and read
- * from the bridge_customers table + config.
+ * Handles RAMP + CARDS purposes (same Bridge customer record under the
+ * hood). TRUSTCERT routes to OndatoKycProvider per config('kyc.routing').
  *
- * getHostedLink(), getWebhookValidator(), and normalizeWebhookPayload()
- * throw a clear "not yet implemented" error pointing at the work that lands
- * in the BridgeProvider PR (handover §3.1, §3.3). They need a real HTTP
- * client against Bridge's REST API + verification of Bridge's exact webhook
- * signature scheme — shipping a guessed validator here would give false
- * confidence in tests.
- *
- * The interface contract is fully implemented so KycProviderRouter::resolve
- * works at runtime; callers that actually invoke the unimplemented methods
- * get a deterministic error rather than a silent failure.
+ * Lazy customer provisioning: first call to `getHostedLink` creates the
+ * Bridge customer + persists the `bridge_customers` row, then requests a
+ * hosted KYC link. Idempotency-Key prevents duplicate Bridge customers
+ * if the local INSERT fails after the remote call.
  *
  * @see docs/BACKEND_HANDOVER_BRIDGE_RAMP.md §3.1, §3.3
  * @see docs/adr/0005-bridge-xyz-over-stripe-crypto-onramp.md
@@ -32,6 +31,12 @@ use RuntimeException;
  */
 final class BridgeKycProvider implements KycProviderInterface
 {
+    public function __construct(
+        private readonly BridgeClient $client,
+        private readonly BridgeWebhookVerifier $verifier,
+    ) {
+    }
+
     public function getName(): string
     {
         return 'bridge';
@@ -39,12 +44,88 @@ final class BridgeKycProvider implements KycProviderInterface
 
     public function getHostedLink(int $userId, KycPurpose $purpose, array $context = []): string
     {
-        throw new RuntimeException(
-            'BridgeKycProvider::getHostedLink not yet implemented. '
-            . 'Lands in the BridgeProvider PR — see docs/BACKEND_HANDOVER_BRIDGE_RAMP.md §3.1. '
-            . 'Must lazily create the Bridge customer on first call with '
-            . 'Idempotency-Key: bridge_customer:{userId}, then POST /v0/customers/{id}/kyc_links.'
+        if ($purpose !== KycPurpose::RAMP && $purpose !== KycPurpose::CARDS) {
+            throw UnsupportedKycPurposeException::for($this->getName(), $purpose);
+        }
+
+        /** @var User $user */
+        $user = User::findOrFail($userId);
+        $customer = $this->findOrCreateBridgeCustomer($user);
+
+        // Reuse a still-valid link to avoid creating duplicate links.
+        if (
+            $customer->kyc_link_url !== null
+            && $customer->kyc_link_url !== ''
+            && $customer->kyc_link_expires_at !== null
+            && $customer->kyc_link_expires_at->isFuture()
+        ) {
+            return $customer->kyc_link_url;
+        }
+
+        $response = $this->client->createKycLink(
+            $customer->bridge_customer_id,
+            [
+                'type'         => 'individual',
+                'full_name'    => (string) ($user->name ?? ''),
+                'email'        => (string) ($user->email ?? ''),
+                'redirect_uri' => (string) config('kyc.providers.bridge.kyc_redirect_uri', ''),
+            ],
+            idempotencyKey: 'bridge_kyc_link:' . $user->id . ':' . now()->timestamp,
         );
+
+        $url = (string) ($response['url'] ?? $response['link'] ?? '');
+        if ($url === '') {
+            throw new RuntimeException('Bridge createKycLink did not return a hosted link URL.');
+        }
+
+        $expiresAt = isset($response['expires_at'])
+            ? Carbon::parse((string) $response['expires_at'])
+            : null;
+
+        $customer->update([
+            'kyc_link_url'        => $url,
+            'kyc_link_expires_at' => $expiresAt,
+            'kyc_status'          => $customer->kyc_status === BridgeCustomer::KYC_NOT_STARTED
+                ? BridgeCustomer::KYC_PENDING
+                : $customer->kyc_status,
+        ]);
+
+        return $url;
+    }
+
+    private function findOrCreateBridgeCustomer(User $user): BridgeCustomer
+    {
+        $existing = BridgeCustomer::where('user_id', $user->id)->first();
+        if ($existing !== null) {
+            return $existing;
+        }
+
+        $defaultFeeBps = (int) config(
+            'kyc.providers.bridge.default_developer_fee_bps',
+            BridgeCustomer::DEV_FEE_BPS_FREE,
+        );
+
+        $response = $this->client->createCustomer(
+            [
+                'type'              => 'individual',
+                'full_name'         => (string) ($user->name ?? ''),
+                'email'             => (string) ($user->email ?? ''),
+                'developer_fee_bps' => $defaultFeeBps,
+            ],
+            idempotencyKey: 'bridge_customer:' . $user->id,
+        );
+
+        $bridgeCustomerId = (string) ($response['id'] ?? '');
+        if ($bridgeCustomerId === '') {
+            throw new RuntimeException('Bridge createCustomer did not return an id.');
+        }
+
+        return BridgeCustomer::create([
+            'user_id'            => $user->id,
+            'bridge_customer_id' => $bridgeCustomerId,
+            'kyc_status'         => BridgeCustomer::KYC_NOT_STARTED,
+            'developer_fee_bps'  => $defaultFeeBps,
+        ]);
     }
 
     public function getStatus(int $userId): array
@@ -77,14 +158,10 @@ final class BridgeKycProvider implements KycProviderInterface
 
     public function getWebhookValidator(): callable
     {
-        return static function (string $rawBody, string $signatureHeader): bool {
-            unset($rawBody, $signatureHeader);
-            throw new RuntimeException(
-                'BridgeKycProvider webhook signature verification not yet implemented. '
-                . 'Lands in the BridgeProvider PR — verify Bridge\'s exact signature scheme '
-                . 'against apidocs.bridge.xyz before shipping a validator.'
-            );
-        };
+        return fn (string $rawBody, string $signatureHeader): bool => $this->verifier->verify(
+            $rawBody,
+            $signatureHeader,
+        );
     }
 
     public function getWebhookSignatureHeader(): string
@@ -94,11 +171,34 @@ final class BridgeKycProvider implements KycProviderInterface
 
     public function normalizeWebhookPayload(array $payload): ?array
     {
-        throw new RuntimeException(
-            'BridgeKycProvider::normalizeWebhookPayload not yet implemented. '
-            . 'Lands in the BridgeProvider PR — must handle customer.kyc_link_completed, '
-            . 'customer.kyc_link_rejected, virtual_account.activity, transfer.completed, '
-            . 'and transfer.failed events per handover §3.1.'
-        );
+        $type = (string) ($payload['type'] ?? '');
+
+        $status = match ($type) {
+            'customer.kyc_link_completed' => 'approved',
+            'customer.kyc_link_rejected'  => 'rejected',
+            default                       => null,
+        };
+
+        if ($status === null) {
+            return null;
+        }
+
+        $object = $payload['data']['object'] ?? $payload['data'] ?? null;
+        if (! is_array($object)) {
+            return null;
+        }
+
+        $bridgeCustomerId = (string) ($object['customer_id'] ?? $object['id'] ?? '');
+        $userId = null;
+        if ($bridgeCustomerId !== '') {
+            $userId = BridgeCustomer::where('bridge_customer_id', $bridgeCustomerId)->value('user_id');
+        }
+
+        return [
+            'user_id'    => $userId !== null ? (int) $userId : null,
+            'event_type' => $type,
+            'status'     => $status,
+            'raw'        => $object,
+        ];
     }
 }

--- a/app/Domain/Ramp/Contracts/RampProviderInterface.php
+++ b/app/Domain/Ramp/Contracts/RampProviderInterface.php
@@ -9,8 +9,18 @@ interface RampProviderInterface
     /**
      * Create a ramp session via checkout API.
      *
-     * @param  array{type: string, fiat_currency: string, fiat_amount: string, crypto_currency: string, wallet_address: string, quote_id: string|null}  $params
-     * @return array{session_id: string, checkout_url: string|null, metadata: array<string, mixed>}
+     * Optional keys:
+     *   - user_id: int — RampService injects the authenticated user's id so
+     *     providers can scope per-user state (e.g. BridgeProvider reads the
+     *     user's bridge_customers row for virtual-account onramp).
+     *   - network: string — destination chain (e.g. 'polygon'). Defaults to
+     *     the provider's default network when omitted.
+     *   - deposit_instructions: when returned, RampService persists into
+     *     ramp_sessions.deposit_instructions (encrypted column) so mobile
+     *     can read account number / IBAN / memo for bank-rail onramp.
+     *
+     * @param  array{type: string, fiat_currency: string, fiat_amount: string, crypto_currency: string, wallet_address: string, quote_id: string|null, user_id?: int, network?: string}  $params
+     * @return array{session_id: string, checkout_url: string|null, metadata: array<string, mixed>, deposit_instructions?: array<string, mixed>|null}
      */
     public function createSession(array $params): array;
 

--- a/app/Domain/Ramp/Providers/BridgeProvider.php
+++ b/app/Domain/Ramp/Providers/BridgeProvider.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Ramp\Providers;
+
+use App\Domain\Compliance\Kyc\Models\BridgeCustomer;
+use App\Domain\Ramp\Contracts\RampProviderInterface;
+use App\Infrastructure\Bridge\BridgeClient;
+use App\Infrastructure\Bridge\BridgeWebhookVerifier;
+use RuntimeException;
+
+/**
+ * Bridge.xyz ramp provider.
+ *
+ * Onramp uses bank-rail virtual accounts: the user wires fiat to the
+ * IBAN/account number on their `bridge_customers` row, Bridge auto-converts
+ * to USDC, and ships it to the wallet address. `createSession` records the
+ * intent + returns the deposit instructions; the actual money movement is
+ * detected via the `virtual_account.activity` webhook (handled by
+ * BridgeWebhookController) which auto-creates / updates the ramp_sessions
+ * row.
+ *
+ * Offramp is deferred to v1.1 — `createSession` with type='off' throws.
+ *
+ * KYC events (`customer.kyc_link_*`) are NOT handled here; they go via the
+ * dedicated /api/v1/webhooks/bridge controller. `normalizeWebhookPayload`
+ * returns null for KYC events so the existing RampWebhookController flow
+ * (if Bridge is misconfigured to point at /ramp/webhook/bridge) doesn't
+ * silently corrupt KYC state.
+ *
+ * @see docs/BACKEND_HANDOVER_BRIDGE_RAMP.md §3.1
+ * @see docs/adr/0005-bridge-xyz-over-stripe-crypto-onramp.md
+ */
+class BridgeProvider implements RampProviderInterface
+{
+    public const PROVIDER_NAME = 'bridge';
+
+    public const DEFAULT_NETWORK = 'polygon';
+
+    /** Fiat ↔ stablecoin (USDC) network where ramped funds land. */
+    public const SUPPORTED_NETWORKS = ['polygon'];
+
+    /** Bridge transfer fee in basis points (per dev fee schedule reference). */
+    private const BRIDGE_FEE_BPS = 10;
+
+    public function __construct(
+        private readonly BridgeClient $client,
+        private readonly BridgeWebhookVerifier $verifier,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return self::PROVIDER_NAME;
+    }
+
+    /**
+     * Onramp: returns deposit instructions for the user's virtual account.
+     * Offramp: not yet implemented in v1 (bank-rail only per the brief).
+     *
+     * For onramp we require:
+     *   - user_id in params (RampService injects from User)
+     *   - bridge_customers row with virtual_account_id provisioned + KYC approved
+     */
+    public function createSession(array $params): array
+    {
+        $type = (string) ($params['type'] ?? '');
+        if ($type === 'off') {
+            throw new RuntimeException('Bridge offramp is deferred to v1.1.');
+        }
+        if ($type !== 'on') {
+            throw new RuntimeException("Bridge provider does not support type '{$type}'.");
+        }
+
+        $userId = isset($params['user_id']) ? (int) $params['user_id'] : null;
+        if ($userId === null) {
+            throw new RuntimeException('Bridge createSession requires user_id (injected by RampService).');
+        }
+
+        $customer = BridgeCustomer::where('user_id', $userId)->first();
+        if ($customer === null || ! $customer->isKycApproved() || ! $customer->hasVirtualAccount()) {
+            throw new RuntimeException(
+                'Bridge onramp requires an approved customer with a provisioned virtual account.'
+            );
+        }
+
+        $details = $customer->virtual_account_details ?? [];
+        $network = strtolower((string) ($params['network'] ?? self::DEFAULT_NETWORK));
+        if (! in_array($network, self::SUPPORTED_NETWORKS, true)) {
+            throw new RuntimeException("Bridge v1 only supports network 'polygon'; got '{$network}'.");
+        }
+
+        // The "session_id" here is a deterministic stable id tying our
+        // ramp_sessions row to the user+VA. Bridge events arrive without
+        // a session_id (they reference the virtual_account_id and a
+        // transfer_id), so we look up by virtual_account_id at webhook
+        // time. Returning a session_id prefixed `bridge_va_` makes the
+        // mismatch impossible to misread in logs.
+        $providerSessionId = 'bridge_va_' . $customer->virtual_account_id;
+
+        return [
+            'session_id'           => $providerSessionId,
+            'checkout_url'         => null,
+            'deposit_instructions' => $this->shapeDepositInstructions($details, $customer),
+            'metadata'             => [
+                'provider'           => self::PROVIDER_NAME,
+                'type'               => 'on',
+                'network'            => $network,
+                'bridge_customer_id' => $customer->bridge_customer_id,
+                'virtual_account_id' => $customer->virtual_account_id,
+                'supported_rails'    => $customer->supported_rails ?? [],
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $details
+     * @return array<string, mixed>
+     */
+    private function shapeDepositInstructions(array $details, BridgeCustomer $customer): array
+    {
+        return [
+            'accountNumber'  => $details['account_number'] ?? null,
+            'routingNumber'  => $details['routing_number'] ?? null,
+            'iban'           => $details['iban'] ?? null,
+            'bic'            => $details['bic'] ?? null,
+            'accountName'    => $details['account_holder_name'] ?? null,
+            'bankName'       => $details['bank_name'] ?? null,
+            'memo'           => $details['memo'] ?? $customer->bridge_customer_id,
+            'supportedRails' => $customer->supported_rails ?? [],
+        ];
+    }
+
+    public function getSessionStatus(string $sessionId): array
+    {
+        if (str_starts_with($sessionId, 'bridge_va_')) {
+            // Virtual-account-initiated onramp sessions don't have a Bridge
+            // transfer id to poll until the user actually deposits. The
+            // canonical status comes from webhooks; this poll path returns
+            // pending (RampService::getSessionStatus already short-circuits
+            // for terminal sessions, so this is the natural "still waiting"
+            // answer).
+            return [
+                'status'        => 'pending',
+                'fiat_amount'   => null,
+                'crypto_amount' => null,
+                'metadata'      => [
+                    'provider' => self::PROVIDER_NAME,
+                    'note'     => 'Onramp session — status updates arrive via Bridge webhook.',
+                ],
+            ];
+        }
+
+        $transfer = $this->client->getTransfer($sessionId);
+        $cryptoAmount = isset($transfer['destination_amount']) && is_numeric($transfer['destination_amount'])
+            ? (float) $transfer['destination_amount']
+            : null;
+
+        return [
+            'status'        => $this->mapBridgeTransferStatus((string) ($transfer['state'] ?? '')),
+            'fiat_amount'   => null,
+            'crypto_amount' => $cryptoAmount,
+            'metadata'      => [
+                'provider'     => self::PROVIDER_NAME,
+                'bridge_state' => $transfer['state'] ?? null,
+            ],
+        ];
+    }
+
+    public function getSupportedCurrencies(): array
+    {
+        return [
+            'fiatCurrencies'   => ['USD', 'EUR', 'GBP'],
+            'cryptoCurrencies' => ['USDC'],
+            'modes'            => ['buy'],  // 'sell' added when offramp lands
+            'limits'           => [
+                'minAmount'  => (int) config('ramp.limits.min_fiat_amount', 10),
+                'maxAmount'  => (int) config('ramp.limits.max_fiat_amount', 10000),
+                'dailyLimit' => (int) config('ramp.limits.daily_limit', 50000),
+            ],
+        ];
+    }
+
+    /**
+     * Synthesizes a deterministic quote per ADR-0006:
+     *   - Bridge fee = 0.10% of fiat amount
+     *   - Network fee = at-cost lookup per network (default Polygon)
+     *   - FX spread = 0 in v1 (Bridge doesn't decompose; we don't mark up FX)
+     * Zelta markup is added by RampService::getQuotes downstream, not here.
+     */
+    public function getQuotes(string $type, string $fiatCurrency, string $fiatAmount, string $cryptoCurrency): array
+    {
+        if (! is_numeric($fiatAmount) || ! preg_match('/^\d+(\.\d+)?$/', $fiatAmount)) {
+            throw new RuntimeException("Bridge quote requires a non-negative numeric fiat amount; got '{$fiatAmount}'.");
+        }
+        /** @var numeric-string $fiatAmount */
+        $amount = bcadd($fiatAmount, '0', 4);
+
+        $bridgeFee = bcadd(bcdiv(bcmul($amount, (string) self::BRIDGE_FEE_BPS, 4), '10000', 4), '0', 2);
+        $networkFee = $this->lookupNetworkFee(self::DEFAULT_NETWORK);
+
+        // USDC tracks the dollar 1:1; conversion through EUR/GBP would carry
+        // a small implicit FX spread we don't unbundle in v1.
+        $cryptoAmount = (float) bcsub($amount, $bridgeFee, 4);
+
+        return [
+            [
+                'provider_name'   => 'Bridge',
+                'quote_id'        => null,  // Bridge has no hosted quote endpoint
+                'fiat_amount'     => (float) $amount,
+                'crypto_amount'   => $cryptoAmount,
+                'exchange_rate'   => 1.0,
+                'fee'             => (float) $bridgeFee,
+                'network_fee'     => (float) $networkFee,
+                'fee_currency'    => $fiatCurrency,
+                'payment_methods' => ['ach', 'sepa', 'sepa_instant'],
+            ],
+        ];
+    }
+
+    private function lookupNetworkFee(string $network): string
+    {
+        // Polygon USDC transfers cost a fraction of a cent. Conservative
+        // upper bound published as the at-cost network fee in the quote.
+        return match ($network) {
+            'polygon' => '0.01',
+            default   => '0.50',
+        };
+    }
+
+    public function getWebhookValidator(): callable
+    {
+        return fn (string $rawBody, string $signatureHeader): bool => $this->verifier->verify(
+            $rawBody,
+            $signatureHeader,
+        );
+    }
+
+    public function getWebhookSignatureHeader(): string
+    {
+        return 'Bridge-Signature';
+    }
+
+    public function normalizeWebhookPayload(array $payload): ?array
+    {
+        $type = (string) ($payload['type'] ?? '');
+
+        if (str_starts_with($type, 'customer.kyc_link_')) {
+            // KYC events flow through the dedicated /api/v1/webhooks/bridge
+            // controller (BridgeWebhookController) which updates
+            // bridge_customers. The ramp seam intentionally ignores them.
+            return null;
+        }
+
+        $object = $payload['data']['object'] ?? $payload['data'] ?? null;
+        if (! is_array($object)) {
+            return null;
+        }
+
+        if ($type === 'virtual_account.activity') {
+            // Incoming deposit detected. Session id = bridge_va_<virtual_account_id>
+            // so the ramp_sessions lookup finds the row created by createSession,
+            // OR the unsolicited-deposit handler can create one retroactively.
+            $virtualAccountId = (string) ($object['virtual_account_id'] ?? $object['id'] ?? '');
+            if ($virtualAccountId === '') {
+                return null;
+            }
+            $cryptoAmount = isset($object['destination_amount']) && is_numeric($object['destination_amount'])
+                ? bcadd((string) $object['destination_amount'], '0', 8)
+                : null;
+
+            return [
+                'session_id'    => 'bridge_va_' . $virtualAccountId,
+                'status'        => 'processing',  // funds detected, conversion underway
+                'crypto_amount' => $cryptoAmount,
+                'raw'           => $object,
+            ];
+        }
+
+        if ($type === 'transfer.completed' || $type === 'transfer.failed') {
+            $transferId = (string) ($object['id'] ?? '');
+            if ($transferId === '') {
+                return null;
+            }
+            $cryptoAmount = isset($object['destination_amount']) && is_numeric($object['destination_amount'])
+                ? bcadd((string) $object['destination_amount'], '0', 8)
+                : null;
+
+            return [
+                'session_id'    => $transferId,
+                'status'        => $type === 'transfer.completed' ? 'completed' : 'failed',
+                'crypto_amount' => $cryptoAmount,
+                'raw'           => $object,
+            ];
+        }
+
+        return null;
+    }
+
+    private function mapBridgeTransferStatus(string $state): string
+    {
+        return match (strtolower($state)) {
+            'completed', 'paid'              => 'completed',
+            'failed', 'returned', 'canceled' => 'failed',
+            'pending', 'awaiting_funds'      => 'pending',
+            'processing', 'in_progress'      => 'processing',
+            default                          => 'pending',
+        };
+    }
+}

--- a/app/Http/Controllers/Api/V1/BridgeWebhookController.php
+++ b/app/Http/Controllers/Api/V1/BridgeWebhookController.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Domain\Compliance\Kyc\Models\BridgeCustomer;
+use App\Domain\Compliance\Kyc\Providers\BridgeKycProvider;
+use App\Domain\Ramp\Providers\BridgeProvider;
+use App\Domain\Subscription\Models\ProcessedWebhookEvent;
+use App\Http\Controllers\Controller;
+use App\Models\RampSession;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use OpenApi\Attributes as OA;
+use Throwable;
+
+/**
+ * Dedicated webhook endpoint for Bridge.xyz events.
+ *
+ * Bridge fires both customer.kyc_link_* (KYC) and virtual_account.activity
+ * / transfer.* (ramp) events to a single configured URL. We can't route
+ * these through the existing /api/v1/ramp/webhook/{provider} seam because
+ * KYC events have no ramp session_id. This controller dispatches by
+ * event_type to either BridgeKycProvider (KYC) or RampService (ramp).
+ *
+ * Event-level dedupe uses the existing `processed_webhook_events` table
+ * (per the grilling-session lock) keyed by (provider='bridge', event_id)
+ * so Bridge retries are idempotent.
+ *
+ * Configure your Bridge dashboard to POST to:
+ *   https://<your-domain>/api/v1/webhooks/bridge
+ *
+ * @see docs/BACKEND_HANDOVER_BRIDGE_RAMP.md §3.1, §3.3
+ */
+class BridgeWebhookController extends Controller
+{
+    public function __construct(
+        private readonly BridgeProvider $rampProvider,
+        private readonly BridgeKycProvider $kycProvider,
+    ) {
+    }
+
+    #[OA\Post(
+        path: '/api/v1/webhooks/bridge',
+        operationId: 'v1BridgeWebhook',
+        tags: ['Bridge Webhooks'],
+        summary: 'Bridge.xyz event webhook (both KYC and ramp events)',
+        description: 'HMAC-verified via Bridge-Signature header. Dispatches by event_type to either KYC or ramp handlers.',
+    )]
+    #[OA\Response(response: 200, description: 'Event accepted (or ignored as no-op)')]
+    #[OA\Response(response: 401, description: 'Invalid signature')]
+    #[OA\Response(response: 400, description: 'Invalid payload')]
+    public function handle(Request $request): JsonResponse
+    {
+        $rawBody = $request->getContent();
+        $signature = (string) $request->header('Bridge-Signature', '');
+
+        // Use the verifier through the ramp provider (same instance as
+        // BridgeKycProvider since both pull BridgeWebhookVerifier via the
+        // container).
+        $validator = $this->rampProvider->getWebhookValidator();
+        if (! $validator($rawBody, $signature)) {
+            Log::warning('Bridge webhook: invalid signature');
+
+            return response()->json(['error' => 'Invalid signature'], 401);
+        }
+
+        $payload = json_decode($rawBody, true);
+        if (! is_array($payload)) {
+            Log::error('Bridge webhook: invalid JSON body');
+
+            return response()->json(['error' => 'Invalid payload'], 400);
+        }
+
+        $eventId = (string) ($payload['id'] ?? '');
+        $eventType = (string) ($payload['type'] ?? '');
+
+        if ($eventId === '' || $eventType === '') {
+            Log::warning('Bridge webhook: missing id or type');
+
+            return response()->json(['error' => 'Missing event id or type'], 400);
+        }
+
+        // Event-level idempotency: per the grilling session lock, reuse the
+        // shared `processed_webhook_events` table.
+        $newRow = ProcessedWebhookEvent::firstOrCreate(
+            ['provider' => 'bridge', 'event_id' => $eventId],
+            ['event_type' => $eventType, 'processed_at' => now()],
+        );
+
+        if (! $newRow->wasRecentlyCreated) {
+            Log::info('Bridge webhook: duplicate event ignored', [
+                'event_id'   => $eventId,
+                'event_type' => $eventType,
+            ]);
+
+            return response()->json(['status' => 'duplicate'], 200);
+        }
+
+        try {
+            if (str_starts_with($eventType, 'customer.kyc_link_')) {
+                $this->dispatchKycEvent($payload);
+            } else {
+                $this->dispatchRampEvent($payload);
+            }
+        } catch (Throwable $e) {
+            Log::error('Bridge webhook: handler threw', [
+                'event_id'   => $eventId,
+                'event_type' => $eventType,
+                'exception'  => $e->getMessage(),
+            ]);
+
+            // Don't surface the exception to Bridge — they'll retry, and
+            // the dedupe row prevents double-application. Operators see
+            // the failure in logs.
+        }
+
+        return response()->json(['status' => 'received'], 200);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function dispatchKycEvent(array $payload): void
+    {
+        $normalized = $this->kycProvider->normalizeWebhookPayload($payload);
+        if ($normalized === null) {
+            return;
+        }
+
+        $bridgeCustomerId = (string) ($normalized['raw']['customer_id'] ?? $normalized['raw']['id'] ?? '');
+        if ($bridgeCustomerId === '') {
+            Log::warning('Bridge KYC webhook: no customer_id in payload');
+
+            return;
+        }
+
+        DB::transaction(function () use ($bridgeCustomerId, $normalized): void {
+            $customer = BridgeCustomer::where('bridge_customer_id', $bridgeCustomerId)
+                ->lockForUpdate()
+                ->first();
+
+            if ($customer === null) {
+                Log::warning('Bridge KYC webhook: bridge_customer not found', [
+                    'bridge_customer_id' => $bridgeCustomerId,
+                ]);
+
+                return;
+            }
+
+            $newStatus = match ($normalized['status']) {
+                'approved' => BridgeCustomer::KYC_APPROVED,
+                'rejected' => BridgeCustomer::KYC_REJECTED,
+                'pending'  => BridgeCustomer::KYC_PENDING,
+                default    => BridgeCustomer::KYC_NOT_STARTED,
+            };
+
+            $customer->update(['kyc_status' => $newStatus]);
+        });
+
+        // TODO: dispatch WS broadcast (private-user.{userId}) + push
+        // notification on bridge.kyc.completed / bridge.kyc.rejected per
+        // handover §4.3. Plumbing lands when the WS event registry +
+        // PushNotificationService bindings are wired in this domain.
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function dispatchRampEvent(array $payload): void
+    {
+        $normalized = $this->rampProvider->normalizeWebhookPayload($payload);
+        if ($normalized === null) {
+            return;
+        }
+
+        DB::transaction(function () use ($normalized, $payload): void {
+            $session = RampSession::where('provider', BridgeProvider::PROVIDER_NAME)
+                ->where('provider_session_id', $normalized['session_id'])
+                ->lockForUpdate()
+                ->first();
+
+            if ($session === null) {
+                // Unsolicited-deposit case (handover §6 lock): auto-create a
+                // retroactive ramp_sessions row for virtual_account.activity
+                // events that arrived without a preceding POST /ramp/session.
+                if (str_starts_with((string) $normalized['session_id'], 'bridge_va_')) {
+                    $this->createRetroactiveSession($normalized, $payload);
+                } else {
+                    Log::warning('Bridge ramp webhook: session not found', [
+                        'session_id' => $normalized['session_id'],
+                    ]);
+                }
+
+                return;
+            }
+
+            if (in_array(
+                $session->status,
+                [RampSession::STATUS_COMPLETED, RampSession::STATUS_FAILED, RampSession::STATUS_EXPIRED],
+                true,
+            )) {
+                Log::info('Bridge ramp webhook: session already terminal', [
+                    'session_id' => $session->id,
+                    'status'     => $session->status,
+                ]);
+
+                return;
+            }
+
+            $session->update([
+                'status'        => $normalized['status'],
+                'crypto_amount' => $normalized['crypto_amount'] !== null
+                    ? (float) $normalized['crypto_amount']
+                    : $session->crypto_amount,
+                'metadata' => array_merge($session->metadata ?? [], [
+                    'webhook' => [
+                        'received_at' => now()->toIso8601String(),
+                        'event'       => $payload['type'] ?? null,
+                    ],
+                ]),
+            ]);
+        });
+    }
+
+    /**
+     * @param  array{session_id: string, status: string, crypto_amount: string|null, raw: array<string, mixed>}  $normalized
+     * @param  array<string, mixed>  $payload
+     */
+    private function createRetroactiveSession(array $normalized, array $payload): void
+    {
+        $virtualAccountId = (string) ($normalized['raw']['virtual_account_id']
+            ?? $normalized['raw']['id'] ?? '');
+
+        $customer = BridgeCustomer::where('virtual_account_id', $virtualAccountId)->first();
+        if ($customer === null) {
+            Log::warning('Bridge ramp webhook: no bridge_customer for unsolicited deposit', [
+                'virtual_account_id' => $virtualAccountId,
+            ]);
+
+            return;
+        }
+
+        $object = $normalized['raw'];
+        $cryptoAmount = isset($object['destination_amount']) && is_numeric($object['destination_amount'])
+            ? (float) $object['destination_amount']
+            : null;
+        $fiatAmount = isset($object['source_amount']) && is_numeric($object['source_amount'])
+            ? (float) $object['source_amount']
+            : null;
+        $fiatCurrency = strtoupper((string) ($object['source_currency'] ?? 'USD'));
+
+        RampSession::create([
+            'user_id'             => $customer->user_id,
+            'provider'            => BridgeProvider::PROVIDER_NAME,
+            'type'                => 'on',
+            'fiat_currency'       => $fiatCurrency,
+            'fiat_amount'         => $fiatAmount,
+            'crypto_currency'     => 'USDC',
+            'crypto_amount'       => $cryptoAmount,
+            'status'              => $normalized['status'],
+            'source'              => RampSession::SOURCE_BRIDGE_INITIATED,
+            'provider_session_id' => $normalized['session_id'],
+            'metadata'            => [
+                'provider' => BridgeProvider::PROVIDER_NAME,
+                'webhook'  => [
+                    'received_at' => now()->toIso8601String(),
+                    'event'       => $payload['type'] ?? null,
+                ],
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/V1/BridgeWebhookController.php
+++ b/app/Http/Controllers/Api/V1/BridgeWebhookController.php
@@ -198,11 +198,13 @@ class BridgeWebhookController extends Controller
                 return;
             }
 
-            if (in_array(
-                $session->status,
-                [RampSession::STATUS_COMPLETED, RampSession::STATUS_FAILED, RampSession::STATUS_EXPIRED],
-                true,
-            )) {
+            if (
+                in_array(
+                    $session->status,
+                    [RampSession::STATUS_COMPLETED, RampSession::STATUS_FAILED, RampSession::STATUS_EXPIRED],
+                    true,
+                )
+            ) {
                 Log::info('Bridge ramp webhook: session already terminal', [
                     'session_id' => $session->id,
                     'status'     => $session->status,

--- a/app/Infrastructure/Bridge/BridgeClient.php
+++ b/app/Infrastructure/Bridge/BridgeClient.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Bridge;
+
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+
+/**
+ * Thin HTTP wrapper around the Bridge.xyz REST API.
+ *
+ * Lives in app/Infrastructure/* rather than under either Ramp or
+ * Compliance because both BridgeProvider (Ramp) and BridgeKycProvider
+ * (Compliance/Kyc) consume it. Putting it in either domain would create
+ * a cross-domain dependency the other side doesn't need.
+ *
+ * Auth: Bridge uses an API key sent as the `Api-Key` header. The exact
+ * header name should be verified against the deployment's Bridge dashboard
+ * before going live — see TODO note on apiHeaders().
+ *
+ * Errors: any non-2xx response throws RuntimeException with the response
+ * body interpolated, so the call site can log + surface a meaningful error
+ * to the user. Callers should distinguish "Bridge said no" from "we
+ * couldn't reach Bridge" via the exception message; transport-level errors
+ * surface as the underlying Guzzle ConnectionException.
+ *
+ * Idempotency: `Idempotency-Key` header is set when supplied, so retries
+ * of POST customers / kyc_links are safe under network blips.
+ *
+ * @see docs/BACKEND_HANDOVER_BRIDGE_RAMP.md §3.1
+ * @see docs/adr/0005-bridge-xyz-over-stripe-crypto-onramp.md
+ */
+final class BridgeClient
+{
+    public function __construct(
+        private readonly string $apiKey,
+        private readonly string $baseUrl,
+    ) {
+    }
+
+    public static function fromConfig(): self
+    {
+        $apiKey = (string) config('kyc.providers.bridge.api_key', '');
+        $baseUrl = rtrim((string) config('kyc.providers.bridge.base_url', 'https://api.bridge.xyz'), '/');
+
+        return new self($apiKey, $baseUrl);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public function createCustomer(array $payload, ?string $idempotencyKey = null): array
+    {
+        return $this->post('/v0/customers', $payload, $idempotencyKey);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public function patchCustomer(string $customerId, array $payload): array
+    {
+        return $this->patch("/v0/customers/{$customerId}", $payload);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public function createKycLink(string $customerId, array $payload, ?string $idempotencyKey = null): array
+    {
+        return $this->post("/v0/customers/{$customerId}/kyc_links", $payload, $idempotencyKey);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public function createVirtualAccount(string $customerId, array $payload, ?string $idempotencyKey = null): array
+    {
+        return $this->post("/v0/customers/{$customerId}/virtual_accounts", $payload, $idempotencyKey);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function listVirtualAccounts(string $customerId): array
+    {
+        return $this->get("/v0/customers/{$customerId}/virtual_accounts");
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public function createTransfer(array $payload, ?string $idempotencyKey = null): array
+    {
+        return $this->post('/v0/transfers', $payload, $idempotencyKey);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getTransfer(string $transferId): array
+    {
+        return $this->get("/v0/transfers/{$transferId}");
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function post(string $path, array $payload, ?string $idempotencyKey = null): array
+    {
+        $headers = $this->apiHeaders();
+        if ($idempotencyKey !== null && $idempotencyKey !== '') {
+            $headers['Idempotency-Key'] = $idempotencyKey;
+        }
+
+        $response = Http::withHeaders($headers)
+            ->acceptJson()
+            ->post($this->baseUrl . $path, $payload);
+
+        return $this->decode($response, 'POST', $path);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function patch(string $path, array $payload): array
+    {
+        $response = Http::withHeaders($this->apiHeaders())
+            ->acceptJson()
+            ->patch($this->baseUrl . $path, $payload);
+
+        return $this->decode($response, 'PATCH', $path);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function get(string $path): array
+    {
+        $response = Http::withHeaders($this->apiHeaders())
+            ->acceptJson()
+            ->get($this->baseUrl . $path);
+
+        return $this->decode($response, 'GET', $path);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function apiHeaders(): array
+    {
+        // TODO: confirm the exact header name in the Bridge sandbox before
+        // going live — the brief references Bridge's docs but doesn't pin
+        // the auth header. `Api-Key` is the documented v0 pattern as of
+        // 2026-05; if Bridge moves to `Authorization: Bearer`, swap here.
+        return [
+            'Api-Key' => $this->apiKey,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(Response $response, string $verb, string $path): array
+    {
+        if ($response->failed()) {
+            Log::warning('Bridge API call failed', [
+                'verb'   => $verb,
+                'path'   => $path,
+                'status' => $response->status(),
+                'body'   => $response->body(),
+            ]);
+
+            throw new RuntimeException(sprintf(
+                'Bridge API %s %s returned %d: %s',
+                $verb,
+                $path,
+                $response->status(),
+                $response->body(),
+            ));
+        }
+
+        $decoded = $response->json();
+        if (! is_array($decoded)) {
+            throw new RuntimeException(sprintf(
+                'Bridge API %s %s returned non-object JSON',
+                $verb,
+                $path,
+            ));
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+}

--- a/app/Infrastructure/Bridge/BridgeWebhookVerifier.php
+++ b/app/Infrastructure/Bridge/BridgeWebhookVerifier.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Bridge;
+
+/**
+ * Verifies a Bridge.xyz webhook signature.
+ *
+ * Bridge sends events with a `Bridge-Signature` header in a format similar
+ * to Stripe's: `t=<unix_timestamp>,v1=<hex_hmac_sha256>`. The HMAC is
+ * computed over `<timestamp>.<raw_body>` using the webhook secret.
+ *
+ * Mirrors the layout of the StripeCryptoOnramp signature scheme so the
+ * pattern reads identically across providers. The signature scheme should
+ * be sanity-checked against an actual Bridge sandbox webhook payload
+ * before the first production deploy — see TODO note on the parser.
+ *
+ * Anti-replay: rejects timestamps drifted more than `tolerance` seconds
+ * from the current time. Default 300 seconds matches Stripe's default.
+ */
+final class BridgeWebhookVerifier
+{
+    private const TOLERANCE_SECONDS = 300;
+
+    public function __construct(
+        private readonly string $secret,
+    ) {
+    }
+
+    public static function fromConfig(): self
+    {
+        return new self((string) config('kyc.providers.bridge.webhook_secret', ''));
+    }
+
+    public function verify(string $rawBody, string $signatureHeader, ?int $now = null): bool
+    {
+        if ($this->secret === '') {
+            // No secret configured: in non-production we accept any well-formed
+            // signature so the dev loop works; in production we hard-fail.
+            return ! app()->environment('production');
+        }
+
+        if ($signatureHeader === '') {
+            return false;
+        }
+
+        // TODO: confirm Bridge's actual signature header format against a
+        // live sandbox webhook. We assume Stripe-style `t=...,v1=...` here.
+        /** @var array<string, list<string>> $parts */
+        $parts = [];
+        foreach (explode(',', $signatureHeader) as $element) {
+            $element = trim($element);
+            if ($element === '') {
+                continue;
+            }
+            $pair = array_pad(explode('=', $element, 2), 2, '');
+            $parts[$pair[0]][] = $pair[1];
+        }
+
+        $timestamp = (int) ($parts['t'][0] ?? 0);
+        $signatures = $parts['v1'] ?? [];
+
+        if ($timestamp === 0 || $signatures === []) {
+            return false;
+        }
+
+        if (abs(($now ?? time()) - $timestamp) > self::TOLERANCE_SECONDS) {
+            return false;
+        }
+
+        $expected = hash_hmac('sha256', $timestamp . '.' . $rawBody, $this->secret);
+
+        foreach ($signatures as $candidate) {
+            if (hash_equals($expected, $candidate)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/app/Providers/KycServiceProvider.php
+++ b/app/Providers/KycServiceProvider.php
@@ -8,6 +8,8 @@ use App\Domain\Compliance\Kyc\Providers\BridgeKycProvider;
 use App\Domain\Compliance\Kyc\Providers\OndatoKycProvider;
 use App\Domain\Compliance\Kyc\Registries\KycProviderRouter;
 use App\Domain\Compliance\Services\OndatoService;
+use App\Infrastructure\Bridge\BridgeClient;
+use App\Infrastructure\Bridge\BridgeWebhookVerifier;
 use Illuminate\Support\ServiceProvider;
 
 /**
@@ -31,11 +33,17 @@ class KycServiceProvider extends ServiceProvider
             'kyc'
         );
 
+        $this->app->singleton(BridgeClient::class, static fn () => BridgeClient::fromConfig());
+        $this->app->singleton(BridgeWebhookVerifier::class, static fn () => BridgeWebhookVerifier::fromConfig());
+
         $this->app->singleton(KycProviderRouter::class, function ($app) {
             return new KycProviderRouter(
                 factories: [
                     'ondato' => static fn () => new OndatoKycProvider($app->make(OndatoService::class)),
-                    'bridge' => static fn () => new BridgeKycProvider(),
+                    'bridge' => static fn () => new BridgeKycProvider(
+                        $app->make(BridgeClient::class),
+                        $app->make(BridgeWebhookVerifier::class),
+                    ),
                 ],
                 routing: (array) config('kyc.routing', []),
             );

--- a/app/Providers/RampServiceProvider.php
+++ b/app/Providers/RampServiceProvider.php
@@ -6,6 +6,7 @@ namespace App\Providers;
 
 use App\Domain\Ramp\Clients\OnramperClient;
 use App\Domain\Ramp\Contracts\RampProviderInterface;
+use App\Domain\Ramp\Providers\BridgeProvider;
 use App\Domain\Ramp\Providers\MockRampProvider;
 use App\Domain\Ramp\Providers\OnramperProvider;
 use App\Domain\Ramp\Providers\StripeCryptoOnrampProvider;
@@ -13,6 +14,8 @@ use App\Domain\Ramp\Registries\RampProviderRegistry;
 use App\Domain\Ramp\Services\RampService;
 use App\Domain\Ramp\Services\StripeCryptoOnrampService;
 use App\Domain\Subscription\Projections\SubscriptionProjection;
+use App\Infrastructure\Bridge\BridgeClient;
+use App\Infrastructure\Bridge\BridgeWebhookVerifier;
 use App\Models\User;
 use Closure;
 use Illuminate\Support\Facades\Log;
@@ -46,8 +49,12 @@ class RampServiceProvider extends ServiceProvider
 
             return match ($provider) {
                 StripeCryptoOnrampProvider::PROVIDER_NAME => new StripeCryptoOnrampProvider($app->make(StripeCryptoOnrampService::class)),
-                'onramper'                                => new OnramperProvider($app->make(OnramperClient::class)),
-                default                                   => new MockRampProvider(),
+                BridgeProvider::PROVIDER_NAME             => new BridgeProvider(
+                    $app->make(BridgeClient::class),
+                    $app->make(BridgeWebhookVerifier::class),
+                ),
+                'onramper' => new OnramperProvider($app->make(OnramperClient::class)),
+                default    => new MockRampProvider(),
             };
         });
 
@@ -69,6 +76,10 @@ class RampServiceProvider extends ServiceProvider
 
         $this->app->singleton(RampProviderRegistry::class, function ($app) {
             $stripeFactory = static fn () => new StripeCryptoOnrampProvider($app->make(StripeCryptoOnrampService::class));
+            $bridgeFactory = static fn () => new BridgeProvider(
+                $app->make(BridgeClient::class),
+                $app->make(BridgeWebhookVerifier::class),
+            );
 
             return new RampProviderRegistry([
                 'onramper'                                => static fn () => new OnramperProvider($app->make(OnramperClient::class)),
@@ -76,6 +87,7 @@ class RampServiceProvider extends ServiceProvider
                 // Deprecated alias — keeps the webhook URL /api/v1/ramp/webhook/stripe_bridge
                 // resolving while deployed env files still carry the legacy name.
                 StripeCryptoOnrampProvider::LEGACY_PROVIDER_NAME => $stripeFactory,
+                BridgeProvider::PROVIDER_NAME                    => $bridgeFactory,
                 'mock'                                           => static fn () => new MockRampProvider(),
             ]);
         });

--- a/config/ramp.php
+++ b/config/ramp.php
@@ -41,6 +41,15 @@ return [
             'enabled'        => (bool) (env('STRIPE_CRYPTO_ONRAMP_ENABLED') ?? env('STRIPE_BRIDGE_ENABLED', false)),
             'webhook_secret' => env('STRIPE_CRYPTO_ONRAMP_WEBHOOK_SECRET') ?? env('STRIPE_BRIDGE_WEBHOOK_SECRET'),
         ],
+
+        // Bridge.xyz — primary v1 fiat ↔ stablecoin rail. Credentials live
+        // under `kyc.providers.bridge.*` in config/kyc.php (single source of
+        // truth for both ramp and KYC flows). This block exists for the
+        // RampProviderRegistry to list `bridge` as a known driver.
+        'bridge' => [
+            'driver'  => 'bridge',
+            'enabled' => (bool) env('BRIDGE_ENABLED', true),
+        ],
     ],
 
     /*

--- a/routes/api.php
+++ b/routes/api.php
@@ -353,6 +353,14 @@ Route::post('v1/ramp/webhook/{provider}', [App\Http\Controllers\Api\V1\RampWebho
     ->middleware('api.rate_limit:webhook')
     ->name('api.v1.ramp.webhook');
 
+// Bridge.xyz dedicated webhook (no auth, HMAC verified) — handles both
+// customer.kyc_link_* and virtual_account.* / transfer.* events. See
+// docs/BACKEND_HANDOVER_BRIDGE_RAMP.md §3.1. Configure Bridge dashboard
+// to POST here.
+Route::post('v1/webhooks/bridge', [App\Http\Controllers\Api\V1\BridgeWebhookController::class, 'handle'])
+    ->middleware('api.rate_limit:webhook')
+    ->name('api.v1.webhooks.bridge');
+
 // Bridge.xyz setup (KYC + virtual account provisioning) — distinct from
 // /v1/ramp/* because setup is per-user and one-time. No require.kyc middleware
 // here: these endpoints are how you START Bridge KYC. See ADR-0005.

--- a/tests/Feature/Api/Bridge/BridgeKycLinkFlowTest.php
+++ b/tests/Feature/Api/Bridge/BridgeKycLinkFlowTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * BridgeKycProvider lazy customer creation + hosted-link issuance flow.
+ * Driven through POST /api/v1/user/bridge-kyc-link end-to-end; Http::fake
+ * stands in for the Bridge.xyz REST API.
+ */
+
+declare(strict_types=1);
+
+use App\Domain\Compliance\Kyc\Models\BridgeCustomer;
+use App\Models\User;
+use Illuminate\Support\Facades\Http;
+use Laravel\Sanctum\Sanctum;
+
+beforeEach(function () {
+    config([
+        'kyc.routing.ramp'                    => 'bridge',
+        'kyc.providers.bridge.api_key'        => 'sk_test_fake',
+        'kyc.providers.bridge.base_url'       => 'https://api.bridge.xyz',
+        'kyc.providers.bridge.webhook_secret' => 'whsec_fake',
+    ]);
+});
+
+it('lazily creates a Bridge customer + KYC link on first POST /bridge-kyc-link', function () {
+    Http::fake([
+        'api.bridge.xyz/v0/customers' => Http::response([
+            'id'        => 'cust_test_999',
+            'full_name' => 'Acme Testing',
+        ], 201),
+        'api.bridge.xyz/v0/customers/cust_test_999/kyc_links' => Http::response([
+            'url'        => 'https://kyc.bridge.xyz/abc-token-xyz',
+            'expires_at' => now()->addHours(2)->toIso8601String(),
+        ], 201),
+    ]);
+
+    $user = User::factory()->create();
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    $response = $this->postJson('/api/v1/user/bridge-kyc-link')
+        ->assertOk();
+
+    expect($response->json('url'))->toBe('https://kyc.bridge.xyz/abc-token-xyz');
+    expect($response->json('expiresAt'))->toBeString();
+
+    // Local row created + status moved to pending
+    $customer = BridgeCustomer::where('user_id', $user->id)->firstOrFail();
+    expect($customer->bridge_customer_id)->toBe('cust_test_999');
+    expect($customer->kyc_status)->toBe(BridgeCustomer::KYC_PENDING);
+    expect($customer->kyc_link_url)->toBe('https://kyc.bridge.xyz/abc-token-xyz');
+
+    // Verify outgoing calls had idempotency keys
+    Http::assertSent(function ($req) {
+        return $req->url() === 'https://api.bridge.xyz/v0/customers'
+            && $req->hasHeader('Idempotency-Key');
+    });
+});
+
+it('reuses an existing bridge_customer row and an unexpired KYC link without hitting Bridge', function () {
+    $user = User::factory()->create();
+    BridgeCustomer::create([
+        'user_id'             => $user->id,
+        'bridge_customer_id'  => 'cust_reuse',
+        'kyc_status'          => BridgeCustomer::KYC_PENDING,
+        'kyc_link_url'        => 'https://kyc.bridge.xyz/already-valid',
+        'kyc_link_expires_at' => now()->addHour(),
+        'developer_fee_bps'   => 75,
+    ]);
+
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    Http::fake();
+
+    $response = $this->postJson('/api/v1/user/bridge-kyc-link')
+        ->assertOk();
+
+    expect($response->json('url'))->toBe('https://kyc.bridge.xyz/already-valid');
+    Http::assertNothingSent();
+});
+
+it('requests a fresh KYC link when the existing one has expired', function () {
+    $user = User::factory()->create();
+    BridgeCustomer::create([
+        'user_id'             => $user->id,
+        'bridge_customer_id'  => 'cust_expired',
+        'kyc_status'          => BridgeCustomer::KYC_PENDING,
+        'kyc_link_url'        => 'https://kyc.bridge.xyz/stale',
+        'kyc_link_expires_at' => now()->subHour(),
+        'developer_fee_bps'   => 75,
+    ]);
+
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    Http::fake([
+        'api.bridge.xyz/v0/customers/cust_expired/kyc_links' => Http::response([
+            'url'        => 'https://kyc.bridge.xyz/fresh',
+            'expires_at' => now()->addHours(2)->toIso8601String(),
+        ], 201),
+    ]);
+
+    $response = $this->postJson('/api/v1/user/bridge-kyc-link')
+        ->assertOk();
+
+    expect($response->json('url'))->toBe('https://kyc.bridge.xyz/fresh');
+});
+
+it('still returns 409 when KYC is already approved (no Bridge call)', function () {
+    $user = User::factory()->create();
+    BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_done',
+        'kyc_status'         => BridgeCustomer::KYC_APPROVED,
+        'developer_fee_bps'  => 75,
+    ]);
+
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    Http::fake();
+
+    $this->postJson('/api/v1/user/bridge-kyc-link')
+        ->assertStatus(409)
+        ->assertJsonPath('error', 'KYC_ALREADY_APPROVED');
+
+    Http::assertNothingSent();
+});

--- a/tests/Feature/Api/Bridge/BridgeProviderContractTest.php
+++ b/tests/Feature/Api/Bridge/BridgeProviderContractTest.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * BridgeProvider unit-style tests that exercise the RampProviderInterface
+ * surface without going through HTTP (the Http::fake calls + DB integration
+ * are covered by BridgeKycLinkFlowTest and BridgeWebhookControllerTest).
+ *
+ * Focus here: quote-synthesis arithmetic, signature header constants,
+ * createSession preconditions.
+ */
+
+declare(strict_types=1);
+
+use App\Domain\Compliance\Kyc\Models\BridgeCustomer;
+use App\Domain\Ramp\Providers\BridgeProvider;
+use App\Infrastructure\Bridge\BridgeClient;
+use App\Infrastructure\Bridge\BridgeWebhookVerifier;
+use App\Models\User;
+
+beforeEach(function () {
+    config([
+        'kyc.providers.bridge.api_key'        => 'sk_test',
+        'kyc.providers.bridge.webhook_secret' => 'whsec_test',
+    ]);
+});
+
+function makeBridgeProvider(): BridgeProvider
+{
+    return new BridgeProvider(BridgeClient::fromConfig(), BridgeWebhookVerifier::fromConfig());
+}
+
+/**
+ * Build a complete RampProviderInterface::createSession params array with
+ * sane defaults; tests override only the keys they care about.
+ *
+ * @param  array<string, mixed>  $overrides
+ * @return array{type: string, fiat_currency: string, fiat_amount: string, crypto_currency: string, wallet_address: string, quote_id: string|null, user_id?: int, network?: string}
+ */
+function bridgeSessionParams(array $overrides = []): array
+{
+    /** @var array{type: string, fiat_currency: string, fiat_amount: string, crypto_currency: string, wallet_address: string, quote_id: string|null, user_id?: int, network?: string} $merged */
+    $merged = array_merge([
+        'type'            => 'on',
+        'fiat_currency'   => 'USD',
+        'fiat_amount'     => '100.00',
+        'crypto_currency' => 'USDC',
+        'wallet_address'  => '0x0000000000000000000000000000000000000001',
+        'quote_id'        => null,
+    ], $overrides);
+
+    return $merged;
+}
+
+it('reports its name as "bridge"', function () {
+    expect(makeBridgeProvider()->getName())->toBe('bridge');
+});
+
+it('reports Bridge-Signature as the webhook signature header', function () {
+    expect(makeBridgeProvider()->getWebhookSignatureHeader())->toBe('Bridge-Signature');
+});
+
+it('reports v1 supported capabilities (USDC, USD/EUR/GBP, buy-only)', function () {
+    $supported = makeBridgeProvider()->getSupportedCurrencies();
+
+    expect($supported['fiatCurrencies'])->toBe(['USD', 'EUR', 'GBP']);
+    expect($supported['cryptoCurrencies'])->toBe(['USDC']);
+    expect($supported['modes'])->toBe(['buy']);  // offramp deferred to v1.1
+});
+
+it('synthesizes a quote with 10bps Bridge fee + at-cost Polygon network fee', function () {
+    $quotes = makeBridgeProvider()->getQuotes('on', 'USD', '1000.00', 'USDC');
+
+    expect($quotes)->toHaveCount(1);
+    $q = $quotes[0];
+    expect($q['provider_name'])->toBe('Bridge');
+    // 0.10% of 1000 = 1.00
+    expect($q['fee'])->toBe(1.0);
+    expect($q['network_fee'])->toBe(0.01);
+    expect($q['fee_currency'])->toBe('USD');
+    expect($q['payment_methods'])->toBe(['ach', 'sepa', 'sepa_instant']);
+});
+
+it('throws when fiat amount is not numeric', function () {
+    expect(fn () => makeBridgeProvider()->getQuotes('on', 'USD', 'abc', 'USDC'))
+        ->toThrow(RuntimeException::class, 'non-negative numeric fiat amount');
+});
+
+it('rejects offramp in v1 (createSession with type=off throws)', function () {
+    expect(fn () => makeBridgeProvider()->createSession(bridgeSessionParams(['type' => 'off'])))
+        ->toThrow(RuntimeException::class, 'deferred to v1.1');
+});
+
+it('requires user_id in createSession params', function () {
+    expect(fn () => makeBridgeProvider()->createSession(bridgeSessionParams()))
+        ->toThrow(RuntimeException::class, 'user_id');
+});
+
+it('requires a KYC-approved customer with a virtual account for onramp', function () {
+    $user = User::factory()->create();
+    // No bridge_customers row at all
+    expect(fn () => makeBridgeProvider()->createSession(bridgeSessionParams(['user_id' => $user->id])))
+        ->toThrow(RuntimeException::class, 'approved customer with a provisioned virtual account');
+});
+
+it('returns deposit instructions for an approved customer onramp session', function () {
+    $user = User::factory()->create();
+    BridgeCustomer::create([
+        'user_id'                 => $user->id,
+        'bridge_customer_id'      => 'cust_create_session',
+        'kyc_status'              => BridgeCustomer::KYC_APPROVED,
+        'virtual_account_id'      => 'va_create_session',
+        'virtual_account_details' => [
+            'iban'                => 'GB29NWBK60161331926819',
+            'account_holder_name' => 'Acme Ramping',
+            'memo'                => 'CUSTREF-X9',
+        ],
+        'supported_rails'   => ['sepa', 'sepa_instant'],
+        'developer_fee_bps' => 75,
+    ]);
+
+    $result = makeBridgeProvider()->createSession(bridgeSessionParams(['user_id' => $user->id]));
+    $deposit = $result['deposit_instructions']
+        ?? throw new RuntimeException('Expected deposit_instructions on onramp session');
+
+    expect($result['session_id'])->toBe('bridge_va_va_create_session');
+    expect($result['checkout_url'])->toBeNull();
+    expect($deposit['iban'])->toBe('GB29NWBK60161331926819');
+    expect($deposit['memo'])->toBe('CUSTREF-X9');
+    expect($deposit['supportedRails'])->toBe(['sepa', 'sepa_instant']);
+    expect($result['metadata']['provider'])->toBe('bridge');
+    expect($result['metadata']['network'])->toBe('polygon');
+});
+
+it('rejects unsupported networks in v1 (Solana etc.)', function () {
+    $user = User::factory()->create();
+    BridgeCustomer::create([
+        'user_id'                 => $user->id,
+        'bridge_customer_id'      => 'cust_net',
+        'kyc_status'              => BridgeCustomer::KYC_APPROVED,
+        'virtual_account_id'      => 'va_net',
+        'virtual_account_details' => ['iban' => 'X'],
+        'developer_fee_bps'       => 75,
+    ]);
+
+    expect(fn () => makeBridgeProvider()->createSession(bridgeSessionParams([
+        'user_id' => $user->id,
+        'network' => 'solana',
+    ])))->toThrow(RuntimeException::class, "only supports network 'polygon'");
+});

--- a/tests/Feature/Api/Bridge/BridgeSetupControllerTest.php
+++ b/tests/Feature/Api/Bridge/BridgeSetupControllerTest.php
@@ -3,23 +3,25 @@
 /**
  * Integration tests for the /api/v1/user/bridge-* endpoints (handover §3.3).
  *
- * Status endpoint is fully wired against bridge_customers + the KYC router.
- * KYC-link endpoint surfaces the BridgeKycProvider's "deferred" exception
- * as a structured 501 so mobile gets a deterministic signal pending the
- * BridgeProvider PR (§3.1).
+ * Status endpoint reads from bridge_customers via the KYC router. KYC-link
+ * endpoint goes through BridgeKycProvider → BridgeClient (Http::fake stands
+ * in for Bridge.xyz in tests).
  */
 
 declare(strict_types=1);
 
 use App\Domain\Compliance\Kyc\Models\BridgeCustomer;
 use App\Models\User;
+use Illuminate\Support\Facades\Http;
 use Laravel\Sanctum\Sanctum;
 
 beforeEach(function () {
     config([
-        'kyc.routing.trustcert' => 'ondato',
-        'kyc.routing.ramp'      => 'bridge',
-        'kyc.routing.cards'     => 'bridge',
+        'kyc.routing.trustcert'         => 'ondato',
+        'kyc.routing.ramp'              => 'bridge',
+        'kyc.routing.cards'             => 'bridge',
+        'kyc.providers.bridge.api_key'  => 'sk_test',
+        'kyc.providers.bridge.base_url' => 'https://api.bridge.xyz',
     ]);
 });
 
@@ -92,15 +94,28 @@ it('rejects unauthenticated POST /bridge-kyc-link', function () {
         ->assertStatus(401);
 });
 
-it('surfaces BridgeKycProvider deferred state as 501 PROVIDER_NOT_IMPLEMENTED', function () {
+it('returns the hosted KYC link URL when BridgeKycProvider is wired (post-§3.1)', function () {
+    // After PR §3.1 landed, the deferred 501 path no longer applies; the
+    // controller now returns a real Bridge-hosted KYC link URL on success.
+    Http::fake([
+        'api.bridge.xyz/v0/customers' => Http::response([
+            'id'        => 'cust_setup_first',
+            'full_name' => 'Setup User',
+        ], 201),
+        'api.bridge.xyz/v0/customers/cust_setup_first/kyc_links' => Http::response([
+            'url'        => 'https://kyc.bridge.xyz/setup-token',
+            'expires_at' => now()->addHours(2)->toIso8601String(),
+        ], 201),
+    ]);
+
     $user = User::factory()->create();
     Sanctum::actingAs($user, ['read', 'write', 'delete']);
 
     $response = $this->postJson('/api/v1/user/bridge-kyc-link')
-        ->assertStatus(501);
+        ->assertOk();
 
-    expect($response->json('error'))->toBe('PROVIDER_NOT_IMPLEMENTED');
-    expect($response->json('message'))->toContain('BridgeProvider PR');
+    expect($response->json('url'))->toBe('https://kyc.bridge.xyz/setup-token');
+    expect($response->json('expiresAt'))->toBeString();
 });
 
 it('returns 409 when bridge_customers row exists and KYC is approved', function () {

--- a/tests/Feature/Api/Bridge/BridgeWebhookControllerTest.php
+++ b/tests/Feature/Api/Bridge/BridgeWebhookControllerTest.php
@@ -1,0 +1,192 @@
+<?php
+
+/**
+ * Tests the dedicated /api/v1/webhooks/bridge endpoint — signature
+ * verification, KYC vs ramp dispatch, event-level dedupe via
+ * processed_webhook_events, unsolicited-deposit retroactive session
+ * creation.
+ */
+
+declare(strict_types=1);
+
+use App\Domain\Compliance\Kyc\Models\BridgeCustomer;
+use App\Domain\Subscription\Models\ProcessedWebhookEvent;
+use App\Models\RampSession;
+use App\Models\User;
+
+beforeEach(function () {
+    config([
+        'kyc.providers.bridge.webhook_secret' => 'whsec_test',
+        'kyc.providers.bridge.api_key'        => 'sk_test',
+    ]);
+});
+
+/** Helper: produce a valid Bridge-Signature header for the given body. */
+function signBridge(string $body, string $secret = 'whsec_test', ?int $ts = null): string
+{
+    $ts ??= time();
+    $sig = hash_hmac('sha256', $ts . '.' . $body, $secret);
+
+    return "t={$ts},v1={$sig}";
+}
+
+it('rejects a missing signature header', function () {
+    $this->postJson('/api/v1/webhooks/bridge', ['type' => 'customer.kyc_link_completed'])
+        ->assertStatus(401);
+});
+
+it('rejects a tampered body', function () {
+    $body = (string) json_encode(['id' => 'evt_1', 'type' => 'customer.kyc_link_completed', 'data' => []]);
+    $sig = signBridge($body);
+
+    // Tamper by appending whitespace (signature was computed on original body)
+    $this->call(
+        'POST',
+        '/api/v1/webhooks/bridge',
+        [],
+        [],
+        [],
+        ['HTTP_BRIDGE_SIGNATURE' => $sig, 'CONTENT_TYPE' => 'application/json'],
+        $body . ' ',
+    )->assertStatus(401);
+});
+
+it('approves a bridge_customers row on customer.kyc_link_completed', function () {
+    $user = User::factory()->create();
+    BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_42',
+        'kyc_status'         => BridgeCustomer::KYC_PENDING,
+        'developer_fee_bps'  => 75,
+    ]);
+
+    $body = (string) json_encode([
+        'id'   => 'evt_kyc_1',
+        'type' => 'customer.kyc_link_completed',
+        'data' => ['object' => ['customer_id' => 'cust_42']],
+    ]);
+
+    $this->call(
+        'POST',
+        '/api/v1/webhooks/bridge',
+        [],
+        [],
+        [],
+        ['HTTP_BRIDGE_SIGNATURE' => signBridge($body), 'CONTENT_TYPE' => 'application/json'],
+        $body,
+    )->assertOk();
+
+    expect(BridgeCustomer::where('user_id', $user->id)->value('kyc_status'))
+        ->toBe(BridgeCustomer::KYC_APPROVED);
+
+    // Dedupe row written
+    expect(ProcessedWebhookEvent::where(['provider' => 'bridge', 'event_id' => 'evt_kyc_1'])->exists())
+        ->toBeTrue();
+});
+
+it('rejects a bridge_customers row on customer.kyc_link_rejected', function () {
+    $user = User::factory()->create();
+    BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_rej',
+        'kyc_status'         => BridgeCustomer::KYC_PENDING,
+        'developer_fee_bps'  => 75,
+    ]);
+
+    $body = (string) json_encode([
+        'id'   => 'evt_kyc_rej_1',
+        'type' => 'customer.kyc_link_rejected',
+        'data' => ['object' => ['customer_id' => 'cust_rej']],
+    ]);
+
+    $this->call(
+        'POST',
+        '/api/v1/webhooks/bridge',
+        [],
+        [],
+        [],
+        ['HTTP_BRIDGE_SIGNATURE' => signBridge($body), 'CONTENT_TYPE' => 'application/json'],
+        $body,
+    )->assertOk();
+
+    expect(BridgeCustomer::where('user_id', $user->id)->value('kyc_status'))
+        ->toBe(BridgeCustomer::KYC_REJECTED);
+});
+
+it('is idempotent on duplicate event_id (returns duplicate, applies no side effect)', function () {
+    $user = User::factory()->create();
+    BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_idem',
+        'kyc_status'         => BridgeCustomer::KYC_PENDING,
+        'developer_fee_bps'  => 75,
+    ]);
+
+    ProcessedWebhookEvent::create([
+        'provider'     => 'bridge',
+        'event_id'     => 'evt_dup',
+        'event_type'   => 'customer.kyc_link_completed',
+        'processed_at' => now(),
+    ]);
+
+    $body = (string) json_encode([
+        'id'   => 'evt_dup',
+        'type' => 'customer.kyc_link_completed',
+        'data' => ['object' => ['customer_id' => 'cust_idem']],
+    ]);
+
+    $response = $this->call(
+        'POST',
+        '/api/v1/webhooks/bridge',
+        [],
+        [],
+        [],
+        ['HTTP_BRIDGE_SIGNATURE' => signBridge($body), 'CONTENT_TYPE' => 'application/json'],
+        $body,
+    );
+
+    $response->assertOk()->assertJson(['status' => 'duplicate']);
+
+    // KYC status NOT mutated
+    expect(BridgeCustomer::where('user_id', $user->id)->value('kyc_status'))
+        ->toBe(BridgeCustomer::KYC_PENDING);
+});
+
+it('auto-creates a retroactive ramp_session for unsolicited virtual_account.activity', function () {
+    $user = User::factory()->create();
+    BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_va',
+        'kyc_status'         => BridgeCustomer::KYC_APPROVED,
+        'virtual_account_id' => 'va_unsolicited_1',
+        'developer_fee_bps'  => 75,
+    ]);
+
+    $body = (string) json_encode([
+        'id'   => 'evt_va_1',
+        'type' => 'virtual_account.activity',
+        'data' => ['object' => [
+            'virtual_account_id' => 'va_unsolicited_1',
+            'source_amount'      => '250.00',
+            'source_currency'    => 'USD',
+            'destination_amount' => '249.75',
+        ]],
+    ]);
+
+    $this->call(
+        'POST',
+        '/api/v1/webhooks/bridge',
+        [],
+        [],
+        [],
+        ['HTTP_BRIDGE_SIGNATURE' => signBridge($body), 'CONTENT_TYPE' => 'application/json'],
+        $body,
+    )->assertOk();
+
+    $session = RampSession::where('user_id', $user->id)->firstOrFail();
+    expect($session->source)->toBe(RampSession::SOURCE_BRIDGE_INITIATED);
+    expect($session->provider)->toBe('bridge');
+    expect($session->status)->toBe('processing');
+    expect((float) $session->fiat_amount)->toBe(250.0);
+    expect((float) $session->crypto_amount)->toBe(249.75);
+});

--- a/tests/Feature/Compliance/Kyc/BridgeKycProviderTest.php
+++ b/tests/Feature/Compliance/Kyc/BridgeKycProviderTest.php
@@ -1,32 +1,46 @@
 <?php
 
 /**
- * Tests for the BridgeKycProvider skeleton — only the methods that are
- * actually implemented in this PR. The "not yet implemented" methods
- * (getHostedLink, getWebhookValidator-execution, normalizeWebhookPayload)
- * deliberately throw RuntimeException and will be replaced + tested in the
- * BridgeProvider PR (handover §3.1).
+ * Unit tests for BridgeKycProvider's status + signature paths. The
+ * lazy-customer-creation flow + webhook normalization are covered by the
+ * full integration tests in tests/Feature/Api/Bridge/*.
+ *
+ * Pre-§3.1 this file also asserted "deferred" 501 behavior; those tests
+ * were removed when the real implementation landed.
  */
 
 declare(strict_types=1);
 
-use App\Domain\Compliance\Kyc\Enums\KycPurpose;
 use App\Domain\Compliance\Kyc\Models\BridgeCustomer;
 use App\Domain\Compliance\Kyc\Providers\BridgeKycProvider;
+use App\Infrastructure\Bridge\BridgeClient;
+use App\Infrastructure\Bridge\BridgeWebhookVerifier;
 use App\Models\User;
 
+beforeEach(function () {
+    config([
+        'kyc.providers.bridge.api_key'        => 'sk_test',
+        'kyc.providers.bridge.webhook_secret' => 'whsec_test',
+    ]);
+});
+
+function makeBridgeKycProvider(): BridgeKycProvider
+{
+    return new BridgeKycProvider(BridgeClient::fromConfig(), BridgeWebhookVerifier::fromConfig());
+}
+
 it('reports its name as "bridge"', function () {
-    expect((new BridgeKycProvider())->getName())->toBe('bridge');
+    expect(makeBridgeKycProvider()->getName())->toBe('bridge');
 });
 
 it('reports Bridge-Signature as the webhook signature header', function () {
-    expect((new BridgeKycProvider())->getWebhookSignatureHeader())->toBe('Bridge-Signature');
+    expect(makeBridgeKycProvider()->getWebhookSignatureHeader())->toBe('Bridge-Signature');
 });
 
 it('returns not_started status when no bridge_customers row exists', function () {
     $user = User::factory()->create();
 
-    $result = (new BridgeKycProvider())->getStatus($user->id);
+    $result = makeBridgeKycProvider()->getStatus($user->id);
 
     expect($result['status'])->toBe('not_started');
     expect($result['metadata'])->toBe([]);
@@ -43,7 +57,7 @@ it('reads kyc_status from bridge_customers row', function () {
         'developer_fee_bps'  => 75,
     ]);
 
-    $result = (new BridgeKycProvider())->getStatus($user->id);
+    $result = makeBridgeKycProvider()->getStatus($user->id);
 
     expect($result['status'])->toBe('approved');
     expect($result['metadata']['bridge_customer_id'])->toBe('cust_test_123');
@@ -60,20 +74,34 @@ it('reports virtual_account_ready false when no virtual_account_id yet', functio
         'developer_fee_bps'  => 75,
     ]);
 
-    $result = (new BridgeKycProvider())->getStatus($user->id);
+    $result = makeBridgeKycProvider()->getStatus($user->id);
 
     expect($result['status'])->toBe('pending');
     expect($result['metadata']['virtual_account_ready'])->toBeFalse();
 });
 
-it('throws a clear "deferred" RuntimeException for getHostedLink', function () {
-    expect(fn () => (new BridgeKycProvider())->getHostedLink(1, KycPurpose::RAMP))
-        ->toThrow(RuntimeException::class, 'BridgeProvider PR');
+it('normalizes customer.kyc_link_completed → approved', function () {
+    $user = User::factory()->create();
+    BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_norm_1',
+        'kyc_status'         => BridgeCustomer::KYC_PENDING,
+        'developer_fee_bps'  => 75,
+    ]);
+
+    $normalized = makeBridgeKycProvider()->normalizeWebhookPayload([
+        'type' => 'customer.kyc_link_completed',
+        'data' => ['object' => ['customer_id' => 'cust_norm_1']],
+    ]) ?? throw new RuntimeException('Expected normalized payload, got null');
+
+    expect($normalized['status'])->toBe('approved');
+    expect($normalized['event_type'])->toBe('customer.kyc_link_completed');
+    expect($normalized['user_id'])->toBe($user->id);
 });
 
-it('throws a clear "deferred" RuntimeException for normalizeWebhookPayload', function () {
-    expect(fn () => (new BridgeKycProvider())->normalizeWebhookPayload(['type' => 'transfer.completed']))
-        ->toThrow(RuntimeException::class, 'BridgeProvider PR');
+it('returns null from normalizeWebhookPayload on unrelated event types (e.g. transfer.*)', function () {
+    expect(makeBridgeKycProvider()->normalizeWebhookPayload(['type' => 'transfer.completed']))
+        ->toBeNull();
 });
 
 it('encrypts virtual_account_details at rest', function () {
@@ -99,7 +127,7 @@ it('encrypts virtual_account_details at rest', function () {
 
     // Encrypted ciphertext should NOT contain the plaintext IBAN
     expect($raw)->not->toContain('GB29NWBK60161331926819');
-    expect($raw)->not->toBe(json_encode($details));
+    expect($raw)->not->toBe((string) json_encode($details));
 
     // Reading through the model returns the decrypted array
     $customer = BridgeCustomer::where('user_id', $user->id)->firstOrFail();


### PR DESCRIPTION
## Summary

Real Bridge.xyz integration on top of the foundations PR #1090. Mobile's `POST /api/v1/user/bridge-kyc-link` flips from `501` → `200` with a real Bridge-hosted KYC link URL. The full event lifecycle (KYC + ramp) is wired through a dedicated `/api/v1/webhooks/bridge` controller. Closes the §3.1 item from `docs/BACKEND_HANDOVER_BRIDGE_RAMP.md`.

### Infrastructure (app/Infrastructure/Bridge/)

- **`BridgeClient`** — HTTP wrapper around Bridge's v0 REST API. Customers, kyc_links, virtual_accounts, transfers. Auth via `Api-Key` header; `Idempotency-Key` on POSTs. Non-2xx throws `RuntimeException` with response body. Lives outside both Ramp and Compliance/Kyc because both consume it.
- **`BridgeWebhookVerifier`** — Stripe-style HMAC-SHA256 over `<ts>.<body>` with a 300s anti-replay window. Header format follows the same `t=...,v1=...` shape as Stripe's. **Should be sanity-checked against the live Bridge sandbox before first prod deploy** (TODO noted inline).

### Ramp provider (`BridgeProvider`)

- `createSession` (onramp only in v1): reads `bridge_customers`, returns `deposit_instructions` (IBAN/account/memo). `session_id` deterministically derived from `virtual_account_id` so unsolicited deposits can find/create the matching `ramp_sessions` row at webhook time.
- `createSession` with `type=off` throws "deferred to v1.1"
- `getSessionStatus`: short-circuits to `pending` for virtual-account sessions (canonical status comes from webhooks); polls Bridge `/v0/transfers/{id}` once offramp lands.
- `getQuotes`: synthesized per [ADR-0006](docs/adr/0006-bridge-developer-fees-as-markup-mechanism.md) (10 bps Bridge fee + 0.01 USD Polygon network fee + 0 FX in v1). Zelta markup layered downstream by `RampService`.
- `getSupportedCurrencies`: v1 = USD/EUR/GBP + USDC + `buy` only.
- `normalizeWebhookPayload`: handles `virtual_account.activity` + `transfer.completed/failed`. Returns null for KYC events.

### KYC adapter

- `BridgeKycProvider::getHostedLink` — real implementation. Lazy customer creation via `Idempotency-Key: bridge_customer:{user_id}`. Reuses existing valid KYC link; requests fresh one if expired. Status `not_started` → `pending` on first link issue.
- `normalizeWebhookPayload` handles `customer.kyc_link_completed/rejected`.

### Dedicated webhook controller

New `POST /api/v1/webhooks/bridge` (not registry-routed):
- HMAC-verified via `Bridge-Signature` header
- Event-level dedupe via `processed_webhook_events (provider='bridge', event_id)`
- Dispatches by event_type:
  - `customer.kyc_link_*` → `bridge_customers.kyc_status` update
  - `virtual_account.activity` → `ramp_sessions` update **OR** retroactive create for unsolicited deposits (handover §6 lock)
  - `transfer.*` → `ramp_sessions` update
- Handler errors are swallowed + logged so Bridge retries land safely via the dedupe row

### Interface change

`RampProviderInterface::createSession` docblock extended with optional `user_id`, `network`, and `deposit_instructions` return key. Additive — other providers ignore.

### Config + env

- `config/ramp.php` gains a `bridge` driver entry
- `.env.*` examples add `BRIDGE_API_KEY`, `BRIDGE_WEBHOOK_SECRET`, `BRIDGE_API_BASE_URL`, `BRIDGE_DEFAULT_DEV_FEE_BPS`
- `.env.zelta.example` + `.env.production.example` flip `RAMP_PROVIDER` default from `stripe_crypto_onramp` → `bridge`

### Tests

50 tests pass (23 new + 27 carried from PR #1090). PHPStan Level 8 clean.

| New test file | What it covers |
|---|---|
| `BridgeProviderContractTest` | Quote arithmetic, createSession preconditions, network gating, signature header |
| `BridgeKycLinkFlowTest` | Http::fake-driven lazy customer creation, KYC link issuance, link reuse on cache hit, expired-link refresh, 409 on already-approved |
| `BridgeWebhookControllerTest` | Signature rejection (missing/tampered), KYC status flip on completed/rejected, event-level dedupe, retroactive ramp_session for unsolicited virtual_account.activity |

Two existing tests updated (obsolete after the deferred behaviors became real):
- `BridgeSetupControllerTest` — "deferred 501" expectation flipped to Http::fake-driven 200
- `BridgeKycProviderTest` — pre-§3.1 "deferred" tests replaced with real webhook-normalization tests

### What's still pending

- 🟡 WebSocket broadcast events (`bridge.kyc.completed` / `bridge.kyc.rejected` / `bridge.virtual_account.ready`) — wired when WS event registry binding lands
- 🟡 Push notification fallback (per the locked grilling decision: push on KYC terminal events only) — same dependency
- 🟡 SubscriptionTierChanged listener that PATCHes the Bridge customer's `developer_fee_bps` on Pro upgrade/downgrade (per ADR-0006) — separate small PR
- 🟡 Offramp (`type=off`) — explicit v1.1 scope per the handover

### Test plan

- [x] PHPStan Level 8 clean on all touched paths
- [x] 50 tests pass locally (Bridge integration + Compliance/Kyc + Ramp API)
- [ ] CI green on PR (in progress)
- [ ] Multi-connection tests pass (touched models include encrypted `bridge_customers` + new `ramp_sessions.source` writes)
- [ ] Manual smoke test against Bridge sandbox before prod (verify the signature scheme matches the TODO in `BridgeWebhookVerifier`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)