### PR TITLE
feat(compliance): GDPR export/erasure coverage for all post-v7.13 user-data tables

### DIFF
--- a/app/Domain/Auth/Services/PrivyEmailOtpClient.php
+++ b/app/Domain/Auth/Services/PrivyEmailOtpClient.php
@@ -74,6 +74,55 @@ class PrivyEmailOtpClient
     }
 
     /**
+     * Delete a Privy user (GDPR Art. 17(2) processor fan-out for an erased
+     * account's identity link). Uses the same server-to-server Basic-auth
+     * conventions as the OTP endpoints. A 404 is treated as success — the
+     * user is already gone on Privy's side, keeping the call idempotent.
+     *
+     * @throws PrivyEmailOtpException when Privy rejects the deletion or the request cannot be sent
+     */
+    public function deleteUser(string $privyUserId): void
+    {
+        $base = rtrim((string) config('privy.api_base_url', 'https://auth.privy.io'), '/');
+        $appId = (string) config('privy.app_id');
+        $appSecret = (string) config('privy.app_secret');
+
+        if ($appId === '' || $appSecret === '') {
+            throw PrivyEmailOtpException::misconfigured();
+        }
+
+        $path = '/api/v1/users/' . rawurlencode($privyUserId);
+
+        $request = new GuzzleRequest(
+            'DELETE',
+            $base . $path,
+            [
+                'Accept'        => 'application/json',
+                'privy-app-id'  => $appId,
+                'Authorization' => 'Basic ' . base64_encode($appId . ':' . $appSecret),
+                'Origin'        => $this->resolveOrigin(),
+            ],
+        );
+
+        try {
+            $response = $this->http->send($request, ['http_errors' => false]);
+        } catch (GuzzleException $e) {
+            throw PrivyEmailOtpException::transport($path, $e);
+        }
+
+        $status = $response->getStatusCode();
+
+        if ($status === 404) {
+            return; // already deleted on Privy's side — idempotent success
+        }
+
+        if ($status >= 400) {
+            $message = $this->extractErrorMessage((string) $response->getBody()) ?? "Privy returned HTTP {$status}";
+            throw PrivyEmailOtpException::apiError($path, $status, $message);
+        }
+    }
+
+    /**
      * @param  array<string, mixed> $body
      * @return array<string, mixed>
      *

--- a/app/Domain/Compliance/Services/GdprService.php
+++ b/app/Domain/Compliance/Services/GdprService.php
@@ -4,14 +4,251 @@ declare(strict_types=1);
 
 namespace App\Domain\Compliance\Services;
 
+use App\Domain\Account\Models\BlockchainAddress;
 use App\Domain\Account\Models\TransactionProjection;
+use App\Domain\Auth\Services\PrivyEmailOtpClient;
+use App\Domain\Compliance\Kyc\Models\BridgeCustomer;
 use App\Domain\Compliance\Models\AuditLog;
+use App\Domain\Mobile\Models\BiometricChallenge;
+use App\Domain\Mobile\Models\DeviceReassignmentLog;
+use App\Domain\Mobile\Models\MobileDevice;
+use App\Domain\Mobile\Models\MobileDeviceSession;
+use App\Domain\Mobile\Models\MobileNotificationPreference;
+use App\Domain\Mobile\Models\MobilePushNotification;
+use App\Domain\MobilePayment\Models\ActivityFeedItem;
+use App\Domain\MobilePayment\Models\PaymentIntent;
+use App\Domain\MobilePayment\Models\PaymentReceipt;
+use App\Domain\Payment\Models\HyperSwitchDepositIntent;
+use App\Domain\Subscription\Models\Cue;
+use App\Domain\Subscription\Models\IapReceipt;
+use App\Domain\Subscription\Models\IapSubscription;
+use App\Domain\Subscription\Models\SubscriptionConsentLog;
+use App\Domain\Subscription\Models\TrialCardFingerprint;
+use App\Domain\Wallet\Models\WalletSendRecord;
+use App\Infrastructure\Bridge\BridgeClient;
+use App\Models\McpToolInvocation;
+use App\Models\RampSession;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
+use Laravel\Cashier\Subscription as CashierSubscription;
+use Throwable;
 
+/**
+ * GDPR service: Art. 15/20 export and Art. 17 erasure across every table
+ * that stores user-linked personal data.
+ *
+ * Event-store position: event-stream payloads (stored_events + the
+ * domain-specific event tables) are append-only financial records and are
+ * retained under the Art. 17(3)(b) legal-obligation exemption; erasure
+ * anonymizes the *projections* (users row, transaction projections,
+ * per-domain read models) so no personal data remains queryable through any
+ * read path. There is no per-user crypto-shredding mechanism in the event
+ * store today (verified 2026-06: no per-user encryption keys exist for
+ * stored events), so payload-level redaction of historical events is not
+ * possible without a replay-rewrite, which is out of scope here.
+ *
+ * Processor fan-out (Art. 17(2)): notifyProcessorsOfErasure() forwards the
+ * erasure to Bridge.xyz (customer delete) and Privy (user delete). Apple
+ * App Store and Google Play expose no server-side API to delete IAP
+ * subscriber data — when the user has IAP records, a structured
+ * `gdpr.processor_erasure_manual` audit row and log entry are emitted and
+ * an operator must follow the manual step (data-deletion request via
+ * App Store Connect / Google Play Console). Documented here because no
+ * GDPR runbook exists under docs/operations/ yet.
+ *
+ * Coverage guard: COVERED_USER_DATA_TABLES + EXCLUDED_USER_DATA_TABLES must
+ * jointly account for every schema table that carries a user FK column
+ * (user_id / user_uuid / privy_user_id, or a *_user_id / *_user_uuid
+ * suffix) — enforced by tests/Feature/Compliance/GdprCoverageGuardTest.php.
+ * A new user-data table must consciously opt in (export/erasure handling
+ * here + entry in COVERED) or out (justified entry in EXCLUDED).
+ */
 class GdprService
 {
+    /**
+     * Tables actively handled by exportUserData() and/or deleteUserData().
+     *
+     * @var array<int, string>
+     */
+    public const COVERED_USER_DATA_TABLES = [
+        'users',
+        'accounts',
+        'kyc_documents',
+        'audit_logs',
+        // Subscriptions / IAP (v7.13+)
+        'subscriptions',
+        'iap_subscriptions',
+        'iap_receipts',
+        'subscription_consent_log',
+        'trial_card_fingerprints',
+        'cues',
+        // Bridge.xyz ramp (v7.15+)
+        'bridge_customers',
+        'ramp_sessions',
+        // Wallet (v7.12+)
+        'blockchain_addresses',
+        'wallet_send_records',
+        // Mobile payments
+        'payment_intents',
+        'payment_receipts',
+        'activity_feed_items',
+        'hyperswitch_deposit_intents',
+        // Mobile devices / notifications
+        'mobile_devices',
+        'mobile_device_sessions',
+        'mobile_notification_preferences',
+        'mobile_push_notifications',
+        'biometric_challenges',
+        'device_reassignment_log',
+        // API audit
+        'mcp_tool_invocations',
+    ];
+
+    private const EXCL_LEGACY = 'Pre-v7.13 prototype/demo domain — not enabled on the Zelta production deployment; tracked for a dedicated GDPR coverage pass.';
+
+    private const EXCL_FINANCIAL = 'Financial/accounting record retained under the Art. 17(3)(b) legal-obligation exemption; no direct identifiers beyond the FK to the anonymized users row.';
+
+    private const EXCL_SECURITY = 'Security/fraud/audit trail retained under Art. 17(3)(e) (establishment/defence of legal claims); pruned by its own retention policy.';
+
+    private const EXCL_EPHEMERAL = 'Ephemeral or framework state with its own expiry; no exportable personal-data payload.';
+
+    private const EXCL_CONSENT = 'Proof-of-consent audit record retained under Art. 17(3)(e).';
+
+    private const EXCL_TENANCY = 'Tenancy/membership structure; no personal data beyond the user FK (which points at the anonymized users row after erasure).';
+
+    /**
+     * Tables with a user FK that are deliberately NOT touched by export or
+     * erasure, each with the justification for that decision.
+     *
+     * @var array<string, string>
+     */
+    public const EXCLUDED_USER_DATA_TABLES = [
+        'account_flags'                => 'Operator-set capability flags (reviewer bypasses); no personal data beyond the user FK; swept by the reviewer-account lifecycle tooling.',
+        'ach_batches'                  => self::EXCL_LEGACY,
+        'ai_llm_usage'                 => self::EXCL_FINANCIAL,
+        'anomaly_detections'           => self::EXCL_SECURITY,
+        'api_keys'                     => 'Hashed API credentials revoked on account closure; no readable personal data.',
+        'bank_accounts'                => self::EXCL_LEGACY,
+        'bank_connections'             => self::EXCL_LEGACY,
+        'bank_transfers'               => self::EXCL_LEGACY,
+        'batch_jobs'                   => self::EXCL_EPHEMERAL,
+        'behavioral_profiles'          => self::EXCL_LEGACY,
+        'blockchain_wallets'           => self::EXCL_LEGACY,
+        'blockchain_withdrawals'       => self::EXCL_LEGACY,
+        'bridge_transactions'          => self::EXCL_LEGACY, // legacy cross-chain bridge demo — unrelated to Bridge.xyz
+        'card_transactions'            => self::EXCL_LEGACY,
+        'card_waitlist'                => self::EXCL_LEGACY,
+        'card_waitlist_deposits'       => self::EXCL_LEGACY,
+        'cardholders'                  => self::EXCL_LEGACY,
+        'cards'                        => self::EXCL_LEGACY,
+        'certificates'                 => self::EXCL_LEGACY,
+        'cgo_investments'              => self::EXCL_LEGACY,
+        'cgo_refunds'                  => self::EXCL_LEGACY,
+        'compliance_alerts'            => self::EXCL_SECURITY,
+        'consent_records'              => self::EXCL_CONSENT,
+        'consents'                     => self::EXCL_CONSENT,
+        'customer_risk_profiles'       => 'AML/CTF risk-scoring record retained under Art. 17(3)(b) statutory retention.',
+        'data_transfer_logs'           => self::EXCL_SECURITY,
+        'defi_positions'               => self::EXCL_LEGACY,
+        'delegated_proof_jobs'         => self::EXCL_LEGACY,
+        'device_fingerprints'          => self::EXCL_SECURITY,
+        'exports'                      => self::EXCL_EPHEMERAL,
+        'gcu_votes'                    => self::EXCL_LEGACY,
+        'hardware_wallet_associations' => self::EXCL_LEGACY,
+        'idempotency_keys'             => self::EXCL_EPHEMERAL,
+        'imports'                      => self::EXCL_EPHEMERAL,
+        'key_access_logs'              => self::EXCL_LEGACY, // legacy custodial key management (custodial endpoints removed in v7.12)
+        'key_reconstruction_logs'      => self::EXCL_LEGACY,
+        'key_shards'                   => self::EXCL_LEGACY,
+        'kyc_verifications'            => 'KYC/AML verification trail retained under Art. 17(3)(b) statutory retention (AMLD); uploaded documents are deleted via deleteKycDocuments().',
+        'mfi_field_officers'           => self::EXCL_LEGACY,
+        'mfi_group_members'            => self::EXCL_LEGACY,
+        'mfi_share_accounts'           => self::EXCL_LEGACY,
+        'mfi_teller_cashiers'          => self::EXCL_LEGACY,
+        'multi_sig_approval_requests'  => self::EXCL_LEGACY,
+        'multi_sig_signer_approvals'   => self::EXCL_LEGACY,
+        'multi_sig_wallet_signers'     => self::EXCL_LEGACY,
+        'multi_sig_wallets'            => self::EXCL_LEGACY,
+        'oauth_access_tokens'          => 'Auth artifacts (hashed tokens) revoked on account closure; no personal-data payload.',
+        'oauth_auth_codes'             => 'Auth artifacts (hashed codes) revoked on account closure; no personal-data payload.',
+        'orders'                       => self::EXCL_LEGACY,
+        'payment_rail_transactions'    => self::EXCL_LEGACY,
+        'pending_signing_requests'     => self::EXCL_EPHEMERAL,
+        'price_quotes'                 => self::EXCL_EPHEMERAL,
+        'privacy_commitments'          => self::EXCL_LEGACY,
+        'privacy_transactions'         => self::EXCL_LEGACY,
+        'promotions'                   => self::EXCL_LEGACY,
+        'railgun_wallets'              => self::EXCL_LEGACY,
+        'recovery_backups'             => self::EXCL_LEGACY,
+        'recovery_shard_cloud_backups' => self::EXCL_LEGACY,
+        'referral_codes'               => 'Random referral code + counters; no personal data beyond the FK to the anonymized users row.',
+        'revenue_events'               => self::EXCL_FINANCIAL,
+        'reward_profiles'              => self::EXCL_FINANCIAL,
+        'security_audit_logs'          => self::EXCL_SECURITY,
+        'sepa_mandates'                => self::EXCL_LEGACY,
+        'sessions'                     => self::EXCL_EPHEMERAL,
+        'shielded_balances'            => self::EXCL_LEGACY,
+        'smart_accounts'               => self::EXCL_LEGACY,
+        'suspicious_activity_reports'  => 'AML/CTF SAR — statutory retention plus tipping-off prohibition: exempt from both Art. 15 disclosure and Art. 17 erasure.',
+        'team_user'                    => self::EXCL_TENANCY,
+        'team_user_roles'              => self::EXCL_TENANCY,
+        'teams'                        => self::EXCL_TENANCY,
+        'tenant_audit_logs'            => self::EXCL_SECURITY,
+        'user_activities'              => self::EXCL_LEGACY,
+        'user_bank_preferences'        => self::EXCL_LEGACY,
+        'user_fee_tiers'               => 'Fee-tier assignment; no personal data beyond the user FK.',
+        'user_products'                => self::EXCL_LEGACY,
+        'user_profiles'                => self::EXCL_LEGACY,
+        'verification_payments'        => self::EXCL_LEGACY,
+        'virtuals_agent_profiles'      => self::EXCL_LEGACY,
+        'visa_cli_enrolled_cards'      => self::EXCL_LEGACY,
+        'votes'                        => self::EXCL_LEGACY,
+        'websocket_subscriptions'      => self::EXCL_EPHEMERAL,
+    ];
+
+    /**
+     * Both clients are optional so `new GdprService()` keeps working in unit
+     * tests and the container can fall back to lazy resolution (BridgeClient
+     * needs runtime config, so it is built via fromConfig() on first use).
+     */
+    public function __construct(
+        private readonly ?BridgeClient $bridgeClient = null,
+        private readonly ?PrivyEmailOtpClient $privyClient = null,
+    ) {
+    }
+
+    /**
+     * True when a column name marks its table as user-linked data
+     * (used by the schema coverage guard).
+     */
+    public static function isUserLinkColumn(string $column): bool
+    {
+        $column = strtolower($column);
+
+        return in_array($column, ['user_id', 'user_uuid', 'privy_user_id'], true)
+            || str_ends_with($column, '_user_id')
+            || str_ends_with($column, '_user_uuid');
+    }
+
+    /**
+     * Pure diff used by the coverage guard: every user-linked table must be
+     * either covered or explicitly excluded with a justification.
+     *
+     * @param  array<int, string>  $tablesWithUserColumns
+     * @return array<int, string>  tables that are neither covered nor excluded
+     */
+    public static function uncoveredUserDataTables(array $tablesWithUserColumns): array
+    {
+        $known = array_merge(
+            self::COVERED_USER_DATA_TABLES,
+            array_keys(self::EXCLUDED_USER_DATA_TABLES),
+        );
+
+        return array_values(array_diff($tablesWithUserColumns, $known));
+    }
+
     /**
      * Export all user data (GDPR Article 20 - Right to data portability).
      */
@@ -27,12 +264,18 @@ class GdprService
         );
 
         return [
-            'user'          => $this->getUserData($user),
-            'accounts'      => $this->getAccountData($user),
-            'transactions'  => $this->getTransactionData($user),
-            'kyc_documents' => $this->getKycData($user),
-            'audit_logs'    => $this->getAuditData($user),
-            'consents'      => $this->getConsentData($user),
+            'user'            => $this->getUserData($user),
+            'accounts'        => $this->getAccountData($user),
+            'transactions'    => $this->getTransactionData($user),
+            'kyc_documents'   => $this->getKycData($user),
+            'audit_logs'      => $this->getAuditData($user),
+            'consents'        => $this->getConsentData($user),
+            'subscriptions'   => $this->getSubscriptionData($user),
+            'bridge'          => $this->getBridgeData($user),
+            'wallet'          => $this->getWalletData($user),
+            'mobile_payments' => $this->getMobilePaymentData($user),
+            'devices'         => $this->getDeviceData($user),
+            'api_usage'       => $this->getApiUsageData($user),
         ];
     }
 
