### PR TITLE
feat: Bridge KYC WS broadcasts + push fallback + auto-VA provisioning (handover §4.3)

### DIFF
--- a/app/Domain/Compliance/Kyc/Events/Broadcast/BridgeKycCompleted.php
+++ b/app/Domain/Compliance/Kyc/Events/Broadcast/BridgeKycCompleted.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Compliance\Kyc\Events\Broadcast;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Fires when Bridge.xyz reports KYC approved for the user. Mirrors the
+ * private-user.{userId} convention from existing mobile broadcasts (see
+ * NotificationCountUpdated). Mobile listens on the same channel + handler.
+ *
+ * Payload includes bridge_customer_id so mobile can correlate with the
+ * /bridge-setup-status response shape without an extra round-trip.
+ *
+ * @see docs/BACKEND_HANDOVER_BRIDGE_RAMP.md §4.3
+ */
+class BridgeKycCompleted implements ShouldBroadcast
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public static string $queue = 'events';
+
+    public function __construct(
+        public readonly int $userId,
+        public readonly string $bridgeCustomerId,
+    ) {
+    }
+
+    /** @return array<int, PrivateChannel> */
+    public function broadcastOn(): array
+    {
+        return [new PrivateChannel("user.{$this->userId}")];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'bridge.kyc.completed';
+    }
+
+    /** @return array{bridge_customer_id: string} */
+    public function broadcastWith(): array
+    {
+        return [
+            'bridge_customer_id' => $this->bridgeCustomerId,
+        ];
+    }
+}

--- a/app/Domain/Compliance/Kyc/Events/Broadcast/BridgeKycRejected.php
+++ b/app/Domain/Compliance/Kyc/Events/Broadcast/BridgeKycRejected.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Compliance\Kyc\Events\Broadcast;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Fires when Bridge.xyz reports KYC rejected. Mobile handles via the same
+ * notification listener as BridgeKycCompleted, branching on event name.
+ *
+ * @see docs/BACKEND_HANDOVER_BRIDGE_RAMP.md §4.3
+ */
+class BridgeKycRejected implements ShouldBroadcast
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public static string $queue = 'events';
+
+    public function __construct(
+        public readonly int $userId,
+        public readonly string $bridgeCustomerId,
+        public readonly ?string $reason = null,
+    ) {
+    }
+
+    /** @return array<int, PrivateChannel> */
+    public function broadcastOn(): array
+    {
+        return [new PrivateChannel("user.{$this->userId}")];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'bridge.kyc.rejected';
+    }
+
+    /** @return array{bridge_customer_id: string, reason: string|null} */
+    public function broadcastWith(): array
+    {
+        return [
+            'bridge_customer_id' => $this->bridgeCustomerId,
+            'reason'             => $this->reason,
+        ];
+    }
+}

--- a/app/Domain/Compliance/Kyc/Events/Broadcast/BridgeVirtualAccountReady.php
+++ b/app/Domain/Compliance/Kyc/Events/Broadcast/BridgeVirtualAccountReady.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Compliance\Kyc\Events\Broadcast;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Fires when the user's Bridge virtual account is provisioned (post-KYC).
+ * Mobile uses this to surface the "ready to receive deposits" state on
+ * the Buy screen without polling. Deposit instructions themselves are
+ * fetched via GET /bridge-setup-status — keeping IBAN/account_number out
+ * of the WS payload (they're PII at rest, encrypted via the model cast).
+ *
+ * No push notification on this event per the grilling-locked decision —
+ * VA provisioning is a quiet step; pushing for it creates notification
+ * fatigue without changing what the user does next.
+ *
+ * @see docs/BACKEND_HANDOVER_BRIDGE_RAMP.md §4.3
+ */
+class BridgeVirtualAccountReady implements ShouldBroadcast
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public static string $queue = 'events';
+
+    public function __construct(
+        public readonly int $userId,
+        public readonly string $bridgeCustomerId,
+        /** @var list<string> */
+        public readonly array $supportedRails,
+    ) {
+    }
+
+    /** @return array<int, PrivateChannel> */
+    public function broadcastOn(): array
+    {
+        return [new PrivateChannel("user.{$this->userId}")];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'bridge.virtual_account.ready';
+    }
+
+    /** @return array{bridge_customer_id: string, supported_rails: list<string>} */
+    public function broadcastWith(): array
+    {
+        return [
+            'bridge_customer_id' => $this->bridgeCustomerId,
+            'supported_rails'    => $this->supportedRails,
+        ];
+    }
+}

