### PR TITLE
fix(mcp): enforce spending limits on ramp.start + sms.send, JSON-RPC conformance, truthful copy

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -529,6 +529,10 @@ MCP_SERVER_VERSION=0.1.0
 MCP_DEFAULT_DAILY_LIMIT_MINOR=50000
 MCP_DEFAULT_DAILY_LIMIT_CURRENCY=USD
 
+# Flat per-message charge (minor units, USD) reserved against the daily
+# spending limit for every sms.send call. Default 10 = $0.10.
+MCP_SMS_PRICE_MINOR=10
+
 # Idempotency cache. Lock TTL must be >= the slowest payment rail (Lightning
 # HTLC, congested L1 confirmation) — too short lets a stalled first call's
 # concurrent retry double-charge. 300s is conservative.

--- a/.env.zelta.example
+++ b/.env.zelta.example
@@ -600,6 +600,10 @@ MCP_SERVER_VERSION=0.1.0
 MCP_DEFAULT_DAILY_LIMIT_MINOR=50000
 MCP_DEFAULT_DAILY_LIMIT_CURRENCY=USD
 
+# Flat per-message charge (minor units, USD) reserved against the daily
+# spending limit for every sms.send call. Default 10 = $0.10.
+MCP_SMS_PRICE_MINOR=10
+
 # Idempotency cache. Lock TTL must be >= the slowest payment rail.
 MCP_IDEMPOTENCY_STORE=redis
 MCP_IDEMPOTENCY_LOCK_TTL_SECONDS=300

--- a/.github/workflows/mcp-release.yml
+++ b/.github/workflows/mcp-release.yml
@@ -43,6 +43,10 @@ jobs:
         working-directory: packages/finaegis-mcp-stdio
         run: npm ci
 
+      - name: Test
+        working-directory: packages/finaegis-mcp-stdio
+        run: npm test
+
       - name: Build
         working-directory: packages/finaegis-mcp-stdio
         run: npm run build

