### PR TITLE
feat: bridge:sync-dev-fee operator command (ADR-0006 followup)

### DIFF
--- a/app/Console/Commands/BridgeSyncDevFeeCommand.php
+++ b/app/Console/Commands/BridgeSyncDevFeeCommand.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Compliance\Kyc\Models\BridgeCustomer;
+use App\Domain\Compliance\Kyc\Services\BridgeDeveloperFeeSync;
+use App\Models\User;
+use Illuminate\Console\Command;
+use Throwable;
+
+/**
+ * Operator command: reconcile each Bridge customer's per-customer
+ * `developer_fee_bps` with the user's current subscription tier per
+ * ADR-0006. Use cases:
+ *
+ *   - One-off fix after a manual tier change in admin:
+ *       php artisan bridge:sync-dev-fee --email=user@example.com
+ *
+ *   - Batch backfill (e.g. after a billing event the auto-trigger
+ *     missed, or before flipping a feature flag that depends on
+ *     correct dev-fee defaults):
+ *       php artisan bridge:sync-dev-fee --all
+ *
+ * Until the Subscription domain emits a SubscriptionTierChanged event
+ * we can hook automatically, this command is the source of truth for
+ * keeping the per-customer default correct on Pro upgrade / downgrade.
+ *
+ * @see docs/adr/0006-bridge-developer-fees-as-markup-mechanism.md
+ */
+class BridgeSyncDevFeeCommand extends Command
+{
+    /** @var string */
+    protected $signature = 'bridge:sync-dev-fee
+                            {--email= : Sync a single user by email}
+                            {--all : Sync every user with a bridge_customers row}
+                            {--dry-run : Print intended changes without PATCHing Bridge}';
+
+    /** @var string */
+    protected $description = 'Reconcile each Bridge customer\'s per-customer developer_fee_bps with the user\'s tier';
+
+    public function handle(BridgeDeveloperFeeSync $sync): int
+    {
+        $email = $this->option('email');
+        $all = (bool) $this->option('all');
+        $dryRun = (bool) $this->option('dry-run');
+
+        if ($email === null && ! $all) {
+            $this->error('Provide --email=<user@example.com> or --all.');
+
+            return 1;
+        }
+
+        if ($email !== null && $all) {
+            $this->error('--email and --all are mutually exclusive.');
+
+            return 1;
+        }
+
+        if ($email !== null) {
+            return $this->syncOne((string) $email, $sync, $dryRun);
+        }
+
+        return $this->syncAll($sync, $dryRun);
+    }
+
+    private function syncOne(string $email, BridgeDeveloperFeeSync $sync, bool $dryRun): int
+    {
+        $user = User::where('email', $email)->first();
+        if ($user === null) {
+            $this->error("User not found: {$email}");
+
+            return 1;
+        }
+
+        return $this->process($user, $sync, $dryRun);
+    }
+
+    private function syncAll(BridgeDeveloperFeeSync $sync, bool $dryRun): int
+    {
+        $count = BridgeCustomer::count();
+        if ($count === 0) {
+            $this->info('No bridge_customers rows to sync.');
+
+            return 0;
+        }
+
+        $this->info("Syncing {$count} Bridge customers...");
+        $bar = $this->output->createProgressBar($count);
+        $bar->start();
+
+        $failures = 0;
+
+        BridgeCustomer::query()
+            ->select(['user_id', 'developer_fee_bps'])
+            ->cursor()
+            ->each(function (BridgeCustomer $customer) use ($sync, $dryRun, $bar, &$failures): void {
+                $user = User::find($customer->user_id);
+                if ($user === null) {
+                    $failures++;
+                    $bar->advance();
+
+                    return;
+                }
+
+                try {
+                    if ($dryRun) {
+                        $bar->advance();
+
+                        return;
+                    }
+                    $sync->syncForUser($user);
+                } catch (Throwable $e) {
+                    $failures++;
+                }
+
+                $bar->advance();
+            });
+
+        $bar->finish();
+        $this->newLine(2);
+
+        if ($failures > 0) {
+            $this->warn("{$failures} customer(s) failed — see logs for details.");
+
+            return 2;
+        }
+
+        $this->info('All customers synced.');
+
+        return 0;
+    }
+
+    private function process(User $user, BridgeDeveloperFeeSync $sync, bool $dryRun): int
+    {
+        $customer = BridgeCustomer::where('user_id', $user->id)->first();
+        if ($customer === null) {
+            $this->warn("No bridge_customers row for {$user->email} (KYC not started).");
+
+            return 0;
+        }
+
+        if ($dryRun) {
+            $this->line(sprintf(
+                'DRY-RUN: would sync %s — current developer_fee_bps=%d',
+                $user->email,
+                $customer->developer_fee_bps,
+            ));
+
+            return 0;
+        }
+
+        $result = $sync->syncForUser($user);
+
+        if ($result === null) {
+            $this->error("Unexpected: bridge_customers row vanished mid-sync for {$user->email}.");
+
+            return 1;
+        }
+
+        $this->info(sprintf('%s: developer_fee_bps now %d.', $user->email, $result));
+
+        return 0;
+    }
+}

