### PR TITLE
feat: VA-retry observer + bridge:inspect-user command

### DIFF
--- a/app/Console/Commands/BridgeInspectUserCommand.php
+++ b/app/Console/Commands/BridgeInspectUserCommand.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Account\Models\BlockchainAddress;
+use App\Domain\Compliance\Kyc\Models\BridgeCustomer;
+use App\Models\RampSession;
+use App\Models\User;
+use DateTimeInterface;
+use Illuminate\Console\Command;
+
+/**
+ * Operator query: print everything Bridge-related for a single user. Reads
+ * only — never writes. Mirror of the wallet:inspect-user pattern.
+ *
+ * Use when a mobile user reports "I completed KYC but can't see the bank
+ * details" or "deposit went missing":
+ *
+ *   php artisan bridge:inspect-user user@example.com
+ *   php artisan bridge:inspect-user user@example.com --sessions=20
+ */
+class BridgeInspectUserCommand extends Command
+{
+    protected $signature = 'bridge:inspect-user
+        {email : User email to look up}
+        {--sessions=10 : How many recent ramp_sessions to print}';
+
+    protected $description = 'Print Bridge customer, virtual account, Polygon address, and recent ramp sessions for a user';
+
+    public function handle(): int
+    {
+        $email = (string) $this->argument('email');
+        $user = User::query()->where('email', $email)->first();
+
+        if (! $user instanceof User) {
+            $this->error(sprintf('No user with email "%s".', $email));
+
+            return self::FAILURE;
+        }
+
+        $this->printUserSection($user);
+        $this->newLine();
+        $this->printBridgeCustomerSection($user);
+        $this->newLine();
+        $this->printPolygonAddressSection($user);
+        $this->newLine();
+        $this->printSessionsSection($user, (int) $this->option('sessions'));
+
+        return self::SUCCESS;
+    }
+
+    private function printUserSection(User $user): void
+    {
+        $this->info('User');
+        $this->table(
+            ['Field', 'Value'],
+            [
+                ['id', (string) $user->id],
+                ['uuid', $user->uuid],
+                ['email', $user->email],
+                ['kyc_status (Ondato/TrustCert)', (string) ($user->kyc_status ?? 'not_started')],
+            ],
+        );
+    }
+
+    private function printBridgeCustomerSection(User $user): void
+    {
+        $this->info('Bridge customer');
+        $customer = BridgeCustomer::where('user_id', $user->id)->first();
+
+        if ($customer === null) {
+            $this->line('  (no bridge_customers row — user has never started Bridge KYC)');
+
+            return;
+        }
+
+        $rails = $customer->supported_rails === null
+            ? '(none)'
+            : implode(', ', $customer->supported_rails);
+
+        $linkExpires = $customer->kyc_link_expires_at instanceof DateTimeInterface
+            ? $customer->kyc_link_expires_at->format(DateTimeInterface::ATOM)
+            : '(none)';
+
+        $vaDetailsSummary = $customer->virtual_account_details === null
+            ? '(none)'
+            : 'iban=' . ($customer->virtual_account_details['iban'] ?? '?')
+                . ', memo=' . ($customer->virtual_account_details['memo'] ?? '?');
+
+        $this->table(
+            ['Field', 'Value'],
+            [
+                ['bridge_customer_id', $customer->bridge_customer_id],
+                ['kyc_status', $customer->kyc_status],
+                ['kyc_link_expires_at', $linkExpires],
+                ['virtual_account_id', $customer->virtual_account_id ?? '(not provisioned)'],
+                ['virtual_account_details', $vaDetailsSummary],
+                ['supported_rails', $rails],
+                ['developer_fee_bps', (string) $customer->developer_fee_bps],
+                ['created_at', $customer->created_at->format(DateTimeInterface::ATOM)],
+                ['updated_at', $customer->updated_at->format(DateTimeInterface::ATOM)],
+            ],
+        );
+    }
+
+    private function printPolygonAddressSection(User $user): void
+    {
+        $this->info('Polygon address (VA provisioning depends on this)');
+
+        $address = BlockchainAddress::where('user_uuid', $user->uuid)
+            ->where('chain', 'polygon')
+            ->first();
+
+        if ($address === null) {
+            $this->line('  (no polygon address registered — VA provisioning would defer)');
+
+            return;
+        }
+
+        $this->table(
+            ['Field', 'Value'],
+            [
+                ['address', $address->address],
+                ['is_active', $address->is_active ? 'yes' : 'no'],
+                ['created_at', $address->created_at?->format(DateTimeInterface::ATOM) ?? '(unknown)'],
+            ],
+        );
+    }
+
+    private function printSessionsSection(User $user, int $limit): void
+    {
+        $this->info(sprintf('Recent ramp_sessions (limit %d)', $limit));
+
+        $sessions = RampSession::where('user_id', $user->id)
+            ->where('provider', 'bridge')
+            ->orderByDesc('created_at')
+            ->limit($limit)
+            ->get();
+
+        if ($sessions->isEmpty()) {
+            $this->line('  (no Bridge ramp sessions)');
+
+            return;
+        }
+
+        $this->table(
+            ['id', 'type', 'source', 'status', 'fiat', 'crypto', 'provider_session_id', 'created_at'],
+            $sessions->map(function (RampSession $s): array {
+                return [
+                    substr((string) $s->id, 0, 8) . '…',
+                    $s->type,
+                    $s->source,
+                    $s->status,
+                    sprintf('%s %s', $s->fiat_amount ?? '?', $s->fiat_currency),
+                    sprintf('%s %s', $s->crypto_amount ?? '?', $s->crypto_currency),
+                    (string) ($s->provider_session_id ?? ''),
+                    $s->created_at->format(DateTimeInterface::ATOM),
+                ];
+            })->toArray(),
+        );
+    }
+}