--- a/app/Domain/Compliance/Kyc/Services/BridgePostKycHandler.php
+++ b/app/Domain/Compliance/Kyc/Services/BridgePostKycHandler.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Compliance\Kyc\Services;
+
+use App\Domain\Account\Models\BlockchainAddress;
+use App\Domain\Compliance\Kyc\Events\Broadcast\BridgeKycCompleted;
+use App\Domain\Compliance\Kyc\Events\Broadcast\BridgeKycRejected;
+use App\Domain\Compliance\Kyc\Events\Broadcast\BridgeVirtualAccountReady;
+use App\Domain\Compliance\Kyc\Models\BridgeCustomer;
+use App\Domain\Mobile\Services\PushNotificationService;
+use App\Infrastructure\Bridge\BridgeClient;
+use App\Models\User;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Runs the post-KYC-event side effects: broadcast event + push notification +
+ * (for approval) auto-provision the user's Bridge virtual account.
+ *
+ * Extracted from BridgeWebhookController so the controller stays a thin
+ * dispatcher and the side-effect chain is testable in isolation.
+ *
+ * Push fallback follows the locked grilling decision (PR #1090 reply):
+ * push fires on kyc.completed and kyc.rejected, NOT on virtual_account.ready
+ * (that's a quiet provisioning step the user doesn't need to be paged for).
+ *
+ * @see docs/BACKEND_HANDOVER_BRIDGE_RAMP.md §3.1, §4.3
+ */
+final class BridgePostKycHandler
+{
+    /** Bridge VA destination defaults to Polygon USDC per ADR-0005 (v1 network scope). */
+    private const DEFAULT_VA_NETWORK = 'polygon';
+
+    private const DEFAULT_VA_ASSET = 'usdc';
+
+    public function __construct(
+        private readonly BridgeClient $client,
+        private readonly PushNotificationService $push,
+    ) {
+    }
+
+    public function handleApproved(BridgeCustomer $customer): void
+    {
+        $user = User::find($customer->user_id);
+        if ($user === null) {
+            Log::warning('BridgePostKycHandler: user not found for approved KYC', [
+                'user_id' => $customer->user_id,
+            ]);
+
+            return;
+        }
+
+        BridgeKycCompleted::dispatch($user->id, $customer->bridge_customer_id);
+
+        $this->safePush(
+            $user,
+            type: 'bridge.kyc.completed',
+            title: 'Identity verification approved',
+            body: 'You can now buy and sell crypto with bank transfers.',
+            data: ['bridge_customer_id' => $customer->bridge_customer_id],
+        );
+
+        $this->provisionVirtualAccount($customer, $user);
+    }
+
+    public function handleRejected(BridgeCustomer $customer, ?string $reason = null): void
+    {
+        $user = User::find($customer->user_id);
+        if ($user === null) {
+            Log::warning('BridgePostKycHandler: user not found for rejected KYC', [
+                'user_id' => $customer->user_id,
+            ]);
+
+            return;
+        }
+
+        BridgeKycRejected::dispatch($user->id, $customer->bridge_customer_id, $reason);
+
+        $this->safePush(
+            $user,
+            type: 'bridge.kyc.rejected',
+            title: 'Identity verification not approved',
+            body: $reason ?? 'Please contact support for next steps.',
+            data: ['bridge_customer_id' => $customer->bridge_customer_id],
+        );
+    }
+
+    private function provisionVirtualAccount(BridgeCustomer $customer, User $user): void
+    {
+        if ($customer->hasVirtualAccount()) {
+            return;
+        }
+
+        // blockchain_addresses links to users via user_uuid (not user_id).
+        $destinationAddress = BlockchainAddress::where('user_uuid', $user->uuid)
+            ->where('chain', self::DEFAULT_VA_NETWORK)
+            ->value('address');
+
+        if ($destinationAddress === null || $destinationAddress === '') {
+            // User hasn't registered a Polygon wallet address yet — common
+            // when KYC completes before mobile finishes wallet setup. The
+            // VA can be provisioned later by a separate trigger; for v1 we
+            // log and let the user re-trigger by re-opening the Buy screen.
+            Log::info('BridgePostKycHandler: deferring VA provisioning — no Polygon address yet', [
+                'user_id' => $user->id,
+            ]);
+
+            return;
+        }
+
+        try {
+            $response = $this->client->createVirtualAccount(
+                $customer->bridge_customer_id,
+                [
+                    'source'      => ['currency' => 'usd'],
+                    'destination' => [
+                        'currency'     => self::DEFAULT_VA_ASSET,
+                        'payment_rail' => self::DEFAULT_VA_NETWORK,
+                        'to_address'   => $destinationAddress,
+                    ],
+                ],
+                idempotencyKey: 'bridge_va:' . $user->id,
+            );
+        } catch (Throwable $e) {
+            // Bridge call failed — log + continue. The user is KYC-approved
+            // but can't onramp yet; a separate operator retry path can
+            // re-trigger provisioning. WS event NOT dispatched so mobile
+            // accurately shows virtualAccountReady=false.
+            Log::error('BridgePostKycHandler: VA provisioning failed', [
+                'user_id'   => $user->id,
+                'exception' => $e->getMessage(),
+            ]);
+
+            return;
+        }
+
+        $vaId = (string) ($response['id'] ?? '');
+        if ($vaId === '') {
+            Log::error('BridgePostKycHandler: Bridge createVirtualAccount returned no id', [
+                'user_id'  => $user->id,
+                'response' => $response,
+            ]);
+
+            return;
+        }
+
+        /** @var array<string, mixed> $details */
+        $details = (array) ($response['destination'] ?? []) + (array) ($response['source'] ?? []);
+        /** @var list<string> $rails */
+        $rails = array_values((array) ($response['supported_rails'] ?? ['ach', 'sepa']));
+
+        $customer->update([
+            'virtual_account_id'      => $vaId,
+            'virtual_account_details' => $details,
+            'supported_rails'         => $rails,
+        ]);
+
+        BridgeVirtualAccountReady::dispatch($user->id, $customer->bridge_customer_id, $rails);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function safePush(User $user, string $type, string $title, string $body, array $data = []): void
+    {
+        try {
+            $this->push->sendToUser($user, $type, $title, $body, $data);
+        } catch (Throwable $e) {
+            Log::warning('BridgePostKycHandler: push notification failed', [
+                'user_id'   => $user->id,
+                'type'      => $type,
+                'exception' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/app/Http/Controllers/Api/V1/BridgeWebhookController.php
+++ b/app/Http/Controllers/Api/V1/BridgeWebhookController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers\Api\V1;
 
 use App\Domain\Compliance\Kyc\Models\BridgeCustomer;
 use App\Domain\Compliance\Kyc\Providers\BridgeKycProvider;
+use App\Domain\Compliance\Kyc\Services\BridgePostKycHandler;
 use App\Domain\Ramp\Providers\BridgeProvider;
 use App\Domain\Subscription\Models\ProcessedWebhookEvent;
 use App\Http\Controllers\Controller;
@@ -40,6 +41,7 @@ class BridgeWebhookController extends Controller
     public function __construct(
         private readonly BridgeProvider $rampProvider,
         private readonly BridgeKycProvider $kycProvider,
+        private readonly BridgePostKycHandler $postKycHandler,
     ) {
     }
 
@@ -138,7 +140,7 @@ class BridgeWebhookController extends Controller
             return;
         }
 
-        DB::transaction(function () use ($bridgeCustomerId, $normalized): void {
+        $customer = DB::transaction(function () use ($bridgeCustomerId, $normalized): ?BridgeCustomer {
             $customer = BridgeCustomer::where('bridge_customer_id', $bridgeCustomerId)
                 ->lockForUpdate()
                 ->first();
@@ -148,7 +150,7 @@ class BridgeWebhookController extends Controller
                     'bridge_customer_id' => $bridgeCustomerId,
                 ]);
 
-                return;
+                return null;
             }
 
             $newStatus = match ($normalized['status']) {
@@ -159,12 +161,27 @@ class BridgeWebhookController extends Controller
             };
 
             $customer->update(['kyc_status' => $newStatus]);
+
+            return $customer->fresh();
         });
 
-        // TODO: dispatch WS broadcast (private-user.{userId}) + push
-        // notification on bridge.kyc.completed / bridge.kyc.rejected per
-        // handover §4.3. Plumbing lands when the WS event registry +
-        // PushNotificationService bindings are wired in this domain.
+        if ($customer === null) {
+            return;
+        }
+
+        // Run post-KYC side effects (WS broadcast + push fallback +
+        // virtual-account auto-provisioning on approval) outside the
+        // transaction so a slow Bridge API call doesn't hold a row lock.
+        match ($normalized['status']) {
+            'approved' => $this->postKycHandler->handleApproved($customer),
+            'rejected' => $this->postKycHandler->handleRejected(
+                $customer,
+                isset($normalized['raw']['rejection_reason'])
+                    ? (string) $normalized['raw']['rejection_reason']
+                    : null,
+            ),
+            default => null,
+        };
     }
 
     /**

--- a/tests/Feature/Compliance/Kyc/BridgePostKycHandlerTest.php
+++ b/tests/Feature/Compliance/Kyc/BridgePostKycHandlerTest.php
@@ -1,0 +1,200 @@
+<?php
+
+/**
+ * Post-KYC side-effect chain: WS broadcast events + push notification
+ * fallback + virtual-account auto-provisioning. Wired through
+ * BridgeWebhookController in production; tested here directly against
+ * BridgePostKycHandler so the assertions are simple.
+ */
+
+declare(strict_types=1);
+
+use App\Domain\Account\Models\BlockchainAddress;
+use App\Domain\Compliance\Kyc\Events\Broadcast\BridgeKycCompleted;
+use App\Domain\Compliance\Kyc\Events\Broadcast\BridgeKycRejected;
+use App\Domain\Compliance\Kyc\Events\Broadcast\BridgeVirtualAccountReady;
+use App\Domain\Compliance\Kyc\Models\BridgeCustomer;
+use App\Domain\Compliance\Kyc\Services\BridgePostKycHandler;
+use App\Domain\Mobile\Services\PushNotificationService;
+use App\Infrastructure\Bridge\BridgeClient;
+use App\Models\User;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    config([
+        'kyc.providers.bridge.api_key'  => 'sk_test',
+        'kyc.providers.bridge.base_url' => 'https://api.bridge.xyz',
+    ]);
+});
+
+function makePostKycHandler(): BridgePostKycHandler
+{
+    return new BridgePostKycHandler(
+        BridgeClient::fromConfig(),
+        app(PushNotificationService::class),
+    );
+}
+
+it('dispatches BridgeKycCompleted + provisions VA + dispatches BridgeVirtualAccountReady on approval', function () {
+    Event::fake([
+        BridgeKycCompleted::class,
+        BridgeVirtualAccountReady::class,
+    ]);
+
+    Http::fake([
+        'api.bridge.xyz/v0/customers/cust_va_ok/virtual_accounts' => Http::response([
+            'id'          => 'va_provisioned_1',
+            'destination' => [
+                'currency'     => 'usdc',
+                'payment_rail' => 'polygon',
+                'to_address'   => '0xabc',
+            ],
+            'source' => [
+                'iban'           => 'GB29NWBK60161331926819',
+                'account_holder' => 'Acme Test',
+                'memo'           => 'CUSTREF-VA1',
+            ],
+            'supported_rails' => ['ach', 'sepa', 'sepa_instant'],
+        ], 201),
+    ]);
+
+    $user = User::factory()->create();
+    BlockchainAddress::create([
+        'user_uuid'  => $user->uuid,
+        'chain'      => 'polygon',
+        'address'    => '0xabc',
+        'public_key' => '0x' . str_repeat('a', 128),
+    ]);
+
+    $customer = BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_va_ok',
+        'kyc_status'         => BridgeCustomer::KYC_APPROVED,
+        'developer_fee_bps'  => 75,
+    ]);
+
+    makePostKycHandler()->handleApproved($customer);
+
+    Event::assertDispatched(
+        BridgeKycCompleted::class,
+        fn (BridgeKycCompleted $e) => $e->userId === $user->id
+            && $e->bridgeCustomerId === 'cust_va_ok',
+    );
+
+    Event::assertDispatched(
+        BridgeVirtualAccountReady::class,
+        fn (BridgeVirtualAccountReady $e) => $e->userId === $user->id
+            && $e->supportedRails === ['ach', 'sepa', 'sepa_instant'],
+    );
+
+    $customer->refresh();
+    expect($customer->virtual_account_id)->toBe('va_provisioned_1');
+    expect($customer->supported_rails)->toBe(['ach', 'sepa', 'sepa_instant']);
+    expect($customer->virtual_account_details['iban'] ?? null)->toBe('GB29NWBK60161331926819');
+});
+
+it('dispatches BridgeKycRejected + push but NOT BridgeVirtualAccountReady on rejection', function () {
+    Event::fake([
+        BridgeKycRejected::class,
+        BridgeVirtualAccountReady::class,
+    ]);
+
+    $user = User::factory()->create();
+    $customer = BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_rej_ok',
+        'kyc_status'         => BridgeCustomer::KYC_REJECTED,
+        'developer_fee_bps'  => 75,
+    ]);
+
+    makePostKycHandler()->handleRejected($customer, 'Document expired');
+
+    Event::assertDispatched(
+        BridgeKycRejected::class,
+        fn (BridgeKycRejected $e) => $e->userId === $user->id
+            && $e->reason === 'Document expired',
+    );
+    Event::assertNotDispatched(BridgeVirtualAccountReady::class);
+});
+
+it('defers VA provisioning when the user has no Polygon address (logs + no event)', function () {
+    Event::fake([BridgeVirtualAccountReady::class]);
+
+    $user = User::factory()->create();
+    // Intentionally no blockchain_addresses row
+    $customer = BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_no_addr',
+        'kyc_status'         => BridgeCustomer::KYC_APPROVED,
+        'developer_fee_bps'  => 75,
+    ]);
+
+    Http::fake();
+
+    makePostKycHandler()->handleApproved($customer);
+
+    Event::assertNotDispatched(BridgeVirtualAccountReady::class);
+    Http::assertSentCount(0);
+    expect($customer->fresh()->virtual_account_id)->toBeNull();
+});
+
+it('does not re-provision a VA if one is already present', function () {
+    Event::fake([BridgeVirtualAccountReady::class, BridgeKycCompleted::class]);
+
+    $user = User::factory()->create();
+    BlockchainAddress::create([
+        'user_uuid'  => $user->uuid,
+        'chain'      => 'polygon',
+        'address'    => '0xexisting',
+        'public_key' => '0x' . str_repeat('b', 128),
+    ]);
+    $customer = BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_has_va',
+        'kyc_status'         => BridgeCustomer::KYC_APPROVED,
+        'virtual_account_id' => 'va_already_there',
+        'developer_fee_bps'  => 75,
+    ]);
+
+    Http::fake();
+
+    makePostKycHandler()->handleApproved($customer);
+
+    // KYC completed event still fires; VA-ready event does not (it would
+    // have already fired the first time provisioning happened).
+    Event::assertDispatched(BridgeKycCompleted::class);
+    Event::assertNotDispatched(BridgeVirtualAccountReady::class);
+    Http::assertSentCount(0);
+});
+
+it('still dispatches BridgeKycCompleted when VA provisioning fails (logs + skips VA event)', function () {
+    Event::fake([BridgeKycCompleted::class, BridgeVirtualAccountReady::class]);
+
+    Http::fake([
+        'api.bridge.xyz/v0/customers/*/virtual_accounts' => Http::response(
+            ['error' => 'bridge_temporary_failure'],
+            500,
+        ),
+    ]);
+
+    $user = User::factory()->create();
+    BlockchainAddress::create([
+        'user_uuid'  => $user->uuid,
+        'chain'      => 'polygon',
+        'address'    => '0xfailva',
+        'public_key' => '0x' . str_repeat('c', 128),
+    ]);
+    $customer = BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_va_fail',
+        'kyc_status'         => BridgeCustomer::KYC_APPROVED,
+        'developer_fee_bps'  => 75,
+    ]);
+
+    makePostKycHandler()->handleApproved($customer);
+
+    Event::assertDispatched(BridgeKycCompleted::class);
+    Event::assertNotDispatched(BridgeVirtualAccountReady::class);
+    expect($customer->fresh()->virtual_account_id)->toBeNull();
+});


