### PR TITLE
feat(wallet): record sponsored-send gas costs + USD daily budget cap

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -241,6 +241,11 @@ WALLET_SEND_EVM_NETWORKS=polygon,base,arbitrum
 # paymaster bill against scripted abuse and viral spikes.
 WALLET_SEND_PER_USER_DAILY_LIMIT=30
 WALLET_SEND_GLOBAL_DAILY_LIMIT=5000
+# Optional value-denominated cap on top of the count caps: total estimated
+# USD spent on sponsored gas per UTC day. Spend accumulates at confirmation
+# time from recorded per-send fees; when reached, prepares return 429.
+# Leave empty to disable. Inspect with: php artisan wallet:sponsorship-spend
+WALLET_SPONSORSHIP_DAILY_BUDGET_USD=
 
 # Solana fee-payer (sponsor) account. A non-custodial wallet holds SPL tokens
 # but no SOL, so it cannot pay its own transaction fee — when this key is set

--- a/.env.zelta.example
+++ b/.env.zelta.example
@@ -369,6 +369,11 @@ WALLET_SEND_EVM_NETWORKS=polygon,base,arbitrum
 # paymaster bill against scripted abuse and viral spikes.
 WALLET_SEND_PER_USER_DAILY_LIMIT=30
 WALLET_SEND_GLOBAL_DAILY_LIMIT=5000
+# Optional value-denominated cap on top of the count caps: total estimated
+# USD spent on sponsored gas per UTC day. Spend accumulates at confirmation
+# time from recorded per-send fees; when reached, prepares return 429.
+# Leave empty to disable. Inspect with: php artisan wallet:sponsorship-spend
+WALLET_SPONSORSHIP_DAILY_BUDGET_USD=
 
 # Solana fee-payer (sponsor) account. A non-custodial wallet holds SPL tokens
 # but no SOL, so it cannot pay its own transaction fee — when this key is set

--- a/app/Console/Commands/WalletSponsorshipSpendCommand.php
+++ b/app/Console/Commands/WalletSponsorshipSpendCommand.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Domain\Wallet\Models\WalletSendRecord;
+use App\Domain\Wallet\Services\SponsorshipCostTracker;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Operator visibility into today's sponsored-send spend.
+ *
+ * Sponsored sends draw real platform money (Pimlico gas on EVM, sponsor SOL
+ * on Solana). This command shows, for the current UTC day: how many sends
+ * were prepared, how many confirmed with a recorded fee per network, the
+ * accumulated native-unit cost, a best-effort USD estimate, and the state of
+ * the optional daily USD budget (WALLET_SPONSORSHIP_DAILY_BUDGET_USD).
+ *
+ * Per-network costs come from wallet_send_records (sponsored_fee_raw is
+ * persisted at confirmation time); the prepare count and USD spend counter
+ * come from the same cache keys the prepare-path guardrail uses.
+ */
+class WalletSponsorshipSpendCommand extends Command
+{
+    protected $signature = 'wallet:sponsorship-spend {--json : Output machine-readable JSON}';
+
+    protected $description = "Show today's sponsored-send count and accumulated gas cost per network (UTC day)";
+
+    public function handle(SponsorshipCostTracker $tracker): int
+    {
+        $dayStart = now()->utc()->startOfDay();
+
+        /** @var \Illuminate\Database\Eloquent\Collection<int, WalletSendRecord> $records */
+        $records = WalletSendRecord::query()
+            ->where('status', WalletSendRecord::STATUS_CONFIRMED)
+            ->whereNotNull('sponsored_fee_raw')
+            ->where('confirmed_at', '>=', $dayStart)
+            ->get(['network', 'sponsored_fee_raw', 'sponsored_fee_asset']);
+
+        /** @var array<string, array{count: int, fee_raw_total: numeric-string, fee_asset: string|null}> $byNetwork */
+        $byNetwork = [];
+
+        foreach ($records as $record) {
+            $network = strtolower($record->network);
+            $feeRaw = (string) $record->sponsored_fee_raw;
+
+            if (! is_numeric($feeRaw)) {
+                continue;
+            }
+
+            if (! isset($byNetwork[$network])) {
+                $byNetwork[$network] = [
+                    'count'         => 0,
+                    'fee_raw_total' => '0',
+                    'fee_asset'     => $record->sponsored_fee_asset,
+                ];
+            }
+
+            $byNetwork[$network]['count']++;
+            $byNetwork[$network]['fee_raw_total'] = bcadd($byNetwork[$network]['fee_raw_total'], $feeRaw, 0);
+        }
+
+        ksort($byNetwork);
+
+        $networks = [];
+
+        foreach ($byNetwork as $network => $totals) {
+            $usd = $tracker->estimateUsd($network, $totals['fee_raw_total']);
+
+            $networks[] = [
+                'network'       => $network,
+                'count'         => $totals['count'],
+                'fee_raw_total' => $totals['fee_raw_total'],
+                'fee_asset'     => $totals['fee_asset'] ?? SponsorshipCostTracker::feeAssetForNetwork($network),
+                'usd_estimate'  => $usd !== null ? bcadd($usd, '0', 6) : null,
+            ];
+        }
+
+        $prepareCountRaw = Cache::get(SponsorshipCostTracker::globalSendCountCacheKey());
+        $prepareCount = is_numeric($prepareCountRaw) ? (int) $prepareCountRaw : 0;
+
+        $spentMicro = $tracker->todaysSpendUsdMicro();
+        $spentUsd = bcdiv((string) $spentMicro, '1000000', 6);
+        $budgetUsd = $tracker->dailyBudgetUsd();
+
+        $summary = [
+            'utc_day'               => $dayStart->format('Y-m-d'),
+            'prepares_today'        => $prepareCount,
+            'confirmed_with_fee'    => array_sum(array_column($networks, 'count')),
+            'networks'              => $networks,
+            'budget_spent_usd'      => $spentUsd,
+            'budget_configured_usd' => $budgetUsd,
+            'budget_exhausted'      => $tracker->isDailyBudgetExhausted(),
+        ];
+
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($summary, JSON_PRETTY_PRINT));
+
+            return self::SUCCESS;
+        }
+
+        $this->info("Sponsored-send spend for {$summary['utc_day']} (UTC)");
+        $this->line("Prepared sends today (count guardrail): {$prepareCount}");
+        $this->newLine();
+
+        if ($networks === []) {
+            $this->line('No confirmed sends with a recorded sponsored fee today.');
+        } else {
+            $this->table(
+                ['Network', 'Confirmed sends', 'Total fee (native)', 'Asset', '~USD'],
+                array_map(
+                    static fn (array $row): array => [
+                        $row['network'],
+                        (string) $row['count'],
+                        $row['fee_raw_total'],
+                        $row['fee_asset'] ?? '—',
+                        $row['usd_estimate'] ?? 'n/a (no rate)',
+                    ],
+                    $networks,
+                ),
+            );
+        }
+
+        $this->newLine();
+        $this->line("USD spend counter (budget basis): \${$spentUsd}");
+
+        if ($budgetUsd === null) {
+            $this->line('Daily USD budget: not configured (WALLET_SPONSORSHIP_DAILY_BUDGET_USD unset).');
+        } else {
+            $state = $summary['budget_exhausted'] ? 'EXHAUSTED — prepares return 429' : 'within budget';
+            $this->line("Daily USD budget: \${$budgetUsd} ({$state})");
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Domain/Relayer/Services/PimlicoBundlerService.php
+++ b/app/Domain/Relayer/Services/PimlicoBundlerService.php
@@ -78,6 +78,9 @@ class PimlicoBundlerService implements BundlerInterface
                     $success = ($receiptArray['success'] ?? false) === true
                         || ($receiptArray['success'] ?? '') === 'true';
 
+                    /** @var array<string, mixed> $innerReceipt */
+                    $innerReceipt = is_array($receiptArray['receipt'] ?? null) ? $receiptArray['receipt'] : [];
+
                     return [
                         'status'  => $success ? 'confirmed' : 'failed',
                         'tx_hash' => $receiptArray['receipt']['transactionHash'] ?? null,
@@ -88,6 +91,20 @@ class PimlicoBundlerService implements BundlerInterface
                                 : 0,
                             'blockNumber' => isset($receiptArray['receipt']['blockNumber'])
                                 ? (int) hexdec((string) $receiptArray['receipt']['blockNumber'])
+                                : null,
+                            // Raw hex quantities for sponsorship cost accounting.
+                            // Kept as hex strings — 256-bit values overflow
+                            // hexdec()/PHP ints; downstream converts via bcmath.
+                            // `actualGasCost` is the ERC-4337 receipt field: the
+                            // exact wei the paymaster was charged for this op.
+                            'actualGasCost' => is_string($receiptArray['actualGasCost'] ?? null)
+                                ? $receiptArray['actualGasCost']
+                                : null,
+                            'txGasUsed' => is_string($innerReceipt['gasUsed'] ?? null)
+                                ? $innerReceipt['gasUsed']
+                                : null,
+                            'effectiveGasPrice' => is_string($innerReceipt['effectiveGasPrice'] ?? null)
+                                ? $innerReceipt['effectiveGasPrice']
                                 : null,
                         ],
                     ];

