### PR TITLE
fix(mcp): noindex + proper SEO meta on OAuth consent screen

### DIFF
--- a/resources/views/mcp/consent.blade.php
+++ b/resources/views/mcp/consent.blade.php
@@ -2,6 +2,14 @@
 
 @section('title', 'Authorize ' . ($client->name ?? 'application'))
 
+@section('seo')
+    @include('partials.seo', [
+        'title'       => 'Authorize ' . ($client->name ?? 'application') . ' — ' . config('brand.name', 'Zelta'),
+        'description' => 'Review and approve the permissions ' . ($client->name ?? 'this application') . ' is requesting on your ' . config('brand.name', 'Zelta') . ' account.',
+        'robots'      => 'noindex, nofollow',
+    ])
+@endsection
+
 @section('content')
 <div class="max-w-xl mx-auto py-12 px-4">
   <div class="bg-white rounded-2xl shadow border border-slate-200 p-8">
@@ -18,7 +26,7 @@
     </div>
 
     <p class="text-slate-700 mb-6">
-      <strong>{{ $client->name }}</strong> wants to connect to your Zelta account. Review the permissions below before approving.
+      <strong>{{ $client->name }}</strong> wants to connect to your {{ config('brand.name', 'Zelta') }} account. Review the permissions below before approving.
     </p>
 
     <ul class="space-y-3 mb-6">


### PR DESCRIPTION
## Summary

Follow-up to [#1113](https://github.com/FinAegis/core-banking-prototype-laravel/pull/1113). `mcp/consent.blade.php` was relying entirely on the `layouts/public` SEO fallback, which after #1113 ships the product-pitch description and `index, follow` robots — neither of which fits an OAuth authorization surface.

- `@section('seo')` override with consent-flow title + description naming the requesting client
- `'robots' => 'noindex, nofollow'` via the partial's `$robots` channel introduced in #1113 (no duplicate meta tags)
- Swap one hardcoded "Zelta account" in the consent prose for `config('brand.name', 'Zelta')` so demo deployments don't leak the prod brand into a reused flow (per `CLAUDE.md` "Brand: Zelta in prod, FinAegis in demo")

## Test plan

- [ ] CI green
- [ ] View-source on an `/oauth/authorize` consent flow shows `<meta name="robots" content="noindex, nofollow">`
- [ ] og:title reads "Authorize {client_name} — Zelta" (or brand name on demo)
- [ ] No duplicate `<meta name="robots">` tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)