### PR TITLE
feat: Bridge ramp mobile followups (VA retry endpoint, push deep-link, quote expiration, user_id fix)

### DIFF
--- a/app/Domain/Compliance/Kyc/Services/BridgePostKycHandler.php
+++ b/app/Domain/Compliance/Kyc/Services/BridgePostKycHandler.php
@@ -35,6 +35,14 @@ final class BridgePostKycHandler
 
     private const DEFAULT_VA_ASSET = 'usdc';
 
+    /**
+     * Deep-link route mobile uses on push notification tap. Hardcoded for v1
+     * because the Bridge surface has exactly one screen mobile would route to
+     * regardless of event type. If we later add separate KYC vs deposit
+     * screens, factor this into a per-event const.
+     */
+    private const MOBILE_ROUTE = '/flows/bridge-setup';
+
     public function __construct(
         private readonly BridgeClient $client,
         private readonly PushNotificationService $push,
@@ -59,7 +67,10 @@ final class BridgePostKycHandler
             type: 'bridge.kyc.completed',
             title: 'Identity verification approved',
             body: 'You can now buy and sell crypto with bank transfers.',
-            data: ['bridge_customer_id' => $customer->bridge_customer_id],
+            data: [
+                'bridge_customer_id' => $customer->bridge_customer_id,
+                'route'              => self::MOBILE_ROUTE,
+            ],
         );
 
         $this->tryProvisionVirtualAccount($customer);
@@ -102,7 +113,10 @@ final class BridgePostKycHandler
             type: 'bridge.kyc.rejected',
             title: 'Identity verification not approved',
             body: $reason ?? 'Please contact support for next steps.',
-            data: ['bridge_customer_id' => $customer->bridge_customer_id],
+            data: [
+                'bridge_customer_id' => $customer->bridge_customer_id,
+                'route'              => self::MOBILE_ROUTE,
+            ],
         );
     }
 

--- a/app/Domain/Ramp/Exceptions/QuoteExpiredException.php
+++ b/app/Domain/Ramp/Exceptions/QuoteExpiredException.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Ramp\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Thrown by RampService::createSession when the supplied quote_id encodes a
+ * timestamp older than the quote's validity window (default 60s per the
+ * `validUntil` returned by GET /api/v1/ramp/quotes).
+ *
+ * Surfaced as HTTP 422 with error code `ERR_RAMP_QUOTE_EXPIRED` so mobile
+ * can render "Quote expired, refresh and try again" instead of a generic
+ * SESSION_ERROR toast.
+ *
+ * Validation is stateless: quote_id format is `qt_<unix_timestamp>_<random>`
+ * and we validate the timestamp prefix. Providers that emit quote_ids in
+ * other formats (Onramper, StripeCryptoOnramp) pass through unchecked —
+ * their quote-id semantics are their own concern.
+ */
+final class QuoteExpiredException extends RuntimeException
+{
+    public function __construct(int $issuedAt, int $now, int $ttlSeconds)
+    {
+        parent::__construct(sprintf(
+            'Quote expired: issued at %d (UNIX), validity window %ds, current time %d.',
+            $issuedAt,
+            $ttlSeconds,
+            $now,
+        ));
+    }
+}

--- a/app/Domain/Ramp/Providers/BridgeProvider.php
+++ b/app/Domain/Ramp/Providers/BridgeProvider.php
@@ -204,10 +204,17 @@ class BridgeProvider implements RampProviderInterface
         // a small implicit FX spread we don't unbundle in v1.
         $cryptoAmount = (float) bcsub($amount, $bridgeFee, 4);
 