@@ -41,6 +284,16 @@ class GdprService
      */
     public function deleteUserData(User $user, array $options = []): void
     {
+        // Processor fan-out runs BEFORE local erasure: it needs the processor
+        // references (bridge_customer_id, privy_user_id) that the local pass
+        // deletes/nulls, and it is failure-tolerant — every failure is caught,
+        // logged and recorded as an AuditLog row for operator retry, so a
+        // processor 5xx can never block erasure of local data.
+        $this->notifyProcessorsOfErasure($user);
+
+        // NOTE: every model mutated inside this transaction lives on the
+        // default connection — never add a UsesTenantConnection model here
+        // (separate MySQL session => self-deadlock; see CLAUDE.md).
         DB::transaction(
             function () use ($user, $options) {
                 // Log the deletion request
@@ -66,6 +319,14 @@ class GdprService
                     $this->anonymizeTransactions($user);
                 }
 
+                // Per-table erasure for everything added since v7.13
+                $this->eraseSubscriptionData($user);
+                $this->eraseBridgeData($user);
+                $this->eraseWalletData($user);
+                $this->eraseMobilePaymentData($user);
+                $this->eraseDeviceData($user);
+                $this->eraseApiAuditData($user);
+
                 // Log the deletion completion
                 AuditLog::log(
                     'gdpr.deletion_completed',
@@ -77,6 +338,21 @@ class GdprService
                 );
             }
         );