--- a/app/Domain/Compliance/Kyc/Services/BridgeDeveloperFeeSync.php
+++ b/app/Domain/Compliance/Kyc/Services/BridgeDeveloperFeeSync.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Compliance\Kyc\Services;
+
+use App\Domain\Compliance\Kyc\Models\BridgeCustomer;
+use App\Infrastructure\Bridge\BridgeClient;
+use App\Models\User;
+use Closure;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Keeps each Bridge customer's per-customer `developer_fee_bps` in sync
+ * with the user's current subscription tier per ADR-0006.
+ *
+ * Why per-customer (not per-transfer): unsolicited virtual-account
+ * deposits are initiated by Bridge, not us, so we can't set the
+ * per-transfer dev fee at that moment. The customer-level default is the
+ * source of truth for that path.
+ *
+ * Currently invoked via the `bridge:sync-dev-fee` Artisan command for
+ * one-off corrections / batch backfill. The eventual auto-trigger lives
+ * downstream of a `SubscriptionTierChanged` event the Subscription domain
+ * has not yet introduced; once it does, a listener under this domain will
+ * call this service.
+ *
+ * @see docs/adr/0006-bridge-developer-fees-as-markup-mechanism.md
+ */
+final class BridgeDeveloperFeeSync
+{
+    /**
+     * @param  Closure(User): string  $tierResolver  Returns 'pro' or 'free'. Bound via
+     *                                               KycServiceProvider against SubscriptionProjection
+     *                                               in production; tests inject a stub closure
+     *                                               directly to sidestep the final class.
+     */
+    public function __construct(
+        private readonly BridgeClient $client,
+        private readonly Closure $tierResolver,
+    ) {
+    }
+
+    /**
+     * Resolve the desired developer_fee_bps for the user, PATCH Bridge if
+     * different from the local cache, and update the local row. Returns
+     * the new effective value (or null if no Bridge customer exists yet).
+     */
+    public function syncForUser(User $user): ?int
+    {
+        $customer = BridgeCustomer::where('user_id', $user->id)->first();
+        if ($customer === null) {
+            return null;
+        }
+
+        $desired = $this->desiredFeeBpsFor($user);
+
+        if ($customer->developer_fee_bps === $desired) {
+            return $desired;
+        }
+
+        try {
+            $this->client->patchCustomer(
+                $customer->bridge_customer_id,
+                ['developer_fee_bps' => $desired],
+            );
+        } catch (Throwable $e) {
+            Log::error('BridgeDeveloperFeeSync: PATCH failed', [
+                'user_id'   => $user->id,
+                'desired'   => $desired,
+                'previous'  => $customer->developer_fee_bps,
+                'exception' => $e->getMessage(),
+            ]);
+
+            return $customer->developer_fee_bps;
+        }
+
+        $customer->update(['developer_fee_bps' => $desired]);
+
+        Log::info('BridgeDeveloperFeeSync: dev fee updated', [
+            'user_id'  => $user->id,
+            'previous' => $customer->getOriginal('developer_fee_bps'),
+            'current'  => $desired,
+        ]);
+
+        return $desired;
+    }
+
+    private function desiredFeeBpsFor(User $user): int
+    {
+        $tier = ($this->tierResolver)($user);
+
+        return $tier === 'pro' ? BridgeCustomer::DEV_FEE_BPS_PRO : BridgeCustomer::DEV_FEE_BPS_FREE;
+    }
+}

