### PR TITLE
feat(ops): route critical alerts to Slack via log stack + gate metrics endpoints

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -27,10 +27,17 @@ APP_MAINTENANCE_DRIVER=file
 BCRYPT_ROUNDS=12
 
 LOG_CHANNEL=stack
-LOG_STACK=daily
+# Leave LOG_STACK unset: it defaults to "daily" and auto-adds "slack" when
+# LOG_SLACK_WEBHOOK_URL is set. An explicit LOG_STACK overrides the default.
+#LOG_STACK=daily
 LOG_DAILY_DAYS=14
 LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=warning
+# Setting LOG_SLACK_WEBHOOK_URL auto-enables Slack alerting for critical logs
+LOG_SLACK_WEBHOOK_URL=
+LOG_SLACK_USERNAME="Zelta Ops"
+LOG_SLACK_EMOJI=:rotating_light:
+LOG_SLACK_LEVEL=critical
 
 # =============================================================================
 # DEMO MODE — ALL DISABLED FOR PRODUCTION
@@ -133,6 +140,12 @@ CSP_WS_ENDPOINT=wss://ws.your-domain.com
 
 # Sanctum Token Expiration (minutes, 1440 = 24 hours)
 SANCTUM_TOKEN_EXPIRATION=1440
+
+# Metrics endpoint gate (/api/monitoring/{metrics,prometheus}, /api/metrics/prometheus).
+# Bearer token for the Prometheus scraper; required in production (403 otherwise)
+METRICS_TOKEN=
+# Optional comma-separated IP allowlist as an alternative to the bearer token
+METRICS_ALLOWED_IPS=
 
 # =============================================================================
 # MOBILE APP

--- a/.env.zelta.example
+++ b/.env.zelta.example
@@ -26,10 +26,17 @@ APP_MAINTENANCE_DRIVER=file
 BCRYPT_ROUNDS=12
 
 LOG_CHANNEL=stack
-LOG_STACK=daily
+# Leave LOG_STACK unset: it defaults to "daily" and auto-adds "slack" when
+# LOG_SLACK_WEBHOOK_URL is set. An explicit LOG_STACK overrides the default.
+#LOG_STACK=daily
 LOG_DAILY_DAYS=14
 LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=warning
+# Setting LOG_SLACK_WEBHOOK_URL auto-enables Slack alerting for critical logs
+LOG_SLACK_WEBHOOK_URL=
+LOG_SLACK_USERNAME="Zelta Ops"
+LOG_SLACK_EMOJI=:rotating_light:
+LOG_SLACK_LEVEL=critical
 
 # =============================================================================
 # BRANDING
@@ -134,6 +141,12 @@ CSP_CONNECT_SOURCES=
 
 # Sanctum Token Expiration (minutes, 1440 = 24 hours)
 SANCTUM_TOKEN_EXPIRATION=1440
+
+# Metrics endpoint gate (/api/monitoring/{metrics,prometheus}, /api/metrics/prometheus).
+# Bearer token for the Prometheus scraper; required in production (403 otherwise)
+METRICS_TOKEN=
+# Optional comma-separated IP allowlist as an alternative to the bearer token
+METRICS_ALLOWED_IPS=
 
 # =============================================================================
 # PUSHER (Broadcasting)