### PR DESCRIPTION
## Summary

Closes the open follow-up from PR #1091. The TODO marker in `BridgeWebhookController::dispatchKycEvent` is replaced with real post-KYC-event behavior so users actually see the state change in the app + on push without polling. Also closes the v1-blocker that PR #1091 left open: the Bridge **virtual account auto-provisioning** that has to fire after KYC approval (without it, the onramp flow can't start).

### Broadcast events

All three on the existing `private-user.{userId}` channel (matches `NotificationCountUpdated` convention):

| Event class | `broadcastAs` | Payload |
|---|---|---|
| `BridgeKycCompleted` | `bridge.kyc.completed` | `bridge_customer_id` |
| `BridgeKycRejected` | `bridge.kyc.rejected` | `bridge_customer_id`, `reason` |
| `BridgeVirtualAccountReady` | `bridge.virtual_account.ready` | `bridge_customer_id`, `supported_rails` |

Account number / IBAN intentionally NOT in the WS payload — that's PII, surface via `GET /bridge-setup-status` which reads the encrypted column.

### Push fallback (per grilling-locked decision in PR #1090)

- Fire on `kyc.completed` and `kyc.rejected` only.
- **Not** on `virtual_account.ready` — quiet step, pushing creates fatigue.
- Push failures swallowed + logged so a FCM blip doesn't break the webhook handler.

