### PR TITLE
fix: malformed Android install URL (double `?` → `&`)

### DIFF
--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -508,9 +508,9 @@
          CSS, so cache drift on app-landing.css can't break the section.
     ═══════════════════════════════════════════════════════════════ --}}
     @php
-        $androidUtm = '?utm_source=zelta_landing&utm_medium=cta&utm_campaign=android_open_test';
-        $androidOptInUrl = 'https://play.google.com/apps/testing/com.zelta.wallet' . $androidUtm;
-        $androidInstallUrl = 'https://play.google.com/store/apps/details?id=com.zelta.wallet' . $androidUtm;
+        $androidUtm = 'utm_source=zelta_landing&utm_medium=cta&utm_campaign=android_open_test';
+        $androidOptInUrl = 'https://play.google.com/apps/testing/com.zelta.wallet?' . $androidUtm;
+        $androidInstallUrl = 'https://play.google.com/store/apps/details?id=com.zelta.wallet&' . $androidUtm;
     @endphp
 
     <style>


### PR DESCRIPTION
## Summary
- The `#get-the-app` Step 2 install link was emitting `…/details?id=com.zelta.wallet?utm_source=…` — two `?` separators back-to-back. Google parses everything after the first `?` as the query string, so `id` got the value `com.zelta.wallet?utm_source=…` and the listing lookup failed.
- Opt-in URL was unaffected (no existing query string).
- Split the UTM body from its leading separator so each URL appends the right one: `?` for opt-in, `&` for install.

## Test plan
- [ ] Hit the deployed `#get-the-app` Step 2 button, confirm the URL is `…/details?id=com.zelta.wallet&utm_source=…` (single `?`, `&` before the UTM block).
- [ ] Confirm the opt-in link still reads `…/apps/testing/com.zelta.wallet?utm_source=…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)