### PR TITLE
feat: SubscriptionTierChanged event + auto-PATCH Bridge dev fee (closes ADR-0006 loop)

### DIFF
--- a/app/Domain/Compliance/Kyc/Listeners/SyncBridgeDevFeeOnTierChange.php
+++ b/app/Domain/Compliance/Kyc/Listeners/SyncBridgeDevFeeOnTierChange.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Compliance\Kyc\Listeners;
+
+use App\Domain\Compliance\Kyc\Services\BridgeDeveloperFeeSync;
+use App\Domain\Subscription\Events\SubscriptionTierChanged;
+use App\Models\User;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Listens for SubscriptionTierChanged and PATCHes the user's Bridge
+ * customer developer_fee_bps per ADR-0006.
+ *
+ * Queued so a slow Bridge API call doesn't block the synchronous webhook
+ * response. BridgeDeveloperFeeSync no-ops when desired == current, so
+ * spurious dispatches (e.g. subscription.updated with no tier-affecting
+ * change) cost a single DB read, not a Bridge round-trip.
+ *
+ * @see docs/adr/0006-bridge-developer-fees-as-markup-mechanism.md
+ */
+final class SyncBridgeDevFeeOnTierChange implements ShouldQueue
+{
+    public string $queue = 'events';
+
+    public function __construct(
+        private readonly BridgeDeveloperFeeSync $sync,
+    ) {
+    }
+
+    public function handle(SubscriptionTierChanged $event): void
+    {
+        try {
+            $user = User::find($event->userId);
+            if ($user === null) {
+                return;
+            }
+
+            $this->sync->syncForUser($user);
+        } catch (Throwable $e) {
+            Log::error('SyncBridgeDevFeeOnTierChange: handler failed', [
+                'user_id'   => $event->userId,
+                'source'    => $event->source,
+                'exception' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/app/Domain/Subscription/Events/SubscriptionTierChanged.php
+++ b/app/Domain/Subscription/Events/SubscriptionTierChanged.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Subscription\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Fired when a user's effective subscription tier may have changed —
+ * subscription created, updated, or deleted on Stripe.
+ *
+ * Listeners that act on tier change should call SubscriptionProjection::for
+ * to discover the *current* tier rather than trusting any payload here.
+ * That keeps the event a simple "re-check me" signal and avoids the need
+ * to encode every tier-transition rule (trial vs paid vs grace vs canceled)
+ * into the dispatch site.
+ *
+ * Consumers:
+ *   - Compliance/Kyc: BridgeDeveloperFeeSync (per ADR-0006, the
+ *     per-customer developer_fee_bps on the Bridge customer record needs
+ *     to track Pro/Free).
+ *   - Future: anything else that mirrors tier into an external system.
+ *
+ * Not a broadcast event — internal cross-domain signal only.
+ *
+ * @see docs/adr/0006-bridge-developer-fees-as-markup-mechanism.md
+ */
+final class SubscriptionTierChanged
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly int $userId,
+        public readonly string $source,
+    ) {
+    }
+}

--- a/app/Domain/Subscription/Webhooks/SubscriptionWebhookController.php
+++ b/app/Domain/Subscription/Webhooks/SubscriptionWebhookController.php
@@ -30,6 +30,7 @@ declare(strict_types=1);
 
 namespace App\Domain\Subscription\Webhooks;
 
+use App\Domain\Subscription\Events\SubscriptionTierChanged;
 use App\Domain\Subscription\Events\SubscriptionTrialStarted;
 use App\Domain\Subscription\Jobs\Cue\EnqueueTrialEnding1d;
 use App\Domain\Subscription\Jobs\Cue\EnqueueTrialEnding1h;
@@ -207,6 +208,14 @@ final class SubscriptionWebhookController
                     trialEndsAt: $trialEndsAt,
                 ));
             }
+
+            // Tier may have just transitioned (free → pro). Cross-domain listeners
+            // (Compliance/Kyc dev-fee PATCH per ADR-0006) re-read tier from
+            // SubscriptionProjection rather than trusting any payload here.
+            Event::dispatch(new SubscriptionTierChanged(
+                userId: $user->id,
+                source: 'stripe.subscription.created',
+            ));
         }
     }
 
@@ -368,6 +377,19 @@ final class SubscriptionWebhookController
                 );
             }
         }