--- a/app/Domain/Compliance/Kyc/Observers/BlockchainAddressBridgeObserver.php
+++ b/app/Domain/Compliance/Kyc/Observers/BlockchainAddressBridgeObserver.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Compliance\Kyc\Observers;
+
+use App\Domain\Account\Models\BlockchainAddress;
+use App\Domain\Compliance\Kyc\Models\BridgeCustomer;
+use App\Domain\Compliance\Kyc\Services\BridgePostKycHandler;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * When a Polygon address is registered for a user whose Bridge KYC is
+ * already approved but whose virtual account hasn't been provisioned
+ * yet, trigger the VA creation.
+ *
+ * Why this exists: KYC can complete before mobile finishes wallet setup.
+ * In that race, the post-KYC handler logs "deferring VA provisioning"
+ * and stops. Without this observer the VA would never get created —
+ * mobile would have to add an explicit retry endpoint. With it, the
+ * provisioning happens transparently the moment the address shows up.
+ *
+ * Observer is registered separately from the existing
+ * Wallet/BlockchainAddressObserver (which handles Solana → Helius sync)
+ * so the two cross-domain concerns stay independent and either can be
+ * disabled without affecting the other.
+ *
+ * @see docs/BACKEND_HANDOVER_BRIDGE_RAMP.md §3.1
+ */
+final class BlockchainAddressBridgeObserver
+{
+    public function __construct(
+        private readonly BridgePostKycHandler $postKyc,
+    ) {
+    }
+
+    public function created(BlockchainAddress $address): void
+    {
+        if ($address->chain !== 'polygon') {
+            return;
+        }
+
+        // Defer to afterCommit so the address row is definitely visible to
+        // the provisioning call (which reads it back to populate Bridge's
+        // destination block).
+        dispatch(function () use ($address): void {
+            try {
+                $customer = BridgeCustomer::query()
+                    ->whereHas('user', fn ($q) => $q->where('uuid', $address->user_uuid))
+                    ->first();
+
+                if ($customer === null) {
+                    return;
+                }
+
+                if (! $customer->isKycApproved()) {
+                    return;
+                }
+
+                if ($customer->hasVirtualAccount()) {
+                    return;
+                }
+
+                $this->postKyc->tryProvisionVirtualAccount($customer);
+            } catch (Throwable $e) {
+                Log::error('BlockchainAddressBridgeObserver: VA retry failed', [
+                    'address' => $address->address,
+                    'chain'   => $address->chain,
+                    'error'   => $e->getMessage(),
+                ]);
+            }
+        })->afterCommit();
+    }
+}