+    }
+
+    /**
+     * Art. 17(2) processor fan-out: forward the erasure request to every
+     * processor that holds this user's personal data on our behalf.
+     *
+     * Queue-safe and failure-tolerant: each processor call is individually
+     * wrapped — a failure is logged + recorded as a `gdpr.processor_erasure_failed`
+     * audit row (so operators can retry) and never propagates to the caller.
+     */
+    public function notifyProcessorsOfErasure(User $user): void
+    {
+        $this->notifyBridgeOfErasure($user);
+        $this->notifyPrivyOfErasure($user);
+        $this->recordManualStoreErasureSteps($user);
     }
 
     /**
@@ -131,8 +407,12 @@ class GdprService
             'email_verified_at' => $user->email_verified_at,
             'kyc_status'        => $user->kyc_status,
             'kyc_level'         => $user->kyc_level,
-            'created_at'        => $user->created_at,
-            'updated_at'        => $user->updated_at,
+            // Identity-provider link: the Privy DID is an identifier assigned
+            // to the user, so Art. 15 includes it.
+            'privy_user_id'   => $user->privy_user_id,
+            'privy_linked_at' => $user->privy_linked_at,
+            'created_at'      => $user->created_at,
+            'updated_at'      => $user->updated_at,
         ];
     }
 
@@ -250,6 +530,311 @@ class GdprService
     }
 
     /**
+     * Stripe (Cashier) + IAP subscription data, per-renewal IAP payment
+     * records and the withdrawal-consent log.
+     *
+     * Field choices:
+     * - `stripe_id` (Cashier) is a processor-side pseudonymous reference,
+     *   not user-readable personal data — omitted.
+     * - IAP store-account tokens / pseudonymised receipt hashes
+     *   (apple_app_account_token, google_obfuscated_account_id,
+     *   google_purchase_token_hash, receipt_blob) are opaque pseudonyms that
+     *   reveal nothing readable to the user — omitted; the subscription and
+     *   payment facts are included instead.
+     * - trial_card_fingerprints is deliberately NOT exported: it holds only
+     *   an HMAC card fingerprint kept for trial-abuse prevention; it contains
+     *   no user-readable personal data.
+     *
+     * @return array<string, mixed>
+     */
+    protected function getSubscriptionData(User $user): array
+    {
+        return [
+            'stripe' => CashierSubscription::query()->where('user_id', $user->id)->get()->map(
+                fn (CashierSubscription $subscription): array => [
+                    'type'          => $subscription->type,
+                    'stripe_status' => $subscription->stripe_status,
+                    'stripe_price'  => $subscription->stripe_price,
+                    'quantity'      => $subscription->quantity,
+                    'trial_ends_at' => $subscription->trial_ends_at,
+                    'ends_at'       => $subscription->ends_at,
+                    'created_at'    => $subscription->created_at,
+                ]
+            )->all(),
+            'iap' => IapSubscription::where('user_id', $user->id)->get()->map(
+                fn (IapSubscription $subscription): array => [
+                    'store'                    => $subscription->store,
+                    'tier'                     => $subscription->tier,
+                    'status'                   => $subscription->status,
+                    'trial_started_at'         => $subscription->trial_started_at,
+                    'trial_ends_at'            => $subscription->trial_ends_at,
+                    'current_period_starts_at' => $subscription->current_period_starts_at,
+                    'current_period_ends_at'   => $subscription->current_period_ends_at,
+                    'cancel_at_period_end'     => $subscription->cancel_at_period_end,
+                    'cancelled_at'             => $subscription->cancelled_at,
+                    'expired_at'               => $subscription->expired_at,
+                    'refunded_at'              => $subscription->refunded_at,
+                    'created_at'               => $subscription->created_at,
+                ]
+            )->all(),
+            'iap_payments' => IapReceipt::where('user_id', $user->id)->get()->map(
+                fn (IapReceipt $receipt): array => [
+                    'store'                => $receipt->store,
+                    'product_id'           => $receipt->product_id,
+                    'tier'                 => $receipt->tier,
+                    'amount_smallest_unit' => $receipt->amount_smallest_unit,
+                    'amount_decimals'      => $receipt->amount_decimals,
+                    'amount_currency'      => $receipt->amount_currency,
+                    'period_starts_at'     => $receipt->period_starts_at,
+                    'period_ends_at'       => $receipt->period_ends_at,
+                    'environment'          => $receipt->environment,
+                    'created_at'           => $receipt->created_at,
+                ]
+            )->all(),
+            // consent_text/version/timestamps are the user's consent record;
+            // ip_hash is omitted (pseudonymised, not user-readable).
+            'consent_log' => SubscriptionConsentLog::where('user_id', $user->id)->get()->map(
+                fn (SubscriptionConsentLog $log): array => [
+                    'consent_text'    => $log->consent_text,
+                    'consent_version' => $log->consent_version,
+                    'shown_at'        => $log->shown_at,
+                    'accepted_at'     => $log->accepted_at,
+                    'user_agent'      => $log->user_agent,
+                ]
+            )->all(),
+        ];
+    }
+
+    /**
+     * Bridge.xyz customer record + ramp sessions.
+     *
+     * Field choices:
+     * - virtual_account_details is exported decrypted: the virtual account
+     *   routing details ARE the user's own deposit bank details.
+     * - deposit_instructions likewise (the user's bank-transfer details).
+     * - kyc_link_url is omitted: a single-use signed onboarding URL is a
+     *   credential, not personal data.
+     * - stripe_client_secret / provider_session_id / stripe_session_id are
+     *   omitted: processor-side secrets and references.
+     *
+     * @return array<string, mixed>
+     */
+    protected function getBridgeData(User $user): array
+    {
+        /** @var BridgeCustomer|null $customer */
+        $customer = BridgeCustomer::where('user_id', $user->id)->first();
+
+        return [
+            'customer' => $customer === null ? null : [
+                'bridge_customer_id'      => $customer->bridge_customer_id,
+                'kyc_status'              => $customer->kyc_status,
+                'developer_fee_bps'       => $customer->developer_fee_bps,
+                'supported_rails'         => $customer->supported_rails,
+                'virtual_account_id'      => $customer->virtual_account_id,
+                'virtual_account_details' => $customer->virtual_account_details,
+                'created_at'              => $customer->created_at,
+            ],
+            'ramp_sessions' => RampSession::where('user_id', $user->id)->get()->map(
+                fn (RampSession $session): array => [
+                    'id'                   => $session->id,
+                    'provider'             => $session->provider,
+                    'type'                 => $session->type,
+                    'fiat_currency'        => $session->fiat_currency,
+                    'fiat_amount'          => $session->fiat_amount,
+                    'crypto_currency'      => $session->crypto_currency,
+                    'crypto_amount'        => $session->crypto_amount,
+                    'wallet_address'       => $session->wallet_address,
+                    'status'               => $session->status,
+                    'source'               => $session->source,
+                    'deposit_instructions' => $session->deposit_instructions,
+                    'created_at'           => $session->created_at,
+                ]
+            )->all(),
+        ];
+    }
+
+    /**
+     * Non-custodial wallet data: on-chain addresses + send history.
+     *
+     * Field choices:
+     * - public_key is included (public material owned by the user);
+     *   derivation_path + metadata are omitted (server-side wallet/sync
+     *   internals, not user-readable personal data).
+     * - For sends, tx_hash is the canonical on-chain reference; the internal
+     *   user_op_hash / idempotency_key / quote_id / metadata are omitted
+     *   (server-side processing references).
+     *
+     * @return array<string, mixed>
+     */
+    protected function getWalletData(User $user): array
+    {
+        return [
+            'blockchain_addresses' => BlockchainAddress::where('user_uuid', $user->uuid)->get()->map(
+                fn (BlockchainAddress $address): array => [
+                    'chain'      => $address->chain,
+                    'address'    => $address->address,
+                    'public_key' => $address->public_key,
+                    'label'      => $address->label,
+                    'is_active'  => $address->is_active,
+                    'created_at' => $address->created_at,
+                ]
+            )->all(),
+            'sends' => WalletSendRecord::where('user_id', $user->id)->get()->map(
+                fn (WalletSendRecord $send): array => [
+                    'public_id'         => $send->public_id,
+                    'network'           => $send->network,
+                    'asset'             => $send->asset,
+                    'amount'            => $send->amount,
+                    'sender_address'    => $send->sender_address,
+                    'recipient_address' => $send->recipient_address,
+                    'status'            => $send->status,
+                    'tx_hash'           => $send->tx_hash,
+                    'error_code'        => $send->error_code,
+                    'created_at'        => $send->created_at,
+                    'submitted_at'      => $send->submitted_at,
+                    'confirmed_at'      => $send->confirmed_at,
+                    'failed_at'         => $send->failed_at,
+                ]
+            )->all(),
+        ];
+    }
+
+    /**
+     * Mobile payment intents, receipts and card deposits.
+     *
+     * Field choices:
+     * - idempotency_key / metadata / internal ids omitted (server-side).
+     * - activity_feed_items is not exported: it is a denormalised UI mirror
+     *   of the transaction data already exported above.
+     * - hyperswitch_payment_id omitted (processor-side reference).
+     *
+     * @return array<string, mixed>
+     */
+    protected function getMobilePaymentData(User $user): array
+    {
+        return [
+            'payment_intents' => PaymentIntent::where('user_id', $user->id)->get()->map(
+                fn (PaymentIntent $intent): array => [
+                    'public_id'   => $intent->public_id,
+                    'merchant_id' => $intent->merchant_id,
+                    'asset'       => $intent->asset,
+                    'network'     => $intent->network,
+                    'amount'      => $intent->amount,
+                    'status'      => $intent->status->value,
+                    'tx_hash'     => $intent->tx_hash,
+                    'created_at'  => $intent->created_at,
+                    'expires_at'  => $intent->expires_at,
+                ]
+            )->all(),
+            'payment_receipts' => PaymentReceipt::where('user_id', $user->id)->get()->map(
+                fn (PaymentReceipt $receipt): array => [
+                    'public_id'      => $receipt->public_id,
+                    'merchant_name'  => $receipt->merchant_name,
+                    'amount'         => $receipt->amount,
+                    'asset'          => $receipt->asset,
+                    'network'        => $receipt->network,
+                    'tx_hash'        => $receipt->tx_hash,
+                    'network_fee'    => $receipt->network_fee,
+                    'transaction_at' => $receipt->transaction_at,
+                ]
+            )->all(),
+            'card_deposits' => HyperSwitchDepositIntent::where('user_uuid', $user->uuid)->get()->map(
+                fn (HyperSwitchDepositIntent $intent): array => [
+                    'amount_cents' => $intent->amount_cents,
+                    'currency'     => $intent->currency,
+                    'status'       => $intent->status,
+                    'created_at'   => $intent->created_at,
+                ]
+            )->all(),
+        ];
+    }
+
+    /**
+     * Registered mobile devices, notification preferences and device
+     * reassignment history.
+     *
+     * Field choices:
+     * - push_token + biometric/passkey public keys are omitted: device/server
+     *   credentials, not user-readable personal data.
+     * - mobile_push_notifications / mobile_device_sessions /
+     *   biometric_challenges are not exported: transient delivery/session/
+     *   challenge artifacts (they are hard-deleted on erasure).
+     * - On reassignment rows, ip_address/user_agent belong to the
+     *   *registering* user — they are only disclosed when this user is the
+     *   new owner, never for previous-owner rows (another data subject).
+     *
+     * @return array<string, mixed>
+     */
+    protected function getDeviceData(User $user): array
+    {
+        return [
+            'devices' => MobileDevice::where('user_id', $user->id)->get()->map(
+                fn (MobileDevice $device): array => [
+                    'device_name'       => $device->device_name,
+                    'device_model'      => $device->device_model,
+                    'platform'          => $device->platform,
+                    'os_version'        => $device->os_version,
+                    'app_version'       => $device->app_version,
+                    'biometric_enabled' => $device->biometric_enabled,
+                    'last_active_at'    => $device->last_active_at,
+                    'created_at'        => $device->created_at,
+                ]
+            )->all(),
+            'notification_preferences' => MobileNotificationPreference::where('user_id', $user->id)->get()->map(
+                fn (MobileNotificationPreference $preference): array => [
+                    'notification_type' => $preference->notification_type,
+                    'push_enabled'      => $preference->push_enabled,
+                    'email_enabled'     => $preference->email_enabled,
+                ]
+            )->all(),
+            'device_reassignments' => DeviceReassignmentLog::where('previous_user_id', $user->id)
+                ->orWhere('new_user_id', $user->id)
+                ->get()
+                ->map(
+                    fn (DeviceReassignmentLog $log): array => [
+                        'device_id'             => $log->device_id,
+                        'role'                  => $log->new_user_id === $user->id ? 'new_owner' : 'previous_owner',
+                        'reason'                => $log->reason,
+                        'had_bound_credentials' => $log->had_bound_credentials,
+                        'ip_address'            => $log->new_user_id === $user->id ? $log->ip_address : null,
+                        'user_agent'            => $log->new_user_id === $user->id ? $log->user_agent : null,
+                        'created_at'            => $log->created_at,
+                    ]
+                )->all(),
+        ];
+    }
+
+    /**
+     * MCP / API audit data attributed to the user.
+     *
+     * Field choices: token_id/client_id/args_hash omitted (server-side
+     * references and pseudonymous hashes); capped at 1000 rows like the
+     * audit_logs section.
+     *
+     * @return array<string, mixed>
+     */
+    protected function getApiUsageData(User $user): array
+    {
+        return [
+            'mcp_tool_invocations' => McpToolInvocation::where('user_id', $user->id)
+                ->orderByDesc('created_at')
+                ->limit(1000)
+                ->get()
+                ->map(
+                    fn (McpToolInvocation $invocation): array => [
+                        'tool_name'     => $invocation->tool_name,
+                        'result_status' => $invocation->result_status,
+                        'error_code'    => $invocation->error_code,
+                        'ip'            => $invocation->ip,
+                        'user_agent'    => $invocation->user_agent,
+                        'duration_ms'   => $invocation->duration_ms,
+                        'created_at'    => $invocation->created_at,
+                    ]
+                )->all(),
+        ];
+    }
+
+    /**
      * Anonymize user data.
      */
     protected function anonymizeUser(User $user): void