+
+        // Tier may have transitioned in either direction; fire a re-check
+        // signal so listeners (Compliance/Kyc dev-fee PATCH) can reconcile.
+        // SubscriptionProjection is the source of truth — listener re-reads
+        // it rather than trusting status here.
+        $stripeCustomerId = (string) ($subscription['customer'] ?? '');
+        $user = $stripeCustomerId !== '' ? $this->resolveUserByStripeCustomer($stripeCustomerId) : null;
+        if ($user instanceof User) {
+            Event::dispatch(new SubscriptionTierChanged(
+                userId: $user->id,
+                source: 'stripe.subscription.updated',
+            ));
+        }
     }
 
     /**
@@ -387,6 +409,17 @@ final class SubscriptionWebhookController
 
         // Cashier already keeps subscriptions/items rows in sync.
 
+        // Tier just transitioned pro → free; fire a re-check signal so
+        // listeners (Compliance/Kyc dev-fee PATCH) can reconcile.
+        $stripeCustomerId = (string) ($subscription['customer'] ?? '');
+        $user = $stripeCustomerId !== '' ? $this->resolveUserByStripeCustomer($stripeCustomerId) : null;
+        if ($user instanceof User) {
+            Event::dispatch(new SubscriptionTierChanged(
+                userId: $user->id,
+                source: 'stripe.subscription.deleted',
+            ));
+        }
+
         // Slice 4: insert subscription_canceled_external cue for user-initiated cancels only.
         $cancellationDetails = (array) ($subscription['cancellation_details'] ?? []);
         $reason = (string) ($cancellationDetails['reason'] ?? '');
@@ -394,9 +427,6 @@ final class SubscriptionWebhookController
         if ($reason !== 'cancellation_requested') {
             return;
         }
-
-        $stripeCustomerId = (string) ($subscription['customer'] ?? '');
-        $user = $stripeCustomerId !== '' ? $this->resolveUserByStripeCustomer($stripeCustomerId) : null;
 
         if (! $user instanceof User) {
             return;

--- a/app/Providers/KycServiceProvider.php
+++ b/app/Providers/KycServiceProvider.php
@@ -5,17 +5,20 @@ declare(strict_types=1);
 namespace App\Providers;
 
 use App\Domain\Account\Models\BlockchainAddress;
+use App\Domain\Compliance\Kyc\Listeners\SyncBridgeDevFeeOnTierChange;
 use App\Domain\Compliance\Kyc\Observers\BlockchainAddressBridgeObserver;
 use App\Domain\Compliance\Kyc\Providers\BridgeKycProvider;
 use App\Domain\Compliance\Kyc\Providers\OndatoKycProvider;
 use App\Domain\Compliance\Kyc\Registries\KycProviderRouter;
 use App\Domain\Compliance\Kyc\Services\BridgeDeveloperFeeSync;
 use App\Domain\Compliance\Services\OndatoService;
+use App\Domain\Subscription\Events\SubscriptionTierChanged;
 use App\Domain\Subscription\Projections\SubscriptionProjection;
 use App\Infrastructure\Bridge\BridgeClient;
 use App\Infrastructure\Bridge\BridgeWebhookVerifier;
 use App\Models\User;
 use Closure;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 
 /**
@@ -78,5 +81,12 @@ class KycServiceProvider extends ServiceProvider
         // model. Separate from Wallet/BlockchainAddressObserver (Helius/Solana
         // sync) so the two cross-domain concerns can be disabled independently.
         BlockchainAddress::observe(BlockchainAddressBridgeObserver::class);
+
+        // Per ADR-0006, keep the Bridge customer's per-customer
+        // developer_fee_bps in sync with the user's subscription tier
+        // automatically. The Subscription webhook controller dispatches the
+        // event on every tier-affecting transition; the listener no-ops
+        // when desired == current.
+        Event::listen(SubscriptionTierChanged::class, SyncBridgeDevFeeOnTierChange::class);
     }
 }

--- a/tests/Feature/Compliance/Kyc/SyncBridgeDevFeeOnTierChangeTest.php
+++ b/tests/Feature/Compliance/Kyc/SyncBridgeDevFeeOnTierChangeTest.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * Tests the auto-trigger that closes the loop on ADR-0006: when the
+ * SubscriptionWebhookController dispatches SubscriptionTierChanged after
+ * a Stripe lifecycle event, the listener calls BridgeDeveloperFeeSync,
+ * which PATCHes Bridge if the desired dev_fee_bps differs from the cached
+ * value.
+ */
+
+declare(strict_types=1);
+
+use App\Domain\Compliance\Kyc\Listeners\SyncBridgeDevFeeOnTierChange;
+use App\Domain\Compliance\Kyc\Models\BridgeCustomer;
+use App\Domain\Compliance\Kyc\Services\BridgeDeveloperFeeSync;
+use App\Domain\Subscription\Events\SubscriptionTierChanged;
+use App\Models\User;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    config([
+        'kyc.providers.bridge.api_key'  => 'sk_test',
+        'kyc.providers.bridge.base_url' => 'https://api.bridge.xyz',
+    ]);
+});
+
+/** Bind a stub sync that captures the call rather than hitting Bridge. */
+function fakeFeeSync(string $tier): BridgeDeveloperFeeSync
+{
+    return new BridgeDeveloperFeeSync(
+        App\Infrastructure\Bridge\BridgeClient::fromConfig(),
+        static fn (User $user): string => $tier,
+    );
+}
+
+it('PATCHes Bridge with Pro fee (0 bps) when listener fires for a Free → Pro user', function () {
+    $user = User::factory()->create();
+    BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_tier_change_1',
+        'kyc_status'         => BridgeCustomer::KYC_APPROVED,
+        'developer_fee_bps'  => BridgeCustomer::DEV_FEE_BPS_FREE,
+    ]);
+
+    Http::fake([
+        'api.bridge.xyz/v0/customers/cust_tier_change_1' => Http::response(
+            ['id' => 'cust_tier_change_1', 'developer_fee_bps' => 0],
+            200,
+        ),
+    ]);
+
+    app()->instance(BridgeDeveloperFeeSync::class, fakeFeeSync('pro'));
+
+    // Invoke the listener synchronously (queueing is bypassed by Pest)
+    $listener = app(SyncBridgeDevFeeOnTierChange::class);
+    $listener->handle(new SubscriptionTierChanged($user->id, 'stripe.subscription.created'));
+
+    Http::assertSent(fn ($req) => str_ends_with($req->url(), '/v0/customers/cust_tier_change_1'));
+    expect(BridgeCustomer::where('user_id', $user->id)->value('developer_fee_bps'))
+        ->toBe(BridgeCustomer::DEV_FEE_BPS_PRO);
+});
+
+it('PATCHes Bridge back to Free (75 bps) when listener fires for a Pro → Free downgrade', function () {
+    $user = User::factory()->create();
+    BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_downgrade_listener',
+        'kyc_status'         => BridgeCustomer::KYC_APPROVED,
+        'developer_fee_bps'  => BridgeCustomer::DEV_FEE_BPS_PRO,
+    ]);
+
+    Http::fake([
+        'api.bridge.xyz/v0/customers/cust_downgrade_listener' => Http::response(
+            ['id' => 'cust_downgrade_listener', 'developer_fee_bps' => 75],
+            200,
+        ),
+    ]);
+
+    app()->instance(BridgeDeveloperFeeSync::class, fakeFeeSync('free'));
+
+    $listener = app(SyncBridgeDevFeeOnTierChange::class);
+    $listener->handle(new SubscriptionTierChanged($user->id, 'stripe.subscription.deleted'));
+
+    expect(BridgeCustomer::where('user_id', $user->id)->value('developer_fee_bps'))
+        ->toBe(BridgeCustomer::DEV_FEE_BPS_FREE);
+});
+
+it('no-ops when the user has no bridge_customers row (e.g. tier change before KYC)', function () {
+    $user = User::factory()->create();
+
+    Http::fake();
+    app()->instance(BridgeDeveloperFeeSync::class, fakeFeeSync('pro'));
+
+    $listener = app(SyncBridgeDevFeeOnTierChange::class);
+    $listener->handle(new SubscriptionTierChanged($user->id, 'stripe.subscription.created'));
+
+    Http::assertSentCount(0);
+});
+
+it('no-ops when the desired fee already matches the cached value (idempotent)', function () {
+    $user = User::factory()->create();
+    BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_same_tier',
+        'kyc_status'         => BridgeCustomer::KYC_APPROVED,
+        'developer_fee_bps'  => BridgeCustomer::DEV_FEE_BPS_FREE,
+    ]);
+
+    Http::fake();
+    app()->instance(BridgeDeveloperFeeSync::class, fakeFeeSync('free'));
+
+    $listener = app(SyncBridgeDevFeeOnTierChange::class);
+    $listener->handle(new SubscriptionTierChanged($user->id, 'stripe.subscription.updated'));
+
+    Http::assertSentCount(0);
+});
+
+it('swallows handler exceptions and logs (Bridge being down does not break the webhook)', function () {
+    $user = User::factory()->create();
+    BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_bridge_down',
+        'kyc_status'         => BridgeCustomer::KYC_APPROVED,
+        'developer_fee_bps'  => BridgeCustomer::DEV_FEE_BPS_FREE,
+    ]);
+
+    Http::fake([
+        'api.bridge.xyz/v0/customers/cust_bridge_down' => Http::response(
+            ['error' => 'bridge_down'],
+            503,
+        ),
+    ]);
+
+    app()->instance(BridgeDeveloperFeeSync::class, fakeFeeSync('pro'));
+
+    $listener = app(SyncBridgeDevFeeOnTierChange::class);
+    // Should not throw — BridgeDeveloperFeeSync swallows + the listener
+    // wraps everything in a try/catch
+    $listener->handle(new SubscriptionTierChanged($user->id, 'stripe.subscription.updated'));
+
+    // Local row unchanged because the PATCH failed
+    expect(BridgeCustomer::where('user_id', $user->id)->value('developer_fee_bps'))
+        ->toBe(BridgeCustomer::DEV_FEE_BPS_FREE);
+});
+
+it('listener is wired to SubscriptionTierChanged via KycServiceProvider', function () {
+    Event::fake([SubscriptionTierChanged::class]);
+
+    // No-op — just verifies the listener registration doesn't blow up on boot
+    expect(Event::hasListeners(SubscriptionTierChanged::class))->toBeTrue();
+});