--- a/app/Providers/KycServiceProvider.php
+++ b/app/Providers/KycServiceProvider.php
@@ -7,9 +7,13 @@ namespace App\Providers;
 use App\Domain\Compliance\Kyc\Providers\BridgeKycProvider;
 use App\Domain\Compliance\Kyc\Providers\OndatoKycProvider;
 use App\Domain\Compliance\Kyc\Registries\KycProviderRouter;
+use App\Domain\Compliance\Kyc\Services\BridgeDeveloperFeeSync;
 use App\Domain\Compliance\Services\OndatoService;
+use App\Domain\Subscription\Projections\SubscriptionProjection;
 use App\Infrastructure\Bridge\BridgeClient;
 use App\Infrastructure\Bridge\BridgeWebhookVerifier;
+use App\Models\User;
+use Closure;
 use Illuminate\Support\ServiceProvider;
 
 /**
@@ -35,6 +39,22 @@ class KycServiceProvider extends ServiceProvider
 
         $this->app->singleton(BridgeClient::class, static fn () => BridgeClient::fromConfig());
         $this->app->singleton(BridgeWebhookVerifier::class, static fn () => BridgeWebhookVerifier::fromConfig());
+
+        // Bridge dev-fee resolver — same Closure-binding pattern as
+        // RampService's tier resolver. Sidesteps the final SubscriptionProjection
+        // class for testability.
+        $this->app->bind('bridge.tier_resolver', function ($app): Closure {
+            $projection = $app->make(SubscriptionProjection::class);
+
+            return static fn (User $user): string => ($projection->for($user)['tier'] ?? 'free') === 'pro' ? 'pro' : 'free';
+        });
+
+        $this->app->bind(BridgeDeveloperFeeSync::class, function ($app): BridgeDeveloperFeeSync {
+            return new BridgeDeveloperFeeSync(
+                $app->make(BridgeClient::class),
+                $app->make('bridge.tier_resolver'),
+            );
+        });
 
         $this->app->singleton(KycProviderRouter::class, function ($app) {
             return new KycProviderRouter(

--- a/tests/Feature/Compliance/Kyc/BridgeDeveloperFeeSyncTest.php
+++ b/tests/Feature/Compliance/Kyc/BridgeDeveloperFeeSyncTest.php
@@ -1,0 +1,187 @@
+<?php
+
+/**
+ * Tests for BridgeDeveloperFeeSync — the bridge_customers <-> Bridge.xyz
+ * developer_fee_bps reconciliation per ADR-0006.
+ *
+ * Subscription tier resolution is swapped via the same `ramp.tier_resolver`
+ * closure-binding pattern used by RampService tests, BUT here we override
+ * SubscriptionProjection directly because BridgeDeveloperFeeSync injects
+ * it directly (not via the tier_resolver closure).
+ */
+
+declare(strict_types=1);
+
+use App\Domain\Compliance\Kyc\Models\BridgeCustomer;
+use App\Domain\Compliance\Kyc\Services\BridgeDeveloperFeeSync;
+use App\Infrastructure\Bridge\BridgeClient;
+use App\Models\User;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    config([
+        'kyc.providers.bridge.api_key'  => 'sk_test',
+        'kyc.providers.bridge.base_url' => 'https://api.bridge.xyz',
+    ]);
+});
+
+/**
+ * Build the service with a stub tier resolver. Production wires this through
+ * SubscriptionProjection via KycServiceProvider; tests pass a closure directly
+ * because the projection class is final and not easily mockable.
+ */
+function makeFeeSync(string $tier): BridgeDeveloperFeeSync
+{
+    return new BridgeDeveloperFeeSync(
+        BridgeClient::fromConfig(),
+        static fn (User $user): string => $tier,
+    );
+}
+
+it('returns null when the user has no bridge_customers row', function () {
+    $user = User::factory()->create();
+    Http::fake();
+
+    expect(makeFeeSync('free')->syncForUser($user))->toBeNull();
+    Http::assertSentCount(0);
+});
+
+it('no-ops when the current dev fee already matches the desired value', function () {
+    $user = User::factory()->create();
+    BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_already_synced',
+        'kyc_status'         => BridgeCustomer::KYC_APPROVED,
+        'developer_fee_bps'  => BridgeCustomer::DEV_FEE_BPS_FREE,
+    ]);
+
+    Http::fake();
+
+    $result = makeFeeSync('free')->syncForUser($user);
+
+    expect($result)->toBe(BridgeCustomer::DEV_FEE_BPS_FREE);
+    Http::assertSentCount(0);
+});
+
+it('PATCHes Bridge + updates local row when upgrading Free → Pro', function () {
+    $user = User::factory()->create();
+    $customer = BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_upgrade',
+        'kyc_status'         => BridgeCustomer::KYC_APPROVED,
+        'developer_fee_bps'  => BridgeCustomer::DEV_FEE_BPS_FREE,
+    ]);
+
+    Http::fake([
+        'api.bridge.xyz/v0/customers/cust_upgrade' => Http::response([
+            'id'                => 'cust_upgrade',
+            'developer_fee_bps' => 0,
+        ], 200),
+    ]);
+
+    $result = makeFeeSync('pro')->syncForUser($user);
+
+    expect($result)->toBe(BridgeCustomer::DEV_FEE_BPS_PRO);
+    expect($customer->fresh()->developer_fee_bps)->toBe(BridgeCustomer::DEV_FEE_BPS_PRO);
+    Http::assertSentCount(1);
+});
+
+it('PATCHes Bridge + updates local row when downgrading Pro → Free', function () {
+    $user = User::factory()->create();
+    $customer = BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_downgrade',
+        'kyc_status'         => BridgeCustomer::KYC_APPROVED,
+        'developer_fee_bps'  => BridgeCustomer::DEV_FEE_BPS_PRO,
+    ]);
+
+    Http::fake([
+        'api.bridge.xyz/v0/customers/cust_downgrade' => Http::response([
+            'id'                => 'cust_downgrade',
+            'developer_fee_bps' => 75,
+        ], 200),
+    ]);
+
+    $result = makeFeeSync('free')->syncForUser($user);
+
+    expect($result)->toBe(BridgeCustomer::DEV_FEE_BPS_FREE);
+    expect($customer->fresh()->developer_fee_bps)->toBe(BridgeCustomer::DEV_FEE_BPS_FREE);
+});
+
+it('keeps the local row unchanged when the Bridge PATCH fails', function () {
+    $user = User::factory()->create();
+    $customer = BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_fail_patch',
+        'kyc_status'         => BridgeCustomer::KYC_APPROVED,
+        'developer_fee_bps'  => BridgeCustomer::DEV_FEE_BPS_FREE,
+    ]);
+
+    Http::fake([
+        'api.bridge.xyz/v0/customers/cust_fail_patch' => Http::response(
+            ['error' => 'bridge_temporary_failure'],
+            500,
+        ),
+    ]);
+
+    $result = makeFeeSync('pro')->syncForUser($user);
+
+    // Returns the *current* (unchanged) value, not the desired one
+    expect($result)->toBe(BridgeCustomer::DEV_FEE_BPS_FREE);
+    expect($customer->fresh()->developer_fee_bps)->toBe(BridgeCustomer::DEV_FEE_BPS_FREE);
+});
+
+it('bridge:sync-dev-fee --email shows the new dev fee on success', function () {
+    $user = User::factory()->create(['email' => 'cli-test@example.com']);
+    BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_cli_1',
+        'kyc_status'         => BridgeCustomer::KYC_APPROVED,
+        'developer_fee_bps'  => BridgeCustomer::DEV_FEE_BPS_FREE,
+    ]);
+
+    Http::fake([
+        'api.bridge.xyz/v0/customers/cust_cli_1' => Http::response(['id' => 'cust_cli_1'], 200),
+    ]);
+
+    // Bind the service with a Pro-tier stub for the command run
+    app()->instance(BridgeDeveloperFeeSync::class, makeFeeSync('pro'));
+
+    $this->artisan('bridge:sync-dev-fee', ['--email' => 'cli-test@example.com'])
+        ->expectsOutputToContain('developer_fee_bps now 0')
+        ->assertSuccessful();
+});
+
+it('bridge:sync-dev-fee --email reports when no bridge_customers row exists', function () {
+    $user = User::factory()->create(['email' => 'no-bridge@example.com']);
+
+    $this->artisan('bridge:sync-dev-fee', ['--email' => 'no-bridge@example.com'])
+        ->expectsOutputToContain('No bridge_customers row')
+        ->assertSuccessful();
+});
+
+it('bridge:sync-dev-fee rejects mutually exclusive --email + --all', function () {
+    $this->artisan('bridge:sync-dev-fee', ['--email' => 'x@y.com', '--all' => true])
+        ->assertExitCode(1);
+});
+
+it('bridge:sync-dev-fee --dry-run shows the would-be change without PATCHing Bridge', function () {
+    $user = User::factory()->create(['email' => 'dry-run@example.com']);
+    BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_dry_1',
+        'kyc_status'         => BridgeCustomer::KYC_APPROVED,
+        'developer_fee_bps'  => BridgeCustomer::DEV_FEE_BPS_FREE,
+    ]);
+
+    Http::fake();
+
+    $this->artisan('bridge:sync-dev-fee', [
+        '--email'   => 'dry-run@example.com',
+        '--dry-run' => true,
+    ])
+        ->expectsOutputToContain('DRY-RUN')
+        ->assertSuccessful();
+
+    Http::assertSentCount(0);
+});


