### PR TITLE
feat(ops): ops:verify-env production preflight gate + env template sync

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -38,8 +38,10 @@ LOG_LEVEL=warning
 DEMO_INSTANT_DEPOSITS=false
 DEMO_SKIP_KYC=false
 DEMO_MOCK_BANKS=false
+DEMO_MOCK_EXTERNAL_APIS=false
 DEMO_FAKE_BLOCKCHAIN=false
 DEMO_FIXED_EXCHANGE_RATES=false
+DEMO_AUTO_APPROVE=false
 DEMO_AUTO_APPROVE_TRANSACTIONS=false
 DEMO_DEFAULT_DEPOSIT_AMOUNT=0
 DEMO_DEFAULT_CURRENCY=USD
@@ -167,6 +169,10 @@ MOBILE_STALE_DEVICE_DAYS=90
 MOBILE_MAX_BIOMETRIC_FAILURES=5
 MOBILE_BIOMETRIC_BLOCK_MINUTES=30
 
+# Device attestation (Apple App Attest / Google Play Integrity). Keep false
+# until the mobile-supplied challenge is wired through — see config/mobile.php.
+MOBILE_ATTESTATION_ENABLED=false
+
 # =============================================================================
 # BIOMETRIC JWT (v2.6.0+)
 # =============================================================================
@@ -181,6 +187,9 @@ BIOMETRIC_JWT_REVOKED_TTL=24
 HSM_ENABLED=true
 HSM_PROVIDER=aws
 HSM_KEY_ID=
+# Defaults to TRUE in config/keymanagement.php — must be explicitly false in
+# production or a simulated HSM signs in place of the real cloud HSM.
+KEY_MANAGEMENT_DEMO_MODE=false
 
 # =============================================================================
 # PRIVACY / ZK
@@ -275,6 +284,13 @@ ARBITRUM_PAYMASTER_ADDRESS=
 ALCHEMY_API_KEY=
 ALCHEMY_NOTIFY_TOKEN=
 
+# Helius (Solana webhooks, balances + transaction backfill).
+# The API key is passed as a query param (?api-key=) — Helius has no
+# Authorization-header support.
+HELIUS_API_KEY=
+HELIUS_WEBHOOK_ID=
+HELIUS_WEBHOOK_SECRET=
+
 # =============================================================================
 # X402 PROTOCOL — PRODUCTION
 # =============================================================================
@@ -334,6 +350,9 @@ GOPLUS_APP_SECRET=
 # Chainalysis Sanctions Screening (paid, optional)
 CHAINALYSIS_API_KEY=
 CHAINALYSIS_ENABLED=false
+
+# AI services (config/ai.php) — demo mode defaults to TRUE; must be off in prod
+AI_DEMO_MODE=false
 
 # =============================================================================
 # TENANCY

--- a/.env.zelta.example
+++ b/.env.zelta.example
@@ -49,7 +49,7 @@ SHOW_PROMO_PAGES=false
 
 # Admin panel — visible module groups (comma-separated). Empty = show all.
 # Zelta production hides domains that are not part of the mobile wallet scope.
-ADMIN_MODULES="System,Mobile,Relayer,TrustCert,Banking,AI Agents,Commerce,Mobile Payments,Privacy,Fraud Detection,Key Management"
+ADMIN_MODULES="System,Mobile,Relayer,TrustCert,Banking,AI Agents,Commerce,Mobile Payments,Privacy,Fraud Detection,Key Management,MCP"
 
 # =============================================================================
 # DEMO MODE — ALL DISABLED FOR PRODUCTION
@@ -57,8 +57,10 @@ ADMIN_MODULES="System,Mobile,Relayer,TrustCert,Banking,AI Agents,Commerce,Mobile
 DEMO_INSTANT_DEPOSITS=false
 DEMO_SKIP_KYC=false
 DEMO_MOCK_BANKS=false
+DEMO_MOCK_EXTERNAL_APIS=false
 DEMO_FAKE_BLOCKCHAIN=false
 DEMO_FIXED_EXCHANGE_RATES=false
+DEMO_AUTO_APPROVE=false
 DEMO_AUTO_APPROVE_TRANSACTIONS=false
 DEMO_DEFAULT_DEPOSIT_AMOUNT=0
 DEMO_DEFAULT_CURRENCY=USD
@@ -295,6 +297,10 @@ MOBILE_STALE_DEVICE_DAYS=90
 MOBILE_MAX_BIOMETRIC_FAILURES=5
 MOBILE_BIOMETRIC_BLOCK_MINUTES=30
 
+# Device attestation (Apple App Attest / Google Play Integrity). Keep false
+# until the mobile-supplied challenge is wired through — see config/mobile.php.
+MOBILE_ATTESTATION_ENABLED=false
+
 # =============================================================================
 # BIOMETRIC JWT
 # =============================================================================