--- a/app/Domain/Wallet/Jobs/PollEvmWalletSendConfirmations.php
+++ b/app/Domain/Wallet/Jobs/PollEvmWalletSendConfirmations.php
@@ -6,6 +6,7 @@ namespace App\Domain\Wallet\Jobs;
 
 use App\Domain\Relayer\Contracts\BundlerInterface;
 use App\Domain\Wallet\Models\WalletSendRecord;
+use App\Domain\Wallet\Services\SponsorshipCostTracker;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -37,7 +38,7 @@ class PollEvmWalletSendConfirmations implements ShouldQueue
 
     public int $timeout = 60;
 
-    public function handle(BundlerInterface $bundler): void
+    public function handle(BundlerInterface $bundler, SponsorshipCostTracker $costTracker): void
     {
         $records = WalletSendRecord::query()
             ->where('status', WalletSendRecord::STATUS_SUBMITTED)
@@ -48,12 +49,15 @@ class PollEvmWalletSendConfirmations implements ShouldQueue
             ->get();
 
         foreach ($records as $record) {
-            $this->reconcile($bundler, $record);
+            $this->reconcile($bundler, $costTracker, $record);
         }
     }
 
-    private function reconcile(BundlerInterface $bundler, WalletSendRecord $record): void
-    {
+    private function reconcile(
+        BundlerInterface $bundler,
+        SponsorshipCostTracker $costTracker,
+        WalletSendRecord $record,
+    ): void {
         if ($record->user_op_hash === null) {
             return;
         }
@@ -79,11 +83,29 @@ class PollEvmWalletSendConfirmations implements ShouldQueue
         $txHash = isset($status['tx_hash']) && is_string($status['tx_hash']) ? $status['tx_hash'] : null;
 
         if ($reportedStatus === 'confirmed') {
-            $record->update([
+            // Sponsorship cost tracking: every userOp send goes through the
+            // Pimlico paymaster, so the gas for a confirmed EVM send was
+            // platform-sponsored — record what it actually cost (wei).
+            $feeWei = $this->resolveSponsoredFeeWei(
+                isset($status['receipt']) && is_array($status['receipt']) ? $status['receipt'] : null
+            );
+
+            $update = [
                 'status'       => WalletSendRecord::STATUS_CONFIRMED,
                 'tx_hash'      => $txHash,
                 'confirmed_at' => now(),
-            ]);
+            ];
+
+            if ($feeWei !== null) {
+                $update['sponsored_fee_raw'] = $feeWei;
+                $update['sponsored_fee_asset'] = SponsorshipCostTracker::feeAssetForNetwork($record->network);
+            }
+
+            $record->update($update);
+
+            if ($feeWei !== null) {
+                $costTracker->recordSpendUsd($record->network, $feeWei);
+            }
 
             return;
         }
@@ -99,5 +121,53 @@ class PollEvmWalletSendConfirmations implements ShouldQueue
         }
 
         // pending / unknown → leave the row in submitted; we'll poll again next tick.
+    }
+
+    /**
+     * Total sponsored gas cost in wei for a confirmed userOp.
+     *
+     * Prefers the bundler receipt's `actualGasCost` (ERC-4337 field — the
+     * exact wei the paymaster was charged for this op). Falls back to
+     * gasUsed * effectiveGasPrice from the inner tx receipt; when the bundle
+     * carries multiple ops that is the whole bundle's cost, i.e. an upper
+     * bound — acceptable as a conservative estimate. All hex→dec conversion
+     * is bcmath-based: 256-bit values overflow hexdec()/PHP ints.
+     *
+     * @param array<string, mixed>|null $receipt
+     *
+     * @return numeric-string|null
+     */
+    private function resolveSponsoredFeeWei(?array $receipt): ?string
+    {
+        if ($receipt === null) {
+            return null;
+        }
+
+        $actualGasCost = $receipt['actualGasCost'] ?? null;
+
+        if (is_string($actualGasCost) && $actualGasCost !== '') {
+            $wei = SponsorshipCostTracker::hexToDecimalString($actualGasCost);
+
+            if (bccomp($wei, '0', 0) > 0) {
+                return $wei;
+            }
+        }
+
+        $gasUsed = $receipt['txGasUsed'] ?? null;
+        $gasPrice = $receipt['effectiveGasPrice'] ?? null;
+
+        if (is_string($gasUsed) && $gasUsed !== '' && is_string($gasPrice) && $gasPrice !== '') {
+            $wei = bcmul(
+                SponsorshipCostTracker::hexToDecimalString($gasUsed),
+                SponsorshipCostTracker::hexToDecimalString($gasPrice),
+                0,
+            );
+
+            if (bccomp($wei, '0', 0) > 0) {
+                return $wei;
+            }
+        }
+
+        return null;
     }
 }

--- a/app/Domain/Wallet/Models/WalletSendRecord.php
+++ b/app/Domain/Wallet/Models/WalletSendRecord.php
@@ -21,6 +21,8 @@ use Illuminate\Database\Eloquent\Model;
  * @property string|null $user_op_hash
  * @property string|null $idempotency_key
  * @property string|null $quote_id
+ * @property string|null $sponsored_fee_raw   Sponsored network fee in native units (lamports/wei) as a decimal string — bcmath only, never float
+ * @property string|null $sponsored_fee_asset Asset the sponsored fee was paid in (SOL, MATIC, ETH-BASE, ETH-ARB, ETH)
  * @property string|null $error_code
  * @property string|null $error_message
  * @property array<string, mixed>|null $metadata
@@ -49,6 +51,8 @@ class WalletSendRecord extends Model
         'user_op_hash',
         'idempotency_key',
         'quote_id',
+        'sponsored_fee_raw',
+        'sponsored_fee_asset',
         'error_code',
         'error_message',
         'metadata',