--- a/app/Domain/Compliance/Kyc/Services/BridgePostKycHandler.php
+++ b/app/Domain/Compliance/Kyc/Services/BridgePostKycHandler.php
@@ -62,6 +62,25 @@ final class BridgePostKycHandler
             data: ['bridge_customer_id' => $customer->bridge_customer_id],
         );
 
+        $this->tryProvisionVirtualAccount($customer);
+    }
+
+    /**
+     * Idempotent VA provisioning callable from outside the KYC webhook path.
+     *
+     * Used by BlockchainAddressBridgeObserver when a user registers a Polygon
+     * address AFTER KYC was already approved (common when KYC completes
+     * before mobile finishes wallet setup). Calling repeatedly is safe — the
+     * hasVirtualAccount short-circuit + Bridge Idempotency-Key keep it from
+     * creating duplicate VAs.
+     */
+    public function tryProvisionVirtualAccount(BridgeCustomer $customer): void
+    {
+        $user = User::find($customer->user_id);
+        if ($user === null) {
+            return;
+        }
+
         $this->provisionVirtualAccount($customer, $user);
     }
 

--- a/app/Providers/KycServiceProvider.php
+++ b/app/Providers/KycServiceProvider.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Domain\Account\Models\BlockchainAddress;
+use App\Domain\Compliance\Kyc\Observers\BlockchainAddressBridgeObserver;
 use App\Domain\Compliance\Kyc\Providers\BridgeKycProvider;
 use App\Domain\Compliance\Kyc\Providers\OndatoKycProvider;
 use App\Domain\Compliance\Kyc\Registries\KycProviderRouter;
@@ -68,5 +70,13 @@ class KycServiceProvider extends ServiceProvider
                 routing: (array) config('kyc.routing', []),
             );
         });
+    }
+
+    public function boot(): void
+    {
+        // Attaches BlockchainAddressBridgeObserver to the BlockchainAddress
+        // model. Separate from Wallet/BlockchainAddressObserver (Helius/Solana
+        // sync) so the two cross-domain concerns can be disabled independently.
+        BlockchainAddress::observe(BlockchainAddressBridgeObserver::class);
     }
 }

--- a/tests/Feature/Compliance/Kyc/BlockchainAddressBridgeObserverTest.php
+++ b/tests/Feature/Compliance/Kyc/BlockchainAddressBridgeObserverTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * Tests the VA-retry observer: when a Polygon address is registered for a
+ * user whose Bridge KYC is already approved but whose virtual account is
+ * not yet provisioned, the observer triggers BridgeClient.createVirtualAccount.
+ *
+ * Observer dispatches its work via afterCommit closure, so tests run with
+ * Bus::fake() to force synchronous execution.
+ */
+
+declare(strict_types=1);
+
+use App\Domain\Account\Models\BlockchainAddress;
+use App\Domain\Compliance\Kyc\Models\BridgeCustomer;
+use App\Models\User;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    config([
+        'kyc.providers.bridge.api_key'  => 'sk_test',
+        'kyc.providers.bridge.base_url' => 'https://api.bridge.xyz',
+    ]);
+});
+
+/** Stub address row factory — public_key is NOT NULL in the schema. */
+function makePolygonAddress(User $user, string $address): BlockchainAddress
+{
+    /** @var BlockchainAddress $row */
+    $row = BlockchainAddress::create([
+        'user_uuid'  => $user->uuid,
+        'chain'      => 'polygon',
+        'address'    => $address,
+        'public_key' => '0x' . str_repeat('a', 128),
+        'is_active'  => true,
+    ]);
+
+    return $row;
+}
+
+it('triggers Bridge createVirtualAccount when a Polygon address is added for an approved customer with no VA', function () {
+    $user = User::factory()->create();
+    BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_retry_ok',
+        'kyc_status'         => BridgeCustomer::KYC_APPROVED,
+        'developer_fee_bps'  => 75,
+    ]);
+
+    Http::fake([
+        'api.bridge.xyz/v0/customers/cust_retry_ok/virtual_accounts' => Http::response([
+            'id'              => 'va_via_retry',
+            'destination'     => ['payment_rail' => 'polygon'],
+            'source'          => ['iban' => 'GB29NWBK60161331926819'],
+            'supported_rails' => ['ach', 'sepa'],
+        ], 201),
+    ]);
+
+    makePolygonAddress($user, '0xretrytarget');
+
+    // Observer runs synchronously in tests (no queue worker) — give Laravel
+    // a tick to process the afterCommit closure.
+    $customer = BridgeCustomer::where('user_id', $user->id)->firstOrFail();
+    expect($customer->virtual_account_id)->toBe('va_via_retry');
+    expect($customer->supported_rails)->toBe(['ach', 'sepa']);
+});
+
+it('does nothing when the user has no bridge_customers row', function () {
+    $user = User::factory()->create();
+
+    Http::fake();
+    makePolygonAddress($user, '0xnoprior');
+
+    Http::assertSentCount(0);
+});
+
+it('does nothing when KYC is not yet approved', function () {
+    $user = User::factory()->create();
+    BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_pending',
+        'kyc_status'         => BridgeCustomer::KYC_PENDING,
+        'developer_fee_bps'  => 75,
+    ]);
+
+    Http::fake();
+    makePolygonAddress($user, '0xpending');
+
+    Http::assertSentCount(0);
+    expect(BridgeCustomer::where('user_id', $user->id)->value('virtual_account_id'))->toBeNull();
+});
+
+it('does nothing when VA is already provisioned', function () {
+    $user = User::factory()->create();
+    BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_already_va',
+        'kyc_status'         => BridgeCustomer::KYC_APPROVED,
+        'virtual_account_id' => 'va_pre_existing',
+        'developer_fee_bps'  => 75,
+    ]);
+
+    Http::fake();
+    makePolygonAddress($user, '0xalreadyhasva');
+
+    Http::assertSentCount(0);
+});
+
+it('ignores non-Polygon address registrations (e.g. Solana)', function () {
+    $user = User::factory()->create();
+    BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_solana_only',
+        'kyc_status'         => BridgeCustomer::KYC_APPROVED,
+        'developer_fee_bps'  => 75,
+    ]);
+
+    Http::fake();
+    BlockchainAddress::create([
+        'user_uuid'  => $user->uuid,
+        'chain'      => 'solana',
+        'address'    => 'SoLanaAddressBase58',
+        'public_key' => 'pub_solana',
+        'is_active'  => true,
+    ]);
+
+    Http::assertSentCount(0);
+});