@@ -309,6 +315,9 @@ BIOMETRIC_JWT_REVOKED_TTL=24
 HSM_ENABLED=true
 HSM_PROVIDER=aws
 HSM_KEY_ID=
+# Defaults to TRUE in config/keymanagement.php — must be explicitly false in
+# production or a simulated HSM signs in place of the real cloud HSM.
+KEY_MANAGEMENT_DEMO_MODE=false
 
 # =============================================================================
 # PRIVACY / ZK
@@ -403,6 +412,13 @@ ARBITRUM_PAYMASTER_ADDRESS=
 ALCHEMY_API_KEY=
 ALCHEMY_NOTIFY_TOKEN=
 
+# Helius (Solana webhooks, balances + transaction backfill).
+# The API key is passed as a query param (?api-key=) — Helius has no
+# Authorization-header support.
+HELIUS_API_KEY=
+HELIUS_WEBHOOK_ID=
+HELIUS_WEBHOOK_SECRET=
+
 # =============================================================================
 # X402 PROTOCOL — PRODUCTION
 # =============================================================================
@@ -467,6 +483,8 @@ CHAINALYSIS_ENABLED=false
 # AI FRAMEWORK
 # =============================================================================
 AI_LLM_PROVIDER=openai
+# Defaults to TRUE in config/ai.php — must be explicitly false in production.
+AI_DEMO_MODE=false
 AI_VECTOR_DB_PROVIDER=pinecone
 AI_AUTO_CREATE_INDEX=false
 AI_CONVERSATION_TTL=86400

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,9 @@ php artisan account:purge-reviewer --email=X --confirm  # anonymizes email + dis
 php artisan bridge:inspect-user user@example.com         # print bridge_customer + va + ramp sessions
 php artisan bridge:sync-dev-fee --email=user@example.com # reconcile dev_fee_bps with current tier
 php artisan bridge:sync-dev-fee --all --dry-run          # batch backfill (preview mode)