--- a/app/Domain/Wallet/Services/HeliusTransactionProcessor.php
+++ b/app/Domain/Wallet/Services/HeliusTransactionProcessor.php
@@ -23,6 +23,11 @@ use Illuminate\Support\Facades\Log;
  */
 class HeliusTransactionProcessor
 {
+    public function __construct(
+        private readonly SponsorshipCostTracker $costTracker,
+    ) {
+    }
+
     /**
      * Allowed metadata keys stored alongside blockchain transactions.
      *
@@ -91,7 +96,20 @@ class HeliusTransactionProcessor
                 ->where('network', 'solana')
                 ->first();
 
+        // Sponsor-paid fee (lamports) for a tracked outbound send. Only
+        // recorded when the platform fee-payer is configured — without it the
+        // sender paid its own fee and there is no platform cost to track.
+        // The Helius enhanced payload carries the tx fee in lamports.
+        $sponsoredFeeLamports = null;
+        if ($walletSend !== null && $this->costTracker->isSolanaSponsorConfigured() && is_numeric($feeRaw)) {
+            $lamports = bcadd($feeRaw, '0', 0);
+            if (bccomp($lamports, '0', 0) > 0) {
+                $sponsoredFeeLamports = $lamports;
+            }
+        }
+
         $wasCreated = false;
+        $sponsoredFeeRecorded = false;
 
         DB::transaction(function () use (
             $signature,
@@ -109,7 +127,9 @@ class HeliusTransactionProcessor
             $txFailed,
             $walletSend,
             $isDust,
+            $sponsoredFeeLamports,
             &$wasCreated,
+            &$sponsoredFeeRecorded,
         ): void {
             try {
                 $btx = BlockchainTransaction::firstOrCreate(
@@ -183,15 +203,33 @@ class HeliusTransactionProcessor
                         'failed_at'     => now(),
                     ]);
                 } else {
-                    $walletSend->update([
+                    $update = [
                         'status'       => 'confirmed',
                         'confirmed_at' => now(),
-                    ]);
+                    ];
+
+                    // Sponsorship cost tracking: persist the actual fee the
+                    // platform fee-payer spent on this send (lamports).
+                    if ($sponsoredFeeLamports !== null) {
+                        $update['sponsored_fee_raw'] = $sponsoredFeeLamports;
+                        $update['sponsored_fee_asset'] = SponsorshipCostTracker::feeAssetForNetwork('solana');
+                        $sponsoredFeeRecorded = true;
+                    }
+
+                    $walletSend->update($update);
                 }
             }
 
             $wasCreated = $btx->wasRecentlyCreated;
         });
+
+        // Bump today's USD spend counter for the daily sponsorship budget.
+        // Outside the DB transaction (cache is not transactional) and only
+        // when this call actually flipped the record — webhook retries on an
+        // already-confirmed send must not double-count.
+        if ($sponsoredFeeRecorded && $sponsoredFeeLamports !== null) {
+            $this->costTracker->recordSpendUsd('solana', $sponsoredFeeLamports);
+        }
 
         return $wasCreated;
     }

--- a/app/Domain/Wallet/Services/SponsorshipCostTracker.php
+++ b/app/Domain/Wallet/Services/SponsorshipCostTracker.php
@@ -1,0 +1,300 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Wallet\Services;
+
+use App\Domain\Asset\Services\ExchangeRateService;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Tracks the real cost of gas-sponsored wallet sends.
+ *
+ * Sponsored sends spend platform money on every transaction — Pimlico
+ * paymaster gas on EVM, sponsor-account SOL on Solana. The count caps in
+ * `config/wallet.php` bound *volume*, but a count alone is blind to gas
+ * price: a slow bleed of expensive sends stays invisible under it. This
+ * service records the actual per-send fee at confirmation time and keeps a
+ * daily USD spend counter so the prepare path can also enforce a
+ * value-denominated budget (`wallet.sponsorship.daily_budget_usd`).
+ *
+ * Budget semantics — checked pre-send, incremented post-confirmation: the
+ * counter only grows once the on-chain fee is known, so a burst of
+ * in-flight sends can overshoot the configured budget. Accepted: the
+ * overshoot is bounded by the per-user/global count caps, and a hard
+ * pre-send reservation would have to guess the fee (and block sends
+ * whenever rates are unavailable).
+ *
+ * USD conversion goes through the platform's ExchangeRateService
+ * (read-only). When no native→USD rate is available the increment is
+ * logged and skipped — cost tracking must never block or fail a
+ * confirmation path.
+ */
+class SponsorshipCostTracker
+{
+    /**
+     * The budget counter's minor unit is micro-USD (1e-6 USD). Cents are
+     * too coarse — a single L2 send costs fractions of a cent and would
+     * round to zero forever.
+     */
+    private const string USD_MICRO_FACTOR = '1000000';
+
+    public function __construct(
+        private readonly ExchangeRateService $exchangeRates,
+    ) {
+    }
+
+    /**
+     * Native asset code recorded on the send record for the given network.
+     */
+    public static function feeAssetForNetwork(string $network): ?string
+    {
+        return match (strtolower($network)) {
+            'solana'   => 'SOL',
+            'polygon'  => 'MATIC',
+            'base'     => 'ETH-BASE',
+            'arbitrum' => 'ETH-ARB',
+            'ethereum' => 'ETH',
+            default    => null,
+        };
+    }
+
+    /**
+     * Decimals of the network's native fee unit (lamports → SOL = 9,
+     * wei → ETH/MATIC = 18).
+     */
+    public static function feeDecimalsForNetwork(string $network): int
+    {
+        return strtolower($network) === 'solana' ? 9 : 18;
+    }
+
+    /**
+     * Symbol used for the USD rate lookup. L2 fee assets price as ETH.
+     */
+    public static function rateSymbolForNetwork(string $network): ?string
+    {
+        return match (strtolower($network)) {
+            'solana'                       => 'SOL',
+            'polygon'                      => 'MATIC',
+            'base', 'arbitrum', 'ethereum' => 'ETH',
+            default                        => null,
+        };
+    }
+
+    /**
+     * Whether the Solana fee-payer (sponsor) account is configured — i.e.
+     * whether the platform, not the sender, pays Solana tx fees.
+     */
+    public function isSolanaSponsorConfigured(): bool
+    {
+        return (string) config('wallet.solana.sponsor.secret_key', '') !== '';
+    }
+
+    /**
+     * Configured USD budget per UTC day, or null when budget enforcement is
+     * disabled (WALLET_SPONSORSHIP_DAILY_BUDGET_USD unset / non-numeric / <= 0).
+     *
+     * @return numeric-string|null
+     */
+    public function dailyBudgetUsd(): ?string
+    {
+        $budget = config('wallet.sponsorship.daily_budget_usd');
+
+        if (! is_numeric($budget)) {
+            return null;
+        }
+
+        $normalized = bcadd((string) $budget, '0', 6);
+
+        return bccomp($normalized, '0', 6) > 0 ? $normalized : null;
+    }
+
+    /**
+     * Whether today's accumulated sponsored spend has reached the configured
+     * USD budget. Always false when no budget is configured.
+     */
+    public function isDailyBudgetExhausted(): bool
+    {
+        $budget = $this->dailyBudgetUsd();
+
+        if ($budget === null) {
+            return false;
+        }
+
+        $spentMicro = (string) $this->todaysSpendUsdMicro();
+        $budgetMicro = bcmul($budget, self::USD_MICRO_FACTOR, 0);
+
+        return bccomp($spentMicro, $budgetMicro, 0) >= 0;
+    }
+
+    /**
+     * Accumulated sponsored spend for the current UTC day, in micro-USD.
+     */
+    public function todaysSpendUsdMicro(): int
+    {
+        $value = Cache::get(self::budgetCacheKey());
+
+        return is_numeric($value) ? (int) $value : 0;
+    }
+
+    /**
+     * Cache key for today's (UTC) global USD spend counter. Day-stamped so
+     * it naturally resets at 00:00 UTC, matching the count-cap keys.
+     */
+    public static function budgetCacheKey(): string
+    {
+        return 'wallet_send:budget_usd_micro:global:' . now()->utc()->format('Y-m-d');
+    }
+
+    /**
+     * Cache key for today's (UTC) global send count — shared with the
+     * count-cap enforcement in MobileWalletController.
+     */
+    public static function globalSendCountCacheKey(): string
+    {
+        return 'wallet_send:count:global:' . now()->utc()->format('Y-m-d');
+    }
+
+    /**
+     * Add a confirmed send's sponsored fee to today's USD spend counter.
+     *
+     * Best-effort by design: when no native→USD rate is available the
+     * increment is skipped (with a warning) rather than blocking the
+     * confirmation path. The raw fee is still persisted on the send record,
+     * so the spend can be reconciled later.
+     *
+     * @param string $feeRaw Native units as a decimal string (lamports/wei)
+     */
+    public function recordSpendUsd(string $network, string $feeRaw): void
+    {
+        if (! is_numeric($feeRaw) || bccomp(bcadd($feeRaw, '0', 0), '0', 0) <= 0) {
+            return;
+        }
+
+        $usdMicro = $this->estimateUsdMicro($network, $feeRaw);
+
+        if ($usdMicro === null) {
+            Log::warning('Sponsored-send cost: no USD rate available, skipping budget increment', [
+                'network' => $network,
+                'fee_raw' => $feeRaw,
+            ]);
+
+            return;
+        }
+
+        $key = self::budgetCacheKey();
+
+        // Cache::add + increment — never read-then-write (concurrency-safe).
+        Cache::add($key, 0, now()->addDay());
+        Cache::increment($key, $usdMicro);
+    }
+
+    /**
+     * Conservative micro-USD estimate for a native fee amount, rounded UP
+     * to a whole micro-USD so dust-sized fees are never counted as zero.
+     */
+    public function estimateUsdMicro(string $network, string $feeRaw): ?int
+    {
+        $usd = $this->estimateUsd($network, $feeRaw);
+
+        if ($usd === null) {
+            return null;
+        }
+
+        $micro = bcmul($usd, self::USD_MICRO_FACTOR, 6);
+        $floor = bcadd($micro, '0', 0);
+
+        if (bccomp($micro, $floor, 6) > 0) {
+            $floor = bcadd($floor, '1', 0);
+        }
+
+        return (int) $floor;
+    }
+
+    /**
+     * USD estimate for a native fee amount, or null when the network is
+     * unknown or no rate is available.
+     *
+     * @return numeric-string|null USD value at 12-decimal precision
+     */
+    public function estimateUsd(string $network, string $feeRaw): ?string
+    {
+        if (! is_numeric($feeRaw)) {
+            return null;
+        }
+
+        $symbol = self::rateSymbolForNetwork($network);
+
+        if ($symbol === null) {
+            return null;
+        }
+
+        $rate = $this->usdRateFor($symbol);
+
+        if ($rate === null) {
+            return null;
+        }
+
+        $decimals = self::feeDecimalsForNetwork($network);
+        $major = bcdiv(bcadd($feeRaw, '0', 0), bcpow('10', (string) $decimals, 0), $decimals);
+
+        return bcmul($major, $rate, 12);
+    }
+
+    /**
+     * Convert a hex quantity (`0x…`) to a base-10 string via bcmath —
+     * 256-bit EVM values overflow hexdec()/PHP ints.
+     *
+     * @return numeric-string
+     */
+    public static function hexToDecimalString(string $hex): string
+    {
+        $hex = (string) preg_replace('/^0x/i', '', trim($hex));
+
+        if ($hex === '' || ! ctype_xdigit($hex)) {
+            return '0';
+        }
+
+        /** @var numeric-string $decimal */
+        $decimal = '0';
+
+        foreach (str_split($hex) as $nibble) {
+            $decimal = bcadd(bcmul($decimal, '16', 0), (string) (int) hexdec($nibble), 0);
+        }
+
+        return $decimal;
+    }
+
+    /**
+     * Current native→USD rate, read through the platform rate service.
+     *
+     * @return numeric-string|null
+     */
+    private function usdRateFor(string $symbol): ?string
+    {
+        try {
+            $rate = $this->exchangeRates->getRate($symbol, 'USD');
+        } catch (Throwable $e) {
+            Log::warning('Sponsored-send cost: exchange rate lookup failed', [
+                'symbol' => $symbol,
+                'error'  => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+
+        if ($rate === null) {
+            return null;
+        }
+
+        $value = (string) $rate->rate;
+
+        if (! is_numeric($value)) {
+            return null;
+        }
+
+        return bcadd($value, '0', 10);
+    }
+}

--- a/app/Http/Controllers/Api/Wallet/MobileWalletController.php
+++ b/app/Http/Controllers/Api/Wallet/MobileWalletController.php
@@ -29,6 +29,7 @@ use App\Domain\Wallet\Services\Send\EvmUserOpPreparer;
 use App\Domain\Wallet\Services\Send\EvmUserOpSubmitter;
 use App\Domain\Wallet\Services\Send\SolanaSendPreparer;
 use App\Domain\Wallet\Services\Send\SolanaSendSubmitter;
+use App\Domain\Wallet\Services\SponsorshipCostTracker;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -51,6 +52,7 @@ class MobileWalletController extends Controller
         private readonly SolanaSendSubmitter $solanaSendSubmitter,
         private readonly EvmUserOpPreparer $evmUserOpPreparer,
         private readonly EvmUserOpSubmitter $evmUserOpSubmitter,
+        private readonly SponsorshipCostTracker $sponsorshipCostTracker,
     ) {
     }
 
@@ -885,13 +887,35 @@ class MobileWalletController extends Controller
      */
     private function enforceSendRateLimit(\App\Models\User $user): ?JsonResponse
     {
+        // Value-denominated budget: when WALLET_SPONSORSHIP_DAILY_BUDGET_USD
+        // is configured, stop new prepares once today's accumulated sponsored
+        // spend reaches it. The counter is incremented at confirmation time —
+        // when the real on-chain fee is known — so the budget is checked
+        // pre-send but charged post-confirmation. A burst of in-flight sends
+        // can therefore overshoot the budget slightly; accepted, because the
+        // overshoot is bounded by the count caps below.
+        if ($this->sponsorshipCostTracker->isDailyBudgetExhausted()) {
+            Log::critical('wallet.send daily sponsorship USD budget exhausted', [
+                'spent_usd_micro' => $this->sponsorshipCostTracker->todaysSpendUsdMicro(),
+                'budget_usd'      => $this->sponsorshipCostTracker->dailyBudgetUsd(),
+            ]);
+
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'SEND_TEMPORARILY_UNAVAILABLE',
+                    'message' => 'Sends are temporarily paused. Please try again later.',
+                ],
+            ], 429);
+        }
+
         $perUserLimit = (int) config('wallet.sponsorship.per_user_daily_limit', 30);
         $globalLimit = (int) config('wallet.sponsorship.global_daily_limit', 5000);
 
         $day = now()->utc()->format('Y-m-d');
         $expiry = now()->addDay();
         $perUserKey = "wallet_send:count:user:{$user->id}:{$day}";
-        $globalKey = "wallet_send:count:global:{$day}";
+        $globalKey = SponsorshipCostTracker::globalSendCountCacheKey();
 
         // Cache::add + increment — never read-then-write (concurrency-safe).
         Cache::add($perUserKey, 0, $expiry);

--- a/config/wallet.php
+++ b/config/wallet.php
@@ -103,5 +103,13 @@ return [
     'sponsorship' => [
         'per_user_daily_limit' => (int) env('WALLET_SEND_PER_USER_DAILY_LIMIT', 30),
         'global_daily_limit'   => (int) env('WALLET_SEND_GLOBAL_DAILY_LIMIT', 5000),
+
+        // Optional value-denominated cap on top of the count caps: total
+        // estimated USD the platform will spend on sponsored gas per UTC day.
+        // Null/empty disables the check. The spend counter accumulates at
+        // confirmation time (when the real fee is known), so enforcement
+        // trails in-flight sends slightly — a burst can overshoot the budget,
+        // bounded by the count caps above. See SponsorshipCostTracker.
+        'daily_budget_usd' => env('WALLET_SPONSORSHIP_DAILY_BUDGET_USD'),
     ],
 ];

--- a/database/migrations/2026_06_11_000001_add_sponsored_fee_columns_to_wallet_send_records_table.php
+++ b/database/migrations/2026_06_11_000001_add_sponsored_fee_columns_to_wallet_send_records_table.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Sponsored-send cost tracking.
+ *
+ * Gas-sponsored sends (Pimlico paymaster on EVM, fee-payer account on
+ * Solana) spend platform money on every transaction, but until now no
+ * per-send cost was ever recorded — monthly spend and cost-per-user were
+ * invisible. These columns capture the actual fee at confirmation time.
+ *
+ * `sponsored_fee_raw` stores the native unit as a decimal string —
+ * lamports for Solana, wei for EVM. 78 chars covers a full 256-bit value.
+ * Always handle via bcmath; never cast to float/int.
+ */
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('wallet_send_records', function (Blueprint $table): void {
+            $table->string('sponsored_fee_raw', 78)->nullable()->after('quote_id')
+                ->comment('Sponsored network fee in native units (lamports/wei), decimal string');
+            $table->string('sponsored_fee_asset', 16)->nullable()->after('sponsored_fee_raw')
+                ->comment('Asset the sponsored fee was paid in (SOL, MATIC, ETH-BASE, ETH-ARB, ETH)');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('wallet_send_records', function (Blueprint $table): void {
+            $table->dropColumn(['sponsored_fee_raw', 'sponsored_fee_asset']);
+        });
+    }
+};

--- a/tests/Feature/Api/Wallet/WalletTransactionPrepareTest.php
+++ b/tests/Feature/Api/Wallet/WalletTransactionPrepareTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Api\Wallet;
 
+use App\Domain\Wallet\Services\SponsorshipCostTracker;
 use App\Models\User;
 use Illuminate\Support\Facades\Cache;
 use Tests\TestCase;
@@ -211,5 +212,49 @@ class WalletTransactionPrepareTest extends TestCase
 
         $this->withToken($this->token)->postJson('/api/v1/wallet/transactions/prepare', $body)
             ->assertStatus(429)->assertJsonPath('error.code', 'SEND_TEMPORARILY_UNAVAILABLE');
+    }
+
+    public function test_prepare_blocks_when_daily_usd_budget_is_exhausted(): void
+    {
+        config(['wallet.sponsorship.daily_budget_usd' => '10']);
+
+        // Simulate $10.000000 of sponsored spend accumulated by confirmations.
+        $key = SponsorshipCostTracker::budgetCacheKey();
+        Cache::add($key, 0, now()->addDay());
+        Cache::increment($key, 10_000_000);
+
+        $body = [
+            'to'       => '0x742d35cc6634c0532925a3b844bc454e4438f44e',
+            'token'    => 'USDC',
+            'amount'   => '1.50',
+            'network'  => 'polygon',
+            'quote_id' => 'q_test_budget',
+        ];
+
+        // Same 429 shape as the global count ceiling.
+        $this->withToken($this->token)->postJson('/api/v1/wallet/transactions/prepare', $body)
+            ->assertStatus(429)->assertJsonPath('error.code', 'SEND_TEMPORARILY_UNAVAILABLE');
+    }
+
+    public function test_prepare_ignores_spend_counter_when_no_budget_is_configured(): void
+    {
+        config(['wallet.sponsorship.daily_budget_usd' => null]);
+
+        // Massive accumulated spend, but no budget configured → no behavior change.
+        $key = SponsorshipCostTracker::budgetCacheKey();
+        Cache::add($key, 0, now()->addDay());
+        Cache::increment($key, 999_999_999);
+
+        $body = [
+            'to'       => '0x742d35cc6634c0532925a3b844bc454e4438f44e',
+            'token'    => 'USDC',
+            'amount'   => '1.50',
+            'network'  => 'polygon',
+            'quote_id' => 'q_test_no_budget',
+        ];
+
+        // Fails later for an unrelated reason (no sender address) — not a 429.
+        $this->withToken($this->token)->postJson('/api/v1/wallet/transactions/prepare', $body)
+            ->assertStatus(422)->assertJsonPath('error.code', 'NO_SENDER_ADDRESS');
     }
 }