### Auto VA provisioning

This was implicitly missing from PR #1091 — KYC approval landed but no Bridge call was made to create the virtual account, so `virtualAccountReady` stayed false forever and onramp couldn't begin.

- Triggered as a side effect of `kyc.completed`.
- Looks up the user's Polygon destination address from `blockchain_addresses` (`user_uuid` join — that's the FK, NOT `user_id`).
- If no Polygon address yet (common when KYC completes before mobile finishes wallet setup), logs + defers. User can re-trigger by re-opening the Buy screen later.
- Already-provisioned customers are skipped (idempotent on re-trigger).
- Bridge API errors are swallowed + logged. `BridgeKycCompleted` still fires; `BridgeVirtualAccountReady` does not, matching mobile's expectation that `virtualAccountReady=false` until provisioning succeeds.

### Service extraction

`BridgePostKycHandler` (`app/Domain/Compliance/Kyc/Services/`) owns the chain so `BridgeWebhookController` stays a thin dispatcher. Called **outside** the DB transaction so a slow Bridge API call doesn't hold the `bridge_customers` row lock.

### Tests

5 new + 55 touched tests still green. PHPStan Level 8 clean.

| Test | Asserts |
|---|---|
| handleApproved happy path | events dispatched, Http::fake VA call, bridge_customers updated with va_id + supported_rails + decrypted details |
| handleRejected | KycRejected dispatched with reason; VirtualAccountReady NOT dispatched |
| No Polygon address | VA call skipped, no event, customer untouched |
| Already-provisioned VA | KycCompleted dispatched but VA call + event skipped |
| Bridge VA call fails | KycCompleted dispatched, VA call attempted but swallowed, VirtualAccountReady NOT dispatched, virtual_account_id stays null |

## What's left

After this merges, the only items remaining from the brief:

- 🟡 SubscriptionTierChanged listener PATCHing Bridge customer's `developer_fee_bps` on Pro upgrade/downgrade per ADR-0006 — small standalone PR
- 🟡 Offramp (`type=off`) — explicit v1.1 scope per the handover
- 🟡 Bridge sandbox sanity check of the assumed Stripe-style signature scheme in `BridgeWebhookVerifier` — operational, not code

## Test plan

- [x] PHPStan Level 8 clean
- [x] PHPCS PSR-12 clean (lesson from PR #1091 — local PHPCS now part of pre-push)
- [x] 55 tests pass locally
- [ ] CI green
- [ ] Multi-connection tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)