+        // Stateless quote_id: encodes the issue timestamp + random tail so
+        // RampService can validate freshness at createSession time without a
+        // DB lookup. Format: qt_<unix_ts>_<8-hex>. RampService matches on
+        // the `qt_` prefix and decodes the timestamp; other providers'
+        // quote_id formats are passed through unchecked.
+        $quoteId = sprintf('qt_%d_%s', time(), bin2hex(random_bytes(4)));
+
         return [
             [
                 'provider_name'   => 'Bridge',
-                'quote_id'        => null,  // Bridge has no hosted quote endpoint
+                'quote_id'        => $quoteId,
                 'fiat_amount'     => (float) $amount,
                 'crypto_amount'   => $cryptoAmount,
                 'exchange_rate'   => 1.0,

--- a/app/Domain/Ramp/Services/RampService.php
+++ b/app/Domain/Ramp/Services/RampService.php
@@ -6,6 +6,7 @@ namespace App\Domain\Ramp\Services;
 
 use App\Domain\Ramp\Contracts\RampProviderInterface;
 use App\Domain\Ramp\Exceptions\InvalidWebhookSignatureException;
+use App\Domain\Ramp\Exceptions\QuoteExpiredException;
 use App\Models\RampSession;
 use App\Models\User;
 use Closure;
@@ -24,6 +25,14 @@ class RampService
     private const ZELTA_MARKUP_BPS_FREE = 75;
 
     private const ZELTA_MARKUP_BPS_PRO = 0;
+
+    /**
+     * Validity window for stateless quote_ids (matches the `validUntil`
+     * returned from GET /api/v1/ramp/quotes). Quote_ids in the
+     * `qt_<timestamp>_<random>` format older than this are rejected at
+     * createSession with QuoteExpiredException → ERR_RAMP_QUOTE_EXPIRED.
+     */
+    private const QUOTE_TTL_SECONDS = 60;
 
     /**
      * @param  Closure(User): string|null  $tierResolver  Returns 'free' or 'pro' for the given user.
@@ -133,6 +142,28 @@ class RampService
         return bcadd($str, '0', 2);
     }
 
+    /**
+     * Reject expired quote_ids of the form `qt_<unix_timestamp>_<random>`
+     * (issued by BridgeProvider::getQuotes — see also docs/adr/0006).
+     * Other providers' quote_id formats pass through unchecked — their
+     * freshness semantics are owned by them.
+     *
+     * @throws QuoteExpiredException
+     */
+    private function validateQuoteFreshness(?string $quoteId): void
+    {
+        if ($quoteId === null || ! preg_match('/^qt_(\d+)_[0-9a-f]+$/', $quoteId, $matches)) {
+            return;
+        }
+
+        $issuedAt = (int) $matches[1];
+        $now = time();
+
+        if (($now - $issuedAt) > self::QUOTE_TTL_SECONDS) {
+            throw new QuoteExpiredException($issuedAt, $now, self::QUOTE_TTL_SECONDS);
+        }
+    }
+
     private function resolveTier(?User $user): string
     {
         if ($user === null || $this->tierResolver === null) {
@@ -154,7 +185,14 @@ class RampService
         ?string $quoteId = null,
     ): RampSession {
         $this->validateRampParams($type, $fiatCurrency, $fiatAmount, $cryptoCurrency);
+        $this->validateQuoteFreshness($quoteId);
 
+        // user_id is part of the additive shape per RampProviderInterface
+        // (PR #1091). BridgeProvider requires it to scope per-user state
+        // like the bridge_customers row; other providers may ignore it.
+        // Latent gap fix: PR #1091 documented the param on the interface
+        // but never threaded it through here; first real Bridge session
+        // attempt would have failed.
         $providerResult = $this->provider->createSession([
             'type'            => $type,
             'fiat_currency'   => $fiatCurrency,
@@ -162,6 +200,7 @@ class RampService
             'crypto_currency' => $cryptoCurrency,
             'wallet_address'  => $walletAddress,
             'quote_id'        => $quoteId,
+            'user_id'         => $user->id,
         ]);
 
         $sessionData = [

--- a/app/Domain/Ramp/Services/StripeCryptoOnrampService.php
+++ b/app/Domain/Ramp/Services/StripeCryptoOnrampService.php
@@ -299,6 +299,16 @@ class StripeCryptoOnrampService
 
     /**
      * Map crypto symbol to its network for Stripe.
+     *
+     * TODO (v1.1 enablement): this hardcodes `ethereum` for USDC/USDT/ETH and
+     * the default branch. BridgeProvider's createSession was parameterized
+     * (`network` param, default `polygon`) per handover §3.4, but this legacy
+     * Stripe Crypto Onramp service body was preserved as-is during the PR
+     * #1090 rename. Before re-enabling `stripe_crypto_onramp` as the
+     * card-payment fallback (ADR-0005), this method should accept the
+     * destination network as a parameter so v1.1 quote/session requests can
+     * route to polygon/base/etc. The provider's createSession already takes
+     * the network in params; just thread it through.
      */
     private function mapNetwork(string $crypto): string
     {

--- a/app/Http/Controllers/Api/V1/BridgeSetupController.php
+++ b/app/Http/Controllers/Api/V1/BridgeSetupController.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Api\V1;
 
+use App\Domain\Account\Models\BlockchainAddress;
 use App\Domain\Compliance\Kyc\Enums\KycPurpose;
 use App\Domain\Compliance\Kyc\Models\BridgeCustomer;
 use App\Domain\Compliance\Kyc\Registries\KycProviderRouter;
+use App\Domain\Compliance\Kyc\Services\BridgePostKycHandler;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -27,6 +29,7 @@ class BridgeSetupController extends Controller
 {
     public function __construct(
         private readonly KycProviderRouter $router,
+        private readonly BridgePostKycHandler $postKyc,
     ) {
     }
 
@@ -115,6 +118,69 @@ class BridgeSetupController extends Controller
         return response()->json([
             'url'       => $url,
             'expiresAt' => $expiresAt?->toIso8601String(),
+        ]);
+    }
+
+    #[OA\Post(
+        path: '/api/v1/user/bridge-va-provision',
+        operationId: 'v1UserBridgeVaProvision',
+        tags: ['Bridge Setup'],
+        summary: 'Trigger Bridge virtual account provisioning for the authenticated user',
+        description: 'Idempotent retry path for the ramp screen: if KYC is approved + a Polygon address exists + no VA yet, calls Bridge to provision one. Mobile calls this on screen mount when bridge-setup-status reports kycStatus=approved && !virtualAccountReady.',
+        security: [['sanctum' => []]],
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Current VA state after the provisioning attempt. virtualAccountReady=false means Bridge is still processing OR the call failed (check /bridge-setup-status again, listen for bridge.virtual_account.ready WS event).',
+        content: new OA\JsonContent(properties: [
+        new OA\Property(property: 'virtualAccountReady', type: 'boolean', example: true),
+        new OA\Property(property: 'supportedRails', type: 'array', items: new OA\Items(type: 'string', enum: ['ach', 'sepa', 'sepa_instant'])),
+        ])
+    )]
+    #[OA\Response(response: 401, description: 'Unauthenticated')]
+    #[OA\Response(response: 409, description: 'KYC not approved, no Polygon address, or VA already provisioned')]
+    public function provisionVirtualAccount(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        abort_if($user === null, 401);
+
+        $customer = BridgeCustomer::where('user_id', $user->id)->first();
+
+        if ($customer === null || ! $customer->isKycApproved()) {
+            return response()->json([
+                'error'   => 'KYC_NOT_APPROVED',
+                'message' => 'Complete Bridge KYC before provisioning a virtual account.',
+            ], 409);
+        }
+
+        if ($customer->hasVirtualAccount()) {
+            return response()->json([
+                'error'   => 'VA_ALREADY_PROVISIONED',
+                'message' => 'A virtual account is already provisioned for this user.',
+            ], 409);
+        }
+
+        $hasPolygonAddress = BlockchainAddress::where('user_uuid', $user->uuid)
+            ->where('chain', 'polygon')
+            ->exists();
+
+        if (! $hasPolygonAddress) {
+            return response()->json([
+                'error'   => 'NO_POLYGON_ADDRESS',
+                'message' => 'Register a Polygon wallet address before provisioning a virtual account.',
+            ], 409);
+        }
+
+        // Idempotent at the Bridge layer via Idempotency-Key=bridge_va:{userId}.
+        // Failures are swallowed + logged inside the handler; we surface the
+        // resulting state via a fresh read of bridge_customers.
+        $this->postKyc->tryProvisionVirtualAccount($customer);
+
+        $customer->refresh();
+
+        return response()->json([
+            'virtualAccountReady' => $customer->hasVirtualAccount(),
+            'supportedRails'      => $customer->supported_rails ?? [],
         ]);
     }
 }

--- a/app/Http/Controllers/Api/V1/RampController.php
+++ b/app/Http/Controllers/Api/V1/RampController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api\V1;
 
 use App\Domain\Ramp\Contracts\RampProviderInterface;
+use App\Domain\Ramp\Exceptions\QuoteExpiredException;
 use App\Domain\Ramp\Services\RampService;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\V1\RampSessionResource;
@@ -135,6 +136,12 @@ class RampController extends Controller
             return response()->json([
                 'data' => new RampSessionResource($session),
             ], 201);
+        } catch (QuoteExpiredException $e) {
+            // Specific code so mobile can render "Quote expired, refresh"
+            // instead of a generic toast. Quote's `validUntil` is 60s.
+            return response()->json([
+                'error' => ['code' => 'ERR_RAMP_QUOTE_EXPIRED', 'message' => $e->getMessage()],
+            ], 422);
         } catch (RuntimeException $e) {
             return response()->json([
                 'error' => ['code' => 'SESSION_ERROR', 'message' => $e->getMessage()],

--- a/routes/api.php
+++ b/routes/api.php
@@ -372,6 +372,8 @@ Route::prefix('v1/user')->name('api.v1.user.')
             ->name('bridge-setup-status');
         Route::post('/bridge-kyc-link', [App\Http\Controllers\Api\V1\BridgeSetupController::class, 'kycLink'])
             ->name('bridge-kyc-link');
+        Route::post('/bridge-va-provision', [App\Http\Controllers\Api\V1\BridgeSetupController::class, 'provisionVirtualAccount'])
+            ->name('bridge-va-provision');
     });
 
 // v5.14.0 — Alchemy Address Activity Webhook (no auth, HMAC verified)

--- a/tests/Feature/Api/Bridge/BridgeVaProvisionEndpointTest.php
+++ b/tests/Feature/Api/Bridge/BridgeVaProvisionEndpointTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * Integration tests for POST /api/v1/user/bridge-va-provision — the explicit
+ * retry endpoint mobile calls on ramp-screen mount when
+ * bridge-setup-status reports kycStatus=approved && !virtualAccountReady.
+ */
+
+declare(strict_types=1);
+
+use App\Domain\Account\Models\BlockchainAddress;
+use App\Domain\Compliance\Kyc\Models\BridgeCustomer;
+use App\Models\User;
+use Illuminate\Support\Facades\Http;
+use Laravel\Sanctum\Sanctum;
+
+beforeEach(function () {
+    config([
+        'kyc.providers.bridge.api_key'  => 'sk_test',
+        'kyc.providers.bridge.base_url' => 'https://api.bridge.xyz',
+    ]);
+});
+
+function provisionAddress(User $user): BlockchainAddress
+{
+    /** @var BlockchainAddress $row */
+    $row = BlockchainAddress::create([
+        'user_uuid'  => $user->uuid,
+        'chain'      => 'polygon',
+        'address'    => '0xprovision',
+        'public_key' => '0x' . str_repeat('a', 128),
+        'is_active'  => true,
+    ]);
+
+    return $row;
+}
+
+it('rejects unauthenticated requests', function () {
+    $this->postJson('/api/v1/user/bridge-va-provision')->assertStatus(401);
+});
+
+it('returns 409 KYC_NOT_APPROVED when bridge_customer is missing', function () {
+    $user = User::factory()->create();
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    $this->postJson('/api/v1/user/bridge-va-provision')
+        ->assertStatus(409)
+        ->assertJsonPath('error', 'KYC_NOT_APPROVED');
+});
+
+it('returns 409 KYC_NOT_APPROVED when bridge_customer KYC is pending', function () {
+    $user = User::factory()->create();
+    BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_va_pending',
+        'kyc_status'         => BridgeCustomer::KYC_PENDING,
+        'developer_fee_bps'  => 75,
+    ]);
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    $this->postJson('/api/v1/user/bridge-va-provision')
+        ->assertStatus(409)
+        ->assertJsonPath('error', 'KYC_NOT_APPROVED');
+});
+
+it('returns 409 VA_ALREADY_PROVISIONED when a virtual_account_id already exists', function () {
+    $user = User::factory()->create();
+    BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_va_done',
+        'kyc_status'         => BridgeCustomer::KYC_APPROVED,
+        'virtual_account_id' => 'va_already',
+        'developer_fee_bps'  => 75,
+    ]);
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    Http::fake();
+
+    $this->postJson('/api/v1/user/bridge-va-provision')
+        ->assertStatus(409)
+        ->assertJsonPath('error', 'VA_ALREADY_PROVISIONED');
+
+    Http::assertSentCount(0);
+});
+
+it('returns 409 NO_POLYGON_ADDRESS when KYC is approved but no Polygon address exists', function () {
+    $user = User::factory()->create();
+    BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_va_noaddr',
+        'kyc_status'         => BridgeCustomer::KYC_APPROVED,
+        'developer_fee_bps'  => 75,
+    ]);
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    Http::fake();
+
+    $this->postJson('/api/v1/user/bridge-va-provision')
+        ->assertStatus(409)
+        ->assertJsonPath('error', 'NO_POLYGON_ADDRESS');
+
+    Http::assertSentCount(0);
+});
+
+it('happy path: provisions VA and returns ready state + rails', function () {
+    $user = User::factory()->create();
+    BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_va_retry_ok',
+        'kyc_status'         => BridgeCustomer::KYC_APPROVED,
+        'developer_fee_bps'  => 75,
+    ]);
+    provisionAddress($user);
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    Http::fake([
+        'api.bridge.xyz/v0/customers/cust_va_retry_ok/virtual_accounts' => Http::response([
+            'id'              => 'va_from_retry',
+            'destination'     => ['payment_rail' => 'polygon'],
+            'source'          => ['iban' => 'GB29NWBK60161331926819'],
+            'supported_rails' => ['ach', 'sepa_instant'],
+        ], 201),
+    ]);
+
+    $this->postJson('/api/v1/user/bridge-va-provision')
+        ->assertOk()
+        ->assertExactJson([
+            'virtualAccountReady' => true,
+            'supportedRails'      => ['ach', 'sepa_instant'],
+        ]);
+});
+
+it('reports virtualAccountReady=false when Bridge call fails (handler swallows)', function () {
+    $user = User::factory()->create();
+    BridgeCustomer::create([
+        'user_id'            => $user->id,
+        'bridge_customer_id' => 'cust_va_bridge_down',
+        'kyc_status'         => BridgeCustomer::KYC_APPROVED,
+        'developer_fee_bps'  => 75,
+    ]);
+    provisionAddress($user);
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    Http::fake([
+        'api.bridge.xyz/v0/customers/cust_va_bridge_down/virtual_accounts' => Http::response(
+            ['error' => 'bridge_down'],
+            503,
+        ),
+    ]);
+
+    $this->postJson('/api/v1/user/bridge-va-provision')
+        ->assertOk()
+        ->assertJsonPath('virtualAccountReady', false);
+});