### PR DESCRIPTION
## Summary

Closes the last open follow-up from the original handover: the auto-trigger from a tier change to the Bridge per-customer `developer_fee_bps` PATCH that PR #1093 made operator-callable. After this merges, the loop is closed end-to-end — a user upgrading to Pro on Stripe results in their Bridge dev fee being PATCHed to 0 within seconds, no operator intervention.

Cross-domain signal: **Subscription → Compliance/Kyc**.

### Event: `SubscriptionTierChanged`

`app/Domain/Subscription/Events/SubscriptionTierChanged.php`

- Constructor: `(int $userId, string $source)` where `source` is the Stripe webhook event type (or `'iap'` once Apple/Google are wired)
- **No `fromTier` / `toTier`** on the payload — encoding every tier-transition rule (trial vs paid vs grace vs canceled) into the dispatch site is fragile. Listeners re-read tier from `SubscriptionProjection` on receive; the event is a "re-check me" signal.
- Not a broadcast event (internal only).

### Dispatch points in `SubscriptionWebhookController`

| Method | When |
|---|---|
| `onSubscriptionCreated` | After user record resolved + trial handling complete |
| `onSubscriptionUpdated` | After the `past_due` / `grace_period_started` branch — tier may have transitioned in either direction |
| `onSubscriptionDeleted` | Immediately on cancel webhook; **moved before the cancellation-reason filter** so even administrator-initiated cancels trigger the dev-fee reconciliation |