@@ -259,6 +844,11 @@ class GdprService
                 'name'     => 'ANONYMIZED_' . substr($user->uuid, 0, 8),
                 'email'    => 'deleted-' . $user->uuid . '@anonymized.local',
                 'kyc_data' => null,
+                // The Privy DID is an identity-provider link (personal data);
+                // the Privy-side record itself is deleted via
+                // notifyProcessorsOfErasure().
+                'privy_user_id'   => null,
+                'privy_linked_at' => null,
             ]
         );
     }
@@ -292,6 +882,277 @@ class GdprService
             null,
             null,
             'gdpr,compliance,anonymization'
+        );
+    }
+
+    /**
+     * Erase subscription/IAP personal data while preserving financial records.
+     */
+    protected function eraseSubscriptionData(User $user): void
+    {
+        // iap_subscriptions: subscription rows are financial records
+        // (Art. 17(3)(b)) — keep tier/status/period + original_transaction_id
+        // (needed for refund/dispute correlation with the store), strip the
+        // store-account-level identifiers.
+        IapSubscription::where('user_id', $user->id)->update([
+            'apple_app_account_token'      => null,
+            'google_obfuscated_account_id' => null,
+            'google_purchase_token_hash'   => null,
+        ]);
+
+        // iap_receipts: per-renewal payment records — amounts + store
+        // transaction refs retained (Art. 17(3)(b)); account-level identifiers
+        // and the raw receipt blob are erased.
+        IapReceipt::where('user_id', $user->id)->update([
+            'apple_app_account_token'      => null,
+            'google_obfuscated_account_id' => null,
+            'receipt_blob'                 => null,
+        ]);
+
+        // subscriptions (Cashier/Stripe): retained as-is — billing records
+        // under Art. 17(3)(b); the only identifier is the pseudonymous
+        // stripe_id, and the Stripe-side customer object is purged separately
+        // (GdprController::purgeStripeCustomerData).
+
+        // subscription_consent_log: proof of consent retained for defence of
+        // legal claims (Art. 17(3)(e)); user_agent is device-fingerprint PII
+        // with no evidentiary value beyond the (kept) ip_hash — erased.
+        SubscriptionConsentLog::where('user_id', $user->id)->update(['user_agent' => null]);
+
+        // trial_card_fingerprints: the HMAC fingerprint is retained for
+        // trial-abuse/fraud prevention (legitimate interest; contains no
+        // readable PII) — the links to this user are severed.
+        TrialCardFingerprint::where('first_user_id', $user->id)->update(['first_user_id' => null]);
+        TrialCardFingerprint::where('last_user_id', $user->id)->update(['last_user_id' => null]);
+
+        // cues: transient, expiring UI nudge state with no record-keeping
+        // duty — hard delete (Art. 17(1)(a)).
+        Cue::where('user_id', $user->id)->delete();
+    }
+
+    /**
+     * Erase Bridge.xyz ramp personal data while preserving financial records.
+     */
+    protected function eraseBridgeData(User $user): void
+    {
+        // bridge_customers: pure identity/KYC-link record (1:1 with the user,
+        // no monetary fields) — hard delete (Art. 17(1)); the Bridge-side
+        // customer object is deleted via notifyProcessorsOfErasure(), and
+        // Bridge retains its own statutory KYC records as a controller.
+        BridgeCustomer::where('user_id', $user->id)->delete();
+
+        // ramp_sessions: on/off-ramp transactions are financial records
+        // (Art. 17(3)(b)) — amounts/currencies/status retained; the encrypted
+        // bank deposit_instructions (the user's bank details), processor
+        // client secret and free-form metadata are erased.
+        RampSession::where('user_id', $user->id)->update([
+            'deposit_instructions' => null,
+            'stripe_client_secret' => null,
+            'metadata'             => null,
+        ]);
+    }
+
+    /**
+     * Erase wallet personal data while preserving the on-chain financial trace.
+     */
+    protected function eraseWalletData(User $user): void
+    {
+        // blockchain_addresses: rows are FK targets for transaction mirrors
+        // and part of the on-chain financial trace (Art. 17(3)(b)), and the
+        // Helius webhook matches inbound txs by address — hard delete would
+        // orphan projections, so we keep the row, deactivate it (which drops
+        // it from the Helius/Alchemy watch lists on the next sync) and strip
+        // the free-text label + sync metadata. The owner link now points at
+        // the anonymized users row. Mass update intentionally bypasses the
+        // model observers (no Helius/Bridge re-sync on erasure).
+        BlockchainAddress::where('user_uuid', $user->uuid)->update([
+            'is_active' => false,
+            'label'     => null,
+            'metadata'  => null,
+        ]);
+
+        // wallet_send_records: on-chain sends are financial records
+        // (Art. 17(3)(b)) — amounts/addresses/hashes retained; free-form
+        // request metadata and error text are erased.
+        WalletSendRecord::where('user_id', $user->id)->update([
+            'metadata'      => null,
+            'error_message' => null,
+        ]);
+    }
+
+    /**
+     * Erase mobile-payment personal data while preserving monetary records.
+     */
+    protected function eraseMobilePaymentData(User $user): void
+    {
+        // payment_intents: monetary records (Art. 17(3)(b)) — amounts/
+        // merchant/tx refs retained; free-form request metadata erased.
+        PaymentIntent::where('user_id', $user->id)->update(['metadata' => null]);
+
+        // payment_receipts: retained unchanged — monetary receipt records
+        // (Art. 17(3)(b)); merchant_name identifies the merchant, not the user.
+
+        // hyperswitch_deposit_intents: retained unchanged — card-deposit
+        // financial records (Art. 17(3)(b)) with no direct PII fields.
+
+        // activity_feed_items: denormalised UI mirror of transaction data
+        // (the source records are retained above) — hard delete.
+        ActivityFeedItem::where('user_id', $user->id)->delete();
+    }
+
+    /**
+     * Erase mobile device data (pure device PII, no financial-record duty).
+     */
+    protected function eraseDeviceData(User $user): void
+    {
+        // Sessions, challenges, push history, preferences and the device rows
+        // themselves are pure device PII (push tokens, device names,
+        // biometric/passkey public keys, session tokens) with no
+        // record-keeping duty — hard delete (Art. 17(1)(a)).
+        MobileDeviceSession::where('user_id', $user->id)->delete();
+        BiometricChallenge::where('user_id', $user->id)->delete();
+        MobilePushNotification::where('user_id', $user->id)->delete();
+        MobileNotificationPreference::where('user_id', $user->id)->delete();
+        MobileDevice::where('user_id', $user->id)->delete();
+
+        // device_reassignment_log: the reassignment fact is a security audit
+        // trail retained for defence against device-takeover claims
+        // (Art. 17(3)(e)); the request-fingerprint PII (ip/user_agent) is erased.
+        DeviceReassignmentLog::where('previous_user_id', $user->id)
+            ->orWhere('new_user_id', $user->id)
+            ->update([
+                'ip_address' => null,
+                'user_agent' => null,
+            ]);
+    }
+
+    /**
+     * Erase API-audit personal data while preserving the security trail.
+     */
+    protected function eraseApiAuditData(User $user): void
+    {
+        // mcp_tool_invocations: the invocation history is a security/billing
+        // audit trail (Art. 17(3)(e)); the request-fingerprint PII
+        // (ip/user_agent) is erased.
+        McpToolInvocation::where('user_id', $user->id)->update([
+            'ip'         => null,
+            'user_agent' => null,
+        ]);
+    }
+
+    /**
+     * (a) Bridge.xyz: delete the customer object (PII + KYC artifacts held by
+     * Bridge as our processor for the ramp rail).
+     */
+    protected function notifyBridgeOfErasure(User $user): void
+    {
+        $bridgeCustomerId = BridgeCustomer::where('user_id', $user->id)->value('bridge_customer_id');
+
+        if (! is_string($bridgeCustomerId) || $bridgeCustomerId === '') {
+            return;
+        }
+
+        try {
+            ($this->bridgeClient ?? BridgeClient::fromConfig())->deleteCustomer($bridgeCustomerId);
+
+            AuditLog::log(
+                'gdpr.processor_erasure_requested',
+                $user,
+                null,
+                null,
+                ['processor' => 'bridge', 'reference' => $bridgeCustomerId],
+                'gdpr,compliance,deletion'
+            );
+        } catch (Throwable $e) {
+            Log::error('GDPR: Bridge customer deletion failed — recorded for operator retry', [
+                'user_id'            => $user->id,
+                'bridge_customer_id' => $bridgeCustomerId,
+                'error'              => $e->getMessage(),
+            ]);
+
+            AuditLog::log(
+                'gdpr.processor_erasure_failed',
+                $user,
+                null,
+                null,
+                ['processor' => 'bridge', 'reference' => $bridgeCustomerId, 'error' => $e->getMessage()],
+                'gdpr,compliance,deletion'
+            );
+        }
+    }
+
+    /**
+     * (b) Privy: delete the identity-provider user (email + wallet links held
+     * by Privy as our processor for auth/wallets).
+     */
+    protected function notifyPrivyOfErasure(User $user): void
+    {
+        $privyUserId = $user->privy_user_id;
+
+        if (! is_string($privyUserId) || $privyUserId === '') {
+            return;
+        }
+
+        try {
+            $client = $this->privyClient ?? app(PrivyEmailOtpClient::class);
+            $client->deleteUser($privyUserId);
+
+            AuditLog::log(
+                'gdpr.processor_erasure_requested',
+                $user,
+                null,
+                null,
+                ['processor' => 'privy', 'reference' => $privyUserId],
+                'gdpr,compliance,deletion'
+            );
+        } catch (Throwable $e) {
+            Log::error('GDPR: Privy user deletion failed — recorded for operator retry', [
+                'user_id'       => $user->id,
+                'privy_user_id' => $privyUserId,
+                'error'         => $e->getMessage(),
+            ]);
+
+            AuditLog::log(
+                'gdpr.processor_erasure_failed',
+                $user,
+                null,
+                null,
+                ['processor' => 'privy', 'reference' => $privyUserId, 'error' => $e->getMessage()],
+                'gdpr,compliance,deletion'
+            );
+        }
+    }
+
+    /**
+     * (c) Apple App Store / Google Play: no server-side deletion API exists
+     * for IAP subscriber data — emit a structured TODO (log + audit row) so
+     * an operator performs the manual console step.
+     */
+    protected function recordManualStoreErasureSteps(User $user): void
+    {
+        /** @var array<int, string> $stores */
+        $stores = IapSubscription::where('user_id', $user->id)
+            ->distinct()
+            ->pluck('store')
+            ->all();
+
+        if ($stores === []) {
+            return;
+        }
+
+        Log::info('gdpr.processor_erasure.manual_step_required', [
+            'user_id'    => $user->id,
+            'processors' => $stores,
+            'action'     => 'Submit a subscriber data-deletion request via App Store Connect / Google Play Console for the erased user.',
+        ]);
+
+        AuditLog::log(
+            'gdpr.processor_erasure_manual',
+            $user,
+            null,
+            null,
+            ['processors' => $stores],
+            'gdpr,compliance,deletion'
         );
     }
 

