### PR TITLE
docs: accuracy refresh of README + GitHub presentation

### DIFF
--- a/.serena/memories/development_continuation_guide.md
+++ b/.serena/memories/development_continuation_guide.md
@@ -1,6 +1,6 @@
 # FinAegis Development Continuation Guide
 
-> Last Updated: March 9, 2026
+> Last Updated: June 2, 2026
 
 ## Quick Recovery
 ```bash
@@ -10,27 +10,26 @@ gh pr list --state open
 ```
 
 ## Current State
-- Branch: `fix/ci-pipeline-green` (PR #735 — fixing CI for first green build)
-- Latest release tag: v5.11.0 (v5.12.0 was documented but never tagged)
-- 29 PRs merged since v5.11.0 (#706-#734): notifications, banners, gas sponsorship, referrals, ramp, Foodo, Onramper, design system v2
-- CI Pipeline historically never passed — PR #735 fixes PHPCS, PHPStan, 4 test failures
+- Latest release tag: v7.14.1 (Bridge.xyz ramp documented as v7.15.0 in CLAUDE.md)
+- Recent milestones: public MCP server (v7.11.0), non-custodial wallet send via Privy (v7.12.0), Apple/Google IAP subscriptions (v7.13.0), Bridge.xyz fiat on-ramp (v7.15.0)
+- Bridge webhook verifier now matches Bridge's **asymmetric** `X-Webhook-Signature` (v0 / RSA-SHA256 against `BRIDGE_WEBHOOK_PUBLIC_KEY`); legacy HMAC kept as fallback. Set the public key in prod before activating the webhook.
+- **HyperSwitch** (`app/Domain/Payment/Services/HyperSwitch/`) is EXPERIMENTAL scaffolding — real client + HMAC-verified webhook, but NOT wired into the deposit flow (webhook only logs, no binding, `HYPERSWITCH_ENABLED=false`, no tests). A dedicated multi-connection-tested wire-up PR is planned; discussion #346 stays open until then.
 
 ## Architecture
-- 56 domains in `app/Domain/`, 45 GraphQL schemas
+- 61 domains in `app/Domain/`, 45 GraphQL schema imports (`graphql/schema.graphql`)
 - Stack: PHP 8.4 / Laravel 12 / MySQL 8 / Redis / Pest / PHPStan Level 8
-- Patterns: Event Sourcing (Spatie), CQRS, DDD, GraphQL (Lighthouse), Redis Streams
+- Patterns: Event Sourcing (Spatie), CQRS, DDD, GraphQL (Lighthouse), Redis Streams, multi-tenancy (`UsesTenantConnection`)
 
 ## Key Conventions
 - `Sanctum::actingAs($user, ['read', 'write', 'delete'])` — always pass abilities
-- Code quality: php-cs-fixer → PHPStan → Pest (in that order)
-- Conventional commits: feat/fix/test/refactor + Co-Authored-By
+- Code quality before commit: `php-cs-fixer fix` → PHPStan Level 8 (analyses `tests/` too — guard `openssl_*`/`array|false` returns, no `@var`/assert/cast to silence) → Pest. CI also runs **PHPCS v4** (`vendor/bin/phpcs`) — run it locally to match.
+- Conventional commits: feat/fix/test/refactor + `Co-Authored-By`
+- Multi-connection: never wrap a write to a `UsesTenantConnection` model (e.g. `Account`, `AccountBalance`, tenant-aware stored events) inside a `DB::transaction()` that also holds default-connection rows — it self-deadlocks. Add `tests/MultiConnection/` coverage (required PR check).
 
-## Remaining Serena Memories (9)
-- `coding_standards_and_conventions` — code style details
-- `project_architecture_overview` — deep architecture reference
-- `code_quality_workflow` — CI/CD patterns
-- `cqrs_and_patterns_documentation` — CQRS/ES patterns
-- `event_sourcing_patterns` — event store details
-- `infrastructure-patterns` — infrastructure reference
-- `distributed-tracing-implementation` — observability
-- `hardware_wallet_integration` — Ledger/Trezor details
+## Other Serena Memories
+- `project_architecture_overview`, `project_overview` — architecture references
+- `coding_standards_and_conventions`, `code_style_and_conventions` — code style
+- `code_quality_workflow`, `task_completion_checklist`, `suggested_commands` — workflow
+- `cqrs_and_patterns_documentation`, `event_sourcing_patterns` — DDD/ES patterns
+- `infrastructure-patterns`, `distributed-tracing-implementation` — infra/observability
+- `hardware_wallet_integration`, `account_provisioning_domain` — domain deep-dives

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ php artisan bridge:sync-dev-fee --all --dry-run          # batch backfill (previ
 - **ZK Circuits**: `storage/app/circuits/` (Circom sources + Solidity verifiers)
 - **61 domains** in `app/Domain/` (DDD bounded contexts)
 - **Payment Protocols**: x402 (Coinbase), MPP (Stripe/Tempo), AP2 (Google)
+- **HyperSwitch** (`app/Domain/Payment/Services/HyperSwitch/`): EXPERIMENTAL scaffolding — real client + HMAC-verified webhook, but NOT wired into the deposit flow (webhook only logs, no service binding, `HYPERSWITCH_ENABLED=false`, no tests). Don't describe it as production. Wire-up plan + pre-existing pipeline bugs (corrupted `CreditAccountActivity`, tenant-connection deadlock risk) tracked for a dedicated PR; discussion #346 stays open until then
 - **Packages**: `packages/zelta-sdk/` (Payment SDK), `packages/zelta-cli/` (CLI binary)
 - **Event Sourcing**: Spatie v7.7+ with domain-specific tables
 - **CQRS**: Command/Query Bus in `app/Infrastructure/`

--- a/LICENSE
+++ b/LICENSE
@@ -185,7 +185,7 @@ Apache License
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2024-2026 FinAegis
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,8 @@
+FinAegis Core Banking Platform
+Copyright 2024-2026 FinAegis
+
+This product is licensed under the Apache License, Version 2.0 (the "License");
+you may not use this product except in compliance with the License. A copy of
+the License is provided in the LICENSE file and at:
+
+    http://www.apache.org/licenses/LICENSE-2.0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # FinAegis Core Banking Platform
 
-[![CI Pipeline](https://github.com/finaegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml/badge.svg)](https://github.com/finaegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml)
-[![Version](https://img.shields.io/badge/version-7.10.10-blue.svg)](CHANGELOG.md)
+[![CI Pipeline](https://github.com/FinAegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml/badge.svg)](https://github.com/FinAegis/core-banking-prototype-laravel/actions/workflows/ci-pipeline.yml)
+[![Version](https://img.shields.io/github/v/release/FinAegis/core-banking-prototype-laravel?sort=semver&label=release)](CHANGELOG.md)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![PHP Version](https://img.shields.io/badge/php-%3E%3D8.4-8892BF.svg)](https://php.net/)
 [![Laravel Version](https://img.shields.io/badge/Laravel-12.x-FF2D20.svg)](https://laravel.com/)
@@ -12,6 +12,8 @@
 
 FinAegis provides the foundation for building digital banking applications. The **Global Currency Unit (GCU)** serves as a complete reference implementation demonstrating how to build basket currencies, governance systems, and democratic financial instruments on this platform.
 
+> **FinAegis vs Zelta:** *FinAegis* is this open-source core-banking platform. *Zelta* is the hosted product and mobile wallet built on top of it — so production and hosted surfaces (for example the MCP server at `mcp.zelta.app`) carry the Zelta brand.
+
 [Live Demo](https://finaegis.org) | [Documentation](docs/README.md) | [Quick Start](#quick-start) | [Contributing](CONTRIBUTING.md)
 
 ---
@@ -20,7 +22,7 @@ FinAegis provides the foundation for building digital banking applications. The 
 
 | Challenge | FinAegis Solution |
 |-----------|-------------------|
-| Building financial systems from scratch | 61 production-ready domain modules |
+| Building financial systems from scratch | 61 domain modules |
 | Audit trail requirements | Event sourcing with domain-specific event tables |
 | Complex multi-step transactions | Saga pattern with automatic compensation |
 | Regulatory compliance | Built-in KYC/AML, SOC 2, PCI DSS, GDPR (v3.5.0) |
@@ -47,9 +49,13 @@ FinAegis provides the foundation for building digital banking applications. The 
 | Distributed tracing | OpenTelemetry, Zipkin, Jaeger, per-request trace propagation (v6.2.0) |
 | AI agent commerce | A2A messaging, DID identity, escrow, reputation framework (v6.3.0) |
 | Machine payments | MPP multi-rail (Stripe, USDC, Lightning), AP2 mandates, x402 Solana (v6.4.0) |
-| Payment orchestration | HyperSwitch 150+ connectors, smart routing, failover (v6.4.2) |
+| Payment orchestration (experimental) | HyperSwitch client + webhook scaffold — disabled by default (`HYPERSWITCH_ENABLED=false`), not yet wired into payment flows (v6.4.2) |
 | Mobile launch readiness | Quest auto-triggers, device attestation, JIT funding, rewards (v6.5.0) |
 | SMS multi-rail payments | VertexSMS integration, MPP-gated SMS, MCP tool for AI agents (v7.10.7) |
+| Public MCP server | OAuth-secured Model Context Protocol server at `mcp.zelta.app`, `@finaegis/mcp` npm wrapper (v7.11.0) |
+| Non-custodial wallet | Privy passkey/device-key signing, sponsored EVM + Solana sends, prepare/submit flow (v7.12.0) |
+| Mobile subscriptions | Apple App Store + Google Play IAP verification, pseudonymised receipts, revenue outbox (v7.13.0) |
+| Fiat ↔ stablecoin ramp | Bridge.xyz bank-rail on-ramp, virtual accounts, USDC on Polygon, asymmetric webhook verification (v7.15.0) |
 | Learning modern architecture | Complete DDD + CQRS + Event Sourcing example |
 
 ---
@@ -88,7 +94,7 @@ curl -X POST http://localhost:8000/graphql \
   -d '{"query": "{ accounts { id name balance currency } }"}'
 ```
 
-- **45 domain schemas** — Account, AgentProtocol, AI, Asset, Banking, Basket, Batch, CardIssuance, Cgo, Commerce, Compliance, CrossChain, Custodian, DeFi, Exchange, FinancialInstitution, Fraud, Governance, Interledger, ISO20022, KeyManagement, Ledger, Lending, MachinePay, Microfinance, Mobile, MobilePayment, OpenBanking, Payment, PaymentRails, Plugin, Privacy, Product, RegTech, Regulatory, Relayer, Rewards, SMS, Stablecoin, Treasury, TrustCert, User, Wallet, X402
+- **45 schema imports** — 43 domain schemas (Account, AgentProtocol, AI, Asset, Banking, Basket, Exchange, Compliance, Governance, Lending, Treasury, Wallet, X402, …) plus `directives` and `subscriptions`; see [`graphql/schema.graphql`](graphql/schema.graphql) for the authoritative list
 - **Subscriptions** — Real-time updates via WebSocket (account updates, wallet changes, compliance alerts, order matching)
 - **DataLoaders** — N+1 query prevention with batched loading
 - **Security** — `@guard(with: ["sanctum"])`, query cost analysis, introspection control
@@ -158,7 +164,7 @@ See [ADR-004: GCU Basket Design](docs/ADR/ADR-004-gcu-basket-design.md) for arch
 No external dependencies - everything runs locally:
 
 ```bash
-git clone https://github.com/finaegis/core-banking-prototype-laravel.git
+git clone https://github.com/FinAegis/core-banking-prototype-laravel.git
 cd core-banking-prototype-laravel
 composer install
 cp .env.demo .env
@@ -176,7 +182,7 @@ Visit `http://localhost:8000` with demo credentials:
 ### Full Installation
 
 ```bash
-git clone https://github.com/finaegis/core-banking-prototype-laravel.git
+git clone https://github.com/FinAegis/core-banking-prototype-laravel.git
 cd core-banking-prototype-laravel
 composer install && npm install
 cp .env.example .env
@@ -237,7 +243,7 @@ See [Domain Management Guide](docs/06-DEVELOPMENT/DOMAIN_MANAGEMENT.md) for deta
 |--------|-------------|
 | **Exchange** | Order matching, liquidity pools, AMM, external connectors, WebSocket streaming |
 | **Stablecoin** | Multi-collateral minting, burning, liquidation |
-| **Wallet** | Multi-chain (BTC, ETH, Polygon, BSC), Hardware wallets (Ledger, Trezor), Multi-sig (M-of-N) |
+| **Wallet** | Non-custodial EVM sends (Polygon, Base, Arbitrum) + Solana; USDC receive on Solana/Tron; Ledger/Trezor hardware-wallet integration |
 | **Basket (GCU)** | Weighted currency basket, NAV calculation, rebalancing |
 
 ### Platform Services
@@ -373,7 +379,7 @@ helm upgrade --install finaegis ./helm/finaegis \
 - Prometheus ServiceMonitor for observability
 - Network Policies for pod isolation
 
-See [Kubernetes Deployment Guide](docs/06-DEVELOPMENT/KUBERNETES.md) for details.
+See [Infrastructure & Deployment Guide](docs/06-DEVELOPMENT/INFRASTRUCTURE.md) for details.
 
 ---
 
@@ -401,7 +407,7 @@ Or use the remote URL directly: `https://mcp.zelta.app/mcp`. See [docs/13-AI-FRA
 | **Database** | MySQL 8.0+ / MariaDB 10.3+ / PostgreSQL 13+ |
 | **Cache/Queue/Streaming** | Redis (cache, queues, Streams), Laravel Horizon |
 | **Real-time** | Soketi (Pusher-compatible), Laravel Echo, Redis Streams |
-| **Testing** | Pest PHP (parallel, 886 test files, 6,500+ tests), PHPStan Level 8 |
+| **Testing** | Pest PHP (parallel, 1,170+ test files, 4,900+ tests), PHPStan Level 8 |
 | **Admin** | Filament v3 |
 | **Frontend** | Livewire, Tailwind CSS |
 | **Deployment** | Docker, Kubernetes (Helm), Istio |
@@ -418,14 +424,14 @@ This is a **demonstration platform** showcasing modern banking architecture. Use
 - Contributing to open-source fintech
 - Studying GCU as a basket currency reference
 
-**Production Readiness**: The codebase includes production-grade infrastructure (CQRS, event sourcing, multi-tenancy, GraphQL API, event streaming, 50%+ test coverage, PHPStan Level 8, 6,300+ tests). However, **a security audit and compliance review are required** before any production deployment. See [Security Policy](SECURITY.md) for vulnerability reporting.
+**Production Readiness**: The codebase includes production-grade infrastructure (CQRS, event sourcing, multi-tenancy, GraphQL API, event streaming, 50%+ test coverage, PHPStan Level 8, 4,900+ tests). However, **a security audit and compliance review are required** before any production deployment. See [Security Policy](SECURITY.md) for vulnerability reporting.
 
 ---
 
 ## Community
 
-- [GitHub Discussions](https://github.com/finaegis/core-banking-prototype-laravel/discussions) - Questions & Ideas
-- [GitHub Issues](https://github.com/finaegis/core-banking-prototype-laravel/issues) - Bug Reports
+- [GitHub Discussions](https://github.com/FinAegis/core-banking-prototype-laravel/discussions) - Questions & Ideas
+- [GitHub Issues](https://github.com/FinAegis/core-banking-prototype-laravel/issues) - Bug Reports
 - [Security Policy](SECURITY.md) - Vulnerability Reporting
 - [Code of Conduct](CODE_OF_CONDUCT.md) - Community Guidelines
 - [Changelog](CHANGELOG.md) - Version History


### PR DESCRIPTION
Documentation + GitHub-presentation pass focused on **accuracy first**, from a full audit of the README and repo metadata. No new docs created — all standard health files (LICENSE, CONTRIBUTING, SECURITY, CODE_OF_CONDUCT, issue/PR templates, FUNDING, CODEOWNERS, dependabot) already exist.

## Corrected inaccuracies (the important part)
- **HyperSwitch was presented as "shipped / production-ready" (v6.4.2).** It's actually dormant scaffolding — real client + HMAC-verified webhook, but not bound anywhere, the webhook only logs, `HYPERSWITCH_ENABLED=false`, zero tests. Reworded to *experimental scaffolding, not yet wired into payment flows*. (Wiring it up for real is tracked for a dedicated PR; discussion #346 stays open until then.)
- **Stale version badge** `7.10.10` → dynamic GitHub-release shield (current `v7.14.1`), so it can't drift again. Added the missing post-7.10 milestones (MCP server, wallet send, IAP, Bridge ramp).
- **Test counts were wrong and self-contradictory** (`886 files` / `6,500+ tests` / `6,300+ tests`) → verified `1,170+ files`, `~4,900 tests`, consistent in both places.
- **GitHub description said "56 DDD modules"** → updated to **61** (matches the tree) via API; refreshed topics.
- **Broken link**: `docs/06-DEVELOPMENT/KUBERNETES.md` (missing) → `INFRASTRUCTURE.md`.
- **GraphQL**: replaced the drifting 44-name inline list with "45 imports (43 domains + `directives` + `subscriptions`) → see `graphql/schema.graphql`".
- **Wallet** row aligned to actually-enabled networks (Polygon/Base/Arbitrum + Solana), dropping unimplemented BTC/BSC claims.

## Presentation / trust
- Added a one-line **FinAegis vs Zelta** brand note (resolves the unexplained "Zelta" references in the MCP section).
- **LICENSE detection fix**: restored the Apache `APPENDIX` `[yyyy] [name of copyright owner]` placeholder (a filled-in copyright there made GitHub classify the repo as "Other") and moved the copyright into a standard `NOTICE` file — GitHub will now detect **Apache-2.0**.
- Normalised `github.com/finaegis` → `github.com/FinAegis` link casing.

## Also
- `CLAUDE.md`: note HyperSwitch is experimental scaffolding (not wired).
- Serena `development_continuation_guide`: refreshed badly-stale state (v5.11→v7.14, 56→61 domains) + multi-connection/PHPStan conventions.

The audit served as the content/copywriting/SEO/marketing review (post-phase-review scope). Repo description + topics were applied directly via the GitHub API (not in this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)