--- a/app/Http/Middleware/MetricsAccessMiddleware.php
+++ b/app/Http/Middleware/MetricsAccessMiddleware.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Gates the Prometheus metrics endpoints, which expose business metrics
+ * (user counts, transaction volumes) that must not be public in production.
+ *
+ * Access is granted when either:
+ *  - the request carries a bearer token matching config('monitoring.metrics_token'), or
+ *  - the request IP is in config('monitoring.metrics_allowed_ips').
+ *
+ * When neither a token nor an allowlist is configured, the gate fails closed
+ * in production (403) and stays open in non-production environments.
+ */
+class MetricsAccessMiddleware
+{
+    /**
+     * @param Closure(Request): (Response) $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $token = (string) config('monitoring.metrics_token');
+
+        if ($token !== '' && hash_equals($token, (string) $request->bearerToken())) {
+            return $next($request);
+        }
+
+        $allowedIps = config('monitoring.metrics_allowed_ips', []);
+        $allowedIps = is_array($allowedIps) ? $allowedIps : [];
+
+        if ($allowedIps !== [] && in_array((string) $request->ip(), $allowedIps, true)) {
+            return $next($request);
+        }
+
+        // Nothing configured: dev convenience outside production, fail closed in production.
+        if ($token === '' && $allowedIps === [] && ! app()->environment('production')) {
+            return $next($request);
+        }
+
+        return response()->json([
+            'error'   => 'Forbidden',
+            'message' => 'Metrics access requires a valid bearer token or an allowlisted IP.',
+        ], Response::HTTP_FORBIDDEN);
+    }
+}

--- a/config/logging.php
+++ b/config/logging.php
@@ -53,8 +53,11 @@ return [
     'channels' => [
 
         'stack' => [
-            'driver'            => 'stack',
-            'channels'          => explode(',', env('LOG_STACK', 'daily')),
+            'driver' => 'stack',
+            // Setting LOG_SLACK_WEBHOOK_URL auto-includes the slack channel so
+            // critical/emergency logs page the ops Slack with zero extra config.
+            // An explicit LOG_STACK always wins.
+            'channels'          => explode(',', (string) env('LOG_STACK', env('LOG_SLACK_WEBHOOK_URL') ? 'daily,slack' : 'daily')),
             'ignore_exceptions' => false,
         ],
 
@@ -74,11 +77,13 @@ return [
         ],
 
         'slack' => [
-            'driver'               => 'slack',
-            'url'                  => env('LOG_SLACK_WEBHOOK_URL'),
-            'username'             => env('LOG_SLACK_USERNAME', 'Laravel Log'),
-            'emoji'                => env('LOG_SLACK_EMOJI', ':boom:'),
-            'level'                => env('LOG_LEVEL', 'critical'),
+            'driver'   => 'slack',
+            'url'      => env('LOG_SLACK_WEBHOOK_URL'),
+            'username' => env('LOG_SLACK_USERNAME', 'Laravel Log'),
+            'emoji'    => env('LOG_SLACK_EMOJI', ':boom:'),
+            // Independently tunable: never inherits LOG_LEVEL (a global
+            // LOG_LEVEL=warning would otherwise spam Slack with warnings).
+            'level'                => env('LOG_SLACK_LEVEL', 'critical'),
             'replace_placeholders' => true,
         ],
 

--- a/config/monitoring.php
+++ b/config/monitoring.php
@@ -24,6 +24,14 @@ return [
         ],
     ],
 
+    // Access control for the metrics endpoints (/api/monitoring/{metrics,prometheus},
+    // /api/metrics/prometheus). See App\Http\Middleware\MetricsAccessMiddleware.
+    'metrics_token'       => env('METRICS_TOKEN'),
+    'metrics_allowed_ips' => array_values(array_filter(
+        array_map('trim', explode(',', (string) env('METRICS_ALLOWED_IPS', ''))),
+        static fn (string $ip): bool => $ip !== ''
+    )),
+
     'health' => [
         'checks' => [
             'database' => true,
@@ -53,28 +61,8 @@ return [
         ],
     ],
 
-    'alerts' => [
-        'enabled'  => env('MONITORING_ALERTS_ENABLED', true),
-        'channels' => [
-            'log'   => true,
-            'slack' => env('MONITORING_SLACK_ENABLED', false),
-            'email' => env('MONITORING_EMAIL_ENABLED', false),
-        ],
-        'thresholds' => [
-            'response_time' => [
-                'warning'  => 1.0, // seconds
-                'critical' => 3.0, // seconds
-            ],
-            'error_rate' => [
-                'warning'  => 0.05, // 5%
-                'critical' => 0.10, // 10%
-            ],
-            'memory_usage' => [
-                'warning'  => 0.75, // 75%
-                'critical' => 0.90, // 90%
-            ],
-        ],
-    ],
+    // Alerting goes through the logging stack: the 'slack' channel in config/logging.php
+    // routes Log::critical()/emergency() to Slack when LOG_SLACK_WEBHOOK_URL is set.
 
     'logging' => [
         'structured'         => env('STRUCTURED_LOGGING', true),

--- a/helm/finaegis/templates/servicemonitor.yaml
+++ b/helm/finaegis/templates/servicemonitor.yaml
@@ -17,6 +17,10 @@ spec:
       path: {{ .Values.serviceMonitor.path }}
       interval: {{ .Values.serviceMonitor.interval }}
       scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- with .Values.serviceMonitor.bearerTokenSecret }}
+      bearerTokenSecret:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/helm/finaegis/values.yaml
+++ b/helm/finaegis/values.yaml
@@ -281,6 +281,13 @@ serviceMonitor:
   interval: 30s
   path: /api/monitoring/prometheus
   scrapeTimeout: 10s
+  # The metrics endpoints are gated by METRICS_TOKEN (MetricsAccessMiddleware);
+  # in production Prometheus must scrape with that token (or be allowlisted via
+  # METRICS_ALLOWED_IPS). Reference a Secret holding the token, e.g.:
+  # bearerTokenSecret:
+  #   name: finaegis-metrics-token
+  #   key: token
+  bearerTokenSecret: {}
   labels: {}
 
 # ============================================================================

--- a/routes/api.php
+++ b/routes/api.php
@@ -47,17 +47,24 @@ Route::get('/', function () {
     ]);
 })->name('api.root');
 
-// Monitoring endpoints (public - for Prometheus and Kubernetes)
+// Monitoring endpoints. Health probes stay public (Kubernetes liveness/readiness);
+// metrics endpoints are gated (token or IP allowlist) — they expose business metrics.
 Route::prefix('monitoring')->group(function () {
-    Route::get('/metrics', [App\Http\Controllers\Api\MonitoringController::class, 'prometheus'])->name('monitoring.metrics');
-    Route::get('/prometheus', [App\Http\Controllers\Api\MonitoringController::class, 'prometheus'])->name('monitoring.prometheus');
+    Route::get('/metrics', [App\Http\Controllers\Api\MonitoringController::class, 'prometheus'])
+        ->middleware(App\Http\Middleware\MetricsAccessMiddleware::class)
+        ->name('monitoring.metrics');
+    Route::get('/prometheus', [App\Http\Controllers\Api\MonitoringController::class, 'prometheus'])
+        ->middleware(App\Http\Middleware\MetricsAccessMiddleware::class)
+        ->name('monitoring.prometheus');
     Route::get('/health', [App\Http\Controllers\Api\MonitoringController::class, 'health'])->name('monitoring.health');
     Route::get('/ready', [App\Http\Controllers\Api\MonitoringController::class, 'ready'])->name('monitoring.ready');
     Route::get('/alive', [App\Http\Controllers\Api\MonitoringController::class, 'alive'])->name('monitoring.alive');
 });
 
-// Domain metrics endpoints (public - for Prometheus scraping)
-Route::get('/metrics/prometheus', [App\Http\Controllers\Api\MetricsController::class, 'prometheus'])->name('metrics.prometheus');
+// Domain metrics endpoint for Prometheus scraping (gated: token or IP allowlist)
+Route::get('/metrics/prometheus', [App\Http\Controllers\Api\MetricsController::class, 'prometheus'])
+    ->middleware(App\Http\Middleware\MetricsAccessMiddleware::class)
+    ->name('metrics.prometheus');
 Route::get('/health', [App\Http\Controllers\Api\MetricsController::class, 'health'])->name('health.quick');
 
 // WebSocket configuration endpoints (public - for client initialization)

--- a/routes/console.php
+++ b/routes/console.php
@@ -109,8 +109,7 @@ Schedule::command('system:health-check')
     ->appendOutputTo(storage_path('logs/system-health.log'))
     ->withoutOverlapping()
     ->onFailure(function () {
-        // Use error level instead of critical to reduce memory usage
-        error_log('System health check failed to run');
+        Log::critical('System health check failed to run');
     })
     ->environments(['production', 'staging']);
 
@@ -201,7 +200,7 @@ Schedule::command('fraud:scan-anomalies --hours=' . config('fraud.batch.lookback
     ->appendOutputTo(storage_path('logs/fraud-anomaly-scan.log'))
     ->withoutOverlapping()
     ->onFailure(function () {
-        Log::warning('Fraud anomaly batch scan failed to run');
+        Log::error('Fraud anomaly batch scan failed to run');
     });
 
 // TrustCert Certificate Management

--- a/tests/Feature/Monitoring/MetricsAccessTest.php
+++ b/tests/Feature/Monitoring/MetricsAccessTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+describe('health probes stay public', function () {
+    it('serves /api/monitoring/ready without auth', function () {
+        $this->getJson('/api/monitoring/ready')->assertOk();
+    });
+
+    it('serves /api/monitoring/alive without auth', function () {
+        $this->getJson('/api/monitoring/alive')->assertOk();
+    });
+
+    it('serves /api/monitoring/ready without auth even in production', function () {
+        $this->app['env'] = 'production';
+
+        $this->getJson('/api/monitoring/ready')->assertOk();
+    });
+
+    it('serves /api/monitoring/alive without auth even in production', function () {
+        $this->app['env'] = 'production';
+
+        $this->getJson('/api/monitoring/alive')->assertOk();
+    });
+});
+
+describe('metrics endpoints fail closed in production', function () {
+    beforeEach(function () {
+        $this->app['env'] = 'production';
+        config([
+            'monitoring.metrics_token'       => null,
+            'monitoring.metrics_allowed_ips' => [],
+        ]);
+    });
+
+    it('returns 403 for /api/monitoring/metrics when nothing is configured', function () {
+        $this->getJson('/api/monitoring/metrics')->assertForbidden();
+    });
+
+    it('returns 403 for /api/monitoring/prometheus when nothing is configured', function () {
+        $this->getJson('/api/monitoring/prometheus')->assertForbidden();
+    });
+
+    it('returns 403 for /api/metrics/prometheus when nothing is configured', function () {
+        $this->getJson('/api/metrics/prometheus')->assertForbidden();
+    });
+});
+
+describe('bearer token gate in production', function () {
+    beforeEach(function () {
+        $this->app['env'] = 'production';
+        config([
+            'monitoring.metrics_token'       => 'secret-token',
+            'monitoring.metrics_allowed_ips' => [],
+        ]);
+    });
+
+    it('allows access with the correct bearer token', function () {
+        $this->getJson('/api/monitoring/metrics', ['Authorization' => 'Bearer secret-token'])
+            ->assertOk();
+    });
+
+    it('rejects a wrong bearer token', function () {
+        $this->getJson('/api/monitoring/metrics', ['Authorization' => 'Bearer wrong-token'])
+            ->assertForbidden();
+    });
+
+    it('rejects a missing bearer token', function () {
+        $this->getJson('/api/monitoring/metrics')->assertForbidden();
+    });
+});
+
+describe('IP allowlist gate in production', function () {
+    it('allows access when the client IP is allowlisted', function () {
+        $this->app['env'] = 'production';
+        config([
+            'monitoring.metrics_token'       => null,
+            'monitoring.metrics_allowed_ips' => ['127.0.0.1'],
+        ]);
+
+        $this->getJson('/api/monitoring/metrics')->assertOk();
+    });
+
+    it('rejects access when the client IP is not allowlisted', function () {
+        $this->app['env'] = 'production';
+        config([
+            'monitoring.metrics_token'       => null,
+            'monitoring.metrics_allowed_ips' => ['10.0.0.9'],
+        ]);
+
+        $this->getJson('/api/monitoring/metrics')->assertForbidden();
+    });
+});
+
+describe('non-production convenience', function () {
+    it('allows metrics access with nothing configured outside production', function () {
+        config([
+            'monitoring.metrics_token'       => null,
+            'monitoring.metrics_allowed_ips' => [],
+        ]);
+
+        $this->getJson('/api/monitoring/metrics')->assertOk();
+        $this->getJson('/api/metrics/prometheus')->assertOk();
+    });
+});
+
+describe('slack alerting log config', function () {
+    it('defaults the slack channel level to critical via LOG_SLACK_LEVEL', function () {
+        // LOG_SLACK_LEVEL is unset in testing, so the default must hold — the
+        // slack channel must never inherit the global LOG_LEVEL (e.g. warning).
+        expect(config('logging.channels.slack.level'))->toBe('critical');
+    });
+});


### PR DESCRIPTION
## Summary

Two operational gaps from the comprehensive analysis:

**Alerting was log-only.** A drained Solana sponsor account, failed reconciliation, or dead health check wrote CRITICAL to a local log file and paged nobody. Now:
- Setting `LOG_SLACK_WEBHOOK_URL` auto-includes the existing (previously inert) `slack` logging channel in the default stack — every `Log::critical`/`emergency` reaches Slack with zero further config. Channel level is independently tunable via `LOG_SLACK_LEVEL` (default `critical`) so it never inherits `LOG_LEVEL=warning` spam.
- `routes/console.php` fixes: the system-health-check `onFailure` used `error_log()` (invisible to any channel) — now `Log::critical`; fraud anomaly scan upgraded `warning` → `error`.
- Deleted the confirmed-dead `monitoring.alerts` config block (zero consumers; verified including tests).

**Business metrics were world-readable.** `/api/monitoring/metrics`, `/api/monitoring/prometheus`, and `/api/metrics/prometheus` exposed user counts/transaction volumes publicly. New `MetricsAccessMiddleware`: bearer token (`METRICS_TOKEN`, `hash_equals`) or IP allowlist (`METRICS_ALLOWED_IPS`); **fail-closed 403 in production** when neither is configured; open in non-production. `/health`, `/ready`, `/alive` stay public for k8s probes.

Helm: `serviceMonitor.bearerTokenSecret` support added (empty default = no behavior change) since `helm/finaegis/values.yaml` ships a ServiceMonitor scraping `/api/monitoring/prometheus`.

## Deploy note
When `METRICS_TOKEN` is set in production, the Prometheus scrape needs the same token (k8s Secret + `serviceMonitor.bearerTokenSecret`) or the Prometheus pod IPs in `METRICS_ALLOWED_IPS`.

## Tests
`tests/Feature/Monitoring/MetricsAccessTest.php` — 14/14 green; plus the 3 pre-existing test files hitting the gated routes — 45 passed. PHPStan level 8: no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)