### PR TITLE
fix: explicit width/height on all #get-the-app SVGs

### DIFF
--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -544,7 +544,7 @@
                 <div class="mt-6 flex flex-wrap justify-center gap-2">
                     @foreach(['Free to join', 'No payment info', 'Leave anytime'] as $pill)
                     <span class="inline-flex items-center gap-1.5 rounded-full bg-white bru-border px-3.5 py-1 text-xs font-bold">
-                        <svg class="w-3 h-3 text-z-green" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+                        <svg class="text-z-green" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
                         {{ $pill }}
                     </span>
                     @endforeach
@@ -567,9 +567,9 @@
                     <a href="{{ $androidOptInUrl }}"
                        target="_blank"
                        rel="noopener noreferrer"
-                       class="btn-hover mt-5 inline-flex items-center justify-center gap-2 rounded-full px-6 py-3.5 text-base font-bold bru-card bg-obsidian text-white">
+                       class="btn-hover mt-5 inline-flex items-center justify-center gap-2 rounded-full px-6 py-3.5 text-base font-bold bru-card bg-obsidian text-white self-start">
                         Join the Android beta
-                        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M7 17L17 7M17 7H8M17 7v9"/></svg>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M7 17L17 7M17 7H8M17 7v9"/></svg>
                     </a>
                 </li>
 
@@ -607,7 +607,7 @@
             {{-- iOS waitlist row --}}
             <div class="mt-8 flex flex-col sm:flex-row items-center justify-center gap-3 text-center">
                 <span class="inline-flex items-center gap-2 rounded-full bru-border px-4 py-2 text-sm font-bold font-mono" style="background: rgba(255,255,255,0.7);">
-                    <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
                     iOS · TestFlight coming soon
                 </span>
                 <a href="#cta" class="text-sm font-bold underline decoration-2 underline-offset-4 hover:text-z-purple">


### PR DESCRIPTION
## Summary
Production https://zelta.app/#get-the-app is still rendering with oversized SVGs even after PR #1107's CSS rebuild — the trust-pill checks, the Step 1 CTA arrow, and the iOS clock icon are all huge, and the Step 1 button has expanded into a giant black circle to contain the unsized arrow.

Most likely cause: the deployed CSS is still cached at the CDN/edge, so the rebuilt utility classes haven't actually reached the browser even though the repo has them. We can't invalidate that cache from here, but we **can** stop depending on Tailwind class state for SVG sizing in this section.

## Change
Adds explicit `width`/`height` HTML attributes to every SVG in `#get-the-app`:
- 3 trust-pill check icons (12×12)
- Step 1 CTA's diagonal arrow (16×16)
- iOS pill's clock icon (16×16)

Connector arrows already had explicit dims from #1107. Number badges (w-9/h-9) and the Play badge wrapper use classes that have been in the compiled CSS since forever, so those are fine.

Also adds `self-start` to the Step 1 CTA so its width can't be stretched by the parent flex column.

After this lands the section will render correctly **regardless of CSS cache state** on the edge.

## Adjacent ops note
Worth double-checking on the production host:
- `curl -I https://zelta.app/css/app-landing.css` and look at `Cache-Control` / `Age` — if the CDN is serving a stale copy with a long max-age, a purge will help unblock other CSS-class additions on the same file.
- Confirm whatever process deploys static assets actually overwrites `public/css/app-landing.css`, not just rebuilds the Vite bundle.

## Test plan
- [x] `php -l` clean
- [x] `curl /app` locally — all SVGs emit with explicit width/height; no `w-3`/`w-4` class references remain in the section markup
- [ ] CI green
- [ ] Post-deploy visual on https://zelta.app/#get-the-app + hard refresh — trust pills compact, CTA button pill-shaped, iOS clock icon small

🤖 Generated with [Claude Code](https://claude.com/claude-code)