--- a/tests/Feature/Api/Ramp/RampQuoteExpirationTest.php
+++ b/tests/Feature/Api/Ramp/RampQuoteExpirationTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * Tests the stateless quote-freshness validation added in RampService.
+ * Quote ids of the form `qt_<unix_timestamp>_<random>` (emitted by
+ * BridgeProvider::getQuotes) are validated at createSession time —
+ * past-TTL quotes return HTTP 422 with ERR_RAMP_QUOTE_EXPIRED so mobile
+ * can render a "Quote expired" toast instead of a generic SESSION_ERROR.
+ */
+
+declare(strict_types=1);
+
+use App\Domain\Compliance\Kyc\Models\BridgeCustomer;
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+
+beforeEach(function () {
+    config(['ramp.default_provider' => 'mock']);
+});
+
+it('returns 422 ERR_RAMP_QUOTE_EXPIRED when quote_id is older than the 60s TTL', function () {
+    $user = User::factory()->create(['kyc_status' => 'approved']);
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    // Build a stale quote_id 5 minutes in the past
+    $staleTimestamp = time() - 300;
+    $staleQuoteId = sprintf('qt_%d_%s', $staleTimestamp, bin2hex(random_bytes(4)));
+
+    $this->postJson('/api/v1/ramp/session', [
+        'type'            => 'on',
+        'fiat_currency'   => 'USD',
+        'fiat_amount'     => 100,
+        'crypto_currency' => 'USDC',
+        'wallet_address'  => '0xtest',
+        'quote_id'        => $staleQuoteId,
+    ])
+        ->assertStatus(422)
+        ->assertJsonPath('error.code', 'ERR_RAMP_QUOTE_EXPIRED');
+});
+
+it('accepts a fresh qt_-format quote_id (within TTL)', function () {
+    $user = User::factory()->create(['kyc_status' => 'approved']);
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    $freshQuoteId = sprintf('qt_%d_%s', time(), bin2hex(random_bytes(4)));
+
+    $this->postJson('/api/v1/ramp/session', [
+        'type'            => 'on',
+        'fiat_currency'   => 'USD',
+        'fiat_amount'     => 100,
+        'crypto_currency' => 'USDC',
+        'wallet_address'  => '0xtest',
+        'quote_id'        => $freshQuoteId,
+    ])
+        ->assertStatus(201);
+});
+
+it('passes through quote_ids that do not match the qt_ format (other providers)', function () {
+    $user = User::factory()->create(['kyc_status' => 'approved']);
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    // Onramper / Stripe-style quote_id — RampService doesn't validate
+    // these because freshness is the originating provider's concern.
+    $this->postJson('/api/v1/ramp/session', [
+        'type'            => 'on',
+        'fiat_currency'   => 'USD',
+        'fiat_amount'     => 100,
+        'crypto_currency' => 'USDC',
+        'wallet_address'  => '0xtest',
+        'quote_id'        => 'q_some_onramper_id_format',
+    ])
+        ->assertStatus(201);
+});
+
+it('accepts a request with no quote_id at all', function () {
+    $user = User::factory()->create(['kyc_status' => 'approved']);
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    $this->postJson('/api/v1/ramp/session', [
+        'type'            => 'on',
+        'fiat_currency'   => 'USD',
+        'fiat_amount'     => 100,
+        'crypto_currency' => 'USDC',
+        'wallet_address'  => '0xtest',
+    ])
+        ->assertStatus(201);
+});
+
+it('BridgeProvider::getQuotes returns a quote_id in the qt_ format that RampService accepts immediately', function () {
+    config([
+        'ramp.default_provider'         => 'bridge',
+        'kyc.providers.bridge.api_key'  => 'sk_test',
+        'kyc.providers.bridge.base_url' => 'https://api.bridge.xyz',
+    ]);
+
+    $user = User::factory()->create(['kyc_status' => 'approved']);
+    Sanctum::actingAs($user, ['read', 'write', 'delete']);
+
+    $response = $this->getJson('/api/v1/ramp/quotes?type=on&fiat=USD&amount=100&crypto=USDC')
+        ->assertOk();
+
+    $quoteId = $response->json('data.quotes.0.quote_id');
+    expect($quoteId)->toBeString()->toStartWith('qt_');
+
+    // Round-trip: feed the just-issued quote_id back into createSession.
+    // Bridge createSession requires a customer + VA — provide them:
+    BridgeCustomer::create([
+        'user_id'                 => $user->id,
+        'bridge_customer_id'      => 'cust_qt_roundtrip',
+        'kyc_status'              => BridgeCustomer::KYC_APPROVED,
+        'virtual_account_id'      => 'va_qt_roundtrip',
+        'virtual_account_details' => ['iban' => 'GB29NWBK60161331926819'],
+        'developer_fee_bps'       => 75,
+    ]);
+
+    $this->postJson('/api/v1/ramp/session', [
+        'type'            => 'on',
+        'fiat_currency'   => 'USD',
+        'fiat_amount'     => 100,
+        'crypto_currency' => 'USDC',
+        'wallet_address'  => '0xtest',
+        'quote_id'        => $quoteId,
+    ])->assertStatus(201);
+});