--- a/app/Domain/MCP/Sagas/SpendingEnforcedToolCallSaga.php
+++ b/app/Domain/MCP/Sagas/SpendingEnforcedToolCallSaga.php
@@ -36,8 +36,8 @@ final class SpendingEnforcedToolCallSaga
     }
 
     /**
-     * @param  array<string, mixed> $arguments  The tool call arguments (must contain the configured amount + currency fields).
-     * @param  array{amount_arg?: string, currency_arg?: string}|array<string, mixed> $entry  The catalog entry for this tool.
+     * @param  array<string, mixed> $arguments  The tool call arguments (must contain the configured amount + currency fields unless the entry is fixed-cost).
+     * @param  array{amount_arg?: string, currency_arg?: string, fixed_cost_minor?: int, fixed_cost_currency?: string}|array<string, mixed> $entry  The catalog entry for this tool.
      * @param  callable(): array<string, mixed> $execute  Closure that runs the tool and returns the McpToolAdapter envelope.
      * @return array<string, mixed>
      *
@@ -45,7 +45,7 @@ final class SpendingEnforcedToolCallSaga
      */
     public function run(string $tokenId, array $arguments, array $entry, callable $execute): array
     {
-        [$amountMinor, $currency] = $this->extractAmountAndCurrency($arguments, $entry);
+        [$amountMinor, $currency] = $this->resolveCharge($arguments, $entry);
 
         $reserve = $this->spending->reserve($tokenId, $amountMinor, $currency);
         if (! ($reserve['allowed'] ?? false)) {
@@ -70,6 +70,28 @@ final class SpendingEnforcedToolCallSaga
         }
 
         return $result;
+    }
+
+    /**
+     * Resolve the charge to reserve for this call. Two pricing models:
+     *
+     *  - Fixed-cost tools (catalog `fixed_cost_minor`, e.g. sms.send) charge a
+     *    flat per-call amount in minor units regardless of the call arguments —
+     *    the price isn't in the tool schema, so it lives in the catalog entry.
+     *  - Variable-amount tools read major-unit amount + currency from the call
+     *    arguments via `amount_arg` / `currency_arg` / `amount_decimals`.
+     *
+     * @param  array<string, mixed> $arguments
+     * @param  array<string, mixed> $entry
+     * @return array{0: int, 1: string}
+     */
+    private function resolveCharge(array $arguments, array $entry): array
+    {
+        if (isset($entry['fixed_cost_minor'])) {
+            return [(int) $entry['fixed_cost_minor'], (string) ($entry['fixed_cost_currency'] ?? 'USD')];
+        }
+
+        return $this->extractAmountAndCurrency($arguments, $entry);
     }
 
     /**

--- a/app/Domain/MCP/Server/JsonRpcRouter.php
+++ b/app/Domain/MCP/Server/JsonRpcRouter.php
@@ -23,17 +23,31 @@ use stdClass;
  * endpoint — it assumes the McpRequestContext has already been populated from
  * a verified bearer token.
  *
- * Currently implemented methods: `initialize`, `tools/list`, `tools/call`, `ping`.
- * Unknown methods return -32601 METHOD_NOT_FOUND.
+ * Currently implemented methods: `initialize`, `tools/list`, `tools/call`,
+ * `resources/list`, `resources/read`, `ping`. Unknown methods return -32601
+ * METHOD_NOT_FOUND. Envelopes without an `id` member are JSON-RPC 2.0
+ * notifications (e.g. `notifications/initialized`) — they never get a
+ * response envelope; dispatch() returns [] and the transport answers 202.
  *
  * Spending limits: payment tools (catalog `is_payment: true`) are wrapped in
  *   SpendingEnforcedToolCallSaga, which reserves the requested amount before
- *   execution and releases the reservation if the tool reports failure. Tools
- *   without explicit amounts (sms.send, ramp.start) are NOT yet covered — see
- *   the catalog and Phase 3 follow-up for variable-cost rails.
+ *   execution and releases the reservation if the tool reports failure.
+ *   Covered: payment.transfer + ramp.start (amount from arguments) and
+ *   sms.send (flat `fixed_cost_minor` per call). exchange.trade is NOT
+ *   covered — its quote-currency notional isn't known until the order fills
+ *   (see the catalog comment in config/mcp.php).
  */
 final class JsonRpcRouter
 {
+    /**
+     * Older MCP protocol revisions this server can speak. The current revision
+     * comes from config('mcp.protocol_version'); these are accepted as-is when
+     * a client requests them during `initialize` (MCP version negotiation: if
+     * the server supports the requested version it MUST respond with the same
+     * version, otherwise with its own latest supported version).
+     */
+    private const COMPATIBLE_PROTOCOL_VERSIONS = ['2025-06-18', '2025-03-26'];
+
     public function __construct(
         private readonly ToolRegistry $toolRegistry,
         private readonly McpToolAdapter $adapter,
@@ -45,12 +59,45 @@ final class JsonRpcRouter
     }
 
     /**
+     * Protocol versions this server accepts: the current revision plus older
+     * compatible ones. Used by `initialize` negotiation and by the transport
+     * layer to validate the `MCP-Protocol-Version` HTTP header.
+     *
+     * @return array<int, string>
+     */
+    public static function supportedProtocolVersions(): array
+    {
+        return array_values(array_unique(array_merge(
+            [(string) config('mcp.protocol_version')],
+            self::COMPATIBLE_PROTOCOL_VERSIONS,
+        )));
+    }
+
+    /**
+     * Dispatch a decoded JSON-RPC envelope.
+     *
+     * Returns the JSON-RPC response envelope, or `[]` when the input was a
+     * JSON-RPC notification (no `id` member) — per JSON-RPC 2.0 §4.1 a
+     * notification MUST NOT receive a response, not even an error. The
+     * transport maps `[]` to HTTP 202 with an empty body.
+     *
      * @param  array<string, mixed> $envelope
      * @return array<string, mixed>
      */
     public function dispatch(array $envelope, McpRequestContext $ctx): array
     {
-        $id = $envelope['id'] ?? null;
+        // No `id` member => JSON-RPC notification. Conformant MCP clients send
+        // `notifications/initialized` right after the initialize handshake (and
+        // may send notifications/cancelled etc.) — all are accepted as no-ops
+        // since this server keeps no per-session state. Id-less envelopes for
+        // request/response methods are also dropped WITHOUT execution: every
+        // method we expose returns a result (or a write error) the caller must
+        // see, and JSON-RPC gives a notification no channel to deliver either.
+        if (! array_key_exists('id', $envelope)) {
+            return [];
+        }
+
+        $id = $envelope['id'];
 
         if (($envelope['jsonrpc'] ?? null) !== '2.0' || ! isset($envelope['method'])) {
             return $this->error($id, -32600, 'INVALID_REQUEST');
@@ -61,7 +108,7 @@ final class JsonRpcRouter
         $params = is_array($envelope['params'] ?? null) ? $envelope['params'] : [];
 
         return match ($method) {
-            'initialize'     => $this->handleInitialize($id),
+            'initialize'     => $this->handleInitialize($id, $params),
             'tools/list'     => $this->handleToolsList($id, $ctx),
             'tools/call'     => $this->handleToolsCall($id, $params, $ctx),
             'resources/list' => $this->handleResourcesList($id, $ctx),
@@ -72,15 +119,27 @@ final class JsonRpcRouter
     }
 
     /**
+     * MCP version negotiation: if the client requests a version we support,
+     * echo it back; otherwise respond with our latest supported version (the
+     * client then decides whether to continue or disconnect).
+     *
+     * @param  array<string, mixed> $params
      * @return array<string, mixed>
      */
-    private function handleInitialize(mixed $id): array
+    private function handleInitialize(mixed $id, array $params): array
     {
+        $requested = $params['protocolVersion'] ?? null;
+        $supported = self::supportedProtocolVersions();
+
+        $negotiated = is_string($requested) && in_array($requested, $supported, true)
+            ? $requested
+            : (string) config('mcp.protocol_version');
+
         return [
             'jsonrpc' => '2.0',
             'id'      => $id,
             'result'  => [
-                'protocolVersion' => (string) config('mcp.protocol_version'),
+                'protocolVersion' => $negotiated,
                 'serverInfo'      => (array) config('mcp.server_info'),
                 'capabilities'    => [
                     'tools'     => ['listChanged' => true],
@@ -138,6 +197,13 @@ final class JsonRpcRouter
                     'openWorldHint'   => true,
                 ],
             ];
+
+            // Surface the tool's declared result shape (MCP `outputSchema`,
+            // rev 2025-06-18+) so typed clients can validate structuredContent.
+            $outputSchema = $internal->getOutputSchema();
+            if ($outputSchema !== []) {
+                $tool['outputSchema'] = $outputSchema;
+            }
 
             $tools[] = $tool;
         }

--- a/app/Domain/MCP/Server/StreamableHttpController.php
+++ b/app/Domain/MCP/Server/StreamableHttpController.php
@@ -13,6 +13,8 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * - `POST /mcp` accepts a single JSON-RPC envelope, dispatches it through
  *   {@see JsonRpcRouter}, and returns the JSON-RPC response envelope.
+ *   JSON-RPC notifications (no `id` member, e.g. `notifications/initialized`)
+ *   get HTTP 202 with an empty body — never a response envelope.
  * - `GET /mcp` opens a long-lived SSE channel (server→client notifications)
  *   and emits periodic heartbeats so middleboxes don't drop the connection.
  *
@@ -61,10 +63,31 @@ final class StreamableHttpController
         return $this->sse->open((int) config('mcp.sse.heartbeat_seconds', 25));
     }
 
-    private function handlePost(Request $request): JsonResponse
+    private function handlePost(Request $request): Response
     {
         /** @var array<string, mixed> $envelope */
         $envelope = (array) $request->json()->all();
+
+        // MCP streamable-HTTP: clients SHOULD send `MCP-Protocol-Version` on
+        // every request after initialize. If present and unsupported, the spec
+        // requires HTTP 400. Absent header => assume the current revision
+        // (backwards compatible with older clients). The initialize request is
+        // exempt — version negotiation happens in its params, not the header.
+        $headerVersion = (string) $request->headers->get('MCP-Protocol-Version', '');
+        $method = is_string($envelope['method'] ?? null) ? $envelope['method'] : '';
+        if ($headerVersion !== '' && $method !== 'initialize') {
+            $supported = JsonRpcRouter::supportedProtocolVersions();
+            if (! in_array($headerVersion, $supported, true)) {
+                return new JsonResponse([
+                    'error'             => 'unsupported_protocol_version',
+                    'error_description' => sprintf(
+                        'MCP-Protocol-Version "%s" is not supported by this server.',
+                        $headerVersion,
+                    ),
+                    'supported_versions' => $supported,
+                ], 400);
+            }
+        }
 
         $token = $request->attributes->get('mcp.token');
 
@@ -101,6 +124,13 @@ final class StreamableHttpController
         );
 
         $response = $this->router->dispatch($envelope, $ctx);
+
+        // [] is the router's "no response" sentinel for JSON-RPC notifications
+        // (envelopes without an `id`). Per the MCP streamable-HTTP transport,
+        // accepted notifications get HTTP 202 with an empty body.
+        if ($response === []) {
+            return new Response('', 202);
+        }
 
         return new JsonResponse($response);
     }

--- a/config/mcp.php
+++ b/config/mcp.php
@@ -32,10 +32,10 @@ return [
         'payments:write'    => 'Send payments (subject to spending limit)',
         'transactions:read' => 'Read transaction history and spending analysis',
         'exchange:read'     => 'Get exchange rate quotes',
-        'exchange:write'    => 'Execute exchange trades (subject to spending limit)',
+        'exchange:write'    => 'Execute exchange trades (idempotent; not yet counted against the daily spending limit)',
         'ramp:read'         => 'Read on/offramp session status',
         'ramp:write'        => 'Start on/offramp sessions (subject to spending limit)',
-        'sms:send'          => 'Send SMS messages (paid per-message via x402)',
+        'sms:send'          => 'Send SMS messages (paid per-message via x402, subject to spending limit)',
     ],
 
     /*
@@ -62,13 +62,20 @@ return [
         'exchange.quote'     => ['internal' => 'exchange.quote',                 'title' => 'Get an exchange rate quote',       'scope' => 'exchange:read',     'enabled' => env('MCP_TOOL_EXCHANGE_QUOTE', true),      'is_write' => false, 'requires_user' => true],
         // exchange.trade is intentionally NOT is_payment: the spending-limit
         // commitment is the QUOTE-currency cost (amount * market price), and
-        // market price isn't in the tool arguments. Wire saga coverage once
-        // the trade tool surfaces a settled fiat-equivalent in its result.
+        // market price isn't in the tool arguments. Post-execution debiting is
+        // equally blocked today: the trade result is an *order placement*
+        // (status=pending, filled_amount=0, average_fill_price=0), so there is
+        // no realized quote-currency notional to debit at response time. Wire
+        // saga coverage once the trade tool surfaces a settled fiat-equivalent
+        // in its result. Until then, all public copy must say exchange.trade
+        // is NOT counted against the daily spending limit.
         'exchange.trade' => ['internal' => 'exchange.trade',                 'title' => 'Execute an exchange trade',        'scope' => 'exchange:write',    'enabled' => env('MCP_TOOL_EXCHANGE_TRADE', true),      'is_write' => true,  'requires_user' => true],
-        'ramp.start'     => ['internal' => 'ramp.start',                     'title' => 'Start an on/offramp session',      'scope' => 'ramp:write',        'enabled' => env('MCP_TOOL_RAMP_START', true),          'is_write' => true,  'requires_user' => true],
+        'ramp.start'     => ['internal' => 'ramp.start',                     'title' => 'Start an on/offramp session',      'scope' => 'ramp:write',        'enabled' => env('MCP_TOOL_RAMP_START', true),          'is_write' => true,  'requires_user' => true, 'is_payment' => true,  'amount_arg' => 'fiat_amount', 'currency_arg' => 'fiat_currency', 'amount_decimals' => 2],
         'ramp.status'    => ['internal' => 'ramp.status',                    'title' => 'Check on/offramp session status',  'scope' => 'ramp:read',         'enabled' => env('MCP_TOOL_RAMP_STATUS', true),         'is_write' => false, 'requires_user' => true],
         'mpp.discovery'  => ['internal' => 'mpp.discovery',                  'title' => 'Discover multi-rail payment routes', 'scope' => null,              'enabled' => env('MCP_TOOL_MPP_DISCOVERY', true),       'is_write' => false],
-        'sms.send'       => ['internal' => 'sms.send',                       'title' => 'Send an SMS (paid via x402)',      'scope' => 'sms:send',          'enabled' => env('MCP_TOOL_SMS_SEND', true),            'is_write' => true,  'requires_user' => true],
+        // sms.send is fixed-cost: every call reserves `fixed_cost_minor`
+        // against the daily limit (no amount in the tool arguments).
+        'sms.send' => ['internal' => 'sms.send',                       'title' => 'Send an SMS (paid via x402)',      'scope' => 'sms:send',          'enabled' => env('MCP_TOOL_SMS_SEND', true),            'is_write' => true,  'requires_user' => true, 'is_payment' => true,  'fixed_cost_minor' => (int) env('MCP_SMS_PRICE_MINOR', 10), 'fixed_cost_currency' => 'USD'],
     ],
 
     /*

--- a/docs/operations/mcp-directory-submissions.md
+++ b/docs/operations/mcp-directory-submissions.md
@@ -91,7 +91,7 @@ All of these must be true before submitting (rejection rate is high; the form do
 | Server name | Zelta |
 | Server URL | `https://mcp.zelta.app/mcp` |
 | Tagline | Send payments, manage accounts, and trade across multiple rails — all from your AI assistant. |
-| Description (long) | Zelta is a multi-rail payments and wallet platform. The MCP server exposes 12 tools — accounts, payments, transactions, exchange, on/offramp, and SMS — gated by OAuth 2.1 scopes with per-token daily spending limits, idempotent writes, and a full audit trail. |
+| Description (long) | Zelta is a multi-rail payments and wallet platform. The MCP server exposes 12 tools — accounts, payments, transactions, exchange, on/offramp, and SMS — gated by OAuth 2.1 scopes with per-token daily spending limits on payments, ramp sessions, and SMS sends, idempotent writes, and a full audit trail. |
 | Auth type | OAuth 2.1 (with DCR, RFC 7591) |
 | Transport | streamable-http |
 | Capabilities | tools, resources |
@@ -113,11 +113,11 @@ All of these must be true before submitting (rejection rate is high; the form do
 | `transactions.query` | Query transaction history | readOnlyHint | transactions:read |
 | `spending.analysis` | Spending analysis by category | readOnlyHint | transactions:read |
 | `exchange.quote` | Get an exchange rate quote | readOnlyHint | exchange:read |
-| `exchange.trade` | Execute an exchange trade | destructiveHint (idempotent, spending-limited) | exchange:write |
+| `exchange.trade` | Execute an exchange trade | destructiveHint (idempotent; not yet spending-limited — fiat notional unknown until the order fills) | exchange:write |
 | `ramp.start` | Start an on/offramp session | destructiveHint (idempotent, spending-limited) | ramp:write |
 | `ramp.status` | Check on/offramp session status | readOnlyHint | ramp:read |
 | `mpp.discovery` | Multi-rail payment route discovery | readOnlyHint | (none — public) |
-| `sms.send` | Send an SMS (paid per-message via x402) | destructiveHint (idempotent, spending-limited) | sms:send |
+| `sms.send` | Send an SMS (paid per-message via x402) | destructiveHint (idempotent, spending-limited — flat per-message charge) | sms:send |
 
 ## 3. Smithery
 

--- a/packages/finaegis-mcp-stdio/server.json
+++ b/packages/finaegis-mcp-stdio/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "app.zelta/mcp",
   "title": "Zelta",
-  "description": "Public MCP server for Zelta — a multi-rail payments and wallet platform. Exposes 12 tools across accounts, payments, transactions, exchange, on/offramp, and SMS, gated by OAuth 2.1 with per-token spending limits.",
+  "description": "Public MCP server for Zelta — a multi-rail payments and wallet platform. Exposes 12 tools across accounts, payments, transactions, exchange, on/offramp, and SMS, gated by OAuth 2.1 with per-token spending limits on payments, ramp sessions, and SMS sends.",
   "version": "0.1.6",
   "websiteUrl": "https://finaegis.org/features/mcp",
   "repository": {

--- a/packages/finaegis-mcp-stdio/smithery.yaml
+++ b/packages/finaegis-mcp-stdio/smithery.yaml
@@ -3,7 +3,8 @@ url: "https://mcp.zelta.app/mcp"
 description: |
   Zelta is a multi-rail payments and wallet platform. This MCP server exposes
   12 tools (accounts, payments, transactions, exchange, on/offramp, SMS) gated
-  by OAuth 2.1 with per-token spending limits and idempotency on every write.
+  by OAuth 2.1, with per-token spending limits on payments, ramp sessions and
+  SMS sends, and idempotency on every write.
 homepage: "https://finaegis.org/features/mcp"
 docs: "https://github.com/FinAegis/core-banking-prototype-laravel/blob/main/packages/finaegis-mcp-stdio/README.md"
 repository: "https://github.com/FinAegis/core-banking-prototype-laravel"

--- a/resources/views/developers/mcp-tools.blade.php
+++ b/resources/views/developers/mcp-tools.blade.php
@@ -289,7 +289,7 @@
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div class="border border-slate-200 rounded-xl p-6">
                 <h3 class="font-bold text-lg mb-3">Spending limits</h3>
-                <p class="text-slate-600 text-sm">Per-token, not per-scope. Default <strong>${{ number_format(((int) config('mcp.spending.default_daily_limit_minor', 50000)) / 100, 2) }} / 24h rolling window</strong>. Slider on the consent screen lets the user pick a different cap. Reservations are atomic: the saga reserves before the tool runs and rolls back on any error.</p>
+                <p class="text-slate-600 text-sm">Per-token, not per-scope. Default <strong>${{ number_format(((int) config('mcp.spending.default_daily_limit_minor', 50000)) / 100, 2) }} / 24h rolling window</strong>. Slider on the consent screen lets the user pick a different cap. Reservations are atomic: the saga reserves before the tool runs and rolls back on any error. Applies to <code class="code-font text-xs">payment.transfer</code>, <code class="code-font text-xs">ramp.start</code> and <code class="code-font text-xs">sms.send</code> (flat per-message charge); <code class="code-font text-xs">exchange.trade</code> is not yet counted — its fiat notional isn't known until the order fills.</p>
             </div>
             <div class="border border-slate-200 rounded-xl p-6">
                 <h3 class="font-bold text-lg mb-3">Idempotency</h3>

--- a/resources/views/mcp/consent.blade.php
+++ b/resources/views/mcp/consent.blade.php
@@ -48,7 +48,7 @@
 
       <div class="border-t border-slate-200 pt-4">
         <label class="block text-sm font-medium text-slate-900 mb-2">Daily spending limit</label>
-        <p class="text-xs text-slate-500 mb-3">Maximum total per 24 hours across all financial actions. Will be enforced when you authorize this app.</p>
+        <p class="text-xs text-slate-500 mb-3">Maximum total per 24 hours across payments, on/offramp sessions and SMS sends. Exchange trades are not yet counted against this cap. Will be enforced when you authorize this app.</p>
         <select name="mcp_daily_limit_minor" class="w-full rounded-lg border-slate-300 focus:ring-emerald-500 focus:border-emerald-500">
           @foreach($spending_options as $opt)
             <option value="{{ $opt ?? '' }}" {{ $opt === $default_limit_minor ? 'selected' : '' }}>

--- a/tests/Feature/MCP/StreamableHttpTest.php
+++ b/tests/Feature/MCP/StreamableHttpTest.php
@@ -98,6 +98,100 @@ it('returns 406 directly from the controller when GET lacks Accept: text/event-s
     expect((string) $response->getContent())->toContain('event-stream');
 });
 
+/**
+ * Build a POST /mcp request carrying a JSON-RPC envelope, optionally with
+ * extra headers, suitable for driving StreamableHttpController directly
+ * (bypassing the OAuth middleware — same pattern as the GET tests above).
+ *
+ * @param array<string, mixed>  $envelope
+ * @param array<string, string> $headers
+ */
+function mcpPostRequest(array $envelope, array $headers = []): \Illuminate\Http\Request
+{
+    $request = \Illuminate\Http\Request::create(
+        '/mcp',
+        'POST',
+        server: ['CONTENT_TYPE' => 'application/json'],
+        content: (string) json_encode($envelope),
+    );
+
+    foreach ($headers as $name => $value) {
+        $request->headers->set($name, $value);
+    }
+
+    return $request;
+}
+
+it('returns 202 with an empty body for a JSON-RPC notification (no id) on POST /mcp', function () {
+    $controller = app(\App\Domain\MCP\Server\StreamableHttpController::class);
+
+    // notifications/initialized is what every conformant client sends right
+    // after the initialize handshake. No `id` => notification => no response
+    // envelope, just 202 Accepted.
+    $response = $controller->handle(mcpPostRequest([
+        'jsonrpc' => '2.0',
+        'method'  => 'notifications/initialized',
+    ]));
+
+    expect($response->getStatusCode())->toBe(202);
+    expect((string) $response->getContent())->toBe('');
+});
+
+it('returns 400 naming supported versions for an unsupported MCP-Protocol-Version header', function () {
+    $controller = app(\App\Domain\MCP\Server\StreamableHttpController::class);
+
+    $response = $controller->handle(mcpPostRequest(
+        ['jsonrpc' => '2.0', 'id' => 1, 'method' => 'ping'],
+        ['MCP-Protocol-Version' => '1999-01-01'],
+    ));
+
+    expect($response->getStatusCode())->toBe(400);
+    $body = json_decode((string) $response->getContent(), true);
+    expect($body['error'])->toBe('unsupported_protocol_version');
+    expect($body['supported_versions'])->toContain((string) config('mcp.protocol_version'));
+    expect($body['supported_versions'])->toContain('2025-06-18');
+});
+
+it('accepts a supported MCP-Protocol-Version header on POST /mcp', function () {
+    $controller = app(\App\Domain\MCP\Server\StreamableHttpController::class);
+
+    $response = $controller->handle(mcpPostRequest(
+        ['jsonrpc' => '2.0', 'id' => 9, 'method' => 'ping'],
+        ['MCP-Protocol-Version' => '2025-06-18'],
+    ));
+
+    expect($response->getStatusCode())->toBe(200);
+    $body = json_decode((string) $response->getContent(), true);
+    expect($body['id'])->toBe(9);
+    expect($body)->toHaveKey('result');
+});
+
+it('treats a missing MCP-Protocol-Version header as the current version (backwards compatible)', function () {
+    $controller = app(\App\Domain\MCP\Server\StreamableHttpController::class);
+
+    $response = $controller->handle(mcpPostRequest(['jsonrpc' => '2.0', 'id' => 10, 'method' => 'ping']));
+
+    expect($response->getStatusCode())->toBe(200);
+});
+
+it('ignores the MCP-Protocol-Version header on initialize (negotiation happens in params)', function () {
+    $controller = app(\App\Domain\MCP\Server\StreamableHttpController::class);
+
+    $response = $controller->handle(mcpPostRequest(
+        [
+            'jsonrpc' => '2.0',
+            'id'      => 11,
+            'method'  => 'initialize',
+            'params'  => ['protocolVersion' => '2025-06-18'],
+        ],
+        ['MCP-Protocol-Version' => 'garbage-value'],
+    ));
+
+    expect($response->getStatusCode())->toBe(200);
+    $body = json_decode((string) $response->getContent(), true);
+    expect($body['result']['protocolVersion'])->toBe('2025-06-18');
+});
+
 it('opens SSE stream with right headers on GET Accept: text/event-stream when enabled', function () {
     config(['mcp.sse.enabled' => true]);
     // Don't actually consume the stream body — just verify the headers.

--- a/tests/Feature/MCP/ToolsCallTest.php
+++ b/tests/Feature/MCP/ToolsCallTest.php
@@ -420,6 +420,55 @@ it('releases the reservation when the payment tool reports an error', function (
     expect((int) DB::table('mcp_token_policies')->where('token_id', 'tok_test')->value('daily_spend_minor'))->toBe(0);
 });
 
+it('reserves the ramp.start fiat amount against the daily limit through the catalog wiring', function () {
+    /** @var ToolRegistry $registry */
+    $registry = app(ToolRegistry::class);
+    $registry->register(toolsCallStub('ramp.start', 'Start a ramp session', [
+        'type' => 'object', 'properties' => ['fiat_amount' => ['type' => 'string']],
+    ]));
+
+    $router = app(JsonRpcRouter::class);
+    $ctx = new McpRequestContext('tok_test', 'cli', 1, ['ramp:write']);
+    $resp = $router->dispatch([
+        'jsonrpc' => '2.0', 'id' => 300, 'method' => 'tools/call',
+        'params'  => ['name' => 'ramp.start', 'arguments' => [
+            'type'            => 'on',
+            'fiat_amount'     => '100.00',
+            'fiat_currency'   => 'USD',
+            'crypto_currency' => 'USDC',
+            'wallet_address'  => '0xabc',
+            'idempotency_key' => 'ramp-1',
+        ]],
+    ], $ctx);
+
+    expect($resp['result']['isError'])->toBeFalse();
+    // '100.00' major × amount_decimals=2 → 10000 minor reserved.
+    expect((int) DB::table('mcp_token_policies')->where('token_id', 'tok_test')->value('daily_spend_minor'))->toBe(10000);
+});
+
+it('reserves the flat sms.send cost (fixed_cost_minor) without any amount argument', function () {
+    /** @var ToolRegistry $registry */
+    $registry = app(ToolRegistry::class);
+    $registry->register(toolsCallStub('sms.send', 'Send an SMS', [
+        'type' => 'object', 'properties' => ['to' => ['type' => 'string'], 'message' => ['type' => 'string']],
+    ]));
+
+    $router = app(JsonRpcRouter::class);
+    $ctx = new McpRequestContext('tok_test', 'cli', 1, ['sms:send']);
+    $resp = $router->dispatch([
+        'jsonrpc' => '2.0', 'id' => 301, 'method' => 'tools/call',
+        'params'  => ['name' => 'sms.send', 'arguments' => [
+            'to'              => '+37069912345',
+            'message'         => 'hello from MCP',
+            'idempotency_key' => 'sms-1',
+        ]],
+    ], $ctx);
+
+    expect($resp['result']['isError'])->toBeFalse();
+    // Default MCP_SMS_PRICE_MINOR=10 → $0.10 reserved per message.
+    expect((int) DB::table('mcp_token_policies')->where('token_id', 'tok_test')->value('daily_spend_minor'))->toBe(10);
+});
+
 it('returns -32006 USER_CONTEXT_REQUIRED when a user-context tool is called without a user-bound token', function () {
     // client_credentials grants set user_id=null on the Passport token; the
     // McpRequestContext carries that null forward. payment.transfer is a

--- a/tests/Unit/Domain/MCP/JsonRpcRouterTest.php
+++ b/tests/Unit/Domain/MCP/JsonRpcRouterTest.php
@@ -157,11 +157,76 @@ it('responds to initialize with capabilities and protocol version', function () 
     expect($response['result']['capabilities'])->toHaveKeys(['tools', 'resources', 'prompts', 'logging']);
 });
 
+it('negotiates a compatible older protocol version when the client requests one', function () {
+    /** @var JsonRpcRouter $router */
+    $router = app(JsonRpcRouter::class);
+
+    $response = $router->dispatch([
+        'jsonrpc' => '2.0',
+        'id'      => 1,
+        'method'  => 'initialize',
+        'params'  => ['protocolVersion' => '2025-06-18', 'clientInfo' => ['name' => 'test', 'version' => '0.0.0']],
+    ], fakeMcpContext());
+
+    // Server supports the requested revision → MUST echo it back.
+    expect($response['result']['protocolVersion'])->toBe('2025-06-18');
+});
+
+it('responds with its own protocol version when the requested one is unsupported', function () {
+    /** @var JsonRpcRouter $router */
+    $router = app(JsonRpcRouter::class);
+
+    $response = $router->dispatch([
+        'jsonrpc' => '2.0',
+        'id'      => 1,
+        'method'  => 'initialize',
+        'params'  => ['protocolVersion' => '1999-01-01'],
+    ], fakeMcpContext());
+
+    expect($response['result']['protocolVersion'])->toBe(config('mcp.protocol_version'));
+});
+
+it('drops notifications/initialized without any response envelope (JSON-RPC notification)', function () {
+    /** @var JsonRpcRouter $router */
+    $router = app(JsonRpcRouter::class);
+
+    // No `id` member → notification. Every conformant MCP client sends
+    // notifications/initialized right after initialize; it must NOT get
+    // -32601 (or any response at all).
+    $response = $router->dispatch([
+        'jsonrpc' => '2.0',
+        'method'  => 'notifications/initialized',
+    ], fakeMcpContext());
+
+    expect($response)->toBe([]);
+});
+
+it('drops any id-less envelope without a response, even for unknown or request methods', function () {
+    /** @var JsonRpcRouter $router */
+    $router = app(JsonRpcRouter::class);
+
+    // JSON-RPC 2.0 §4.1: errors for notifications are dropped — no -32601.
+    expect($router->dispatch(['jsonrpc' => '2.0', 'method' => 'does/not/exist'], fakeMcpContext()))->toBe([]);
+
+    // Id-less request/response method: dropped without execution (no channel
+    // to deliver the result or its error).
+    expect($router->dispatch([
+        'jsonrpc' => '2.0',
+        'method'  => 'tools/call',
+        'params'  => ['name' => 'payment.transfer', 'arguments' => ['amount' => 1]],
+    ], fakeMcpContext()))->toBe([]);
+
+    // Malformed id-less envelope (bad jsonrpc field): also no error response.
+    expect($router->dispatch(['method' => 'notifications/initialized'], fakeMcpContext()))->toBe([]);
+});
+
 it('returns -32600 INVALID_REQUEST for an envelope missing method or jsonrpc', function () {
     /** @var JsonRpcRouter $router */
     $router = app(JsonRpcRouter::class);
 
-    $response = $router->dispatch(['method' => 'initialize'], fakeMcpContext());
+    // Carries an id (so it's a request, not a notification) but lacks the
+    // jsonrpc version field → INVALID_REQUEST.
+    $response = $router->dispatch(['id' => 1, 'method' => 'initialize'], fakeMcpContext());
 
     expect($response['error']['code'])->toBe(-32600);
     expect($response['error']['message'])->toBe('INVALID_REQUEST');
@@ -261,4 +326,22 @@ it('emits MCP tool annotations (title + read/destructive/idempotent hints) on ev
     expect($writeAnnotations['readOnlyHint'])->toBeFalse();
     expect($writeAnnotations['destructiveHint'])->toBeTrue();
     expect($writeAnnotations['idempotentHint'])->toBeTrue();
+});
+
+it('includes each tool\'s outputSchema in tools/list when the internal tool declares one', function () {
+    /** @var JsonRpcRouter $router */
+    $router = app(JsonRpcRouter::class);
+
+    $ctx = fakeMcpContext(['scopes' => ['*']]);
+    $envelope = ['jsonrpc' => '2.0', 'id' => 5, 'method' => 'tools/list', 'params' => new stdClass()];
+    $response = $router->dispatch($envelope, $ctx);
+
+    $byName = [];
+    foreach ($response['result']['tools'] as $tool) {
+        $byName[$tool['name']] = $tool;
+    }
+
+    // The stub tools declare ['type' => 'object'] — must surface on the wire.
+    expect($byName['account.balance']['outputSchema'] ?? null)->toBe(['type' => 'object']);
+    expect($byName['payment.transfer']['outputSchema'] ?? null)->toBe(['type' => 'object']);
 });

--- a/tests/Unit/Domain/MCP/SpendingEnforcedToolCallSagaTest.php
+++ b/tests/Unit/Domain/MCP/SpendingEnforcedToolCallSagaTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Domain\MCP;
+
+use App\Domain\MCP\Exceptions\SpendingLimitExceededException;
+use App\Domain\MCP\Policy\SpendingLimitService;
+use App\Domain\MCP\Sagas\SpendingEnforcedToolCallSaga;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+// SpendingLimitService is final (not mockable under type hints), so — like
+// SpendingLimitPolicyTest and ToolsCallTest — the saga is exercised against
+// the service's real mcp_token_policies backing.
+
+function sagaSpendMinor(): int
+{
+    return (int) DB::table('mcp_token_policies')->where('token_id', 'tok_saga')->value('daily_spend_minor');
+}
+
+beforeEach(function () {
+    DB::table('mcp_token_policies')->insert([
+        'token_id'              => 'tok_saga',
+        'daily_limit_minor'     => 50000, // $500.00
+        'daily_limit_currency'  => 'USD',
+        'daily_spend_minor'     => 0,
+        'daily_window_start_at' => now(),
+        'created_at'            => now(),
+        'updated_at'            => now(),
+    ]);
+
+    $this->saga = new SpendingEnforcedToolCallSaga(new SpendingLimitService());
+});
+
+// ---------------------------------------------------------------------------
+// ramp.start — variable amount from fiat_amount/fiat_currency arguments
+// ---------------------------------------------------------------------------
+
+it('reserves the fiat amount in minor units for the real ramp.start catalog entry', function () {
+    // Use the REAL catalog entry so this test breaks if config/mcp.php and the
+    // saga's reader (amount_arg / currency_arg / amount_decimals) drift apart.
+    /** @var array<string, mixed> $entry */
+    $entry = config('mcp.tools')['ramp.start'];
+    expect($entry['is_payment'] ?? false)->toBeTrue();
+
+    $result = $this->saga->run('tok_saga', [
+        'type'            => 'on',
+        'fiat_amount'     => '100.00',
+        'fiat_currency'   => 'USD',
+        'crypto_currency' => 'USDC',
+        'wallet_address'  => '0xabc',
+    ], $entry, fn (): array => ['isError' => false, 'content' => []]);
+
+    expect($result['isError'])->toBeFalse();
+    // '100.00' major × amount_decimals=2 → 10000 minor reserved and kept.
+    expect(sagaSpendMinor())->toBe(10000);
+});
+
+it('releases the ramp.start reservation when the tool reports an error', function () {
+    /** @var array<string, mixed> $entry */
+    $entry = config('mcp.tools')['ramp.start'];
+
+    $result = $this->saga->run('tok_saga', [
+        'fiat_amount'   => '100.00',
+        'fiat_currency' => 'USD',
+    ], $entry, fn (): array => ['isError' => true, 'content' => []]);
+
+    expect($result['isError'])->toBeTrue();
+    expect(sagaSpendMinor())->toBe(0);
+});
+
+it('releases the ramp.start reservation and rethrows when the tool throws', function () {
+    /** @var array<string, mixed> $entry */
+    $entry = config('mcp.tools')['ramp.start'];
+
+    try {
+        $this->saga->run('tok_saga', [
+            'fiat_amount'   => '100.00',
+            'fiat_currency' => 'USD',
+        ], $entry, function (): array {
+            throw new RuntimeException('rail down');
+        });
+        $this->fail('Expected RuntimeException');
+    } catch (RuntimeException $e) {
+        expect($e->getMessage())->toBe('rail down');
+    }
+
+    expect(sagaSpendMinor())->toBe(0);
+});
+
+it('throws SpendingLimitExceededException without executing when ramp.start exceeds the cap', function () {
+    DB::table('mcp_token_policies')->where('token_id', 'tok_saga')->update(['daily_spend_minor' => 45000]);
+
+    /** @var array<string, mixed> $entry */
+    $entry = config('mcp.tools')['ramp.start'];
+
+    $executed = false;
+
+    try {
+        // 45000 spent + 10000 requested > 50000 limit → reject.
+        $this->saga->run('tok_saga', [
+            'fiat_amount'   => '100.00',
+            'fiat_currency' => 'USD',
+        ], $entry, function () use (&$executed): array {
+            $executed = true;
+
+            return ['isError' => false];
+        });
+        $this->fail('Expected SpendingLimitExceededException');
+    } catch (SpendingLimitExceededException $e) {
+        expect($e->data['amount_requested_minor'])->toBe(10000);
+        expect($e->data['currency'])->toBe('USD');
+        expect($e->data['limit_remaining_minor'])->toBe(5000);
+    }
+
+    expect($executed)->toBeFalse();
+    expect(sagaSpendMinor())->toBe(45000);
+});
+
+it('rejects with CURRENCY_MISMATCH when ramp.start fiat_currency differs from the policy currency', function () {
+    /** @var array<string, mixed> $entry */
+    $entry = config('mcp.tools')['ramp.start'];
+
+    $executed = false;
+
+    try {
+        $this->saga->run('tok_saga', [
+            'fiat_amount'   => '100.00',
+            'fiat_currency' => 'EUR', // policy is USD — proves currency_arg is wired through
+        ], $entry, function () use (&$executed): array {
+            $executed = true;
+
+            return ['isError' => false];
+        });
+        $this->fail('Expected SpendingLimitExceededException');
+    } catch (SpendingLimitExceededException $e) {
+        expect($e->data['error_code'])->toBe('CURRENCY_MISMATCH');
+    }
+
+    expect($executed)->toBeFalse();
+    expect(sagaSpendMinor())->toBe(0);
+});
+
+// ---------------------------------------------------------------------------
+// sms.send — flat fixed_cost_minor per call, no amount in the arguments
+// ---------------------------------------------------------------------------
+
+it('reserves the flat fixed cost for the real sms.send catalog entry without any amount arguments', function () {
+    /** @var array<string, mixed> $entry */
+    $entry = config('mcp.tools')['sms.send'];
+    expect($entry['is_payment'] ?? false)->toBeTrue();
+    expect($entry['fixed_cost_minor'] ?? null)->toBe(10);
+
+    // No amount/currency anywhere in the arguments — the charge comes from the catalog.
+    $result = $this->saga->run('tok_saga', [
+        'to'      => '+37069912345',
+        'message' => 'hello',
+    ], $entry, fn (): array => ['isError' => false, 'content' => []]);
+
+    expect($result['isError'])->toBeFalse();
+    expect(sagaSpendMinor())->toBe(10);
+});
+
+it('releases the fixed sms.send cost when the tool reports an error', function () {
+    /** @var array<string, mixed> $entry */
+    $entry = config('mcp.tools')['sms.send'];
+
+    $result = $this->saga->run('tok_saga', [
+        'to'      => '+37069912345',
+        'message' => 'hello',
+    ], $entry, fn (): array => ['isError' => true, 'content' => []]);
+
+    expect($result['isError'])->toBeTrue();
+    expect(sagaSpendMinor())->toBe(0);
+});
+
+it('defaults the fixed-cost currency to USD when fixed_cost_currency is omitted', function () {
+    // Flip the policy to EUR: if the saga defaults the omitted currency to
+    // USD (as documented), the reserve must fail with CURRENCY_MISMATCH.
+    DB::table('mcp_token_policies')->where('token_id', 'tok_saga')->update(['daily_limit_currency' => 'EUR']);
+
+    $entry = [
+        'is_payment'       => true,
+        'fixed_cost_minor' => 25,
+        // no fixed_cost_currency
+    ];
+
+    try {
+        $this->saga->run('tok_saga', [], $entry, fn (): array => ['isError' => false]);
+        $this->fail('Expected SpendingLimitExceededException');
+    } catch (SpendingLimitExceededException $e) {
+        expect($e->data['error_code'])->toBe('CURRENCY_MISMATCH');
+        expect($e->data['currency'])->toBe('USD');
+        expect($e->data['amount_requested_minor'])->toBe(25);
+    }
+});
+
+it('throws SpendingLimitExceededException without executing when the fixed-cost reservation is rejected', function () {
+    DB::table('mcp_token_policies')->where('token_id', 'tok_saga')->delete();
+
+    /** @var array<string, mixed> $entry */
+    $entry = config('mcp.tools')['sms.send'];
+
+    $executed = false;
+
+    try {
+        $this->saga->run('tok_saga', ['to' => '+1', 'message' => 'x'], $entry, function () use (&$executed): array {
+            $executed = true;
+
+            return ['isError' => false];
+        });
+        $this->fail('Expected SpendingLimitExceededException');
+    } catch (SpendingLimitExceededException $e) {
+        expect($e->data['error_code'])->toBe('NO_POLICY');
+        expect($e->data['amount_requested_minor'])->toBe(10);
+    }
+
+    expect($executed)->toBeFalse();
+});


### PR DESCRIPTION
## Summary

Closes the MCP spending-limit gap found in the comprehensive analysis: only `payment.transfer` carried `is_payment`, while the consent screen, `server.json`, `smithery.yaml`, and the directory-submission docs all claimed spending limits across financial actions — a wide-scope OAuth token could start unbounded ramp sessions or SMS sends.

**Spending enforcement**
- `ramp.start` now reserves against the daily cap via its existing `fiat_amount`/`fiat_currency` args (`is_payment` + `amount_arg`/`currency_arg`/`amount_decimals` in the catalog; saga already handles major→minor via bcmath).
- `sms.send` gets a fixed per-message charge: new `fixed_cost_minor` branch in `SpendingEnforcedToolCallSaga` (`MCP_SMS_PRICE_MINOR`, default 10 = $0.10; added to both env templates).
- `exchange.trade` is **deliberately not enforced in code**: `TradeTool` returns an order *placement* (`status: pending`, `filled_amount: 0`) — orders fill asynchronously, so there is no trustworthy realized cost to charge at execute time, and market orders carry no price in args. Instead, every public surface now states coverage truthfully ("spending limits on payments, ramp sessions, and SMS sends; exchange trades not yet counted"): consent screen, `exchange:write` scope description, dev-portal card, `server.json`, `smithery.yaml`, directory-submissions doc.

**JSON-RPC / MCP spec conformance** (pre-directory-submission fixes)
- Notifications (id-less envelopes, e.g. `notifications/initialized` — sent by every conformant client right after `initialize`) previously got a spurious `-32601` error; now HTTP 202 with empty body, per spec.
- Protocol version negotiation: `initialize` echoes a supported requested version (`2025-11-25`, `2025-06-18`, `2025-03-26`); unsupported `MCP-Protocol-Version` header on other calls → 400 listing supported versions.
- `tools/list` now exposes each tool's `outputSchema` (existed internally, was dropped on the wire).
- `mcp-release.yml` now runs the stdio package's vitest suite before publishing (was publish-untested).

## Tests

140/140 MCP tests green (21 new: saga reserve/release for both tools incl. currency-mismatch proofs, notification 202s, version negotiation, outputSchema). PHPStan level 8: no errors. Saga tests intentionally consume the real catalog entries so config↔saga key drift fails tests.

⚠️ `tests/Feature/MCP` does not run in current PR CI — the companion CI PR closes that; merge it first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)