### PR DESCRIPTION
## Summary

Operator path to keep each Bridge customer's per-customer `developer_fee_bps` in sync with the user's current Pro/Free subscription tier per [ADR-0006](docs/adr/0006-bridge-developer-fees-as-markup-mechanism.md).

**The auto-trigger via a `SubscriptionTierChanged` event is the architecturally correct long-term answer**, but it requires cross-domain coordination with the Subscription bounded context to introduce that event in the first place. This PR ships the operator-runnable reconciliation that doesn't need that coordination — the Subscription event can hook into the same `BridgeDeveloperFeeSync` service in a follow-up.

### Service: `BridgeDeveloperFeeSync`

`app/Domain/Compliance/Kyc/Services/BridgeDeveloperFeeSync.php`

- `syncForUser(User): ?int` — reads desired fee from a tier resolver, PATCHes Bridge if different from the cached value, updates the local row. Returns the new effective value (or `null` if no `bridge_customers` row exists yet).
- No-ops when current value already matches (no spurious PATCH).
- Bridge errors are swallowed + logged; local row stays at the previous cached value to avoid drift between our DB and Bridge.
- Tier resolver is a `Closure` (matching `RampService`'s pattern) — sidesteps the `final SubscriptionProjection` for testability; wired through `'bridge.tier_resolver'` container binding in `KycServiceProvider`.

### Command: `php artisan bridge:sync-dev-fee`

| Flag | Purpose |
|---|---|
| `--email=<addr>` | Single user |
| `--all` | Every `bridge_customers` row (cursor-iterated; progress bar) |
| `--dry-run` | Print intended changes without PATCHing Bridge |

`--email` and `--all` are mutually exclusive.

### Tests (9 pass)

- No bridge_customers row → null, no HTTP call
- No-op when desired == current
- Free → Pro PATCH + local update
- Pro → Free PATCH + local update
- Bridge PATCH fails → local row unchanged
- Command `--email` success path
- Command `--email` when no bridge_customers row exists
- Command `--email` + `--all` mutually exclusive
- Command `--dry-run` skips Bridge

### What this enables

- Manual fix after a tier change in admin
- Batch backfill before flipping a feature flag that depends on correct dev-fee defaults
- Source of truth for keeping the per-customer default correct on Pro upgrade / downgrade until the Subscription event-based auto-trigger lands

### What's left from the brief

- 🟡 Offramp (`type=off`) — explicit v1.1 scope
- 🟡 Bridge sandbox sanity check of the assumed Stripe-style signature scheme — operational
- 🟡 `SubscriptionTierChanged` event in the Subscription domain — calls `BridgeDeveloperFeeSync::syncForUser` from a listener

## Test plan

- [x] PHPStan Level 8 clean
- [x] PHPCS PSR-12 clean
- [x] 9 tests pass locally
- [ ] CI green
- [ ] Manually run `php artisan bridge:sync-dev-fee --dry-run --email=<addr>` against a staging user

🤖 Generated with [Claude Code](https://claude.com/claude-code)