### PR TITLE
feat(cli): ramp + subscription commands; gate v2 demo routes; brand-aware schema helper

### DIFF
--- a/.github/workflows/03-test-suite.yml
+++ b/.github/workflows/03-test-suite.yml
@@ -321,6 +321,9 @@ jobs:
             core)
               ./bin/pest-batch tests/Feature/Http tests/Feature/Domain tests/Feature/Models || exit 1
               ./bin/pest-batch tests/Feature/Cache tests/Feature/Exchange tests/Feature/Basket || exit 1
+              # Console + Subscription moved here from the extended shard,
+              # which was brushing its 30-minute cap (timed out at 30m16s).
+              ./bin/pest-batch tests/Feature/Console tests/Feature/Subscription || exit 1
               ;;
             extended)
               # Everything else under tests/Feature — computed by exclusion,
@@ -329,7 +332,8 @@ jobs:
               ./bin/pest-rest tests/Feature \
                 tests/Feature/Api \
                 tests/Feature/Http tests/Feature/Domain tests/Feature/Models \
-                tests/Feature/Cache tests/Feature/Exchange tests/Feature/Basket || exit 1
+                tests/Feature/Cache tests/Feature/Exchange tests/Feature/Basket \
+                tests/Feature/Console tests/Feature/Subscription || exit 1
               ;;
           esac
 