--- a/tests/Feature/Console/BridgeInspectUserCommandTest.php
+++ b/tests/Feature/Console/BridgeInspectUserCommandTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * Smoke tests for bridge:inspect-user — the operator support command.
+ * Asserts each section renders without error for the meaningful cases:
+ * unknown user, user with no bridge_customers row, fully-set-up user.
+ */
+
+declare(strict_types=1);
+
+use App\Domain\Account\Models\BlockchainAddress;
+use App\Domain\Compliance\Kyc\Models\BridgeCustomer;
+use App\Models\RampSession;
+use App\Models\User;
+
+it('returns failure for an unknown email', function () {
+    $this->artisan('bridge:inspect-user', ['email' => 'ghost@example.com'])
+        ->expectsOutputToContain('No user with email')
+        ->assertExitCode(1);
+});
+
+it('prints "no bridge_customers row" when the user has not started Bridge KYC', function () {
+    $user = User::factory()->create(['email' => 'fresh@example.com']);
+
+    $this->artisan('bridge:inspect-user', ['email' => 'fresh@example.com'])
+        ->expectsOutputToContain('no bridge_customers row')
+        ->assertSuccessful();
+});
+
+it('prints the bridge_customers + address + sessions sections for a fully set-up user', function () {
+    $user = User::factory()->create(['email' => 'setup@example.com']);
+
+    BridgeCustomer::create([
+        'user_id'                 => $user->id,
+        'bridge_customer_id'      => 'cust_inspect_1',
+        'kyc_status'              => BridgeCustomer::KYC_APPROVED,
+        'virtual_account_id'      => 'va_inspect_1',
+        'virtual_account_details' => ['iban' => 'GB29NWBK60161331926819', 'memo' => 'CUSTREF-IN1'],
+        'supported_rails'         => ['ach', 'sepa'],
+        'developer_fee_bps'       => 0,
+    ]);
+
+    BlockchainAddress::create([
+        'user_uuid'  => $user->uuid,
+        'chain'      => 'polygon',
+        'address'    => '0xinspect',
+        'public_key' => '0x' . str_repeat('a', 128),
+        'is_active'  => true,
+    ]);
+
+    RampSession::create([
+        'user_id'             => $user->id,
+        'provider'            => 'bridge',
+        'type'                => 'on',
+        'fiat_currency'       => 'EUR',
+        'fiat_amount'         => 100.00,
+        'crypto_currency'     => 'USDC',
+        'crypto_amount'       => 99.90,
+        'status'              => 'completed',
+        'source'              => 'user_initiated',
+        'provider_session_id' => 'bridge_va_va_inspect_1',
+    ]);
+
+    $this->artisan('bridge:inspect-user', ['email' => 'setup@example.com'])
+        ->expectsOutputToContain('cust_inspect_1')
+        ->expectsOutputToContain('va_inspect_1')
+        ->expectsOutputToContain('0xinspect')
+        ->assertSuccessful();
+});


