### PR TITLE
feat(landing): truth-pass content refresh — align copy with shipped product

### DIFF
--- a/app/Helpers/SchemaHelper.php
+++ b/app/Helpers/SchemaHelper.php
@@ -67,8 +67,9 @@ class SchemaHelper
             '@context'            => 'https://schema.org',
             '@type'               => 'MobileApplication',
             'name'                => $brand,
-            'operatingSystem'     => 'iOS, Android',
+            'operatingSystem'     => 'Android',
             'applicationCategory' => 'FinanceApplication',
+            'installUrl'          => 'https://play.google.com/store/apps/details?id=com.zelta.wallet',
             'offers'              => [
                 [
                     '@type'         => 'Offer',
@@ -76,7 +77,7 @@ class SchemaHelper
                     'priceCurrency' => 'USD',
                 ],
             ],
-            'description' => 'Agentic payments — get your personal card or your AI agent a card to spend anywhere. Stablecoin-powered, non-custodial.',
+            'description' => 'Non-custodial stablecoin wallet with passkey sign-in, virtual Visa & Mastercard cards, bank-rail deposits, and an agent-callable MCP API. Six networks (Solana, Tron, Polygon, Base, Arbitrum, Ethereum). In open testing on Android.',
             'developer'   => [
                 '@type' => 'Organization',
                 'name'  => $brand,

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -7,14 +7,14 @@
 
     @php $brand = config('brand.name'); @endphp
 
-    <title>{{ $brand }} — Agentic Payments | Get Your Card to Spend Anywhere</title>
+    <title>{{ $brand }} — Non-custodial stablecoin wallet · Virtual cards · Passkey sign-in</title>
 
     @include('partials.favicon')
 
     @include('partials.seo', [
-        'title' => $brand . ' — Agentic Payments',
-        'description' => 'Agentic payments — stablecoin-powered virtual cards for you and your AI agents. Non-custodial security, tap-to-pay crypto, and privacy built in.',
-        'keywords' => $brand . ', agentic payments, AI agent card, stablecoin card, virtual card, crypto payments, non-custodial wallet, tap to pay crypto, privacy payments',
+        'title' => $brand . ' — Stablecoins. Tap to pay. No seed phrase.',
+        'description' => 'Non-custodial stablecoin wallet with passkey sign-in, virtual Visa & Mastercard cards, bank-rail deposits, and an agent-callable API. Six networks (Solana, Tron, Polygon, Base, Arbitrum, Ethereum). Open testing on Android.',
+        'keywords' => $brand . ', stablecoin wallet, virtual card, USDC card, passkey wallet, non-custodial wallet, tap to pay, agentic payments, MCP wallet',
     ])
 
     {{-- Fonts: Space Grotesk, JetBrains Mono, DM Sans --}}
@@ -359,7 +359,7 @@
                                                 <span class="font-body text-sm font-medium text-text-sec">Total Balance</span>
                                                 <div class="flex items-center rounded-full bg-mint bru-border" style="gap: 4px; padding: 3px 8px;">
                                                     <svg width="11" height="11" viewBox="0 0 24 24" fill="#0a0a0a" xmlns="http://www.w3.org/2000/svg"><path d="M12 2L3 7v5c0 5.5 3.8 10.7 9 12 5.2-1.3 9-6.5 9-12V7l-9-5Z"/></svg>
-                                                    <span class="font-mono text-[11px] font-bold">PROTECTED</span>
+                                                    <span class="font-mono text-[11px] font-bold">PASSKEY</span>
                                                 </div>
                                             </div>
                                             <div class="flex items-baseline gap-1">
@@ -396,7 +396,7 @@
                                 <div class="flex flex-col" style="gap: 12px;">
                                     <span class="font-heading tracking-tighter text-xl font-bold">Security Status</span>
                                     <div class="flex" style="gap: 12px;">
-                                        @foreach([['icon' => '/icons/shield.svg', 'title' => 'Shielded', 'sub' => 'Privacy Active'], ['icon' => '/icons/shield-check.svg', 'title' => 'Verified', 'sub' => 'On-chain Identity']] as $card)
+                                        @foreach([['icon' => '/icons/fingerprint.svg', 'title' => 'Passkey', 'sub' => 'Face ID Active'], ['icon' => '/icons/shield-check.svg', 'title' => 'Verified', 'sub' => 'On-chain Identity']] as $card)
                                         <div class="flex items-center flex-1 bg-white bru-card" style="gap: 12px; padding: 14px; border-radius: 14px;">
                                             <div class="overflow-hidden bru-border flex-shrink-0" style="width: 44px; height: 44px; border-radius: 10px;">
                                                 <img src="{{ $card['icon'] }}" alt="{{ $card['title'] }}" class="w-full h-full">
@@ -420,10 +420,10 @@
                                     <div class="overflow-hidden bg-white bru-card" style="border-radius: 16px;">
                                         @php
                                         $transactions = [
-                                            ['svg' => '/icons/credit-card.svg', 'name' => 'Merchant Payment', 'date' => 'Today 3:41 PM', 'amount' => '-$42.50', 'pos' => false, 'shielded' => true],
-                                            ['svg' => '/icons/arrow-up-right.svg', 'name' => 'Transfer to Wallet', 'date' => 'Yesterday 2:15 PM', 'amount' => '-$14.99', 'pos' => false, 'shielded' => false],
-                                            ['svg' => '/icons/arrow-down-left.svg', 'name' => 'USDC Received', 'date' => 'Yesterday 11:30 AM', 'amount' => '+$500.00', 'pos' => true, 'shielded' => false],
-                                            ['svg' => '/icons/credit-card.svg', 'name' => 'Starbolt Coffee', 'date' => 'Mar 5 9:20 AM', 'amount' => '-$12.00', 'pos' => false, 'shielded' => true],
+                                            ['svg' => '/icons/credit-card.svg', 'name' => 'Merchant Payment', 'date' => 'Today 3:41 PM', 'amount' => '-$42.50', 'pos' => false, 'network' => 'Solana'],
+                                            ['svg' => '/icons/arrow-up-right.svg', 'name' => 'Transfer to Wallet', 'date' => 'Yesterday 2:15 PM', 'amount' => '-$14.99', 'pos' => false, 'network' => 'Polygon'],
+                                            ['svg' => '/icons/arrow-down-left.svg', 'name' => 'USDC Received', 'date' => 'Yesterday 11:30 AM', 'amount' => '+$500.00', 'pos' => true, 'network' => 'Base'],
+                                            ['svg' => '/icons/credit-card.svg', 'name' => 'Starbolt Coffee', 'date' => 'Mar 5 9:20 AM', 'amount' => '-$12.00', 'pos' => false, 'network' => 'Arbitrum'],
                                         ];
                                         @endphp
                                         @foreach($transactions as $i => $tx)
@@ -442,12 +442,7 @@
                                                 </div>
                                                 <div class="flex flex-col items-end flex-shrink-0 gap-0.5">
                                                     <span class="text-sm font-semibold {{ $tx['pos'] ? 'text-z-green' : 'text-obsidian' }}" style="font-variant-numeric: tabular-nums;">{{ $tx['amount'] }}</span>
-                                                    @if($tx['shielded'])
-                                                    <div class="flex items-center gap-0.5">
-                                                        <svg width="10" height="10" viewBox="0 0 24 24" fill="#10b981" xmlns="http://www.w3.org/2000/svg"><path d="M12 2L3 7v5c0 5.5 3.8 10.7 9 12 5.2-1.3 9-6.5 9-12V7l-9-5Z"/></svg>
-                                                        <span class="font-mono text-[10px] text-z-green">Protected</span>
-                                                    </div>
-                                                    @endif
+                                                    <span class="font-mono text-[10px] text-text-muted">{{ $tx['network'] }}</span>
                                                 </div>
                                             </div>
                                             @if($i < count($transactions) - 1)

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -222,38 +222,40 @@
             {{-- Left text --}}
             <div class="anim-fade-in-left">
                 <h1 class="text-5xl sm:text-6xl lg:text-7xl font-black leading-[0.95] font-heading tracking-tighter">
-                    Secure Stablecoin <span class="text-z-purple">Payments</span>
+                    No seed phrase. <span class="text-z-purple">Tap to pay.</span> Truly yours.
                 </h1>
 
                 <p class="mt-6 text-lg md:text-xl max-w-lg font-medium font-body text-text-sec">
-                    The stablecoin wallet that shields your on-chain tracks, ships virtual Visa cards,
-                    gives your AI agents a spending budget, and never asks you to trust a third party with your keys.
+                    {{ $brand }} is the stablecoin wallet that signs in with Face ID, spends through virtual cards
+                    anywhere in the world, and never asks you to trust anyone with your keys. Now in open testing on Android.
                 </p>
 
                 <div class="mt-8 flex flex-wrap gap-4">
-                    <a href="#cta"
+                    <a href="#get-the-app"
                        class="btn-hover rounded-full px-8 py-3.5 text-base font-bold bru-card bg-acid text-obsidian">
-                        Get Early Access
+                        Install on Android &rarr;
                     </a>
-                    <a href="#features"
+                    <a href="#cta"
                        class="btn-hover rounded-full px-8 py-3.5 text-base font-bold bru-card bg-white text-obsidian">
-                        How It Works
+                        Notify me when iOS launches
                     </a>
                 </div>
 
                 {{-- App store badges --}}
                 <div class="mt-8">
-                    <p class="mb-3 text-[10px] uppercase tracking-[0.3em] font-mono text-text-muted">Now in Open Testing on Android</p>
+                    <p class="mb-3 text-[10px] uppercase tracking-[0.3em] font-mono text-text-muted">Get the App</p>
                     <div class="flex gap-3">
-                        {{-- Apple: TestFlight pending --}}
-                        <div class="flex h-10 items-center gap-2 rounded-lg px-4 cursor-not-allowed opacity-50"
-                             style="border: 2px solid rgba(10,10,10,0.12); background: rgba(255,255,255,0.5);"
-                             title="iOS TestFlight coming soon">
+                        {{-- Apple: planned --}}
+                        <a href="#cta"
+                           class="flex h-10 items-center gap-2 rounded-lg px-4 opacity-70 hover:opacity-100 transition-opacity"
+                           style="border: 2px solid rgba(10,10,10,0.25); background: rgba(255,255,255,0.6);"
+                           title="iOS planned — get notified when TestFlight opens"
+                           aria-label="iOS planned — notify me when TestFlight opens">
                             <div>
-                                <p class="text-[8px] text-text-muted">Coming soon to</p>
-                                <p class="text-xs font-semibold text-text-sec">App Store</p>
+                                <p class="text-[8px] uppercase tracking-wider text-text-muted">iOS</p>
+                                <p class="text-xs font-semibold text-text-sec">Planned &middot; Notify me</p>
                             </div>
-                        </div>
+                        </a>
                         {{-- Android: live, links to two-step section below --}}
                         <a href="#get-the-app"
                            class="flex h-10 items-center gap-2 rounded-lg px-4 bru-border hs-4 bg-obsidian text-white"
@@ -643,15 +645,14 @@
         <div class="flex whitespace-nowrap" style="animation: z-marquee 20s linear infinite;">
             @for($dup = 0; $dup < 2; $dup++)
             <span class="text-white text-xl md:text-2xl font-black uppercase tracking-wider font-heading tracking-tighter pr-8">
-                SECURE STABLECOINS <span class="text-acid">&#9670;</span> SHIELD PRIVACY
+                NO SEED PHRASE <span class="text-acid">&#9670;</span> TAP TO PAY
                 <span class="text-acid">&#9670;</span> VIRTUAL CARDS
-                <span class="text-acid">&#9670;</span> AI AGENT BUDGETS
-                <span class="text-acid">&#9670;</span> ZERO TRACE
-                <span class="text-acid">&#9670;</span> x402 + MPP PAYMENTS
-                <span class="text-acid">&#9670;</span> TRUSTCERT IDENTITY
-                <span class="text-acid">&#9670;</span> SPLIT KEY SECURITY
-                <span class="text-acid">&#9670;</span> AGENTIC PAYMENTS
+                <span class="text-acid">&#9670;</span> BANK-RAIL DEPOSITS
+                <span class="text-acid">&#9670;</span> SIX NETWORKS
+                <span class="text-acid">&#9670;</span> AI-CALLABLE
                 <span class="text-acid">&#9670;</span> NON-CUSTODIAL
+                <span class="text-acid">&#9670;</span> ANDROID OPEN BETA
+                <span class="text-acid">&#9670;</span> PASSKEY-NATIVE
                 <span class="text-acid">&#9670;</span>
             </span>
             @endfor
@@ -699,14 +700,14 @@
             $featurePanels = [
                 [
                     'id' => 'core', 'bg' => 'bg-z-blue', 'active' => true,
-                    'title' => 'Your Keys, Split Three Ways',
-                    'desc' => 'Your private key is split into 3 encrypted shards. No single device or server ever holds the full key.',
+                    'title' => 'Your Passkey is Your Wallet',
+                    'desc' => 'Sign in with Face ID or fingerprint. No 12-word phrase to lose, no shards to manage. Your wallet lives in your device\'s Secure Enclave and recovers through your passkey.',
                     'type' => 'shard-flow',
                 ],
                 [
                     'id' => 'pay', 'bg' => 'bg-z-pink', 'active' => false,
                     'title' => 'Pay with Your Card',
-                    'desc' => 'Spin up virtual Visa cards instantly. Spend stablecoins at any merchant worldwide — they see a normal card payment, not a crypto wallet.',
+                    'desc' => 'Spin up virtual cards (Visa &amp; Mastercard) instantly. Spend stablecoins at any merchant worldwide — they see a normal card payment, not a crypto wallet.',
                     'type' => 'card-mockup',
                 ],
                 [
@@ -719,7 +720,8 @@
                 [
                     'id' => 'shield', 'bg' => 'bg-lavender', 'active' => false,
                     'title' => 'Shield Your Transactions',
-                    'desc' => 'Zero-knowledge proofs (ZK-SNARKs) make your balance invisible on-chain. Nobody can trace your spending or total holdings. When compliance is needed, generate a Proof of Innocence — prove your funds are clean without revealing your history.',
+                    'badge' => 'Coming Q3 2026',
+                    'desc' => 'Zero-knowledge proofs (ZK-SNARKs) will make your balance invisible on-chain. Generate a Proof of Innocence when compliance is needed — prove your funds are clean without revealing your history. Launching after public beta.',
                     'type' => 'icon-trio',
                     'icons' => ['/icons/ghost.svg', '/icons/incognito.svg', '/icons/globe.svg'],
                 ],
@@ -732,8 +734,8 @@
                 ],
                 [
                     'id' => 'identity', 'bg' => 'bg-z-green', 'active' => false,
-                    'title' => 'TrustCert Identity',
-                    'desc' => 'Blockchain-verified credentials issued as Soulbound Tokens. Basic (ID), Verified (address), Enhanced (source of funds). Higher levels unlock larger limits and fiat off-ramps. Verifiable by third parties without exposing your personal data.',
+                    'title' => 'Zelta Trust Identity',
+                    'desc' => 'Verified credentials issued as on-chain attestations. Basic (ID + selfie), Verified (proof of address), High (source of funds). Higher levels unlock larger limits and fiat off-ramps. Verifiable by third parties without exposing your personal data.',
                     'type' => 'icon-trio',
                     'icons' => ['/icons/user.svg', '/icons/shield-check.svg', '/icons/checkmark.svg'],
                 ],
@@ -748,6 +750,9 @@
                  id="panel-{{ $panel['id'] }}" role="tabpanel" aria-labelledby="tab-{{ $panel['id'] }}">
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-center">
                     <div>
+                        @if(!empty($panel['badge']))
+                        <span class="inline-block mb-3 px-3 py-1 text-[10px] font-bold uppercase tracking-wider font-mono rounded-full bru-border bg-white text-obsidian">{{ $panel['badge'] }}</span>
+                        @endif
                         <h3 class="text-2xl md:text-3xl font-black mb-2 font-heading tracking-tighter">{{ $panel['title'] }}</h3>
                         <p class="text-base text-text-sec">{{ $panel['desc'] }}</p>
                     </div>
@@ -775,7 +780,7 @@
                             <p class="text-white text-lg font-bold mt-1 tracking-widest font-mono">&bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull; 4291</p>
                             <div class="flex justify-between mt-4">
                                 <span class="text-white/40 text-xs">Valid thru 12/28</span>
-                                <span class="text-white/40 text-xs uppercase">Visa</span>
+                                <span class="text-white/40 text-xs uppercase">Visa &middot; MC</span>
                             </div>
                         </div>
                     </div>
@@ -795,15 +800,18 @@
             {{-- 2-column sub-cards --}}
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                 @foreach([
-                    ['icon' => '/icons/credit-card.svg', 'title' => 'Virtual Visa Cards', 'desc' => 'Generate virtual Visa cards backed by your stablecoin balance. Add to Apple Pay or Google Pay. Merchants see a normal card payment — not a crypto wallet.'],
-                    ['icon' => '/icons/incognito.svg', 'title' => 'ZK Privacy Shield', 'desc' => 'Shield and unshield stablecoins with zero-knowledge proofs. Your on-chain balance becomes invisible. Generate Proof of Innocence for compliance without revealing history.'],
+                    ['icon' => '/icons/credit-card.svg', 'title' => 'Virtual Cards', 'desc' => 'Generate Visa and Mastercard virtual cards backed by your stablecoin balance. Add to Apple Pay or Google Pay. Merchants see a normal card payment — not a crypto wallet.'],
+                    ['icon' => '/icons/incognito.svg', 'title' => 'ZK Privacy Shield', 'badge' => 'Coming Q3 2026', 'desc' => 'Shield and unshield stablecoins with zero-knowledge proofs so your on-chain balance becomes invisible. Generate Proof of Innocence for compliance without revealing history. Launching after public beta.'],
                     ['icon' => '/icons/lock.svg', 'title' => 'x402 Agent Payments', 'desc' => 'Give AI agents a spending allowance. Daily budgets, per-transaction caps, and biometric approval for over-limit requests. Your agents pay for APIs autonomously — within your rules.'],
-                    ['icon' => '/icons/globe.svg', 'title' => 'Multi-Network', 'desc' => 'Base, Polygon, Arbitrum, Ethereum, and Solana. One wallet address for EVM chains, sub-cent fees across all networks. ERC-4337 means you never need ETH for gas.'],
+                    ['icon' => '/icons/globe.svg', 'title' => 'Six Networks', 'desc' => 'Solana, Tron, Polygon, Base, Arbitrum, and Ethereum. One wallet address for EVM chains. Sub-cent fees on L2s and Solana. Pay gas in USDC — no ETH required.'],
                 ] as $subCard)
                 <div class="p-8 bg-white bru-card rounded-[2rem]">
                     <div class="rounded-full overflow-hidden mb-4 bru-card-sm" style="width: 56px; height: 56px;">
                         <img src="{{ $subCard['icon'] }}" alt="" class="h-full w-full" loading="lazy">
                     </div>
+                    @if(!empty($subCard['badge']))
+                    <span class="inline-block mb-3 px-3 py-1 text-[10px] font-bold uppercase tracking-wider font-mono rounded-full bru-border bg-acid text-obsidian">{{ $subCard['badge'] }}</span>
+                    @endif
                     <h3 class="text-xl md:text-2xl font-black mb-2 font-heading tracking-tighter">{{ $subCard['title'] }}</h3>
                     <p class="text-base text-text-sec">{{ $subCard['desc'] }}</p>
                 </div>
@@ -820,10 +828,10 @@
         <div class="mx-auto max-w-6xl">
             <div class="grid grid-cols-2 md:grid-cols-4 gap-6 md:gap-8">
                 @foreach([
-                    ['value' => '5', 'label' => 'Networks', 'sub' => 'Polygon · Base · Arbitrum · Ethereum · Solana'],
-                    ['value' => 'ZK', 'label' => 'Privacy', 'sub' => 'Zero-Knowledge Proofs'],
-                    ['value' => '$0', 'label' => 'Gas Fees', 'sub' => 'ERC-4337 Abstraction'],
-                    ['value' => '3', 'label' => 'Pay Protocols', 'sub' => 'x402 · MPP · AP2'],
+                    ['value' => '6', 'label' => 'Networks', 'sub' => 'Solana · Tron · Polygon · Base · Arbitrum · Ethereum'],
+                    ['value' => '€5', 'label' => 'Cards Deposit', 'sub' => 'Refundable · Visa &amp; Mastercard'],
+                    ['value' => 'No ETH', 'label' => 'Needed', 'sub' => 'Pay gas in USDC'],
+                    ['value' => 'MCP', 'label' => 'Agent-Callable', 'sub' => '12 OAuth tools'],
                 ] as $stat)
                 <div class="text-center">
                     <p class="text-3xl md:text-4xl font-black text-acid font-heading tracking-tighter">{{ $stat['value'] }}</p>
@@ -945,14 +953,14 @@
             <div class="flex flex-col gap-4">
                 @php
                 $faqs = [
-                    ['q' => 'What is ' . $brand . '?', 'a' => $brand . ' is a technology platform providing a user interface for services offered by independent third-party providers. ' . $brand . ' does not offer, hold, or transmit funds, crypto-assets, or provide financial, custodial, or regulated services. All wallet functionality is non-custodial — private keys remain under exclusive user control. Financial services are provided by third-party licensed providers.'],
+                    ['q' => 'What does ' . $brand . ' actually do?', 'a' => $brand . ' is a non-custodial stablecoin wallet that signs in with your passkey, lets you spend with virtual Visa or Mastercard cards anywhere, deposits and withdraws over bank rails, and exposes a 12-tool agent API so AI assistants can pay on your behalf within limits you set. Six networks supported (Solana, Tron, Polygon, Base, Arbitrum, Ethereum). No seed phrase. Open testing on Android now.'],
                     ['q' => 'Is ' . $brand . ' a custodial wallet?', 'a' => 'No. ' . $brand . ' is fully non-custodial. Wallets are powered by Privy embedded wallets — a passkey-controlled smart account on EVM (Polygon, Base, Arbitrum, Ethereum) and a device-bound ed25519 keypair on Solana. Private keys never leave the device or Privy\'s secure infrastructure. Every transaction is signed locally by your passkey or device key; ' . $brand . ' only ever sees public addresses and pre-signed payloads. There is no seed phrase to memorize — your passkey is your account, backed by your device\'s Secure Enclave / Keystore and recoverable through Privy\'s cross-device passkey sync.'],
-                    ['q' => 'How does transaction shielding work?', 'a' => $brand . ' uses zero-knowledge proofs (ZK-SNARKs) to shield your stablecoin balance from public view. Your transactions become unlinkable on-chain — nobody can trace your spending habits or total balance. When compliance is needed, generate a Proof of Innocence: a cryptographic certificate proving your funds are clean, without revealing your history.'],
-                    ['q' => 'Do I pay gas fees?', 'a' => 'No. ' . $brand . ' uses ERC-4337 Account Abstraction so you never need to hold ETH. Gas fees are either sponsored or paid in the stablecoin you\'re spending. You think in dollars, not in gwei.'],
-                    ['q' => 'What is TrustCert?', 'a' => 'TrustCert is ' . $brand . '\'s identity verification system, issued as non-transferable Soulbound Tokens on-chain. Three tiers: Basic (email + phone), Verified (ID + address), Enhanced (full KYB + source of funds). Higher tiers unlock larger spending limits and fiat off-ramps. Certificates are verifiable by third parties without exposing your personal data.'],
-                    ['q' => 'Can AI agents use ' . $brand . '?', 'a' => 'Yes. ' . $brand . ' supports three payment protocols: x402 (USDC micropayments), MPP (Stripe, Lightning, stablecoins), and AP2 mandates (Google\'s agent authorization). Agents pay for APIs, SMS, cloud services, and datasets autonomously — constrained by daily budgets and per-transaction caps that you control.'],
-                    ['q' => 'How do I connect Claude or another AI to my ' . $brand . ' wallet?', 'a' => $brand . ' runs a public Model Context Protocol (MCP) server at mcp.zelta.app — that\'s the open standard Claude, Cursor, ChatGPT, Continue.dev and other agents use to talk to external tools. Sign in to ' . $brand . ', click Connect to Claude (or paste the URL into your client\'s MCP settings), pick the scopes you want, and set a daily spending cap. The agent gets a token bound to those limits — it can never exceed them, and you can revoke at any time. 12 tools cover account balances, payments, exchange, on/off-ramp, transaction history, and SMS.'],
-                    ['q' => 'Which networks are supported?', 'a' => $brand . ' supports Base, Polygon, Arbitrum, Ethereum, and Solana. EVM networks share a single wallet address with sub-cent transaction fees. Solana offers the fastest settlement (~400ms). Switch networks anytime.'],
+                    ['q' => 'Is on-chain privacy (ZK shielding) available today?', 'a' => 'Not yet. Zero-knowledge transaction shielding and Proof of Innocence are on the roadmap for Q3 2026, after public beta. When it ships, you\'ll be able to make your stablecoin balance invisible on-chain and generate compliance proofs without revealing your history. Today\'s wallet is fully functional without it — privacy is an additive layer, not a prerequisite.'],
+                    ['q' => 'Do I pay gas fees?', 'a' => 'No ETH required. ' . $brand . ' uses ERC-4337 Account Abstraction — gas is either sponsored by us or paid in the stablecoin you\'re spending. You think in dollars, not in gwei. Sub-cent fees on Polygon, Base, Arbitrum, and Solana.'],
+                    ['q' => 'What is Zelta Trust identity?', 'a' => $brand . ' Trust is our identity verification layer, issued as on-chain attestations. Three consumer tiers: Basic (government-issued ID + selfie), Verified (proof of address), High (source of funds). Higher levels unlock larger spending limits and fiat off-ramps. Verifiable by third parties without exposing your personal data.'],
+                    ['q' => 'Can AI agents use ' . $brand . '?', 'a' => 'Yes — natively. ' . $brand . ' exposes a public Model Context Protocol (MCP) server at mcp.zelta.app with 12 OAuth-scoped tools covering balances, payments, exchange, on/off-ramp, transaction history, and SMS. Behind that, three agentic payment rails are wired in: x402 (USDC micropayments), MPP (multi-rail discovery via Stripe / Lightning / cards), and AP2 (Google agent mandates). Agents operate inside daily budgets and per-transaction caps you control, and you can revoke at any time.'],
+                    ['q' => 'How do I connect Claude or another AI to my ' . $brand . ' wallet?', 'a' => 'Sign in to ' . $brand . ', click Connect to Claude (or paste mcp.zelta.app into your client\'s MCP settings), pick the scopes you want, and set a daily spending cap. The agent gets a token bound to those limits — it can never exceed them, and you can revoke at any time. Works with Claude, Cursor, ChatGPT, Continue.dev, and any other MCP-aware client.'],
+                    ['q' => 'Which networks are supported?', 'a' => $brand . ' supports six networks: Solana, Tron, Polygon, Base, Arbitrum, and Ethereum. EVM networks share a single wallet address. Sub-cent fees on L2s and Solana. Solana offers the fastest settlement (~400ms). Switch networks anytime.'],
                 ];
                 @endphp
                 @foreach($faqs as $i => $faq)
@@ -984,19 +992,22 @@
     <section id="cta" class="relative px-5 py-20 md:py-28 overflow-hidden bg-acid">
         <div class="relative z-10 mx-auto max-w-3xl text-center">
             <h2 class="text-4xl sm:text-5xl md:text-6xl font-black mb-6 font-heading tracking-tighter" style="transform: rotate(-2deg);">
-                Ready to Go Off-Grid?
+                Don&apos;t miss what&apos;s next.
             </h2>
-            <p class="text-lg md:text-xl mb-10 max-w-xl mx-auto text-text-sec">
-                Drop your email and we&apos;ll send you an invite when the beta launches. No spam, just alpha.
+            <p class="text-lg md:text-xl mb-3 max-w-xl mx-auto text-text-sec font-semibold">
+                Android is open right now &mdash; <a href="#get-the-app" class="underline decoration-2 underline-offset-4 hover:text-z-purple">install on Google Play</a>.
+            </p>
+            <p class="text-base md:text-lg mb-10 max-w-xl mx-auto text-text-sec">
+                Drop your email to be first to know when we ship iOS, ZK Privacy, and the AI Agents console. No spam, no marketing &mdash; just product launches.
             </p>
 
-            <form id="early-access-form" class="flex flex-col sm:flex-row gap-3 max-w-lg mx-auto" aria-label="Early access signup">
+            <form id="early-access-form" class="flex flex-col sm:flex-row gap-3 max-w-lg mx-auto" aria-label="Product launch waitlist signup">
                 <label for="ea-email" class="sr-only">Email address</label>
                 <input type="email" id="ea-email" name="email" required placeholder="your@email.com"
                        class="flex-1 px-6 py-4 text-base outline-none placeholder:text-black/30 bg-white bru-border hs-4 rounded-full">
                 <button type="submit"
                         class="btn-hover px-8 py-4 text-base font-bold rounded-full text-white bg-obsidian bru-border hs-4">
-                    Get Early Access
+                    Notify me
                 </button>
             </form>
 

--- a/tests/Unit/Helpers/SchemaHelperTest.php
+++ b/tests/Unit/Helpers/SchemaHelperTest.php
@@ -86,8 +86,10 @@ class SchemaHelperTest extends TestCase
         $this->assertEquals('https://schema.org', $schema['@context']);
         $this->assertEquals('MobileApplication', $schema['@type']);
         $this->assertEquals($brand, $schema['name']);
-        $this->assertEquals('iOS, Android', $schema['operatingSystem']);
+        $this->assertEquals('Android', $schema['operatingSystem']);
         $this->assertEquals('FinanceApplication', $schema['applicationCategory']);
+        $this->assertArrayHasKey('installUrl', $schema);
+        $this->assertStringContainsString('play.google.com', $schema['installUrl']);
         $this->assertArrayHasKey('offers', $schema);
         $this->assertIsArray($schema['offers']);
         $this->assertCount(1, $schema['offers']);


### PR DESCRIPTION
## Summary
Fixes factual contradictions found during a content/marketing review of \`resources/views/app.blade.php\`. Every claim was verified against the current code before being rewritten — the page now matches what installers actually find in the app.

**Code-truth-pass verification**
- \`App\Domain\MobilePayment\Enums\PaymentNetwork\` — 6 networks (Solana, Tron, Polygon, Base, Arbitrum, Ethereum). No BSC.
- \`App\Domain\CardIssuance\Enums\CardNetwork\` — Visa AND Mastercard via Marqeta.
- \`App\Domain\TrustCert\Enums\TrustLevel\` — Basic / Verified / High (consumer subset).
- \`config/mcp.php\` — 12 OAuth-scoped tools live at \`mcp.zelta.app\`.
- Privy non-custodial migration: passkey-controlled smart accounts on EVM + device-bound ed25519 on Solana. **No Shamir Secret Sharing in the shipped app.**

**What changed**
- **Hero** — H1+subhead rewritten, primary CTA → Play Store testing flow, iOS badge → \"Planned · Notify me\" (was misleading \"Coming Soon\")
- **Feature panels** — Core: passkey framing (was 3-shard SSS). Shield: \"Coming Q3 2026\" badge. Pay: Visa & Mastercard. Identity: \"Zelta Trust\" with code-aligned tier names
- **Sub-cards** — Networks card now lists all 6; ZK Privacy Shield gets roadmap badge; Visa-only language dropped
- **Stats tiles** — \"5 → 6 Networks\", \"\$0 Gas\" overpromise → \"No ETH Needed\", \"3 Pay Protocols\" dev-speak → \"MCP · Agent-Callable\"
- **Marquee** — internal jargon (SPLIT KEY, TRUSTCERT, x402+MPP) → consumer pillars
- **FAQ Q1** — replaced legalese third-party-platform framing with \"What does Zelta actually do?\" (legal disclaimer stays in footer). Q3 reframed as roadmap. Q5/Q8 aligned with code.
- **Email signup** — beta is live on Android; form repurposed for iOS / ZK / Agents waitlist; inline link to \`#get-the-app\` for Android-now users
- **JSON-LD SoftwareApplication** — drop iOS from operatingSystem, add Play Store \`installUrl\`, refresh description

**Out of scope (visual/asset work)**
- No screenshots / product mockups added yet (#14 in review) — needs design assets
- No social proof / ratings yet (#15) — needs first reviews to accumulate

## Test plan
- [ ] \`./vendor/bin/pest tests/Unit/Helpers/SchemaHelperTest.php\` — updated assertions pass
- [ ] Render the page in dev and visually walk hero → marquee → feature tabs (open Shield tab, confirm \"Coming Q3 2026\" badge renders) → sub-cards (ZK Privacy Shield badge) → stats → FAQ Q1 → email-CTA section
- [ ] View page source — confirm SoftwareApplication JSON-LD has \`\"operatingSystem\": \"Android\"\` and an \`installUrl\` pointing to Google Play
- [ ] Click hero \"Install on Android\" — should jump to \`#get-the-app\` two-step section
- [ ] Click iOS badge — should jump to \`#cta\` (waitlist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)