### PR DESCRIPTION
## Summary

Mobile-team feedback bundled into one PR — four items from their post-shipping report on the Bridge ramp work, plus a latent bug the test work caught.

### 1. `POST /api/v1/user/bridge-va-provision` (item #2)

New explicit retry path for the ramp screen mount when status reports `kycStatus=approved && !virtualAccountReady`. Until now the only auto-trigger was `BlockchainAddressBridgeObserver` on address creation; if the user already had the address and the VA was never created (Bridge call failed, race with KYC), there was no mobile-facing trigger.

**Response shape:**

| Status | Body | When |
|---|---|---|
| 200 | `{ virtualAccountReady, supportedRails }` | Provisioning attempted; mobile reads ready state from the body |
| 401 | (default) | Unauthenticated |
| 409 | `{ error: "KYC_NOT_APPROVED", message }` | Customer missing OR kyc_status !== approved |
| 409 | `{ error: "NO_POLYGON_ADDRESS", message }` | KYC approved but no `blockchain_addresses` row for chain=polygon |
| 409 | `{ error: "VA_ALREADY_PROVISIONED", message }` | Idempotent short-circuit — mobile should refresh status |

Idempotent at the Bridge layer (existing Idempotency-Key=`bridge_va:{userId}` in `BridgePostKycHandler::tryProvisionVirtualAccount`).