Apple IAP webhook (`AppleNotificationsWebhookController`) **not wired in this PR** — less common path; can be added later by another small dispatch.

### Listener: `SyncBridgeDevFeeOnTierChange`

`app/Domain/Compliance/Kyc/Listeners/SyncBridgeDevFeeOnTierChange.php`

- `implements ShouldQueue` (`events` queue) so a slow Bridge API call doesn't block the synchronous webhook 200 response
- Calls `BridgeDeveloperFeeSync::syncForUser`, which already no-ops when desired == current and swallows Bridge errors
- Wrapped in `try/catch` so even an unexpected throw doesn't break queue processing for other events
- Registered via `Event::listen` in `KycServiceProvider::boot`

### Tests (6 pass)

| Test | Asserts |
|---|---|
| Free → Pro | PATCHes Bridge to 0 bps, local row updates |
| Pro → Free | PATCHes Bridge to 75 bps, local row updates |
| No bridge_customers row | No HTTP call (tier change before KYC) |
| Desired matches cached | No HTTP call (idempotent) |
| Bridge API down | Handler doesn't throw, local row unchanged |
| Listener registered | `Event::hasListeners` returns true after boot |

### After this merges, the entire brief is done

- ✅ All §3.x items
- ✅ §4.3 WS events + push fallback
- ✅ ADR-0006 markup mechanism: operator command (PR #1093) **and** auto-trigger (this PR)
- ✅ VA auto-provisioning + retry observer (PR #1094)
- ✅ Operator support command (PR #1094)
- 🟡 Offramp (explicit v1.1 deferral per the brief)
- 🟡 Apple IAP equivalent of `SubscriptionTierChanged` dispatch (one-line follow-up if/when needed)
- 🟡 Bridge sandbox signature scheme verification (operational, not code)

## Test plan

- [x] PHPStan Level 8 clean on touched paths
- [x] PHPCS PSR-12 clean
- [x] 6 listener tests pass locally
- [ ] CI green (especially: existing SubscriptionWebhookController test suite — the dispatch additions shouldn't break any consent-log / cue-insertion assertions, but worth verifying)
- [ ] Manually simulate a Stripe subscription.created webhook against staging and confirm Bridge customer dev fee gets PATCHed

🤖 Generated with [Claude Code](https://claude.com/claude-code)