--- a/tests/Feature/Console/WalletSponsorshipSpendCommandTest.php
+++ b/tests/Feature/Console/WalletSponsorshipSpendCommandTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Wallet\Models\WalletSendRecord;
+use App\Domain\Wallet\Services\SponsorshipCostTracker;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+
+beforeEach(function (): void {
+    config(['cache.default' => 'array']);
+    Cache::flush();
+});
+
+it('runs with no recorded spend and reports an unconfigured budget', function (): void {
+    config(['wallet.sponsorship.daily_budget_usd' => null]);
+
+    $this->artisan('wallet:sponsorship-spend')
+        ->expectsOutputToContain('No confirmed sends with a recorded sponsored fee today.')
+        ->expectsOutputToContain('Daily USD budget: not configured')
+        ->assertExitCode(0);
+});
+
+it('aggregates today\'s confirmed sponsored fees per network', function (): void {
+    $user = User::factory()->create();
+
+    foreach ([['solana', '5000', 'SOL'], ['solana', '7000', 'SOL'], ['polygon', '200000000000', 'MATIC']] as $i => [$network, $fee, $asset]) {
+        WalletSendRecord::create([
+            'public_id'           => 'pi_send_spendcmd_' . $i,
+            'user_id'             => $user->id,
+            'network'             => $network,
+            'asset'               => 'USDC',
+            'amount'              => '1.00000000',
+            'sender_address'      => 'sender-address-x',
+            'recipient_address'   => 'recipient-address-x',
+            'status'              => 'confirmed',
+            'confirmed_at'        => now(),
+            'sponsored_fee_raw'   => $fee,
+            'sponsored_fee_asset' => $asset,
+        ]);
+    }
+
+    // A failed send and an unsponsored confirmed send must not be counted.
+    WalletSendRecord::create([
+        'public_id'         => 'pi_send_spendcmd_skip',
+        'user_id'           => $user->id,
+        'network'           => 'solana',
+        'asset'             => 'USDC',
+        'amount'            => '1.00000000',
+        'sender_address'    => 'sender-address-x',
+        'recipient_address' => 'recipient-address-x',
+        'status'            => 'confirmed',
+        'confirmed_at'      => now(),
+    ]);
+
+    $this->artisan('wallet:sponsorship-spend')
+        ->expectsOutputToContain('12000') // 5000 + 7000 lamports
+        ->expectsOutputToContain('200000000000')
+        ->assertExitCode(0);
+});
+
+it('outputs machine-readable JSON with --json', function (): void {
+    config(['wallet.sponsorship.daily_budget_usd' => '25']);
+
+    $key = SponsorshipCostTracker::budgetCacheKey();
+    Cache::add($key, 0, now()->addDay());
+    Cache::increment($key, 1_500_000); // $1.50 spent
+
+    $exitCode = Illuminate\Support\Facades\Artisan::call('wallet:sponsorship-spend', ['--json' => true]);
+    expect($exitCode)->toBe(0);
+
+    $output = Illuminate\Support\Facades\Artisan::output();
+    $decoded = json_decode($output, true);
+
+    expect($decoded)->toBeArray()
+        ->and($decoded['budget_spent_usd'])->toBe('1.500000')
+        ->and($decoded['budget_configured_usd'])->toBe('25.000000')
+        ->and($decoded['budget_exhausted'])->toBeFalse()
+        ->and($decoded['networks'])->toBeArray();
+});