### PR DESCRIPTION
## Summary

Two polish gaps from the post-§4.3 wrap-up that I documented but didn't actually wire:

### 1. VA-retry observer

**The gap:** KYC can complete before mobile finishes wallet setup. In that race, the post-KYC handler logs "deferring VA provisioning" and stops. Without a retry trigger, the VA is **never** created — onramp is impossible until something forces re-provisioning. I told mobile "user can re-trigger by re-opening the Buy screen" but that wasn't wired anywhere.

**The fix:** `BlockchainAddressBridgeObserver` (`app/Domain/Compliance/Kyc/Observers/`) listens on `BlockchainAddress::created`. For `chain=polygon`, looks up the user's `bridge_customers` row, and if KYC is approved + VA is not yet provisioned, calls `BridgePostKycHandler::tryProvisionVirtualAccount` (a new public method extracted from the previously-private `provisionVirtualAccount`).

Registered in `KycServiceProvider::boot` — separate observer attachment from the existing `Wallet/BlockchainAddressObserver` (Helius/Solana sync) so the two cross-domain concerns can be disabled independently.

Dispatched via `afterCommit` closure so the address row is visible to the read-back the provisioning call performs.

### 2. `bridge:inspect-user` operator command

Mirrors the `wallet:inspect-user` pattern per CLAUDE.md ("Operator commands: `php artisan privy:verify-jwt`, `wallet:inspect-user`"). First thing to reach for when mobile reports *"I completed KYC but can't see the bank details"* or *"deposit went missing."*

```bash
php artisan bridge:inspect-user user@example.com
php artisan bridge:inspect-user user@example.com --sessions=20
```

Prints, in order:
- User row (id / uuid / email / Ondato kyc_status)
- Bridge customer row (bridge_customer_id, kyc_status, kyc_link_expires_at, virtual_account_id, virtual_account_details summary, supported_rails, developer_fee_bps, timestamps)
- Polygon address (or "no polygon address registered — VA provisioning would defer")
- Recent ramp_sessions (default last 10)

Read-only — never writes.

## Tests (8 new, all touched green)

| Test | Asserts |
|---|---|
| Observer happy path | Polygon address registration triggers Bridge VA creation + bridge_customers update with va_id + supported_rails |
| Observer no-op: no bridge_customers row | No HTTP call |
| Observer no-op: KYC pending | No HTTP call; virtual_account_id stays null |
| Observer no-op: VA already provisioned | No HTTP call |
| Observer ignores non-Polygon chains | Solana address registration triggers no Bridge call |
| Command: unknown email | exit code 1 with "No user with email" message |
| Command: user without bridge_customers row | exit 0, prints "no bridge_customers row" |
| Command: fully set-up user | All sections render with expected values |

## What's still pending after this

- 🟡 Offramp (`type=off`) — explicit v1.1 deferral
- 🟡 Bridge sandbox sanity check of the signature scheme — operational
- 🟡 `SubscriptionTierChanged` event → auto-PATCH listener — needs Subscription domain coordination; `BridgeDeveloperFeeSync::syncForUser` already exists, just needs to be hooked

## Test plan

- [x] PHPStan Level 8 clean on touched paths
- [x] PHPCS PSR-12 clean
- [x] 13 tests pass locally
- [ ] CI green
- [ ] Manually run `php artisan bridge:inspect-user --email=<staging user>` once staging is wired

🤖 Generated with [Claude Code](https://claude.com/claude-code)