--- a/app/Infrastructure/Bridge/BridgeClient.php
+++ b/app/Infrastructure/Bridge/BridgeClient.php
@@ -111,6 +111,48 @@ final class BridgeClient
     }
 
     /**
+     * Delete a Bridge customer record (GDPR Art. 17(2) processor fan-out).
+     *
+     * A 404 is treated as success — the customer is already gone (Bridge's
+     * sandbox purges records periodically), so the call stays idempotent and
+     * a local erasure is never blocked by a missing remote record. Any other
+     * non-2xx follows the client convention and throws RuntimeException.
+     */
+    public function deleteCustomer(string $customerId): void
+    {
+        $path = "/v0/customers/{$customerId}";
+
+        $response = Http::withHeaders($this->apiHeaders())
+            ->acceptJson()
+            ->delete($this->baseUrl . $path);
+
+        if ($response->status() === 404) {
+            Log::info('Bridge customer already absent during GDPR deletion', [
+                'path'   => $path,
+                'status' => 404,
+            ]);
+
+            return;
+        }
+
+        if ($response->failed()) {
+            Log::warning('Bridge API call failed', [
+                'verb'   => 'DELETE',
+                'path'   => $path,
+                'status' => $response->status(),
+                'body'   => $response->body(),
+            ]);
+
+            throw new RuntimeException(sprintf(
+                'Bridge API DELETE %s returned %d: %s',
+                $path,
+                $response->status(),
+                $response->body(),
+            ));
+        }
+    }
+
+    /**
      * @param  array<string, mixed>  $payload
      * @return array<string, mixed>
      */

--- a/tests/Feature/Compliance/GdprCoverageGuardTest.php
+++ b/tests/Feature/Compliance/GdprCoverageGuardTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Compliance\Services\GdprService;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Schema regression guard for GDPR coverage (mirrors the philosophy of
+ * bin/check-test-coverage): every table carrying a user FK column must be
+ * consciously opted IN (GdprService::COVERED_USER_DATA_TABLES — handled by
+ * export/erasure) or OUT (GdprService::EXCLUDED_USER_DATA_TABLES — with a
+ * written justification). A new user-data table that is neither fails here.
+ */
+
+/**
+ * @return array<int, string> tables in the migrated schema that carry a user FK column
+ */
+function gdprUserLinkedTablesInSchema(): array
+{
+    $found = [];
+
+    /** @var array<int, array{name: string}> $tables */
+    $tables = Schema::getTables();
+
+    foreach ($tables as $table) {
+        $name = $table['name'];
+
+        // Framework-internal bookkeeping table — never user data.
+        if ($name === 'migrations') {
+            continue;
+        }
+
+        foreach (Schema::getColumnListing($name) as $column) {
+            if (GdprService::isUserLinkColumn($column)) {
+                $found[] = $name;
+
+                break;
+            }
+        }
+    }
+
+    sort($found);
+
+    return $found;
+}
+
+test('every table with a user FK column is consciously covered or excluded by GdprService', function () {
+    $userLinkedTables = gdprUserLinkedTablesInSchema();
+
+    expect($userLinkedTables)->not->toBeEmpty();
+
+    $uncovered = GdprService::uncoveredUserDataTables($userLinkedTables);
+
+    expect($uncovered)->toBeEmpty(
+        'New user-data table(s) detected with no GDPR coverage decision: ['
+        . implode(', ', $uncovered) . ']. Either handle them in '
+        . 'GdprService::exportUserData()/deleteUserData() and add them to '
+        . 'GdprService::COVERED_USER_DATA_TABLES, or add a justified entry to '
+        . 'GdprService::EXCLUDED_USER_DATA_TABLES.'
+    );
+});
+
+test('no table is listed as both covered and excluded', function () {
+    $overlap = array_values(array_intersect(
+        GdprService::COVERED_USER_DATA_TABLES,
+        array_keys(GdprService::EXCLUDED_USER_DATA_TABLES),
+    ));
+
+    expect($overlap)->toBeEmpty(
+        'Tables listed in both COVERED_USER_DATA_TABLES and EXCLUDED_USER_DATA_TABLES: ['
+        . implode(', ', $overlap) . ']'
+    );
+});
+
+test('covered and excluded lists contain no stale (dropped or renamed) tables', function () {
+    $userLinkedTables = gdprUserLinkedTablesInSchema();
+
+    $listed = array_merge(
+        GdprService::COVERED_USER_DATA_TABLES,
+        array_keys(GdprService::EXCLUDED_USER_DATA_TABLES),
+    );
+
+    $stale = array_values(array_diff($listed, $userLinkedTables));
+
+    expect($stale)->toBeEmpty(
+        'Tables listed in GdprService coverage constants that no longer exist '
+        . '(or no longer carry a user FK column): [' . implode(', ', $stale) . ']. '
+        . 'Remove or rename the stale entries.'
+    );
+});
+
+test('every excluded table carries a non-empty justification', function () {
+    foreach (GdprService::EXCLUDED_USER_DATA_TABLES as $table => $justification) {
+        expect(trim($justification) !== '')->toBeTrue("Excluded table {$table} has no justification");
+    }
+});
+
+// Unit-level checks of the pure diff logic: the guard must flag a synthetic
+// uncovered table and must accept known covered/excluded ones.
+test('uncoveredUserDataTables flags a synthetic uncovered table', function () {
+    $result = GdprService::uncoveredUserDataTables([
+        'users',                       // covered
+        'sessions',                    // excluded
+        'synthetic_new_pii_table',     // neither => must be flagged
+    ]);
+
+    expect($result)->toBe(['synthetic_new_pii_table']);
+});
+
+test('uncoveredUserDataTables returns empty for fully covered input', function () {
+    expect(GdprService::uncoveredUserDataTables(['users', 'bridge_customers', 'sessions']))->toBeEmpty();
+});
+
+test('isUserLinkColumn matches canonical and suffixed user FK columns only', function () {
+    expect(GdprService::isUserLinkColumn('user_id'))->toBeTrue();
+    expect(GdprService::isUserLinkColumn('user_uuid'))->toBeTrue();
+    expect(GdprService::isUserLinkColumn('privy_user_id'))->toBeTrue();
+    expect(GdprService::isUserLinkColumn('previous_user_id'))->toBeTrue();
+    expect(GdprService::isUserLinkColumn('first_user_id'))->toBeTrue();
+    expect(GdprService::isUserLinkColumn('subject_user_uuid'))->toBeTrue();
+    expect(GdprService::isUserLinkColumn('USER_ID'))->toBeTrue();
+
+    expect(GdprService::isUserLinkColumn('id'))->toBeFalse();
+    expect(GdprService::isUserLinkColumn('uuid'))->toBeFalse();
+    expect(GdprService::isUserLinkColumn('operator_id'))->toBeFalse();
+    expect(GdprService::isUserLinkColumn('user_agent'))->toBeFalse();
+    expect(GdprService::isUserLinkColumn('username'))->toBeFalse();
+});

--- a/tests/Feature/Compliance/GdprServiceTest.php
+++ b/tests/Feature/Compliance/GdprServiceTest.php
@@ -3,12 +3,328 @@
 declare(strict_types=1);
 
 use App\Domain\Account\Models\Account;
+use App\Domain\Account\Models\BlockchainAddress;
+use App\Domain\Auth\Exceptions\PrivyEmailOtpException;
+use App\Domain\Auth\Services\PrivyEmailOtpClient;
+use App\Domain\Compliance\Kyc\Models\BridgeCustomer;
 use App\Domain\Compliance\Models\AuditLog;
 use App\Domain\Compliance\Models\KycDocument;
 use App\Domain\Compliance\Services\GdprService;