### 2. Push notification deep-link (item #3)

`BridgePostKycHandler::safePush` now includes `data.route = "/flows/bridge-setup"` on both KYC events. FCM data payload (all strings):

```json
{
  "bridge_customer_id": "cust_xxxx",
  "notification_id": "1234",
  "notification_type": "bridge.kyc.completed",
  "route": "/flows/bridge-setup",
  "click_action": "FLUTTER_NOTIFICATION_CLICK"
}
```

Mobile handler reads `data.route` directly — one route for all Bridge events in v1. Hardcoded constant in the handler; if we add separate KYC vs deposit screens later, factor into per-event const.

### 3. Quote expiration (item #5)

- New `QuoteExpiredException` extends `RuntimeException`
- `RampService::createSession` validates `qt_<unix_timestamp>_<random>` format quote_ids against a 60s TTL (matches the `validUntil` returned from GET /quotes). **Stateless** — no DB lookup; the timestamp is encoded in the id.
- `BridgeProvider::getQuotes` now emits real quote_ids in this format (was `null` before)
- `RampController::createSession` catches `QuoteExpiredException` specifically and returns 422 with code `ERR_RAMP_QUOTE_EXPIRED` so mobile can render "Quote expired, refresh and try again" instead of generic `SESSION_ERROR`
- Quote_ids in other formats (Onramper, StripeCryptoOnramp) pass through unchecked — their freshness semantics are their own concern

