### PR TITLE
fix: call CustodianRegistry::names() in CustodianHealthMonitor

### DIFF
--- a/app/Domain/Custodian/Services/CustodianHealthMonitor.php
+++ b/app/Domain/Custodian/Services/CustodianHealthMonitor.php
@@ -42,7 +42,7 @@ class CustodianHealthMonitor
     {
         $health = [];
 
-        foreach ($this->registry->getAllConnectorNames() as $custodian) {
+        foreach ($this->registry->names() as $custodian) {
             $health[$custodian] = $this->getCustodianHealth($custodian);
         }
 
@@ -228,7 +228,7 @@ class CustodianHealthMonitor
     {
         $healthScores = [];
 
-        foreach ($this->registry->getAllConnectorNames() as $custodian) {
+        foreach ($this->registry->names() as $custodian) {
             $health = $this->getCustodianHealth($custodian);
 
             // Calculate health score (0-100)

--- a/tests/Domain/Custodian/Services/CustodianHealthMonitorTest.php
+++ b/tests/Domain/Custodian/Services/CustodianHealthMonitorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Custodian\Connectors\MockBankConnector;
+use App\Domain\Custodian\Services\CustodianHealthMonitor;
+use App\Domain\Custodian\Services\CustodianRegistry;
+
+beforeEach(function () {
+    $this->registry = new CustodianRegistry();
+    $this->registry->register('mock', new MockBankConnector(['name' => 'Mock Bank']));
+    $this->monitor = app(CustodianHealthMonitor::class, ['registry' => $this->registry]);
+});
+
+it('iterates over registered custodians for getAllCustodiansHealth', function () {
+    $health = $this->monitor->getAllCustodiansHealth();
+
+    expect($health)->toHaveKey('mock');
+    expect($health['mock'])->toHaveKeys(['custodian', 'status', 'available']);
+    expect($health['mock']['custodian'])->toBe('mock');
+});
+
+it('iterates over registered custodians for getHealthiestCustodian', function () {
+    $healthiest = $this->monitor->getHealthiestCustodian('USD');
+
+    expect($healthiest)->toBe('mock');
+});


### PR DESCRIPTION
## Summary
- Production `banks:monitor-health` was failing every minute with `Call to undefined method App\Domain\Custodian\Services\CustodianRegistry::getAllConnectorNames()` (registry method is `names()`).
- Renames both call sites in `CustodianHealthMonitor` (`getAllCustodiansHealth`, `getHealthiestCustodian`).
- Adds regression test covering both methods against a real registry — would have caught the typo at PR time.

## Out of scope (reported separately to ops)
- `MockRampProvider must not be used in production` — production `.env` is missing `RAMP_PROVIDER=bridge`; defaults to `mock` and the mock constructor hard-fails in prod by design. Ops fix, not a code change.
- `Bridge API call failed` warnings — no stack, needs sandbox repro before code action.

## Test plan
- [x] `./vendor/bin/pest tests/Domain/Custodian/Services/CustodianHealthMonitorTest.php` — 2 passed
- [x] `vendor/bin/phpstan analyse` on touched files — clean
- [x] `php-cs-fixer fix` — clean
- [ ] CI green
- [ ] On deploy, `php artisan banks:monitor-health --interval=60` exits cleanly (no fatal in `production.log`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)