+use App\Domain\Mobile\Models\BiometricChallenge;
+use App\Domain\Mobile\Models\DeviceReassignmentLog;
+use App\Domain\Mobile\Models\MobileDevice;
+use App\Domain\Mobile\Models\MobileDeviceSession;
+use App\Domain\Mobile\Models\MobileNotificationPreference;
+use App\Domain\Mobile\Models\MobilePushNotification;
+use App\Domain\MobilePayment\Models\ActivityFeedItem;
+use App\Domain\MobilePayment\Models\PaymentIntent;
+use App\Domain\MobilePayment\Models\PaymentReceipt;
+use App\Domain\Payment\Models\HyperSwitchDepositIntent;
+use App\Domain\Subscription\Models\Cue;
+use App\Domain\Subscription\Models\IapReceipt;
+use App\Domain\Subscription\Models\IapSubscription;
+use App\Domain\Subscription\Models\SubscriptionConsentLog;
+use App\Domain\Subscription\Models\TrialCardFingerprint;
+use App\Domain\Wallet\Models\WalletSendRecord;
+use App\Models\RampSession;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Laravel\Cashier\Subscription as CashierSubscription;
+use Mockery\MockInterface;
+
+/**
+ * Bind a Mockery PrivyEmailOtpClient into the container (app()->instance()
+ * instead of $this->mock() so PHPStan resolves the mock type — same pattern
+ * as tests/Feature/Web/PrivyWebLoginTest.php).
+ */
+function gdpr_mock_privy_client(): PrivyEmailOtpClient&MockInterface
+{
+    /** @var PrivyEmailOtpClient&MockInterface $privy */
+    $privy = Mockery::mock(PrivyEmailOtpClient::class);
+    app()->instance(PrivyEmailOtpClient::class, $privy);
+
+    return $privy;
+}
+
+/**
+ * Seed one row in every post-v7.13 user-data table so export/erasure
+ * behaviour can be asserted per table.
+ *
+ * @return array<string, mixed>
+ */
+function gdpr_seed_user_data_graph(User $user): array
+{
+    $user->update([
+        'privy_user_id'   => 'did:privy:gdpr-test',
+        'privy_linked_at' => now(),
+    ]);
+
+    $stripeSubscription = CashierSubscription::query()->forceCreate([
+        'user_id'       => $user->id,
+        'type'          => 'default',
+        'stripe_id'     => 'sub_gdpr_123',
+        'stripe_status' => 'active',
+    ]);
+
+    $iapSubscription = IapSubscription::create([
+        'user_id'                      => $user->id,
+        'store'                        => 'apple',
+        'tier'                         => 'pro',
+        'status'                       => 'active',
+        'original_transaction_id'      => 'orig-tx-1',
+        'apple_app_account_token'      => 'apple-token-1',
+        'google_obfuscated_account_id' => 'goog-acct-1',
+        'google_purchase_token_hash'   => 'goog-hash-1',
+    ]);
+
+    $iapReceipt = IapReceipt::create([
+        'user_id'                 => $user->id,
+        'iap_subscription_id'     => $iapSubscription->id,
+        'store'                   => 'apple',
+        'product_id'              => 'pro.monthly',
+        'tier'                    => 'pro',
+        'amount_smallest_unit'    => 999,
+        'amount_decimals'         => 2,
+        'amount_currency'         => 'EUR',
+        'apple_app_account_token' => 'apple-token-1',
+        'receipt_blob'            => 'raw-receipt-blob',
+    ]);
+
+    $consentLog = SubscriptionConsentLog::create([
+        'user_id'         => $user->id,
+        'consent_text'    => 'I consent to immediate service and waive withdrawal.',
+        'consent_version' => 1,
+        'shown_at'        => now(),
+        'accepted_at'     => now(),
+        'ip_hash'         => 'hashed-ip',
+        'user_agent'      => 'ZeltaApp/1.0 (iPhone)',
+    ]);
+
+    $fingerprint = TrialCardFingerprint::create([
+        'fingerprint_hash' => 'fp-hash-gdpr',
+        'first_user_id'    => $user->id,
+        'last_user_id'     => $user->id,
+        'first_used_at'    => now(),
+        'last_used_at'     => now(),
+        'trial_user_count' => 1,
+    ]);
+
+    $cue = Cue::create([
+        'user_id'         => $user->id,
+        'kind'            => 'trial_ending',
+        'priority'        => 'normal',
+        'due_at'          => now(),
+        'expires_at'      => now()->addDay(),
+        'payload'         => ['days_left' => 2],
+        'idempotency_key' => 'cue-idem-1',
+        'created_at'      => now(),
+    ]);
+
+    $bridgeCustomer = BridgeCustomer::create([
+        'user_id'                 => $user->id,
+        'bridge_customer_id'      => 'cust_abc123',
+        'kyc_status'              => 'approved',
+        'virtual_account_id'      => 'va_1',
+        'virtual_account_details' => ['bank_name' => 'Lead Bank', 'account_number' => '123456789'],
+    ]);
+
+    $rampSession = RampSession::create([
+        'user_id'              => $user->id,
+        'provider'             => 'bridge',
+        'type'                 => 'on',
+        'fiat_currency'        => 'EUR',
+        'fiat_amount'          => 100.50,
+        'crypto_currency'      => 'USDC',
+        'status'               => 'completed',
+        'wallet_address'       => '0xabc123',
+        'deposit_instructions' => ['iban' => 'DE89370400440532013000'],
+        'stripe_client_secret' => 'cs_secret_value',
+        'metadata'             => ['note' => 'first deposit'],
+    ]);
+
+    $address = BlockchainAddress::create([
+        'user_uuid'  => $user->uuid,
+        'chain'      => 'solana',
+        'address'    => 'So1anaAddre55',
+        'public_key' => 'So1anaAddre55',
+        'label'      => 'Main wallet',
+        'is_active'  => true,
+        'metadata'   => ['helius_synced' => true],
+    ]);
+
+    $send = WalletSendRecord::create([
+        'public_id'         => 'send_gdpr_1',
+        'user_id'           => $user->id,
+        'network'           => 'SOLANA',
+        'asset'             => 'USDC',
+        'amount'            => '1.5000',
+        'sender_address'    => 'So1anaAddre55',
+        'recipient_address' => 'So1anaRecipient',
+        'status'            => 'confirmed',
+        'tx_hash'           => 'sig-abc-123',
+        'metadata'          => ['device_id' => 'dev-1'],
+        'error_message'     => 'transient failure detail',
+    ]);
+
+    $merchant = App\Domain\Commerce\Models\Merchant::create([
+        'public_id'         => 'merch_gdpr_1',
+        'display_name'      => 'Coffee Corner',
+        'accepted_assets'   => ['USDC'],
+        'accepted_networks' => ['SOLANA'],
+    ]);
+
+    $paymentIntent = PaymentIntent::create([
+        'public_id'   => 'pi_gdpr_1',
+        'user_id'     => $user->id,
+        'merchant_id' => $merchant->id,
+        'asset'       => 'USDC',
+        'network'     => 'SOLANA',
+        'amount'      => '2.5000',
+        'status'      => 'confirmed',
+        'metadata'    => ['table' => '12'],
+        'expires_at'  => now()->addMinutes(15),
+    ]);
+
+    $paymentReceipt = PaymentReceipt::create([
+        'public_id'      => 'rcpt_gdpr_1',
+        'user_id'        => $user->id,
+        'merchant_name'  => 'Coffee Corner',
+        'amount'         => '2.5000',
+        'asset'          => 'USDC',
+        'network'        => 'SOLANA',
+        'tx_hash'        => 'sig-abc-123',
+        'network_fee'    => '0.0001',
+        'share_token'    => 'share-tok-1',
+        'transaction_at' => now(),
+    ]);
+
+    $cardDeposit = HyperSwitchDepositIntent::create([
+        'hyperswitch_payment_id' => 'hs_pay_1',
+        'deposit_uuid'           => (string) Str::uuid(),
+        'account_uuid'           => (string) Str::uuid(),
+        'user_uuid'              => $user->uuid,
+        'amount_cents'           => 1000,
+        'currency'               => 'EUR',
+        'status'                 => 'completed',
+    ]);
+
+    $activityItem = ActivityFeedItem::create([
+        'user_id'       => $user->id,
+        'activity_type' => 'transfer_in',
+        'amount'        => '1.0000',
+        'asset'         => 'USDC',
+        'network'       => 'SOLANA',
+        'status'        => 'completed',
+        'occurred_at'   => now(),
+    ]);
+
+    $device = MobileDevice::create([
+        'user_id'              => $user->id,
+        'device_id'            => 'gdpr-device-1',
+        'platform'             => 'ios',
+        'app_version'          => '1.0.0',
+        'device_name'          => 'Test iPhone',
+        'device_model'         => 'iPhone 17',
+        'push_token'           => 'fcm-token-secret',
+        'biometric_enabled'    => true,
+        'biometric_public_key' => 'biometric-pub-key',
+    ]);
+
+    $session = MobileDeviceSession::create([
+        'mobile_device_id' => $device->id,
+        'user_id'          => $user->id,
+        'session_token'    => 'session-tok-1',
+        'ip_address'       => '10.0.0.1',
+        'last_activity_at' => now(),
+        'expires_at'       => now()->addDay(),
+    ]);
+
+    $challenge = BiometricChallenge::create([
+        'mobile_device_id' => $device->id,
+        'user_id'          => $user->id,
+        'challenge'        => 'challenge-bytes',
+        'status'           => 'pending',
+        'expires_at'       => now()->addMinutes(5),
+    ]);
+
+    $push = MobilePushNotification::create([
+        'user_id'           => $user->id,
+        'mobile_device_id'  => $device->id,
+        'notification_type' => 'transaction',
+        'title'             => 'You received 1 USDC',
+        'body'              => 'From So1anaAddre55',
+    ]);
+
+    $preference = MobileNotificationPreference::create([
+        'user_id'           => $user->id,
+        'mobile_device_id'  => $device->id,
+        'notification_type' => 'transaction',
+        'push_enabled'      => true,
+        'email_enabled'     => false,
+    ]);
+
+    $reassignmentAsNewOwner = DeviceReassignmentLog::create([
+        'device_id'             => 'gdpr-device-1',
+        'previous_user_id'      => null,
+        'new_user_id'           => $user->id,
+        'had_bound_credentials' => false,
+        'reason'                => DeviceReassignmentLog::REASON_AUTO_PUSH_ONLY,
+        'ip_address'            => '10.0.0.1',
+        'user_agent'            => 'ZeltaApp/1.0',
+    ]);
+
+    $otherUser = User::factory()->create();
+    $reassignmentAsPreviousOwner = DeviceReassignmentLog::create([
+        'device_id'             => 'gdpr-device-1',
+        'previous_user_id'      => $user->id,
+        'new_user_id'           => $otherUser->id,
+        'had_bound_credentials' => false,
+        'reason'                => DeviceReassignmentLog::REASON_AUTO_PUSH_ONLY,
+        'ip_address'            => '10.9.9.9', // belongs to $otherUser, must never be exported to $user
+        'user_agent'            => 'OtherUserAgent/1.0',
+    ]);
+
+    DB::table('mcp_tool_invocations')->insert([
+        'token_id'      => 'tok-1',
+        'client_id'     => 'client-1',
+        'user_id'       => $user->id,
+        'tool_name'     => 'accounts_list',
+        'args_hash'     => 'args-hash-1',
+        'result_status' => 'success',
+        'ip'            => '10.0.0.1',
+        'user_agent'    => 'mcp-client/1.0',
+        'created_at'    => now(),
+    ]);
+
+    return [
+        'stripe_subscription' => $stripeSubscription,
+        'iap_subscription'    => $iapSubscription,
+        'iap_receipt'         => $iapReceipt,
+        'consent_log'         => $consentLog,
+        'fingerprint'         => $fingerprint,
+        'cue'                 => $cue,
+        'bridge_customer'     => $bridgeCustomer,
+        'ramp_session'        => $rampSession,
+        'address'             => $address,
+        'send'                => $send,
+        'payment_intent'      => $paymentIntent,
+        'payment_receipt'     => $paymentReceipt,
+        'card_deposit'        => $cardDeposit,
+        'activity_item'       => $activityItem,
+        'device'              => $device,
+        'session'             => $session,
+        'challenge'           => $challenge,
+        'push'                => $push,
+        'preference'          => $preference,
+        'reassignment_new'    => $reassignmentAsNewOwner,
+        'reassignment_prev'   => $reassignmentAsPreviousOwner,
+        'other_user'          => $otherUser,
+    ];
+}
 
 beforeEach(function () {
     Storage::fake('private');
@@ -176,4 +492,276 @@ test('consent tracking works correctly', function () {
     $user->refresh();
     expect($user->marketing_consent_at)->toBeNull();
     expect($user->privacy_policy_accepted_at)->not->toBeNull(); // Others unchanged
+});
+
+test('export includes all post-v7.13 user-data sections with deliberate field choices', function () {
+    Auth::login($this->user);
+    gdpr_seed_user_data_graph($this->user);
+
+    $data = $this->gdprService->exportUserData($this->user->refresh());
+
+    expect($data)->toHaveKeys([
+        'user', 'accounts', 'transactions', 'kyc_documents', 'audit_logs', 'consents',
+        'subscriptions', 'bridge', 'wallet', 'mobile_payments', 'devices', 'api_usage',
+    ]);
+
+    // Identity-provider link is included in the user section
+    expect($data['user']['privy_user_id'])->toBe('did:privy:gdpr-test');
+
+    // Subscriptions: Stripe + IAP metadata included, processor refs/pseudonyms omitted
+    expect($data['subscriptions']['stripe'])->toHaveCount(1);
+    expect($data['subscriptions']['stripe'][0]['stripe_status'])->toBe('active');
+    expect($data['subscriptions']['stripe'][0])->not->toHaveKey('stripe_id');
+    expect($data['subscriptions']['iap'])->toHaveCount(1);
+    expect($data['subscriptions']['iap'][0]['store'])->toBe('apple');
+    expect($data['subscriptions']['iap'][0])->not->toHaveKey('apple_app_account_token');
+    expect($data['subscriptions']['iap'][0])->not->toHaveKey('google_purchase_token_hash');
+    expect($data['subscriptions']['iap_payments'][0]['amount_smallest_unit'])->toBe(999);
+    expect($data['subscriptions']['iap_payments'][0])->not->toHaveKey('receipt_blob');
+    expect($data['subscriptions']['consent_log'][0]['consent_version'])->toBe(1);
+    expect($data['subscriptions']['consent_log'][0])->not->toHaveKey('ip_hash');
+
+    // Bridge: virtual account + deposit instructions are the user's own bank
+    // details and are exported decrypted; processor secrets are omitted
+    expect($data['bridge']['customer']['bridge_customer_id'])->toBe('cust_abc123');
+    expect($data['bridge']['customer']['virtual_account_details'])
+        ->toBe(['bank_name' => 'Lead Bank', 'account_number' => '123456789']);
+    expect($data['bridge']['customer'])->not->toHaveKey('kyc_link_url');
+    expect($data['bridge']['ramp_sessions'][0]['deposit_instructions'])
+        ->toBe(['iban' => 'DE89370400440532013000']);
+    expect($data['bridge']['ramp_sessions'][0])->not->toHaveKey('stripe_client_secret');
+
+    // Wallet: addresses + sends, internal sync/processing fields omitted
+    expect($data['wallet']['blockchain_addresses'][0]['address'])->toBe('So1anaAddre55');
+    expect($data['wallet']['blockchain_addresses'][0])->not->toHaveKey('metadata');
+    expect($data['wallet']['sends'][0]['tx_hash'])->toBe('sig-abc-123');
+    expect($data['wallet']['sends'][0])->not->toHaveKey('metadata');
+
+    // Mobile payments
+    expect($data['mobile_payments']['payment_intents'][0]['status'])->toBe('confirmed');
+    expect($data['mobile_payments']['payment_receipts'][0]['merchant_name'])->toBe('Coffee Corner');
+    expect($data['mobile_payments']['card_deposits'][0]['amount_cents'])->toBe(1000);
+
+    // Devices: descriptive data exported, credentials (push token, biometric keys) omitted
+    expect($data['devices']['devices'][0]['device_name'])->toBe('Test iPhone');
+    expect($data['devices']['devices'][0])->not->toHaveKey('push_token');
+    expect($data['devices']['devices'][0])->not->toHaveKey('biometric_public_key');
+    expect($data['devices']['notification_preferences'][0]['notification_type'])->toBe('transaction');
+
+    // Reassignment rows: ip/user_agent only disclosed where this user is the
+    // registrant — never another data subject's request fingerprint
+    $reassignments = collect($data['devices']['device_reassignments']);
+    $asNewOwner = $reassignments->firstWhere('role', 'new_owner');
+    $asPreviousOwner = $reassignments->firstWhere('role', 'previous_owner');
+    expect($asNewOwner['ip_address'])->toBe('10.0.0.1');
+    expect($asPreviousOwner['ip_address'])->toBeNull();
+    expect($asPreviousOwner['user_agent'])->toBeNull();
+
+    // API usage
+    expect($data['api_usage']['mcp_tool_invocations'][0]['tool_name'])->toBe('accounts_list');
+    expect($data['api_usage']['mcp_tool_invocations'][0])->not->toHaveKey('args_hash');
+});
+
+test('erasure applies the per-table legal action to every post-v7.13 table', function () {
+    Auth::login($this->user);
+    $refs = gdpr_seed_user_data_graph($this->user);
+
+    // Fan-out targets are stubbed: Bridge over fake HTTP, Privy via mock
+    Http::fake(['https://api.bridge.xyz/*' => Http::response(['deleted' => true], 200)]);
+    gdpr_mock_privy_client()
+        ->shouldReceive('deleteUser')->once()->with('did:privy:gdpr-test');
+
+    app(GdprService::class)->deleteUserData($this->user->refresh(), [
+        'delete_documents'       => true,
+        'anonymize_transactions' => true,
+    ]);
+
+    $this->user->refresh();
+
+    // users: anonymized + identity-provider link severed
+    expect($this->user->name)->toStartWith('ANONYMIZED_');
+    expect($this->user->privy_user_id)->toBeNull();
+    expect($this->user->privy_linked_at)->toBeNull();
+
+    // bridge_customers: pure identity/KYC link — hard deleted
+    expect(BridgeCustomer::where('user_id', $this->user->id)->exists())->toBeFalse();
+
+    // ramp_sessions: financial record kept, PII fields nulled
+    $ramp = $refs['ramp_session']->refresh();
+    expect($ramp->deposit_instructions)->toBeNull();
+    expect($ramp->stripe_client_secret)->toBeNull();
+    expect($ramp->metadata)->toBeNull();
+    expect($ramp->fiat_currency)->toBe('EUR');
+    expect($ramp->status)->toBe('completed');
+
+    // iap_subscriptions: financial record kept, store-account identifiers nulled
+    $iap = $refs['iap_subscription']->refresh();
+    expect($iap->apple_app_account_token)->toBeNull();
+    expect($iap->google_obfuscated_account_id)->toBeNull();
+    expect($iap->google_purchase_token_hash)->toBeNull();
+    expect($iap->original_transaction_id)->toBe('orig-tx-1'); // kept for refund/dispute correlation
+    expect($iap->status)->toBe('active');
+
+    // iap_receipts: amounts kept, account identifiers + raw blob nulled
+    $receipt = $refs['iap_receipt']->refresh();
+    expect($receipt->apple_app_account_token)->toBeNull();
+    expect($receipt->receipt_blob)->toBeNull();
+    expect($receipt->amount_smallest_unit)->toBe(999);
+
+    // subscriptions (Cashier): retained unchanged (Art. 17(3)(b))
+    expect(CashierSubscription::query()->where('user_id', $this->user->id)->count())->toBe(1);
+
+    // subscription_consent_log: proof of consent kept, user_agent nulled
+    $consent = $refs['consent_log']->refresh();
+    expect($consent->user_agent)->toBeNull();
+    expect($consent->consent_text)->not->toBeNull();
+
+    // trial_card_fingerprints: fraud-prevention hash kept, user links severed
+    $fp = $refs['fingerprint']->refresh();
+    expect($fp->first_user_id)->toBeNull();
+    expect($fp->last_user_id)->toBeNull();
+    expect($fp->fingerprint_hash)->toBe('fp-hash-gdpr');
+
+    // cues: transient UI state — hard deleted
+    expect(Cue::where('user_id', $this->user->id)->exists())->toBeFalse();
+
+    // blockchain_addresses: row kept (financial trace), deactivated + label/metadata stripped
+    $address = $refs['address']->refresh();
+    expect($address->is_active)->toBeFalse();
+    expect($address->label)->toBeNull();
+    expect($address->metadata)->toBeNull();
+    expect($address->address)->toBe('So1anaAddre55');
+
+    // wallet_send_records: monetary record kept, metadata/error text nulled
+    $send = $refs['send']->refresh();
+    expect($send->metadata)->toBeNull();
+    expect($send->error_message)->toBeNull();
+    expect($send->tx_hash)->toBe('sig-abc-123');
+
+    // payment_intents: monetary record kept, metadata nulled
+    $intent = $refs['payment_intent']->refresh();
+    expect($intent->metadata)->toBeNull();
+    expect($intent->amount)->not->toBeNull();
+
+    // payment_receipts + hyperswitch_deposit_intents: retained unchanged
+    expect(PaymentReceipt::where('user_id', $this->user->id)->exists())->toBeTrue();
+    expect(HyperSwitchDepositIntent::where('user_uuid', $this->user->uuid)->exists())->toBeTrue();
+
+    // activity_feed_items: denormalised mirror — hard deleted
+    expect(ActivityFeedItem::where('user_id', $this->user->id)->exists())->toBeFalse();
+
+    // mobile device PII: hard deleted
+    expect(MobileDevice::where('user_id', $this->user->id)->exists())->toBeFalse();
+    expect(MobileDeviceSession::where('user_id', $this->user->id)->exists())->toBeFalse();
+    expect(BiometricChallenge::where('user_id', $this->user->id)->exists())->toBeFalse();
+    expect(MobilePushNotification::where('user_id', $this->user->id)->exists())->toBeFalse();
+    expect(MobileNotificationPreference::where('user_id', $this->user->id)->exists())->toBeFalse();
+
+    // device_reassignment_log: audit fact kept, request fingerprint nulled
+    $reassignment = $refs['reassignment_new']->refresh();
+    expect($reassignment->ip_address)->toBeNull();
+    expect($reassignment->user_agent)->toBeNull();
+    expect($reassignment->device_id)->toBe('gdpr-device-1');
+
+    // mcp_tool_invocations: audit trail kept, ip/user_agent nulled
+    $invocation = DB::table('mcp_tool_invocations')->where('user_id', $this->user->id)->first();
+    expect($invocation)->not->toBeNull();
+    assert($invocation instanceof stdClass);
+    expect($invocation->ip)->toBeNull();
+    expect($invocation->user_agent)->toBeNull();
+    expect($invocation->tool_name)->toBe('accounts_list');
+});
+
+test('processor fan-out calls Bridge and Privy with the right identifiers', function () {
+    Auth::login($this->user);
+
+    Http::fake(['https://api.bridge.xyz/*' => Http::response(['deleted' => true], 200)]);
+
+    BridgeCustomer::create([
+        'user_id'            => $this->user->id,
+        'bridge_customer_id' => 'cust_abc123',
+        'kyc_status'         => 'approved',
+    ]);
+    $this->user->update(['privy_user_id' => 'did:privy:gdpr-test', 'privy_linked_at' => now()]);
+    IapSubscription::create([
+        'user_id' => $this->user->id,
+        'store'   => 'apple',
+        'tier'    => 'pro',
+        'status'  => 'active',
+    ]);
+
+    gdpr_mock_privy_client()
+        ->shouldReceive('deleteUser')->once()->with('did:privy:gdpr-test');
+
+    app(GdprService::class)->notifyProcessorsOfErasure($this->user->refresh());
+
+    Http::assertSent(function ($request) {
+        return $request->method() === 'DELETE'
+            && $request->url() === 'https://api.bridge.xyz/v0/customers/cust_abc123';
+    });
+
+    $requested = AuditLog::where('action', 'gdpr.processor_erasure_requested')->get();
+    expect($requested->pluck('metadata.processor')->sort()->values()->all())->toBe(['bridge', 'privy']);
+
+    // Apple/Google have no deletion API — manual runbook step is recorded
+    $manual = AuditLog::where('action', 'gdpr.processor_erasure_manual')->first();
+    expect($manual)->not->toBeNull();
+    assert($manual instanceof AuditLog);
+    expect($manual->metadata)->toBe(['processors' => ['apple']]);
+});
+
+test('processor fan-out failures are recorded and never abort local erasure', function () {
+    Auth::login($this->user);
+
+    Http::fake(['https://api.bridge.xyz/*' => Http::response('upstream exploded', 500)]);
+
+    BridgeCustomer::create([
+        'user_id'            => $this->user->id,
+        'bridge_customer_id' => 'cust_failing',
+        'kyc_status'         => 'approved',
+    ]);
+    $this->user->update(['privy_user_id' => 'did:privy:failing', 'privy_linked_at' => now()]);
+
+    gdpr_mock_privy_client()
+        ->shouldReceive('deleteUser')->once()->with('did:privy:failing')
+        ->andThrow(PrivyEmailOtpException::apiError('/api/v1/users/did:privy:failing', 500, 'boom'));
+
+    // Must not throw despite both processors failing
+    app(GdprService::class)->deleteUserData($this->user->refresh());
+
+    $this->user->refresh();
+
+    // Local erasure proceeded
+    expect($this->user->name)->toStartWith('ANONYMIZED_');
+    expect($this->user->privy_user_id)->toBeNull();
+    expect(BridgeCustomer::where('user_id', $this->user->id)->exists())->toBeFalse();
+    expect(AuditLog::where('action', 'gdpr.deletion_completed')->exists())->toBeTrue();
+
+    // Failures recorded for operator retry, with processor + reference
+    $failures = AuditLog::where('action', 'gdpr.processor_erasure_failed')->get();
+    expect($failures->pluck('metadata.processor')->sort()->values()->all())->toBe(['bridge', 'privy']);
+    $bridgeFailure = $failures->firstWhere('metadata.processor', 'bridge');
+    expect($bridgeFailure)->not->toBeNull();
+    assert($bridgeFailure instanceof AuditLog);
+    expect($bridgeFailure->metadata)->toHaveKey('reference', 'cust_failing');
+});
+
+test('a Bridge 404 during fan-out is treated as already-deleted success', function () {
+    Auth::login($this->user);
+
+    Http::fake(['https://api.bridge.xyz/*' => Http::response(['error' => 'not found'], 404)]);
+
+    BridgeCustomer::create([
+        'user_id'            => $this->user->id,
+        'bridge_customer_id' => 'cust_gone',
+        'kyc_status'         => 'approved',
+    ]);
+
+    app(GdprService::class)->notifyProcessorsOfErasure($this->user->refresh());
+
+    expect(AuditLog::where('action', 'gdpr.processor_erasure_failed')->exists())->toBeFalse();
+    $requested = AuditLog::where('action', 'gdpr.processor_erasure_requested')->first();
+    expect($requested)->not->toBeNull();
+    assert($requested instanceof AuditLog);
+    expect($requested->metadata)->toHaveKey('processor', 'bridge');
 });

--- a/tests/Unit/Domain/Auth/Services/PrivyEmailOtpClientTest.php
+++ b/tests/Unit/Domain/Auth/Services/PrivyEmailOtpClientTest.php
@@ -149,3 +149,58 @@ it('throws misconfigured when app_id or app_secret is empty', function (): void 
     $client = new PrivyEmailOtpClient($http);
     expect(fn () => $client->sendCode('jane@example.com'))->toThrow(PrivyEmailOtpException::class, 'credentials');
 });
+
+it('sends an authenticated DELETE to the Privy users endpoint on deleteUser', function (): void {
+    /** @var ClientInterface&MockInterface $http */
+    $http = Mockery::mock(ClientInterface::class);
+    /** @var Mockery\Expectation $expect */
+    $expect = $http->shouldReceive('send');
+    $expect->once()->andReturnUsing(function (RequestInterface $request) {
+        expect($request->getMethod())->toBe('DELETE');
+        expect((string) $request->getUri())->toBe('https://auth.privy.io/api/v1/users/did%3Aprivy%3Aabc123');
+        expect($request->getHeaderLine('privy-app-id'))->toBe('test-app-id');
+        expect($request->getHeaderLine('Authorization'))->toBe('Basic ' . base64_encode('test-app-id:test-app-secret'));
+
+        return new PsrResponse(204, [], '');
+    });
+
+    $client = new PrivyEmailOtpClient($http);
+    $client->deleteUser('did:privy:abc123');
+});
+
+it('treats a 404 on deleteUser as idempotent success', function (): void {
+    /** @var ClientInterface&MockInterface $http */
+    $http = Mockery::mock(ClientInterface::class);
+    /** @var Mockery\Expectation $expect */
+    $expect = $http->shouldReceive('send');
+    $expect->once()->andReturn(new PsrResponse(404, [], '{"error":"User not found"}'));
+
+    $client = new PrivyEmailOtpClient($http);
+    $client->deleteUser('did:privy:already-gone');
+
+    expect(true)->toBeTrue(); // no exception thrown
+});
+
+it('throws apiError when Privy rejects deleteUser', function (): void {
+    /** @var ClientInterface&MockInterface $http */
+    $http = Mockery::mock(ClientInterface::class);
+    /** @var Mockery\Expectation $expect */
+    $expect = $http->shouldReceive('send');
+    $expect->once()->andReturn(new PsrResponse(500, [], '{"error":"internal"}'));
+
+    $client = new PrivyEmailOtpClient($http);
+    expect(fn () => $client->deleteUser('did:privy:abc123'))
+        ->toThrow(PrivyEmailOtpException::class, 'returned 500');
+});
+
+it('throws misconfigured on deleteUser when credentials are empty', function (): void {
+    config(['privy.app_id' => '', 'privy.app_secret' => '']);
+
+    /** @var ClientInterface&MockInterface $http */
+    $http = Mockery::mock(ClientInterface::class);
+    $http->shouldReceive('send')->never();
+
+    $client = new PrivyEmailOtpClient($http);
+    expect(fn () => $client->deleteUser('did:privy:abc123'))
+        ->toThrow(PrivyEmailOtpException::class, 'credentials');
+});


### PR DESCRIPTION
## Summary

`GdprService` was frozen at the pre-v7.13 schema: an Art. 17 erasure or Art. 15 export silently omitted every user-linked table added since — Bridge PII, IAP subscriptions/receipts, on-chain addresses, ramp sessions with encrypted bank details, consent logs, the Privy identity link — and no processor was ever notified.

**Inventory-first**: all **106 tables** with user FK columns are now accounted for in two service constants — 25 COVERED with per-table handling, 81 EXCLUDED with written justification. A regression guard test diffs live schema against the constants, so the next user-data table cannot silently fall out of scope (same philosophy as the CI coverage guard).

**Erasure actions per table** (each justified in code): pure-PII rows deleted (bridge_customers, devices, cues, push tokens); financial records anonymized under Art. 17(3)(b) (ramp_sessions: deposit instructions nulled; iap receipts: store tokens + blobs nulled, transaction ids kept for refund correlation; wallet sends: metadata stripped); audit trails kept with ip/UA nulled under Art. 17(3)(e); `privy_user_id` severed; blockchain addresses deactivated (drops off the Helius watch list) but retained as FK targets for transaction projections.

**Processor fan-out** (before the local transaction; failure-tolerant — a Bridge 5xx never blocks local erasure, failures land as `gdpr.processor_erasure_failed` audit rows for retry): `BridgeClient::deleteCustomer()` (404 = already deleted), `PrivyEmailOtpClient::deleteUser()`, and a structured manual-step audit entry for Apple/Google (no deletion API).

**Export** gains six structured sections (subscriptions, bridge, wallet, mobile payments, devices, API usage) — deposit instructions exported decrypted (the user's own bank data); pseudonymised hashes, processor secrets, and other subjects' data excluded by design.

**Event-store policy** documented on the service: payloads retained under the financial-records exemption; projections anonymized (no per-user crypto-shredding mechanism exists).

## Tests
GdprServiceTest 10 (export/erasure/fan-out incl. failure tolerance), GdprCoverageGuardTest 7, plus 93 green across the touched Privy/Kyc/Bridge suites. PHPStan level 8: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)