--- a/app/Helpers/SchemaHelper.php
+++ b/app/Helpers/SchemaHelper.php
@@ -60,29 +60,42 @@ class SchemaHelper
 
     /**
      * Generate SoftwareApplication schema.
+     *
+     * Brand-aware: the Play Store installUrl + Android-wallet description
+     * describe the Zelta app specifically. Under any other brand (e.g. the
+     * FinAegis demo) the installUrl is omitted and a generic platform
+     * description is used, so demo pages never point at the Zelta listing.
      */
     public static function softwareApplication(): string
     {
         $brand = config('brand.name', 'Zelta');
+        $isZelta = $brand === 'Zelta';
+
         $schema = [
             '@context'            => 'https://schema.org',
             '@type'               => 'MobileApplication',
             'name'                => $brand,
             'operatingSystem'     => 'Android',
             'applicationCategory' => 'FinanceApplication',
-            'installUrl'          => 'https://play.google.com/store/apps/details?id=com.zelta.wallet',
-            'offers'              => [
-                [
-                    '@type'         => 'Offer',
-                    'price'         => '0',
-                    'priceCurrency' => 'USD',
-                ],
+        ];
+
+        if ($isZelta) {
+            $schema['installUrl'] = 'https://play.google.com/store/apps/details?id=com.zelta.wallet';
+        }
+
+        $schema['offers'] = [
+            [
+                '@type'         => 'Offer',
+                'price'         => '0',
+                'priceCurrency' => 'USD',
             ],
-            'description' => 'Non-custodial stablecoin wallet with passkey sign-in, virtual Visa & Mastercard cards, bank-rail deposits, and an agent-callable MCP API. Six networks (Solana, Tron, Polygon, Base, Arbitrum, Ethereum). In open testing on Android.',
-            'developer'   => [
-                '@type' => 'Organization',
-                'name'  => $brand,
-            ],
+        ];
+        $schema['description'] = $isZelta
+            ? 'Non-custodial stablecoin wallet with passkey sign-in, virtual Visa & Mastercard cards, bank-rail deposits, and an agent-callable MCP API. Six networks (Solana, Tron, Polygon, Base, Arbitrum, Ethereum). In open testing on Android.'
+            : $brand . ' — digital banking and stablecoin platform with multi-asset accounts, payment rails, and developer APIs.';
+        $schema['developer'] = [
+            '@type' => 'Organization',
+            'name'  => $brand,
         ];
 
         return self::generateScript($schema);

--- a/packages/zelta-cli/README.md
+++ b/packages/zelta-cli/README.md
@@ -46,12 +46,16 @@ zelta endpoints:list
 | `pay` | send, status, list, stats |
 | `sms` | send, status, rates |
 | `wallet` | balance, transactions, intent, tokens |
+| `ramp` | status, kyc-link |
+| `subscription` | status |
 | `limits` | list, set, remove |
 | `endpoints` | list |
 | `agents` | register, discover |
 | `sdk` | generate |
 
 > **Note on wallet sends** — Zelta wallets are non-custodial: every transaction is signed on-device (Privy passkey / device key), so the CLI cannot send funds. `wallet:transactions` and `wallet:intent` give read-only visibility into wallet activity and send intents.
+
+> **Note on ramp & subscription** — `ramp:status` / `ramp:kyc-link` cover bank-rail deposit setup (KYC + virtual account); `subscription:status` shows your tier and period end. All three are read/setup surfaces — money movement and plan changes happen in the app.
 
 ## AI Agent Support
 

--- a/packages/zelta-cli/app/Commands/Ramp/KycLinkCommand.php
+++ b/packages/zelta-cli/app/Commands/Ramp/KycLinkCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZeltaCli\Commands\Ramp;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use ZeltaCli\Concerns\HasJsonOutput;
+use ZeltaCli\Concerns\RequiresAuth;
+use ZeltaCli\Services\ApiClient;
+use ZeltaCli\Services\AuthManager;
+use ZeltaCli\Services\OutputFormatter;
+
+/**
+ * zelta ramp:kyc-link.
+ *
+ * Issues a hosted KYC link (Bridge.xyz) the user opens in a browser to
+ * complete identity verification for bank-rail deposits. The server lazily
+ * provisions the Bridge customer on first call (idempotent server-side).
+ */
+class KycLinkCommand extends Command
+{
+    use HasJsonOutput;
+    use RequiresAuth;
+
+    public function __construct()
+    {
+        parent::__construct('ramp:kyc-link');
+        $this->setDescription('Get a hosted KYC link to set up bank transfers');
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('json', null, InputOption::VALUE_NONE, 'Output as JSON');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $formatter = new OutputFormatter($output);
+        $auth = new AuthManager();
+
+        if (! $this->ensureAuthenticated($auth, $output)) {
+            return 2;
+        }
+
+        $api = new ApiClient($auth);
+        $result = $api->post('/v1/user/bridge-kyc-link');
+
+        // 409 KYC_ALREADY_APPROVED / 501 PROVIDER_NOT_IMPLEMENTED carry a
+        // machine-readable `error` code — surface it verbatim.
+        if ($result['status'] !== 200) {
+            $formatter->error(
+                $result['body']['error'] ?? 'API_ERROR',
+                $result['body']['message'] ?? "HTTP {$result['status']}",
+            );
+
+            return Command::FAILURE;
+        }
+
+        /** @var array{url?: string, expiresAt?: string|null} $link */
+        $link = $result['body'];
+
+        if ($this->shouldOutputJson($input)) {
+            $formatter->json($link);
+
+            return Command::SUCCESS;
+        }
+
+        $url = $link['url'] ?? '';
+        if ($url === '') {
+            $formatter->error('API_ERROR', 'No KYC link URL in the response.');
+
+            return Command::FAILURE;
+        }
+
+        $formatter->success('Open this link in a browser to complete identity verification:');
+        $output->writeln($url);
+
+        $expiresAt = $link['expiresAt'] ?? null;
+        if (is_string($expiresAt) && $expiresAt !== '') {
+            $output->writeln("<comment>Link expires at: {$expiresAt}</comment>");
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/zelta-cli/app/Commands/Ramp/StatusCommand.php
+++ b/packages/zelta-cli/app/Commands/Ramp/StatusCommand.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZeltaCli\Commands\Ramp;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use ZeltaCli\Concerns\HasJsonOutput;
+use ZeltaCli\Concerns\RequiresAuth;
+use ZeltaCli\Services\ApiClient;
+use ZeltaCli\Services\AuthManager;
+use ZeltaCli\Services\OutputFormatter;
+
+/**
+ * zelta ramp:status.
+ *
+ * Bank-rail (Bridge.xyz) setup state for the authenticated user: KYC
+ * status, virtual-account readiness, and supported rails. Read-only —
+ * the server reads its local webhook-populated cache, never Bridge.
+ */
+class StatusCommand extends Command
+{
+    use HasJsonOutput;
+    use RequiresAuth;
+
+    public function __construct()
+    {
+        parent::__construct('ramp:status');
+        $this->setDescription('Show bank-transfer (ramp) setup status: KYC + virtual account');
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('json', null, InputOption::VALUE_NONE, 'Output as JSON');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $formatter = new OutputFormatter($output);
+        $auth = new AuthManager();
+
+        if (! $this->ensureAuthenticated($auth, $output)) {
+            return 2;
+        }
+
+        $api = new ApiClient($auth);
+        $result = $api->get('/v1/user/bridge-setup-status');
+
+        if ($result['status'] !== 200) {
+            $formatter->error('API_ERROR', $result['body']['message'] ?? "HTTP {$result['status']}");
+
+            return Command::FAILURE;
+        }
+
+        /** @var array{kycStatus?: string, virtualAccountReady?: bool, supportedRails?: list<string>} $status */
+        $status = $result['body'];
+
+        if ($this->shouldOutputJson($input)) {
+            $formatter->json($status);
+
+            return Command::SUCCESS;
+        }
+
+        $kycStatus = $status['kycStatus'] ?? 'unknown';
+        $vaReady = ($status['virtualAccountReady'] ?? false) === true;
+        $rails = $status['supportedRails'] ?? [];
+
+        $formatter->table(['Field', 'Value'], [
+            ['KYC status', $kycStatus],
+            ['Virtual account', $vaReady ? 'ready' : 'not ready'],
+            ['Supported rails', $rails === [] ? '-' : implode(', ', $rails)],
+        ]);
+
+        $output->writeln('');
+        $output->writeln('<comment>' . $this->nextStepHint($kycStatus, $vaReady) . '</comment>');
+
+        return Command::SUCCESS;
+    }
+
+    private function nextStepHint(string $kycStatus, bool $vaReady): string
+    {
+        return match (true) {
+            $kycStatus === 'approved' && $vaReady => 'Bank transfers are ready.',
+            $kycStatus === 'approved'             => 'KYC approved — virtual account provisioning is in progress; check again shortly.',
+            $kycStatus === 'pending'              => 'KYC is in review — check again shortly.',
+            $kycStatus === 'rejected'             => 'KYC was rejected — contact support.',
+            default                               => 'Run "zelta ramp:kyc-link" to start identity verification.',
+        };
+    }
+}

--- a/packages/zelta-cli/app/Commands/Subscription/StatusCommand.php
+++ b/packages/zelta-cli/app/Commands/Subscription/StatusCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZeltaCli\Commands\Subscription;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use ZeltaCli\Concerns\HasJsonOutput;
+use ZeltaCli\Concerns\RequiresAuth;
+use ZeltaCli\Services\ApiClient;
+use ZeltaCli\Services\AuthManager;
+use ZeltaCli\Services\OutputFormatter;
+
+/**
+ * zelta subscription:status.
+ *
+ * Shows the authenticated user's subscription (free/pro tier, source,
+ * period end). Read-only — plan changes happen in the app / web checkout.
+ */
+class StatusCommand extends Command
+{
+    use HasJsonOutput;
+    use RequiresAuth;
+
+    public function __construct()
+    {
+        parent::__construct('subscription:status');
+        $this->setDescription('Show your subscription tier, status, and period end');
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('json', null, InputOption::VALUE_NONE, 'Output as JSON');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $formatter = new OutputFormatter($output);
+        $auth = new AuthManager();
+
+        if (! $this->ensureAuthenticated($auth, $output)) {
+            return 2;
+        }
+
+        $api = new ApiClient($auth);
+        $result = $api->get('/v1/subscription/me');
+
+        if ($result['status'] !== 200) {
+            $formatter->error('API_ERROR', $result['body']['message'] ?? "HTTP {$result['status']}");
+
+            return Command::FAILURE;
+        }
+
+        // Flat shape (no `data` wrapper): tier, status, source, plan,
+        // currentPeriodEnd, trialEndsAt, cancelledAtPeriodEnd, pausedUntil.
+        /** @var array<string, mixed> $subscription */
+        $subscription = $result['body'];
+
+        if ($this->shouldOutputJson($input)) {
+            $formatter->json($subscription);
+
+            return Command::SUCCESS;
+        }
+
+        $rows = [];
+        foreach (['tier', 'status', 'source', 'plan', 'currentPeriodEnd', 'trialEndsAt', 'cancelledAtPeriodEnd', 'pausedUntil'] as $field) {
+            $value = $subscription[$field] ?? null;
+            if ($value === null || $value === '') {
+                continue;
+            }
+            $rows[] = [$field, is_bool($value) ? ($value ? 'yes' : 'no') : (string) $value];
+        }
+
+        if ($rows === []) {
+            $formatter->success('No subscription found — you are on the free tier.');
+
+            return Command::SUCCESS;
+        }
+
+        $formatter->table(['Field', 'Value'], $rows);
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/zelta-cli/tests/Unit/Commands/ProductSurfaceCommandsTest.php
+++ b/packages/zelta-cli/tests/Unit/Commands/ProductSurfaceCommandsTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZeltaCli\Tests\Unit\Commands;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use ZeltaCli\Commands\Ramp\KycLinkCommand;
+use ZeltaCli\Commands\Ramp\StatusCommand as RampStatusCommand;
+use ZeltaCli\Commands\Subscription\StatusCommand as SubscriptionStatusCommand;
+
+/**
+ * ramp:status / ramp:kyc-link / subscription:status.
+ *
+ * Commands construct ApiClient + AuthManager inline, so the network path
+ * is not unit-testable here — these tests pin the command metadata
+ * (name, --json flag) and the unauthenticated short-circuit (exit code 2,
+ * reached before any HTTP call) by pointing HOME at an empty temp dir.
+ */
+class ProductSurfaceCommandsTest extends TestCase
+{
+    private string $homeBackup;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->homeBackup = $_SERVER['HOME'];
+        $_SERVER['HOME'] = sys_get_temp_dir() . '/zelta-cli-cmd-test-' . uniqid();
+    }
+
+    protected function tearDown(): void
+    {
+        $credentials = $_SERVER['HOME'] . '/.zelta/credentials.json';
+        if (file_exists($credentials)) {
+            unlink($credentials);
+        }
+        $_SERVER['HOME'] = $this->homeBackup;
+        parent::tearDown();
+    }
+
+    /**
+     * @return array<string, array{0: class-string<Command>, 1: string}>
+     */
+    public static function commandProvider(): array
+    {
+        return [
+            'ramp:status'         => [RampStatusCommand::class, 'ramp:status'],
+            'ramp:kyc-link'       => [KycLinkCommand::class, 'ramp:kyc-link'],
+            'subscription:status' => [SubscriptionStatusCommand::class, 'subscription:status'],
+        ];
+    }
+
+    /**
+     * @param class-string<Command> $commandClass
+     */
+    #[DataProvider('commandProvider')]
+    public function test_command_metadata(string $commandClass, string $expectedName): void
+    {
+        $command = new $commandClass();
+
+        $this->assertSame($expectedName, $command->getName());
+        $this->assertNotSame('', $command->getDescription());
+        $this->assertTrue($command->getDefinition()->hasOption('json'));
+    }
+
+    /**
+     * @param class-string<Command> $commandClass
+     */
+    #[DataProvider('commandProvider')]
+    public function test_exits_with_auth_code_when_not_logged_in(string $commandClass): void
+    {
+        $tester = new CommandTester(new $commandClass());
+
+        $exitCode = $tester->execute([]);
+
+        $this->assertSame(2, $exitCode);
+        $this->assertStringContainsString('Not authenticated', $tester->getDisplay());
+    }
+}

--- a/packages/zelta-cli/zelta
+++ b/packages/zelta-cli/zelta
@@ -20,6 +20,9 @@ declare(strict_types=1);
  *   zelta wallet balance
  *   zelta wallet transactions --limit 20
  *   zelta wallet intent <intentId>
+ *   zelta ramp status
+ *   zelta ramp kyc-link
+ *   zelta subscription status
  *   zelta limits list
  *   zelta agents discover --capability payment
  *   zelta sdk generate typescript --output ./sdk
@@ -53,10 +56,13 @@ use ZeltaCli\Commands\Pay\ListCommand as PayListCommand;
 use ZeltaCli\Commands\Pay\SendCommand as PaySendCommand;
 use ZeltaCli\Commands\Pay\StatsCommand;
 use ZeltaCli\Commands\Pay\StatusCommand as PayStatusCommand;
+use ZeltaCli\Commands\Ramp\KycLinkCommand as RampKycLinkCommand;
+use ZeltaCli\Commands\Ramp\StatusCommand as RampStatusCommand;
 use ZeltaCli\Commands\Sdk\GenerateCommand;
 use ZeltaCli\Commands\Sms\RatesCommand;
 use ZeltaCli\Commands\Sms\SendCommand;
 use ZeltaCli\Commands\Sms\StatusCommand as SmsStatusCommand;
+use ZeltaCli\Commands\Subscription\StatusCommand as SubscriptionStatusCommand;
 use ZeltaCli\Commands\Wallet\BalanceCommand;
 use ZeltaCli\Commands\Wallet\IntentCommand as WalletIntentCommand;
 use ZeltaCli\Commands\Wallet\TokensCommand;
@@ -91,6 +97,13 @@ $app->add(new BalanceCommand());
 $app->add(new WalletTransactionsCommand());
 $app->add(new WalletIntentCommand());
 $app->add(new TokensCommand());
+
+// Ramp (bank-rail deposits via Bridge.xyz — setup is per-user, one-time)
+$app->add(new RampStatusCommand());
+$app->add(new RampKycLinkCommand());
+
+// Subscription (read-only: plan changes happen in the app / web checkout)
+$app->add(new SubscriptionStatusCommand());
 
 // Limits
 $app->add(new LimitsListCommand());

--- a/routes/api-v2.php
+++ b/routes/api-v2.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Api\V2\FinancialInstitutionController;
 use App\Http\Controllers\Api\V2\GCUController;
 use App\Http\Controllers\Api\V2\PublicApiController;
 use App\Http\Controllers\Api\V2\WebhookController;
+use App\Infrastructure\Domain\DomainManager;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -15,6 +16,11 @@ use Illuminate\Support\Facades\Route;
 |
 | Here is where you can register API routes for version 2 of the public API.
 | These routes are designed for external developers and third-party integrations.
+|
+| Demo-domain groups (baskets, banks, gcu governance/voting) gate on the
+| same MODULES_DISABLED flags as ModuleRouteLoader / routes/console.php —
+| this shared file bypassed the per-domain route loader (#1135 residual).
+| Core v2 surfaces (status, auth, accounts, assets, ...) stay ungated.
 |
 */
 
@@ -44,7 +50,9 @@ Route::prefix('gcu')->group(function () {
     Route::get('/', [GCUController::class, 'index']);
     Route::get('/composition', [GCUController::class, 'composition']);
     Route::get('/value-history', [GCUController::class, 'valueHistory']);
-    Route::get('/governance/active-polls', [GCUController::class, 'activePolls']);
+    if (! DomainManager::isDisabledByConfig('Governance')) {
+        Route::get('/governance/active-polls', [GCUController::class, 'activePolls']);
+    }
     Route::get('/supported-banks', [GCUController::class, 'supportedBanks']);
 
     // Trading endpoints (authenticated)
@@ -57,16 +65,18 @@ Route::prefix('gcu')->group(function () {
         Route::get('/trading-limits', [App\Http\Controllers\Api\V2\GCUTradingController::class, 'tradingLimits']);
     });
 
-    // Voting endpoints
-    Route::prefix('voting')->group(function () {
-        Route::get('/proposals', [App\Http\Controllers\Api\V2\VotingController::class, 'proposals']);
-        Route::get('/proposals/{id}', [App\Http\Controllers\Api\V2\VotingController::class, 'proposalDetails']);
+    // Voting endpoints (Governance domain)
+    if (! DomainManager::isDisabledByConfig('Governance')) {
+        Route::prefix('voting')->group(function () {
+            Route::get('/proposals', [App\Http\Controllers\Api\V2\VotingController::class, 'proposals']);
+            Route::get('/proposals/{id}', [App\Http\Controllers\Api\V2\VotingController::class, 'proposalDetails']);
 
-        Route::middleware('auth:sanctum')->group(function () {
-            Route::post('/proposals/{id}/vote', [App\Http\Controllers\Api\V2\VotingController::class, 'vote']);
-            Route::get('/my-votes', [App\Http\Controllers\Api\V2\VotingController::class, 'myVotes']);
+            Route::middleware('auth:sanctum')->group(function () {
+                Route::post('/proposals/{id}/vote', [App\Http\Controllers\Api\V2\VotingController::class, 'vote']);
+                Route::get('/my-votes', [App\Http\Controllers\Api\V2\VotingController::class, 'myVotes']);
+            });
         });
-    });
+    }
 });
 
 // Webhook event types (public information)
@@ -81,14 +91,16 @@ Route::prefix('financial-institutions')->group(function () {
     Route::get('/api-documentation', [FinancialInstitutionController::class, 'getApiDocumentation']);
 });
 
-// Public basket endpoints (read-only)
-Route::prefix('baskets')->group(function () {
-    Route::get('/', [App\Http\Controllers\Api\BasketController::class, 'index']);
-    Route::get('/{code}', [App\Http\Controllers\Api\BasketController::class, 'show']);
-    Route::get('/{code}/value', [App\Http\Controllers\Api\BasketController::class, 'getValue']);
-    Route::get('/{code}/history', [App\Http\Controllers\Api\BasketController::class, 'getHistory']);
-    Route::get('/{code}/performance', [App\Http\Controllers\Api\BasketController::class, 'getPerformance']);
-});
+// Public basket endpoints (read-only, Basket domain)
+if (! DomainManager::isDisabledByConfig('Basket')) {
+    Route::prefix('baskets')->group(function () {
+        Route::get('/', [App\Http\Controllers\Api\BasketController::class, 'index']);
+        Route::get('/{code}', [App\Http\Controllers\Api\BasketController::class, 'show']);
+        Route::get('/{code}/value', [App\Http\Controllers\Api\BasketController::class, 'getValue']);
+        Route::get('/{code}/history', [App\Http\Controllers\Api\BasketController::class, 'getHistory']);
+        Route::get('/{code}/performance', [App\Http\Controllers\Api\BasketController::class, 'getPerformance']);
+    });
+}
 
 // Authenticated endpoints (supports both Sanctum and API Key authentication)
 Route::middleware(['auth.api_or_sanctum:read'])->group(function () {
@@ -133,12 +145,14 @@ Route::middleware(['auth.api_or_sanctum:read'])->group(function () {
         Route::get('/{uuid}/transactions', [App\Http\Controllers\Api\TransactionController::class, 'history']);
         Route::get('/{uuid}/transfers', [App\Http\Controllers\Api\TransferController::class, 'history']);
 
-        // Basket operations
-        Route::prefix('{uuid}/baskets')->group(function () {
-            Route::get('/', [App\Http\Controllers\Api\BasketAccountController::class, 'getBasketHoldings']);
-            Route::post('/decompose', [App\Http\Controllers\Api\BasketAccountController::class, 'decompose'])->middleware('auth.api_or_sanctum:write');
-            Route::post('/compose', [App\Http\Controllers\Api\BasketAccountController::class, 'compose'])->middleware('auth.api_or_sanctum:write');
-        });
+        // Basket operations (Basket domain)
+        if (! DomainManager::isDisabledByConfig('Basket')) {
+            Route::prefix('{uuid}/baskets')->group(function () {
+                Route::get('/', [App\Http\Controllers\Api\BasketAccountController::class, 'getBasketHoldings']);
+                Route::post('/decompose', [App\Http\Controllers\Api\BasketAccountController::class, 'decompose'])->middleware('auth.api_or_sanctum:write');
+                Route::post('/compose', [App\Http\Controllers\Api\BasketAccountController::class, 'compose'])->middleware('auth.api_or_sanctum:write');
+            });
+        }
     });
 
     // Asset management
@@ -164,11 +178,13 @@ Route::middleware(['auth.api_or_sanctum:read'])->group(function () {
         Route::get('/{uuid}', [App\Http\Controllers\Api\TransferController::class, 'show']);
     });
 
-    // Basket assets (protected operations)
-    Route::prefix('baskets')->group(function () {
-        Route::post('/', [App\Http\Controllers\Api\BasketController::class, 'store'])->middleware('auth.api_or_sanctum:write');
-        Route::post('/{code}/rebalance', [App\Http\Controllers\Api\BasketController::class, 'rebalance'])->middleware('auth.api_or_sanctum:write');
-    });
+    // Basket assets (protected operations, Basket domain)
+    if (! DomainManager::isDisabledByConfig('Basket')) {
+        Route::prefix('baskets')->group(function () {
+            Route::post('/', [App\Http\Controllers\Api\BasketController::class, 'store'])->middleware('auth.api_or_sanctum:write');
+            Route::post('/{code}/rebalance', [App\Http\Controllers\Api\BasketController::class, 'rebalance'])->middleware('auth.api_or_sanctum:write');
+        });
+    }
 
     // Transactions
     Route::prefix('transactions')->group(function () {
@@ -190,23 +206,25 @@ Route::middleware(['auth.api_or_sanctum:read'])->group(function () {
         Route::post('/check-transaction', [ComplianceController::class, 'checkTransactionEligibility']);
     });
 
-    // Bank Integration endpoints
-    Route::prefix('banks')->group(function () {
-        Route::get('/available', [BankIntegrationController::class, 'getAvailableBanks']);
-        Route::get('/health/{bankCode}', [BankIntegrationController::class, 'getBankHealth']);
-        Route::get('/recommendations', [BankIntegrationController::class, 'getRecommendedBanks']);
+    // Bank Integration endpoints (Banking domain — demo connectors)
+    if (! DomainManager::isDisabledByConfig('Banking')) {
+        Route::prefix('banks')->group(function () {
+            Route::get('/available', [BankIntegrationController::class, 'getAvailableBanks']);
+            Route::get('/health/{bankCode}', [BankIntegrationController::class, 'getBankHealth']);
+            Route::get('/recommendations', [BankIntegrationController::class, 'getRecommendedBanks']);
 
-        // User bank connections
-        Route::get('/connections', [BankIntegrationController::class, 'getUserConnections']);
-        Route::post('/connect', [BankIntegrationController::class, 'connectBank']);
-        Route::delete('/disconnect/{bankCode}', [BankIntegrationController::class, 'disconnectBank']);
+            // User bank connections
+            Route::get('/connections', [BankIntegrationController::class, 'getUserConnections']);
+            Route::post('/connect', [BankIntegrationController::class, 'connectBank']);
+            Route::delete('/disconnect/{bankCode}', [BankIntegrationController::class, 'disconnectBank']);
 
-        // Bank accounts
-        Route::get('/accounts', [BankIntegrationController::class, 'getBankAccounts']);
-        Route::post('/accounts/sync/{bankCode}', [BankIntegrationController::class, 'syncAccounts']);
+            // Bank accounts
+            Route::get('/accounts', [BankIntegrationController::class, 'getBankAccounts']);
+            Route::post('/accounts/sync/{bankCode}', [BankIntegrationController::class, 'syncAccounts']);
 
-        // Balances and transfers
-        Route::get('/balance/aggregate', [BankIntegrationController::class, 'getAggregatedBalance']);
-        Route::post('/transfer', [BankIntegrationController::class, 'initiateTransfer'])->middleware('transaction.rate_limit:transfer');
-    });
+            // Balances and transfers
+            Route::get('/balance/aggregate', [BankIntegrationController::class, 'getAggregatedBalance']);
+            Route::post('/transfer', [BankIntegrationController::class, 'initiateTransfer'])->middleware('transaction.rate_limit:transfer');
+        });
+    }
 });

--- a/tests/Feature/Contract/CliRouteContractTest.php
+++ b/tests/Feature/Contract/CliRouteContractTest.php
@@ -50,6 +50,13 @@ function cliRouteContract(): array
         ['GET', '/v1/wallet/transactions', 'Wallet/TransactionsCommand'],
         ['GET', '/v1/wallet/transactions/by-intent/sample-intent-id', 'Wallet/IntentCommand'],
 
+        // Ramp / Bridge.xyz setup (KYC + virtual account)
+        ['GET', '/v1/user/bridge-setup-status', 'Ramp/StatusCommand'],
+        ['POST', '/v1/user/bridge-kyc-link', 'Ramp/KycLinkCommand'],
+
+        // Subscription (read-only tier/status surface)
+        ['GET', '/v1/subscription/me', 'Subscription/StatusCommand'],
+
         // Spending limits
         ['GET', '/v1/x402/spending-limits', 'Limits/ListCommand'],
         ['POST', '/v1/x402/spending-limits', 'Limits/SetCommand'],

--- a/tests/Feature/SchemaMarkupTest.php
+++ b/tests/Feature/SchemaMarkupTest.php
@@ -43,6 +43,12 @@ class SchemaMarkupTest extends TestCase
         $response->assertSee('"@type": "MobileApplication"', false);
         $response->assertSee('"name": "' . config('brand.name') . '"', false);
         $response->assertSee('"@type": "BreadcrumbList"', false);
+
+        // Brand-aware truth fix: the Zelta Play Store installUrl must only
+        // appear when the brand actually IS Zelta (tests run as FinAegis).
+        if (config('brand.name') !== 'Zelta') {
+            $response->assertDontSee('play.google.com/store/apps/details?id=com.zelta.wallet', false);
+        }
     }
 
     #[Test]

--- a/tests/Unit/Helpers/SchemaHelperTest.php
+++ b/tests/Unit/Helpers/SchemaHelperTest.php
@@ -90,8 +90,16 @@ class SchemaHelperTest extends TestCase
         $this->assertEquals($brand, $schema['name']);
         $this->assertEquals('Android', $schema['operatingSystem']);
         $this->assertEquals('FinanceApplication', $schema['applicationCategory']);
-        $this->assertArrayHasKey('installUrl', $schema);
-        $this->assertStringContainsString('play.google.com', $schema['installUrl']);
+
+        // installUrl points at the Zelta wallet's Play Store listing — it is
+        // emitted only under the Zelta brand (demo brands omit it so a
+        // FinAegis-named schema never links the Zelta store entry).
+        if ($brand === 'Zelta') {
+            $this->assertArrayHasKey('installUrl', $schema);
+            $this->assertStringContainsString('play.google.com', $schema['installUrl']);
+        } else {
+            $this->assertArrayNotHasKey('installUrl', $schema);
+        }
         $this->assertArrayHasKey('offers', $schema);
         $this->assertIsArray($schema['offers']);
         $this->assertCount(1, $schema['offers']);

--- a/tests/Unit/Infrastructure/Domain/ModuleRouteLoaderTest.php
+++ b/tests/Unit/Infrastructure/Domain/ModuleRouteLoaderTest.php
@@ -133,6 +133,74 @@ describe('Zelta production surface template (.env.zelta.example)', function () {
     });
 });
 
+describe('routes/api-v2.php demo-domain gating (#1135 residual)', function () {
+    /**
+     * Re-include the shared v2 route file under a unique prefix AFTER
+     * toggling modules.disabled — the copy registered at boot used the
+     * test-default (empty) config, so assertions must run against a
+     * fresh include. api-v2.php has no named routes, so re-including
+     * it is collision-free.
+     */
+    function loadApiV2RoutesUnderPrefix(string $prefix): void
+    {
+        Route::middleware('api')->prefix($prefix)->group(base_path('routes/api-v2.php'));
+    }
+
+    /** Whether $method $path resolves to a registered route. */
+    function apiV2RouteResolves(string $method, string $path): bool
+    {
+        try {
+            Route::getRoutes()->match(Illuminate\Http\Request::create($path, $method));
+
+            return true;
+        } catch (Symfony\Component\HttpKernel\Exception\NotFoundHttpException) {
+            return false;
+        }
+    }
+
+    it('drops basket, banking and governance v2 routes when those modules are disabled', function () {
+        config(['modules.disabled' => ['Basket', 'Banking', 'Governance']]);
+
+        loadApiV2RoutesUnderPrefix('_fixtures/v2-gated');
+
+        // Demo-domain surfaces are gone...
+        expect(apiV2RouteResolves('GET', '/_fixtures/v2-gated/baskets'))->toBeFalse();
+        expect(apiV2RouteResolves('POST', '/_fixtures/v2-gated/baskets'))->toBeFalse();
+        expect(apiV2RouteResolves('GET', '/_fixtures/v2-gated/accounts/sample-uuid/baskets'))->toBeFalse();
+        expect(apiV2RouteResolves('GET', '/_fixtures/v2-gated/banks/available'))->toBeFalse();
+        expect(apiV2RouteResolves('GET', '/_fixtures/v2-gated/gcu/governance/active-polls'))->toBeFalse();
+        expect(apiV2RouteResolves('GET', '/_fixtures/v2-gated/gcu/voting/proposals'))->toBeFalse();
+
+        // ...while core v2 surfaces stay registered.
+        expect(apiV2RouteResolves('GET', '/_fixtures/v2-gated/status'))->toBeTrue();
+        expect(apiV2RouteResolves('GET', '/_fixtures/v2-gated/gcu'))->toBeTrue();
+        expect(apiV2RouteResolves('GET', '/_fixtures/v2-gated/accounts'))->toBeTrue();
+        expect(apiV2RouteResolves('GET', '/_fixtures/v2-gated/assets'))->toBeTrue();
+    });
+
+    it('registers the demo-domain v2 routes when nothing is disabled', function () {
+        config(['modules.disabled' => []]);
+
+        loadApiV2RoutesUnderPrefix('_fixtures/v2-open');
+
+        expect(apiV2RouteResolves('GET', '/_fixtures/v2-open/baskets'))->toBeTrue();
+        expect(apiV2RouteResolves('GET', '/_fixtures/v2-open/accounts/sample-uuid/baskets'))->toBeTrue();
+        expect(apiV2RouteResolves('GET', '/_fixtures/v2-open/banks/available'))->toBeTrue();
+        expect(apiV2RouteResolves('GET', '/_fixtures/v2-open/gcu/governance/active-polls'))->toBeTrue();
+        expect(apiV2RouteResolves('GET', '/_fixtures/v2-open/gcu/voting/proposals'))->toBeTrue();
+        expect(apiV2RouteResolves('GET', '/_fixtures/v2-open/status'))->toBeTrue();
+    });
+
+    it('returns 404 over HTTP for a gated v2 route while a core one resolves', function () {
+        config(['modules.disabled' => ['Basket']]);
+
+        loadApiV2RoutesUnderPrefix('_fixtures/v2-http');
+
+        $this->getJson('/_fixtures/v2-http/baskets')->assertNotFound();
+        $this->getJson('/_fixtures/v2-http/status')->assertOk();
+    });
+});
+
 describe('DomainManager::isDisabledByConfig (boot-time cron gate)', function () {
     it('reads modules.disabled from config only', function () {
         config(['modules.disabled' => ['Governance', 'finaegis/basket', 'CGO']]);


### PR DESCRIPTION
## Summary

Final follow-up batch from the remediation program:

**CLI v1 product surface** — three new commands following the repaired conventions: `ramp:status` (KYC/VA readiness + next-step hint), `ramp:kyc-link` (hosted KYC link with verbatim error-code passthrough), `subscription:status` (`/api/v1/subscription/me`). All endpoints verified against `route:list`; the route-contract test extended so drift fails CI. The landing page deliberately stays at "24 Commands" — that badge describes the published v0.2.9 npm tag; these ship with the next tag.

**`routes/api-v2.php` MODULES_DISABLED residual** (flagged in #1135) — the shared v2 route file's Basket/Banking/Governance groups now respect `DomainManager::isDisabledByConfig()` (domain ownership confirmed via controller imports); core v2 surfaces ungated; empty `MODULES_DISABLED` = zero behavior change. Tested at both route-collection and HTTP levels.

**SchemaHelper brand fix** — demo-brand (FinAegis) pages no longer emit a schema named FinAegis pointing at the Zelta Play Store listing; Zelta production output verified byte-identical.

## Tests
Package PHPUnit 16 green; CliRouteContractTest + SchemaMarkupTest + ModuleRouteLoaderTest 23 green (122 assertions). PHPStan level 8 full run: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)