### PR TITLE
chore(sdk): bump JS SDK 1.0.5 + Python SDK 1.0.2 for the base-URL fix release

### DIFF
--- a/sdks/javascript/package-lock.json
+++ b/sdks/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@finaegis/sdk",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@finaegis/sdk",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.0",

--- a/sdks/javascript/package.json
+++ b/sdks/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finaegis/sdk",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Official FinAegis JavaScript/TypeScript SDK for the FinAegis API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="finaegis",
-    version="1.0.1",
+    version="1.0.2",
     author="FinAegis",
     author_email="sdk@finaegis.org",
     description="Official Python SDK for the FinAegis API",


### PR DESCRIPTION
The npm/PyPI release workflows publish the manifest version. #1139 fixed the SDK production base URLs but didn't bump the manifests — tagging now would republish the old version numbers (npm would reject the duplicate). PHP/Packagist needs no manifest change (version comes from the tag).

After merge: tag `cli-v0.2.9`, `js-sdk-v1.0.5`, `php-sdk-v1.0.2`, `py-sdk-v1.0.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)