### 4. TODO marker on `StripeCryptoOnrampService::mapNetwork` (item #1)

Inline TODO explaining the hardcoded `ethereum` for USDC/USDT/ETH needs to be parameterized before v1.1 re-enables this provider as the card-payment fallback (ADR-0005). `BridgeProvider` already takes `network` as a param; just needs to be threaded through here.

### BONUS: latent bug fix in `RampService::createSession`

PR #1091's interface update added `user_id?: int` to the `createSession` param shape, but `RampService` never actually injected it. **First real Bridge session attempt would have failed** with `Bridge createSession requires user_id (injected by RampService).` — exactly the error my new round-trip test caught. Now properly threaded from the `User` parameter.

No existing test exercised the Bridge `createSession` HTTP path (the Bridge integration tests in `BridgeKycLinkFlowTest` cover the KYC link surface only); the bug only surfaces when mobile actually tries to POST `/ramp/session` against `RAMP_PROVIDER=bridge` with an approved + provisioned user. This PR adds that coverage.

## Tests (12 new, 142 across all touched paths green)

| Test file | Cases |
|---|---|
| `BridgeVaProvisionEndpointTest` | Auth required, 3 distinct 409 error codes, happy path with Http::fake, swallowed-error path returns virtualAccountReady=false |
| `RampQuoteExpirationTest` | Stale qt_ rejected with 422 ERR_RAMP_QUOTE_EXPIRED, fresh qt_ accepted, non-qt_ formats pass through, no quote_id accepts, round-trip BridgeProvider→createSession works end-to-end |

PHPStan Level 8 clean; PHPCS PSR-12 clean.

## Test plan

- [x] PHPStan Level 8 clean on touched paths
- [x] PHPCS PSR-12 clean
- [x] 12 new tests pass locally
- [x] 142 tests across all touched Bridge/Compliance/Kyc/Ramp paths still green
- [ ] CI green
- [ ] Manually smoke `POST /api/v1/user/bridge-va-provision` against staging once the Bridge sandbox creds are wired

🤖 Generated with [Claude Code](https://claude.com/claude-code)