+
+# Deploy preflight (CI/CD gate)
+php artisan ops:verify-env --json    # exit 1 = blocked; FAILs only block in production (or --strict)
 ```
 
 ## Architecture

--- a/app/Console/Commands/OpsVerifyEnvCommand.php
+++ b/app/Console/Commands/OpsVerifyEnvCommand.php
@@ -1,0 +1,502 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Wallet\Services\Send\SolanaSponsorSigner;
+use Illuminate\Console\Command;
+use RuntimeException;
+
+/**
+ * ops:verify-env — deploy-time production preflight gate.
+ *
+ * Every production guard in this platform is lazy: IapReceiptPseudonymiser
+ * hard-throws on the first IAP verify request, QuoteSigner refuses to sign the
+ * first pricing quote, BridgeWebhookVerifier fails closed on the first ramp
+ * webhook — all hours after the deploy looked green. This command front-loads
+ * those guards into a single CI/CD gate that runs before traffic does.
+ *
+ * Exit semantics: exit 0 = safe to deploy, exit 1 = blocked. FAIL results only
+ * block when the app environment is production (or when --strict is passed, so
+ * staging pipelines can opt in). WARN never blocks; checks whose feature is
+ * disabled report SKIP.
+ */
+class OpsVerifyEnvCommand extends Command
+{
+    protected $signature = 'ops:verify-env
+        {--json : Machine-readable output}
+        {--strict : Treat FAIL results as blocking even outside production}';
+
+    protected $description = 'Production preflight: verify env/config guards at deploy time instead of on the first customer request';
+
+    private const PASS = 'PASS';
+
+    private const FAIL = 'FAIL';
+
+    private const WARN = 'WARN';
+
+    private const SKIP = 'SKIP';
+
+    private const CATEGORY_CORE = 'core';
+
+    private const CATEGORY_SECRETS = 'secrets';
+
+    private const CATEGORY_BYPASSES = 'bypasses';
+
+    private const CATEGORY_CONDITIONAL = 'conditional';
+
+    private const CATEGORY_FILES = 'files';
+
+    /** @var list<array{name: string, category: string, result: string, detail: string}> */
+    private array $checks = [];
+
+    public function handle(SolanaSponsorSigner $solanaSponsor): int
+    {
+        $this->checks = [];
+        $isProduction = $this->laravel->environment('production');
+
+        $this->checkCore($isProduction);
+        $this->checkSecrets();
+        $this->checkBypasses();
+        $this->checkConditional($solanaSponsor);
+        $this->checkFiles();
+
+        $failed = array_values(array_filter(
+            $this->checks,
+            static fn (array $check): bool => $check['result'] === self::FAIL,
+        ));
+        $blocking = $failed !== [] && ($isProduction || (bool) $this->option('strict'));
+
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode([
+                'status' => $blocking ? 'fail' : 'pass',
+                'checks' => $this->checks,
+            ], JSON_UNESCAPED_SLASHES));
+        } else {
+            $this->renderHuman($failed, $blocking);
+        }
+
+        return $blocking ? self::FAILURE : self::SUCCESS;
+    }
+
+    // ── Category: core ───────────────────────────────────────────────────
+
+    private function checkCore(bool $isProduction): void
+    {
+        if ((bool) config('app.debug', false)) {
+            $this->add(self::CATEGORY_CORE, 'app.debug', self::FAIL, 'APP_DEBUG=true leaks stack traces, config values and SQL to end users — set APP_DEBUG=false.');
+        } else {
+            $this->add(self::CATEGORY_CORE, 'app.debug', self::PASS);
+        }
+
+        if ($this->configString('app.key') === '') {
+            $this->add(self::CATEGORY_CORE, 'app.key', self::FAIL, 'APP_KEY is empty — encryption and signed cookies are broken. Generate with `php artisan key:generate`.');
+        } else {
+            $this->add(self::CATEGORY_CORE, 'app.key', self::PASS);
+        }
+
+        if ($isProduction) {
+            $this->add(self::CATEGORY_CORE, 'app.env', self::PASS, 'APP_ENV=production');
+        } else {
+            $this->add(self::CATEGORY_CORE, 'app.env', self::WARN, sprintf(
+                'APP_ENV=%s — expected production. FAIL results are non-blocking here unless --strict is passed.',
+                $this->environmentName(),
+            ));
+        }
+    }
+
+    // ── Category: secrets ────────────────────────────────────────────────
+
+    private function checkSecrets(): void
+    {
+        $this->requireNonEmpty(
+            self::CATEGORY_SECRETS,
+            'subscription.iap.receipt_pepper',
+            'IAP_RECEIPT_PEPPER is empty — IapReceiptPseudonymiser hard-throws on the first /subscriptions/iap/verify request. Generate with `openssl rand -hex 32` (one-way: never rotate).',
+        );
+
+        $this->requireNonEmpty(
+            self::CATEGORY_SECRETS,
+            'services.stripe.trial_fingerprint_pepper',
+            'TRIAL_FINGERPRINT_PEPPER is empty — trial-card fingerprint hashing fails on the first trial signup. Generate with `openssl rand -hex 32`.',
+        );
+
+        $this->requireNonEmpty(
+            self::CATEGORY_SECRETS,
+            'services.pricing.quote_pepper',
+            'PRICING_QUOTE_PEPPER is empty — QuoteSigner refuses to sign on the first pricing quote. Generate with `openssl rand -hex 32`.',
+        );
+
+        $this->requireNonEmpty(
+            self::CATEGORY_SECRETS,
+            'mobile.biometric_jwt.secret',
+            'BIOMETRIC_JWT_SECRET is empty — biometric JWT signing fails on the first mobile biometric login. Set a random secret of at least 32 bytes.',
+        );
+    }
+
+    // ── Category: bypasses ───────────────────────────────────────────────
+
+    private function checkBypasses(): void
+    {
+        if ((bool) config('subscription.iap.apple_jws_verification_bypass', false)) {
+            $this->add(self::CATEGORY_BYPASSES, 'subscription.iap.apple_jws_verification_bypass', self::FAIL, 'APPLE_JWS_VERIFICATION_BYPASS=true disables Apple receipt chain validation — any authenticated user can forge a Pro subscription. Staging-only; must be false in production.');
+        } else {
+            $this->add(self::CATEGORY_BYPASSES, 'subscription.iap.apple_jws_verification_bypass', self::PASS);
+        }
+
+        $this->checkBridgeWebhookCredentials();
+
+        $this->requireFalse(self::CATEGORY_BYPASSES, 'demo.mode', 'demo.mode is true — the DemoMode middleware treats the whole app as a demo (blocked webhooks, demo banner). Must be off in production.');
+        $this->requireFalse(self::CATEGORY_BYPASSES, 'demo.sandbox.enabled', 'SANDBOX_MODE=true routes payments through SandboxPaymentService instead of the production rail. Must be false in production.');
+        $this->checkDemoFeatureToggles();
+
+        $this->requireFalse(self::CATEGORY_BYPASSES, 'keymanagement.demo_mode', 'KEY_MANAGEMENT_DEMO_MODE resolves to true (config default is true) — a simulated HSM signs in place of the real cloud HSM. Set KEY_MANAGEMENT_DEMO_MODE=false explicitly.');
+        $this->requireFalse(self::CATEGORY_BYPASSES, 'regtech.demo_mode', 'REGTECH_DEMO_MODE resolves to true (config default is true) — regulatory filings/screening run in demo mode. Set REGTECH_DEMO_MODE=false explicitly.');
+        $this->requireFalse(self::CATEGORY_BYPASSES, 'ai.demo_mode', 'AI_DEMO_MODE resolves to true (config default is true) — AI services return canned demo output. Set AI_DEMO_MODE=false explicitly.');
+    }
+
+    private function checkBridgeWebhookCredentials(): void
+    {
+        $routing = config('kyc.routing');
+        $routesToBridge = is_array($routing) && in_array('bridge', $routing, true);
+
+        if (! $routesToBridge) {
+            $this->add(self::CATEGORY_BYPASSES, 'kyc.providers.bridge', self::SKIP, 'No KYC purpose routes to the bridge provider (kyc.routing).');
+
+            return;
+        }
+
+        $missing = [];
+
+        if ($this->configString('kyc.providers.bridge.api_key') === '') {
+            $missing[] = 'BRIDGE_API_KEY';
+        }
+
+        if (
+            $this->configString('kyc.providers.bridge.webhook_public_key') === ''
+            && $this->configString('kyc.providers.bridge.webhook_secret') === ''
+        ) {
+            $missing[] = 'BRIDGE_WEBHOOK_PUBLIC_KEY (or legacy BRIDGE_WEBHOOK_SECRET)';
+        }
+
+        if ($missing !== []) {
+            $this->add(self::CATEGORY_BYPASSES, 'kyc.providers.bridge', self::FAIL, sprintf(
+                'Bridge is the active ramp/KYC provider but %s empty. With no webhook credential BridgeWebhookVerifier rejects every webhook (401) in production — KYC approvals and ramp activity never land.',
+                implode(' and ', $missing) . (count($missing) > 1 ? ' are' : ' is'),
+            ));
+
+            return;
+        }
+
+        $this->add(self::CATEGORY_BYPASSES, 'kyc.providers.bridge', self::PASS);
+    }
+
+    private function checkDemoFeatureToggles(): void
+    {
+        $features = config('demo.features');
+        $enabled = [];
+
+        if (is_array($features)) {
+            foreach ($features as $feature => $value) {
+                if ((bool) $value) {
+                    $enabled[] = (string) $feature;
+                }
+            }
+        }
+
+        if ($enabled !== []) {
+            $this->add(self::CATEGORY_BYPASSES, 'demo.features', self::FAIL, sprintf(
+                'Demo feature toggles enabled: %s. These default to true — set DEMO_INSTANT_DEPOSITS, DEMO_SKIP_KYC, DEMO_MOCK_EXTERNAL_APIS, DEMO_FIXED_EXCHANGE_RATES and DEMO_AUTO_APPROVE to false in production.',
+                implode(', ', $enabled),
+            ));
+
+            return;
+        }
+
+        $this->add(self::CATEGORY_BYPASSES, 'demo.features', self::PASS);
+    }
+
+    // ── Category: conditional ────────────────────────────────────────────
+
+    private function checkConditional(SolanaSponsorSigner $solanaSponsor): void
+    {
+        if ((bool) config('hyperswitch.enabled', false)) {
+            $missing = [];
+
+            if ($this->configString('hyperswitch.api_key') === '') {
+                $missing[] = 'HYPERSWITCH_API_KEY';
+            }
+
+            if ($this->configString('hyperswitch.webhook_secret') === '') {
+                $missing[] = 'HYPERSWITCH_WEBHOOK_SECRET';
+            }
+
+            if ($missing !== []) {
+                $this->add(self::CATEGORY_CONDITIONAL, 'hyperswitch.credentials', self::FAIL, sprintf(
+                    'HYPERSWITCH_ENABLED=true but %s empty — card deposits route to HyperSwitch and either fail at intent creation or webhook credits are rejected as unverifiable.',
+                    implode(' and ', $missing) . (count($missing) > 1 ? ' are' : ' is'),
+                ));
+            } else {
+                $this->add(self::CATEGORY_CONDITIONAL, 'hyperswitch.credentials', self::PASS);
+            }
+        } else {
+            $this->add(self::CATEGORY_CONDITIONAL, 'hyperswitch.credentials', self::SKIP, 'HYPERSWITCH_ENABLED=false — Stripe remains the deposit rail.');
+        }
+
+        if ($solanaSponsor->isEnabled()) {
+            try {
+                $address = $solanaSponsor->publicKeyBase58();
+                $this->add(self::CATEGORY_CONDITIONAL, 'wallet.solana.sponsor.secret_key', self::PASS, sprintf('Sponsor fee-payer address %s.', $address));
+            } catch (RuntimeException $e) {
+                $this->add(self::CATEGORY_CONDITIONAL, 'wallet.solana.sponsor.secret_key', self::FAIL, $e->getMessage() . ' Every sponsored Solana send would fail at signing time.');
+            }
+        } else {
+            $this->add(self::CATEGORY_CONDITIONAL, 'wallet.solana.sponsor.secret_key', self::SKIP, 'WALLET_SOLANA_SPONSOR_SECRET_KEY not set — Solana sends fall back to sender-pays-fee.');
+        }
+
+        if ($this->configString('services.helius.api_key') === '') {
+            $this->add(self::CATEGORY_CONDITIONAL, 'services.helius.api_key', self::WARN, 'HELIUS_API_KEY is empty — Solana webhook sync, balance lookups and transaction backfill will fail if the Solana wallet surface is live.');
+        } else {
+            $this->add(self::CATEGORY_CONDITIONAL, 'services.helius.api_key', self::PASS);
+        }
+
+        if ((bool) config('mobile.attestation.enabled', false)) {
+            $missing = [];
+            $required = [
+                'mobile.attestation.apple.team_id'           => 'APPLE_TEAM_ID',
+                'mobile.attestation.apple.bundle_id'         => 'APPLE_BUNDLE_ID',
+                'mobile.attestation.google.package_name'     => 'GOOGLE_PACKAGE_NAME',
+                'mobile.attestation.google.decryption_key'   => 'GOOGLE_INTEGRITY_DECRYPTION_KEY',
+                'mobile.attestation.google.verification_key' => 'GOOGLE_INTEGRITY_VERIFICATION_KEY',
+            ];
+
+            foreach ($required as $configKey => $envName) {
+                if ($this->configString($configKey) === '') {
+                    $missing[] = $envName;
+                }
+            }
+
+            if ($missing !== []) {
+                $this->add(self::CATEGORY_CONDITIONAL, 'mobile.attestation', self::FAIL, sprintf(
+                    'MOBILE_ATTESTATION_ENABLED=true but missing: %s — device attestation rejects every client.',
+                    implode(', ', $missing),
+                ));
+            } else {
+                $this->add(self::CATEGORY_CONDITIONAL, 'mobile.attestation', self::PASS);
+            }
+        } else {
+            $this->add(self::CATEGORY_CONDITIONAL, 'mobile.attestation', self::SKIP, 'MOBILE_ATTESTATION_ENABLED=false.');
+        }
+
+        if ((bool) config('privy.web_login_enabled', false)) {
+            $missing = [];
+            $required = [
+                'privy.app_id'     => 'PRIVY_APP_ID',
+                'privy.app_secret' => 'PRIVY_APP_SECRET',
+                'privy.jwks_url'   => 'PRIVY_JWKS_URL',
+            ];
+
+            foreach ($required as $configKey => $envName) {
+                if ($this->configString($configKey) === '') {
+                    $missing[] = $envName;
+                }
+            }
+
+            if ($missing !== []) {
+                $this->add(self::CATEGORY_CONDITIONAL, 'privy.web_login', self::FAIL, sprintf(
+                    'MCP_WEB_PRIVY_LOGIN=true but missing: %s — the web /login surface 500s on the first OTP request.',
+                    implode(', ', $missing),
+                ));
+            } else {
+                $this->add(self::CATEGORY_CONDITIONAL, 'privy.web_login', self::PASS);
+            }
+        } else {
+            $this->add(self::CATEGORY_CONDITIONAL, 'privy.web_login', self::SKIP, 'MCP_WEB_PRIVY_LOGIN=false — legacy Jetstream login in use.');
+        }
+    }
+
+    // ── Category: files ──────────────────────────────────────────────────
+
+    private function checkFiles(): void
+    {
+        $path = $this->configString('subscription.iap.apple.root_ca_path');
+
+        if ($path === '') {
+            $this->add(self::CATEGORY_FILES, 'subscription.iap.apple.root_ca', self::SKIP, 'subscription.iap.apple.root_ca_path is empty — Apple IAP not configured.');
+
+            return;
+        }
+
+        if (! is_file($path)) {
+            $this->add(self::CATEGORY_FILES, 'subscription.iap.apple.root_ca', self::FAIL, sprintf(
+                'Apple Root CA missing at %s — Apple JWS chain validation fails on every IAP receipt and store notification.',
+                $path,
+            ));
+
+            return;
+        }
+
+        $actual = hash_file('sha256', $path);
+
+        if ($actual === false) {
+            $this->add(self::CATEGORY_FILES, 'subscription.iap.apple.root_ca', self::FAIL, sprintf('Could not read %s to compute its sha256 fingerprint.', $path));
+
+            return;
+        }
+
+        $pinned = $this->pinnedAppleFingerprints();
+
+        if ($pinned === []) {
+            $this->add(self::CATEGORY_FILES, 'subscription.iap.apple.root_ca', self::FAIL, 'subscription.iap.apple.root_ca_fingerprints is empty — nothing to pin the Apple root certificate against.');
+
+            return;
+        }
+
+        if (! in_array(strtolower($actual), $pinned, true)) {
+            $this->add(self::CATEGORY_FILES, 'subscription.iap.apple.root_ca', self::FAIL, sprintf(
+                'sha256(%s) = %s does not match any pinned fingerprint (%s) — the bundled certificate was replaced or corrupted.',
+                $path,
+                $actual,
+                implode(', ', $pinned),
+            ));
+
+            return;
+        }
+
+        $this->add(self::CATEGORY_FILES, 'subscription.iap.apple.root_ca', self::PASS, 'Bundled Apple Root CA matches the pinned sha256 fingerprint.');
+    }
+
+    /**
+     * Pinned Apple root fingerprints, lowercased with colon separators removed.
+     *
+     * @return list<string>
+     */
+    private function pinnedAppleFingerprints(): array
+    {
+        $configured = config('subscription.iap.apple.root_ca_fingerprints');
+
+        if (! is_array($configured)) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ($configured as $fingerprint) {
+            if (! is_string($fingerprint)) {
+                continue;
+            }
+
+            $fingerprint = strtolower(str_replace(':', '', trim($fingerprint)));
+
+            if ($fingerprint !== '') {
+                $normalized[] = $fingerprint;
+            }
+        }
+
+        return $normalized;
+    }
+
+    // ── Plumbing ─────────────────────────────────────────────────────────
+
+    private function requireNonEmpty(string $category, string $configKey, string $failDetail): void
+    {
+        if ($this->configString($configKey) === '') {
+            $this->add($category, $configKey, self::FAIL, $failDetail);
+
+            return;
+        }
+
+        $this->add($category, $configKey, self::PASS);
+    }
+
+    private function requireFalse(string $category, string $configKey, string $failDetail): void
+    {
+        if ((bool) config($configKey, false)) {
+            $this->add($category, $configKey, self::FAIL, $failDetail);
+
+            return;
+        }
+
+        $this->add($category, $configKey, self::PASS);
+    }
+
+    private function configString(string $key): string
+    {
+        $value = config($key);
+
+        if (is_string($value)) {
+            return trim($value);
+        }
+
+        if (is_int($value) || is_float($value)) {
+            return trim((string) $value);
+        }
+
+        return '';
+    }
+
+    private function environmentName(): string
+    {
+        $environment = $this->laravel->environment();
+
+        return is_string($environment) ? $environment : 'unknown';
+    }
+
+    private function add(string $category, string $name, string $result, string $detail = ''): void
+    {
+        $this->checks[] = [
+            'name'     => $name,
+            'category' => $category,
+            'result'   => $result,
+            'detail'   => $detail,
+        ];
+    }
+
+    /**
+     * @param list<array{name: string, category: string, result: string, detail: string}> $failed
+     */
+    private function renderHuman(array $failed, bool $blocking): void
+    {
+        $counts = [self::PASS => 0, self::FAIL => 0, self::WARN => 0, self::SKIP => 0];
+
+        foreach ($this->checks as $check) {
+            $counts[$check['result']]++;
+
+            $line = sprintf('[%s] %-12s %s', $check['result'], $check['category'], $check['name']);
+
+            if ($check['detail'] !== '') {
+                $line .= ' — ' . $check['detail'];
+            }
+
+            if ($check['result'] === self::FAIL) {
+                $this->error($line);
+            } elseif ($check['result'] === self::WARN) {
+                $this->warn($line);
+            } else {
+                $this->line($line);
+            }
+        }
+
+        $this->newLine();
+        $this->line(sprintf(
+            '%d passed, %d failed, %d warnings, %d skipped.',
+            $counts[self::PASS],
+            $counts[self::FAIL],
+            $counts[self::WARN],
+            $counts[self::SKIP],
+        ));
+
+        if ($blocking) {
+            $this->error('ops:verify-env FAILED — deploy blocked. Fix the FAIL results above before shipping.');
+        } elseif ($failed !== []) {
+            $this->warn(sprintf(
+                '%d FAIL result(s) present but non-blocking in the "%s" environment — pass --strict to block.',
+                count($failed),
+                $this->environmentName(),
+            ));
+        } else {
+            $this->info('ops:verify-env: all preflight checks passed.');
+        }
+    }
+}

--- a/tests/Feature/Console/OpsVerifyEnvCommandTest.php
+++ b/tests/Feature/Console/OpsVerifyEnvCommandTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Artisan;
+
+/**
+ * Configure every check the preflight gate runs to a production-safe value.
+ *
+ * The testing environment intentionally ships with several "FAIL" defaults
+ * (empty peppers, demo modes defaulting to true), so the happy path must set
+ * the full surface explicitly.
+ */
+function opsVerifyEnvAllGoodConfig(): void
+{
+    config([
+        // core
+        'app.debug' => false,
+        'app.key'   => 'base64:' . base64_encode(random_bytes(32)),
+
+        // secrets
+        'subscription.iap.receipt_pepper'          => 'test-iap-pepper',
+        'services.stripe.trial_fingerprint_pepper' => 'test-trial-pepper',
+        'services.pricing.quote_pepper'            => 'test-quote-pepper',
+        'mobile.biometric_jwt.secret'              => str_repeat('s', 32),
+
+        // bypasses
+        'subscription.iap.apple_jws_verification_bypass' => false,
+        'kyc.routing'                                    => ['trustcert' => 'ondato', 'ramp' => 'bridge', 'cards' => 'bridge'],
+        'kyc.providers.bridge.api_key'                   => 'bridge-api-key',
+        'kyc.providers.bridge.webhook_public_key'        => '-----BEGIN PUBLIC KEY-----test',
+        'kyc.providers.bridge.webhook_secret'            => '',
+        'demo.mode'                                      => false,
+        'demo.sandbox.enabled'                           => false,
+        'demo.features'                                  => [
+            'instant_deposits'     => false,
+            'skip_kyc'             => false,
+            'mock_external_apis'   => false,
+            'fixed_exchange_rates' => false,
+            'auto_approve'         => false,
+        ],
+        'keymanagement.demo_mode' => false,
+        'regtech.demo_mode'       => false,
+        'ai.demo_mode'            => false,
+
+        // conditional
+        'hyperswitch.enabled'              => false,
+        'wallet.solana.sponsor.secret_key' => '',
+        'services.helius.api_key'          => 'test-helius-key',
+        'mobile.attestation.enabled'       => false,
+        'privy.web_login_enabled'          => false,
+
+        // files — the repo ships storage/app/apple/AppleRootCA-G3.cer, whose
+        // sha256 matches the default pinned fingerprint in config/subscription.php.
+    ]);
+}
+
+it('exits 0 in production when every check passes', function (): void {
+    opsVerifyEnvAllGoodConfig();
+    app()->detectEnvironment(fn () => 'production');
+
+    $this->artisan('ops:verify-env')
+        ->expectsOutputToContain('all preflight checks passed')
+        ->assertExitCode(0);
+});
+
+it('blocks the deploy in production when app.debug is true', function (): void {
+    opsVerifyEnvAllGoodConfig();
+    config(['app.debug' => true]);
+    app()->detectEnvironment(fn () => 'production');
+
+    $this->artisan('ops:verify-env')
+        ->expectsOutputToContain('app.debug')
+        ->assertExitCode(1);
+});
+
+it('blocks the deploy in production when IAP_RECEIPT_PEPPER is empty', function (): void {
+    opsVerifyEnvAllGoodConfig();
+    config(['subscription.iap.receipt_pepper' => '']);
+    app()->detectEnvironment(fn () => 'production');
+
+    $this->artisan('ops:verify-env')
+        ->expectsOutputToContain('subscription.iap.receipt_pepper')
+        ->assertExitCode(1);
+});
+
+it('blocks the deploy in production when the Apple JWS verification bypass is on', function (): void {
+    opsVerifyEnvAllGoodConfig();
+    config(['subscription.iap.apple_jws_verification_bypass' => true]);
+    app()->detectEnvironment(fn () => 'production');
+
+    $this->artisan('ops:verify-env')
+        ->expectsOutputToContain('apple_jws_verification_bypass')
+        ->assertExitCode(1);
+});
+
+it('blocks the deploy in production when HyperSwitch is enabled without a webhook secret', function (): void {
+    opsVerifyEnvAllGoodConfig();
+    config([
+        'hyperswitch.enabled'        => true,
+        'hyperswitch.api_key'        => 'hs-api-key',
+        'hyperswitch.webhook_secret' => '',
+    ]);
+    app()->detectEnvironment(fn () => 'production');
+
+    $this->artisan('ops:verify-env')
+        ->expectsOutputToContain('HYPERSWITCH_WEBHOOK_SECRET')
+        ->assertExitCode(1);
+});
+
+it('reports HyperSwitch as skipped when the flag is off', function (): void {
+    opsVerifyEnvAllGoodConfig();
+    app()->detectEnvironment(fn () => 'production');
+
+    $this->artisan('ops:verify-env')
+        ->expectsOutputToContain('HYPERSWITCH_ENABLED=false')
+        ->assertExitCode(0);
+});
+
+it('blocks the deploy in production when the Solana sponsor key is malformed', function (): void {
+    opsVerifyEnvAllGoodConfig();
+    config(['wallet.solana.sponsor.secret_key' => 'not-valid-base58-0OIl']);
+    app()->detectEnvironment(fn () => 'production');
+
+    $this->artisan('ops:verify-env')
+        ->expectsOutputToContain('wallet.solana.sponsor.secret_key')
+        ->assertExitCode(1);
+});
+
+it('blocks the deploy in production when Bridge is routed but has no credentials', function (): void {
+    opsVerifyEnvAllGoodConfig();
+    config([
+        'kyc.providers.bridge.api_key'            => '',
+        'kyc.providers.bridge.webhook_public_key' => '',
+        'kyc.providers.bridge.webhook_secret'     => '',
+    ]);
+    app()->detectEnvironment(fn () => 'production');
+
+    $this->artisan('ops:verify-env')
+        ->expectsOutputToContain('kyc.providers.bridge')
+        ->assertExitCode(1);
+});
+
+it('only warns (never blocks) on a missing Helius API key', function (): void {
+    opsVerifyEnvAllGoodConfig();
+    config(['services.helius.api_key' => '']);
+    app()->detectEnvironment(fn () => 'production');
+
+    $this->artisan('ops:verify-env')
+        ->expectsOutputToContain('HELIUS_API_KEY')
+        ->assertExitCode(0);
+});
+
+it('does not block outside production without --strict', function (): void {
+    opsVerifyEnvAllGoodConfig();
+    config(['subscription.iap.receipt_pepper' => '']); // a real FAIL
+
+    $this->artisan('ops:verify-env')
+        ->expectsOutputToContain('non-blocking')
+        ->assertExitCode(0);
+});
+
+it('blocks outside production when --strict is passed', function (): void {
+    opsVerifyEnvAllGoodConfig();
+    config(['subscription.iap.receipt_pepper' => '']); // a real FAIL
+
+    $this->artisan('ops:verify-env --strict')
+        ->assertExitCode(1);
+});
+
+it('emits parseable JSON with name/category/result/detail per check', function (): void {
+    opsVerifyEnvAllGoodConfig();
+    app()->detectEnvironment(fn () => 'production');
+
+    $exitCode = Artisan::call('ops:verify-env', ['--json' => true]);
+    $decoded = json_decode(Artisan::output(), true);
+
+    expect($exitCode)->toBe(0)
+        ->and($decoded)->toBeArray()
+        ->and($decoded['status'])->toBe('pass')
+        ->and($decoded['checks'])->toBeArray()
+        ->and(count($decoded['checks']))->toBeGreaterThanOrEqual(16)
+        ->and($decoded['checks'][0])->toHaveKeys(['name', 'category', 'result', 'detail']);
+});
+
+it('reports status fail in JSON when a blocking failure exists in production', function (): void {
+    opsVerifyEnvAllGoodConfig();
+    config(['app.debug' => true]);
+    app()->detectEnvironment(fn () => 'production');
+
+    $exitCode = Artisan::call('ops:verify-env', ['--json' => true]);
+    $decoded = json_decode(Artisan::output(), true);
+
+    expect($exitCode)->toBe(1)
+        ->and($decoded['status'])->toBe('fail');
+
+    $debugCheck = collect($decoded['checks'])->firstWhere('name', 'app.debug');
+    expect($debugCheck)->not->toBeNull()
+        ->and($debugCheck['result'])->toBe('FAIL');
+});


### PR DESCRIPTION
## Summary

Every production guard in this platform is lazy: `IapReceiptPseudonymiser` hard-throws on the first IAP verify request, `QuoteSigner` refuses to sign the first pricing quote, `BridgeWebhookVerifier` fails closed on the first ramp webhook — all hours after the deploy looked green. A misdeployed `.env` therefore breaks money flows on first customer use.

This PR adds **`php artisan ops:verify-env`** — a deploy-time preflight gate (exit 1 = blocked deploy) that front-loads those guards:

- **core**: `APP_DEBUG=false`, `APP_KEY` set, `APP_ENV` expectation
- **secrets**: `IAP_RECEIPT_PEPPER`, `TRIAL_FINGERPRINT_PEPPER`, `PRICING_QUOTE_PEPPER`, `BIOMETRIC_JWT_SECRET` non-empty
- **bypasses**: `APPLE_JWS_VERIFICATION_BYPASS` off; Bridge webhook dev-passthrough closed (`BRIDGE_API_KEY` + a webhook credential when `kyc.routing.* = bridge`); all demo-mode toggles off (`demo.mode`, `demo.sandbox.enabled`, `demo.features.*`, `keymanagement/regtech/ai demo_mode`)
- **conditional**: HyperSwitch secrets when `HYPERSWITCH_ENABLED`; Solana sponsor key parses as base58 64-byte ed25519 (reuses `SolanaSponsorSigner`); Helius key WARN; mobile-attestation + Privy web-login config blocks
- **files**: Apple Root CA G3 present and SHA-256 fingerprint matches the configured pin

FAILs only block in `production` (or with `--strict` for staging pipelines); WARNs never block; disabled features report SKIP. `--json` for automation.

Also syncs the env templates (`HELIUS_*`, `MOBILE_ATTESTATION_ENABLED`, demo flags pinned false, `ADMIN_MODULES` gains `MCP` in the Zelta template) — several demo feature flags **default to true** in config, so template-following deploys now pin them off explicitly.

## Tests

- `tests/Feature/Console/OpsVerifyEnvCommandTest.php` — 13 tests / 35 assertions, green locally.
- ⚠️ Note: current PR CI does **not** execute `tests/Feature/Console` (the test-execution hole being fixed in the companion CI PR). Merge that one first, then update this branch so the suite actually gates this PR.

## Deployment follow-up (not in this PR)

Wire `php artisan ops:verify-env` as a blocking step in the deploy workflow once it exists in main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)