--- a/tests/Feature/Domain/Wallet/HeliusTransactionProcessorWalletSendConfirmationTest.php
+++ b/tests/Feature/Domain/Wallet/HeliusTransactionProcessorWalletSendConfirmationTest.php
@@ -33,6 +33,8 @@ beforeEach(function (): void {
         $table->string('user_op_hash', 128)->nullable();
         $table->string('idempotency_key', 128)->nullable()->unique();
         $table->string('quote_id', 64)->nullable();
+        $table->string('sponsored_fee_raw', 78)->nullable();
+        $table->string('sponsored_fee_asset', 16)->nullable();
         $table->string('error_code', 50)->nullable();
         $table->text('error_message')->nullable();
         $table->json('metadata')->nullable();
@@ -97,6 +99,108 @@ it('flips a submitted Solana wallet_send_records to confirmed when its tx hash a
     $sendRecord->refresh();
     expect($sendRecord->status)->toBe('confirmed')
         ->and($sendRecord->confirmed_at)->not->toBeNull();
+});
+
+it('persists the sponsored fee (lamports) on confirmation when the Solana sponsor is configured', function (): void {
+    config(['wallet.solana.sponsor.secret_key' => 'test-sponsor-base58-secret']);
+
+    $signature = '9xSponsoredFeeSig444444444444444444444444444444444444444444444444';
+
+    $sendRecord = WalletSendRecord::create([
+        'public_id'         => 'pi_send_sponsoredfee',
+        'user_id'           => 42,
+        'network'           => 'solana',
+        'asset'             => 'USDC',
+        'amount'            => '1.50000000',
+        'sender_address'    => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        'recipient_address' => 'BobxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxV',
+        'status'            => 'submitted',
+        'tx_hash'           => $signature,
+        'submitted_at'      => now(),
+    ]);
+
+    $blockchainAddress = BlockchainAddress::create([
+        'uuid'       => '44444444-5555-4666-8777-888888888888',
+        'user_uuid'  => 'user-uuid-42',
+        'address'    => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        'public_key' => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        'chain'      => 'solana',
+        'is_active'  => true,
+    ]);
+
+    $tx = [
+        'signature'      => $signature,
+        'fee'            => 5000, // lamports, paid by the platform fee-payer
+        'tokenTransfers' => [[
+            'fromUserAccount' => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+            'toUserAccount'   => 'BobxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxV',
+            'mint'            => 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+            'tokenAmount'     => '1.5',
+        ]],
+    ];
+
+    app(HeliusTransactionProcessor::class)->processTransaction(
+        'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        $blockchainAddress,
+        42,
+        $tx,
+    );
+
+    $sendRecord->refresh();
+    expect($sendRecord->status)->toBe('confirmed')
+        ->and($sendRecord->sponsored_fee_raw)->toBe('5000')
+        ->and($sendRecord->sponsored_fee_asset)->toBe('SOL');
+});
+
+it('does not record a sponsored fee when no Solana sponsor is configured (sender paid its own fee)', function (): void {
+    config(['wallet.solana.sponsor.secret_key' => '']);
+
+    $signature = 'AxUnsponsoredSig55555555555555555555555555555555555555555555555555';
+
+    $sendRecord = WalletSendRecord::create([
+        'public_id'         => 'pi_send_unsponsored',
+        'user_id'           => 42,
+        'network'           => 'solana',
+        'asset'             => 'USDC',
+        'amount'            => '1.50000000',
+        'sender_address'    => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        'recipient_address' => 'BobxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxV',
+        'status'            => 'submitted',
+        'tx_hash'           => $signature,
+        'submitted_at'      => now(),
+    ]);
+
+    $blockchainAddress = BlockchainAddress::create([
+        'uuid'       => '55555555-6666-4777-8888-999999999999',
+        'user_uuid'  => 'user-uuid-42',
+        'address'    => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        'public_key' => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        'chain'      => 'solana',
+        'is_active'  => true,
+    ]);
+
+    $tx = [
+        'signature'      => $signature,
+        'fee'            => 5000,
+        'tokenTransfers' => [[
+            'fromUserAccount' => 'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+            'toUserAccount'   => 'BobxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxV',
+            'mint'            => 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+            'tokenAmount'     => '1.5',
+        ]],
+    ];
+
+    app(HeliusTransactionProcessor::class)->processTransaction(
+        'EfkncjQTojTB6m9DqoyBqizLLwZgLu1uwg3Y3FqE6f7Z',
+        $blockchainAddress,
+        42,
+        $tx,
+    );
+
+    $sendRecord->refresh();
+    expect($sendRecord->status)->toBe('confirmed')
+        ->and($sendRecord->sponsored_fee_raw)->toBeNull()
+        ->and($sendRecord->sponsored_fee_asset)->toBeNull();
 });
 
 it('does not touch wallet_send_records on incoming (receive) Solana tx', function (): void {

--- a/tests/Feature/Domain/Wallet/WalletSendRecordSponsoredFeeTest.php
+++ b/tests/Feature/Domain/Wallet/WalletSendRecordSponsoredFeeTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Wallet\Models\WalletSendRecord;
+use App\Models\User;
+use Illuminate\Support\Facades\Schema;
+
+it('has the sponsored fee columns after migrations', function (): void {
+    expect(Schema::hasColumns('wallet_send_records', ['sponsored_fee_raw', 'sponsored_fee_asset']))->toBeTrue();
+});
+
+it('round-trips sponsored fee values as decimal strings (no float coercion)', function (): void {
+    $user = User::factory()->create();
+
+    $record = WalletSendRecord::create([
+        'public_id'         => 'pi_send_feeroundtrip',
+        'user_id'           => $user->id,
+        'network'           => 'base',
+        'asset'             => 'USDC',
+        'amount'            => '1.00000000',
+        'sender_address'    => '0xsender',
+        'recipient_address' => '0xrecipient',
+        'status'            => 'confirmed',
+        'confirmed_at'      => now(),
+        // 256-bit-scale value: must survive storage untouched as a string.
+        'sponsored_fee_raw'   => '115792089237316195423570985008687907853269984665640564039457584007913129639935',
+        'sponsored_fee_asset' => 'ETH-BASE',
+    ]);
+
+    $record->refresh();
+
+    expect($record->sponsored_fee_raw)
+        ->toBe('115792089237316195423570985008687907853269984665640564039457584007913129639935')
+        ->and($record->sponsored_fee_asset)->toBe('ETH-BASE');
+});
+
+it('defaults sponsored fee columns to null for unsponsored sends', function (): void {
+    $user = User::factory()->create();
+
+    $record = WalletSendRecord::create([
+        'public_id'         => 'pi_send_feedefaults',
+        'user_id'           => $user->id,
+        'network'           => 'solana',
+        'asset'             => 'USDC',
+        'amount'            => '1.00000000',
+        'sender_address'    => 'sender-base58',
+        'recipient_address' => 'recipient-base58',
+        'status'            => 'pending',
+    ]);
+
+    $record->refresh();
+
+    expect($record->sponsored_fee_raw)->toBeNull()
+        ->and($record->sponsored_fee_asset)->toBeNull();
+});

--- a/tests/Unit/Domain/Wallet/Jobs/PollEvmWalletSendConfirmationsTest.php
+++ b/tests/Unit/Domain/Wallet/Jobs/PollEvmWalletSendConfirmationsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Domain\Relayer\Contracts\BundlerInterface;
 use App\Domain\Wallet\Jobs\PollEvmWalletSendConfirmations;
 use App\Domain\Wallet\Models\WalletSendRecord;
+use App\Domain\Wallet\Services\SponsorshipCostTracker;
 use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
 
@@ -26,6 +27,8 @@ beforeEach(function (): void {
         $table->string('user_op_hash', 128)->nullable();
         $table->string('idempotency_key', 128)->nullable()->unique();
         $table->string('quote_id', 64)->nullable();
+        $table->string('sponsored_fee_raw', 78)->nullable();
+        $table->string('sponsored_fee_asset', 16)->nullable();
         $table->string('error_code', 50)->nullable();
         $table->text('error_message')->nullable();
         $table->json('metadata')->nullable();
@@ -66,7 +69,7 @@ it('flips submitted EVM record to confirmed when bundler reports a receipt', fun
             'receipt' => ['success' => true, 'gasUsed' => 0, 'blockNumber' => 1],
         ]);
 
-    (new PollEvmWalletSendConfirmations())->handle($bundler);
+    (new PollEvmWalletSendConfirmations())->handle($bundler, app(SponsorshipCostTracker::class));
 
     $record->refresh();
     expect($record->status)->toBe('confirmed')
@@ -88,7 +91,7 @@ it('flips submitted EVM record to failed when bundler reports a reverted receipt
             'receipt' => null,
         ]);
 
-    (new PollEvmWalletSendConfirmations())->handle($bundler);
+    (new PollEvmWalletSendConfirmations())->handle($bundler, app(SponsorshipCostTracker::class));
 
     $record->refresh();
     expect($record->status)->toBe('failed')
@@ -105,7 +108,7 @@ it('leaves submitted record alone when bundler returns pending', function (): vo
         ->once()
         ->andReturn(['status' => 'pending', 'tx_hash' => null, 'receipt' => null]);
 
-    (new PollEvmWalletSendConfirmations())->handle($bundler);
+    (new PollEvmWalletSendConfirmations())->handle($bundler, app(SponsorshipCostTracker::class));
 
     $record->refresh();
     expect($record->status)->toBe('submitted')
@@ -123,7 +126,7 @@ it('does not touch Solana records (those are handled by Helius webhook)', functi
     $bundler = Mockery::mock(BundlerInterface::class);
     $bundler->shouldNotReceive('getUserOperationStatus');
 
-    (new PollEvmWalletSendConfirmations())->handle($bundler);
+    (new PollEvmWalletSendConfirmations())->handle($bundler, app(SponsorshipCostTracker::class));
 
     $record->refresh();
     expect($record->status)->toBe('submitted'); // unchanged
@@ -138,7 +141,7 @@ it('skips records older than 2 hours (avoids unbounded backlog)', function (): v
     $bundler = Mockery::mock(BundlerInterface::class);
     $bundler->shouldNotReceive('getUserOperationStatus');
 
-    (new PollEvmWalletSendConfirmations())->handle($bundler);
+    (new PollEvmWalletSendConfirmations())->handle($bundler, app(SponsorshipCostTracker::class));
 
     $record->refresh();
     expect($record->status)->toBe('submitted');
@@ -153,8 +156,87 @@ it('logs and continues when bundler throws', function (): void {
         ->once()
         ->andThrow(new RuntimeException('Bundler RPC down'));
 
-    (new PollEvmWalletSendConfirmations())->handle($bundler);
+    (new PollEvmWalletSendConfirmations())->handle($bundler, app(SponsorshipCostTracker::class));
 
     $record->refresh();
     expect($record->status)->toBe('submitted'); // unchanged — caught & logged
+});
+
+it('persists the sponsored fee from the bundler actualGasCost (hex wei → decimal string)', function (): void {
+    $record = makeSubmittedRecord('polygon', '0xUserOpWithCost');
+
+    /** @var BundlerInterface&Mockery\MockInterface $bundler */
+    $bundler = Mockery::mock(BundlerInterface::class);
+    $bundler->shouldReceive('getUserOperationStatus')
+        ->once()
+        ->andReturn([
+            'status'  => 'confirmed',
+            'tx_hash' => '0xcostTxHash',
+            'receipt' => [
+                'success'     => true,
+                'gasUsed'     => 150000,
+                'blockNumber' => 1,
+                // 0x2e90edd000 = 200_000_000_000 wei
+                'actualGasCost'     => '0x2e90edd000',
+                'txGasUsed'         => '0x5208',
+                'effectiveGasPrice' => '0x3b9aca00',
+            ],
+        ]);
+
+    (new PollEvmWalletSendConfirmations())->handle($bundler, app(SponsorshipCostTracker::class));
+
+    $record->refresh();
+    expect($record->status)->toBe('confirmed')
+        ->and($record->sponsored_fee_raw)->toBe('200000000000')
+        ->and($record->sponsored_fee_asset)->toBe('MATIC');
+});
+
+it('falls back to gasUsed * effectiveGasPrice when actualGasCost is absent', function (): void {
+    $record = makeSubmittedRecord('base', '0xUserOpFallbackCost');
+
+    /** @var BundlerInterface&Mockery\MockInterface $bundler */
+    $bundler = Mockery::mock(BundlerInterface::class);
+    $bundler->shouldReceive('getUserOperationStatus')
+        ->once()
+        ->andReturn([
+            'status'  => 'confirmed',
+            'tx_hash' => '0xfallbackTxHash',
+            'receipt' => [
+                'success'     => true,
+                'gasUsed'     => 21000,
+                'blockNumber' => 1,
+                // 0x5208 = 21000 gas * 0x3b9aca00 = 1 gwei → 21_000_000_000_000 wei
+                'actualGasCost'     => null,
+                'txGasUsed'         => '0x5208',
+                'effectiveGasPrice' => '0x3b9aca00',
+            ],
+        ]);
+
+    (new PollEvmWalletSendConfirmations())->handle($bundler, app(SponsorshipCostTracker::class));
+
+    $record->refresh();
+    expect($record->status)->toBe('confirmed')
+        ->and($record->sponsored_fee_raw)->toBe('21000000000000')
+        ->and($record->sponsored_fee_asset)->toBe('ETH-BASE');
+});
+
+it('confirms without a sponsored fee when the receipt has no usable cost fields', function (): void {
+    $record = makeSubmittedRecord('arbitrum', '0xUserOpNoCostFields');
+
+    /** @var BundlerInterface&Mockery\MockInterface $bundler */
+    $bundler = Mockery::mock(BundlerInterface::class);
+    $bundler->shouldReceive('getUserOperationStatus')
+        ->once()
+        ->andReturn([
+            'status'  => 'confirmed',
+            'tx_hash' => '0xnoCostTxHash',
+            'receipt' => ['success' => true, 'gasUsed' => 0, 'blockNumber' => 1],
+        ]);
+
+    (new PollEvmWalletSendConfirmations())->handle($bundler, app(SponsorshipCostTracker::class));
+
+    $record->refresh();
+    expect($record->status)->toBe('confirmed')
+        ->and($record->sponsored_fee_raw)->toBeNull()
+        ->and($record->sponsored_fee_asset)->toBeNull();
 });

--- a/tests/Unit/Domain/Wallet/Services/SponsorshipCostTrackerTest.php
+++ b/tests/Unit/Domain/Wallet/Services/SponsorshipCostTrackerTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Asset\Models\ExchangeRate;
+use App\Domain\Asset\Services\ExchangeRateService;
+use App\Domain\Wallet\Services\SponsorshipCostTracker;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+beforeEach(function (): void {
+    // Array cache: isolated per process, no cross-test interference.
+    config(['cache.default' => 'array']);
+    Cache::flush();
+});
+
+/**
+ * @return ExchangeRateService&Mockery\MockInterface
+ */
+function mockRateService(?string $rate): ExchangeRateService
+{
+    /** @var ExchangeRateService&Mockery\MockInterface $service */
+    $service = Mockery::mock(ExchangeRateService::class);
+
+    if ($rate === null) {
+        $service->shouldReceive('getRate')->andReturn(null);
+    } else {
+        $model = new ExchangeRate();
+        $model->rate = $rate;
+        $service->shouldReceive('getRate')->andReturn($model);
+    }
+
+    return $service;
+}
+
+it('converts hex quantities to decimal strings without overflowing on 256-bit values', function (): void {
+    expect(SponsorshipCostTracker::hexToDecimalString('0x5208'))->toBe('21000')
+        ->and(SponsorshipCostTracker::hexToDecimalString('0x3b9aca00'))->toBe('1000000000')
+        ->and(SponsorshipCostTracker::hexToDecimalString('5208'))->toBe('21000')
+        ->and(SponsorshipCostTracker::hexToDecimalString('0x0'))->toBe('0')
+        ->and(SponsorshipCostTracker::hexToDecimalString(''))->toBe('0')
+        ->and(SponsorshipCostTracker::hexToDecimalString('not-hex'))->toBe('0')
+        // 2^256 - 1: hexdec() would lose precision here; bcmath must not.
+        ->and(SponsorshipCostTracker::hexToDecimalString(
+            '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+        ))->toBe('115792089237316195423570985008687907853269984665640564039457584007913129639935');
+});
+
+it('computes gasUsed * effectiveGasPrice with bcmath (21000 gas at 1 gwei)', function (): void {
+    $wei = bcmul(
+        SponsorshipCostTracker::hexToDecimalString('0x5208'),
+        SponsorshipCostTracker::hexToDecimalString('0x3b9aca00'),
+        0,
+    );
+
+    expect($wei)->toBe('21000000000000');
+});
+
+it('maps networks to fee assets and rate symbols', function (): void {
+    expect(SponsorshipCostTracker::feeAssetForNetwork('solana'))->toBe('SOL')
+        ->and(SponsorshipCostTracker::feeAssetForNetwork('polygon'))->toBe('MATIC')
+        ->and(SponsorshipCostTracker::feeAssetForNetwork('base'))->toBe('ETH-BASE')
+        ->and(SponsorshipCostTracker::feeAssetForNetwork('arbitrum'))->toBe('ETH-ARB')
+        ->and(SponsorshipCostTracker::feeAssetForNetwork('ethereum'))->toBe('ETH')
+        ->and(SponsorshipCostTracker::feeAssetForNetwork('tron'))->toBeNull()
+        ->and(SponsorshipCostTracker::rateSymbolForNetwork('base'))->toBe('ETH')
+        ->and(SponsorshipCostTracker::feeDecimalsForNetwork('solana'))->toBe(9)
+        ->and(SponsorshipCostTracker::feeDecimalsForNetwork('polygon'))->toBe(18);
+});
+
+it('increments the daily USD budget counter from a Solana fee (5000 lamports at $200/SOL = 1000 micro-USD)', function (): void {
+    $tracker = new SponsorshipCostTracker(mockRateService('200'));
+
+    $tracker->recordSpendUsd('solana', '5000');
+
+    expect($tracker->todaysSpendUsdMicro())->toBe(1000);
+});
+
+it('rounds dust fees UP to a whole micro-USD so they are never counted as zero', function (): void {
+    $tracker = new SponsorshipCostTracker(mockRateService('100'));
+
+    // 1 lamport at $100/SOL = 0.0000001 USD = 0.1 micro-USD → ceil → 1
+    $tracker->recordSpendUsd('solana', '1');
+
+    expect($tracker->todaysSpendUsdMicro())->toBe(1);
+});
+
+it('skips the budget increment (without throwing) when no USD rate is available', function (): void {
+    $tracker = new SponsorshipCostTracker(mockRateService(null));
+
+    $tracker->recordSpendUsd('polygon', '200000000000');
+
+    expect($tracker->todaysSpendUsdMicro())->toBe(0);
+});
+
+it('ignores non-numeric and non-positive fee inputs', function (): void {
+    $tracker = new SponsorshipCostTracker(mockRateService('200'));
+
+    $tracker->recordSpendUsd('solana', 'not-a-number');
+    $tracker->recordSpendUsd('solana', '0');
+
+    expect($tracker->todaysSpendUsdMicro())->toBe(0);
+});
+
+it('reports the budget exhausted only when the counter reaches the configured USD cap', function (): void {
+    config(['wallet.sponsorship.daily_budget_usd' => '10']);
+
+    $tracker = new SponsorshipCostTracker(mockRateService(null));
+    $key = SponsorshipCostTracker::budgetCacheKey();
+
+    Cache::add($key, 0, now()->addDay());
+    Cache::increment($key, 9_999_999);
+    expect($tracker->isDailyBudgetExhausted())->toBeFalse();
+
+    Cache::increment($key, 1); // exactly $10.000000
+    expect($tracker->isDailyBudgetExhausted())->toBeTrue();
+});
+
+it('never reports the budget exhausted when no budget is configured', function (): void {
+    config(['wallet.sponsorship.daily_budget_usd' => null]);
+
+    $tracker = new SponsorshipCostTracker(mockRateService(null));
+    $key = SponsorshipCostTracker::budgetCacheKey();
+
+    Cache::add($key, 0, now()->addDay());
+    Cache::increment($key, 999_999_999);
+
+    expect($tracker->isDailyBudgetExhausted())->toBeFalse()
+        ->and($tracker->dailyBudgetUsd())->toBeNull();
+});
+
+it('treats a non-numeric or non-positive configured budget as disabled', function (): void {
+    $tracker = new SponsorshipCostTracker(mockRateService(null));
+
+    config(['wallet.sponsorship.daily_budget_usd' => 'banana']);
+    expect($tracker->dailyBudgetUsd())->toBeNull();
+
+    config(['wallet.sponsorship.daily_budget_usd' => '0']);
+    expect($tracker->dailyBudgetUsd())->toBeNull();
+
+    config(['wallet.sponsorship.daily_budget_usd' => '25.50']);
+    expect($tracker->dailyBudgetUsd())->toBe('25.500000');
+});

--- a/tests/Unit/Http/Controllers/Api/Wallet/MobileWalletControllerTest.php
+++ b/tests/Unit/Http/Controllers/Api/Wallet/MobileWalletControllerTest.php
@@ -12,6 +12,7 @@ use App\Domain\Wallet\Services\Send\EvmUserOpPreparer;
 use App\Domain\Wallet\Services\Send\EvmUserOpSubmitter;
 use App\Domain\Wallet\Services\Send\SolanaSendPreparer;
 use App\Domain\Wallet\Services\Send\SolanaSendSubmitter;
+use App\Domain\Wallet\Services\SponsorshipCostTracker;
 use App\Http\Controllers\Api\Wallet\MobileWalletController;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Collection;
@@ -31,6 +32,8 @@ beforeEach(function (): void {
     $this->solanaSendSubmitter = Mockery::mock(SolanaSendSubmitter::class);
     $this->evmUserOpPreparer = Mockery::mock(EvmUserOpPreparer::class);
     $this->evmUserOpSubmitter = Mockery::mock(EvmUserOpSubmitter::class);
+    $this->sponsorshipCostTracker = Mockery::mock(SponsorshipCostTracker::class);
+    $this->sponsorshipCostTracker->shouldReceive('isDailyBudgetExhausted')->andReturn(false);
 });
 
 function makeWalletController($test): MobileWalletController
@@ -45,6 +48,7 @@ function makeWalletController($test): MobileWalletController
         $test->solanaSendSubmitter,
         $test->evmUserOpPreparer,
         $test->evmUserOpSubmitter,
+        $test->sponsorshipCostTracker,
     );
 }
 


### PR DESCRIPTION
## Summary

Sponsored sends cost real money (Pimlico gas on EVM, sponsor SOL fees), but the caps were count-only (30/user/day, 5000 global) and **no per-send cost was ever recorded** — monthly spend, cost per user, and slow-bleed gas-griefing under the count cap were all invisible until the invoice.

**Cost capture at confirmation** (new nullable `sponsored_fee_raw`/`sponsored_fee_asset` on `wallet_send_records`):
- Solana: the Helius payload already carries the lamport `fee`; persisted when the sponsor key is configured (sender-paid sends excluded). Webhook-retry safe — an already-confirmed record never double-increments.
- EVM: `eth_getUserOperationReceipt`'s `actualGasCost` (the exact wei the paymaster was charged), falling back to `gasUsed × effectiveGasPrice`. Hex→dec via bcmath (verified at 2²⁵⁶−1 — `hexdec` overflows). No new RPC calls.

**USD daily budget** (`WALLET_SPONSORSHIP_DAILY_BUDGET_USD`, default disabled): checked in the existing prepare-path guardrail, returning the same 429 `SEND_TEMPORARILY_UNAVAILABLE` contract mobile already handles; counter is micro-USD via `Cache::add`+`increment`, 00:00 UTC reset, incremented at confirmation using the platform's `ExchangeRateService` (rate failure → log + skip, never blocks confirmation; estimates round **up** so L2 dust never counts as zero). Check-before/increment-after overshoot is documented and bounded by the count caps.

**Visibility**: `php artisan wallet:sponsorship-spend [--json]` — per-network confirmed counts, summed native fees, USD estimate, budget state.

## Tests
61 passed / 186 assertions (tracker unit incl. 256-bit hex, poller cost cases, Helius sponsor-on/off, 429 + unconfigured no-op, migration round-trip, command smoke). Full PHPStan: no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)