### PR TITLE
test(ci): close remaining test-coverage gaps (security catch-all, behat suite, slow gating, k6)

### DIFF
--- a/.github/workflows/03-test-suite.yml
+++ b/.github/workflows/03-test-suite.yml
@@ -439,7 +439,11 @@ jobs:
           DB_DATABASE: testing
           DB_USERNAME: root
           DB_PASSWORD: root
-        run: php -d memory_limit=2G ./vendor/bin/pest --testsuite=Integration --configuration=phpunit.ci-optimized.xml --exclude-group=slow
+        # No --exclude-group=slow: the only @group('slow') tests are the two
+        # Account aggregate tests, which complete in <9s each — well under the
+        # 180s per-test limit — so they gate PRs here instead of only running
+        # in the nightly slow-tests suite.
+        run: php -d memory_limit=2G ./vendor/bin/pest --testsuite=Integration --configuration=phpunit.ci-optimized.xml
 
   multi-connection-tests:
     name: Multi-Connection Tests
@@ -647,29 +651,23 @@ jobs:
           QUEUE_CONNECTION: sync
           CI: true
         run: |
-          # Run only implemented feature files to avoid parsing 19 unimplemented ones
-          # CI=true enables reduced wait times (500ms vs 2-3s) in Behat contexts
+          # Tag-driven: run the full acceptance suite via the `ci` profile,
+          # which excludes @wip (unimplemented specs), @web (promo-page specs),
+          # @skip and @api (separate suite). Implementing a deferred spec is now
+          # just removing its @wip tag — there is no hardcoded filename list to
+          # drift out of date (the previous two-file list silently omitted the
+          # rest of the suite).
+          # CI=true enables reduced wait times (500ms vs 2-3s) in Behat contexts.
           mkdir -p tests-results
-
-          # Run account_management.feature with JUnit output
           vendor/bin/behat \
+            --profile=ci \
+            --suite=acceptance \
             --no-interaction \
             --format=progress \
             --format=junit \
             --out=std \
             --out=tests-results \
-            --stop-on-failure \
-            features/account_management.feature
-
-          # Run basket_management.feature with JUnit output
-          vendor/bin/behat \
-            --no-interaction \
-            --format=progress \
-            --format=junit \
-            --out=std \
-            --out=tests-results \
-            --stop-on-failure \
-            features/basket_management.feature
+            --stop-on-failure
 
       - name: Upload Behat Results
         if: always()

--- a/.github/workflows/04-security-tests.yml
+++ b/.github/workflows/04-security-tests.yml
@@ -300,3 +300,23 @@ jobs:
 
       - name: Run Multi-Tenancy Security Tests
         run: ./vendor/bin/pest tests/Security/MultiTenancy --configuration=phpunit.security.xml --stop-on-failure
+
+      - name: Run Remaining Security Tests (catch-all)
+        # Exclusion-computed catch-all: runs every tests/Security subdirectory
+        # NOT covered by an explicit step above (across all jobs in this file),
+        # plus loose *Test.php files directly under tests/Security — e.g.
+        # ComprehensiveSecurityTest.php, which previously ran in no job at all.
+        # Mirrors the pest-rest pattern in 03-test-suite.yml so a new security
+        # test can never silently fall out of CI. CONFIG_FILE pins the security
+        # phpunit config used by the explicit steps above.
+        env:
+          CONFIG_FILE: phpunit.security.xml
+        run: |
+          chmod +x ./bin/pest-batch ./bin/pest-rest
+          ./bin/pest-rest tests/Security \
+            tests/Security/Penetration \
+            tests/Security/Authentication \
+            tests/Security/API \
+            tests/Security/Vulnerabilities \
+            tests/Security/Cryptography \
+            tests/Security/MultiTenancy

--- a/.github/workflows/05-performance.yml
+++ b/.github/workflows/05-performance.yml
@@ -301,8 +301,44 @@ jobs:
           sleep 5
 
       - name: Run Load Tests
+        # Advisory by design: k6 runs against a single-threaded `php artisan
+        # serve`, so thresholds are inherently noisy and must not hard-gate the
+        # pipeline (continue-on-error). Previously the result was silently
+        # swallowed; the status is now captured and surfaced in the job summary.
+        id: k6
         continue-on-error: true
         run: |
-          if [ -f "tests/k6/load-test.js" ]; then
-            k6 run tests/k6/load-test.js --out json=load-test-results.json
+          if [ ! -f "tests/k6/load-test.js" ]; then
+            echo "K6_STATUS=missing (tests/k6/load-test.js not found)" >> "$GITHUB_ENV"
+            echo "::warning::tests/k6/load-test.js not found — load tests skipped."
+            exit 0
           fi
+          set +e
+          k6 run tests/k6/load-test.js --out json=load-test-results.json
+          RC=$?
+          set -e
+          if [ "$RC" -eq 0 ]; then
+            echo "K6_STATUS=passed" >> "$GITHUB_ENV"
+          else
+            echo "K6_STATUS=threshold breached or error (k6 exit $RC)" >> "$GITHUB_ENV"
+            echo "::warning::k6 load test thresholds breached (exit $RC) — advisory, not blocking."
+          fi
+
+      - name: Publish Load Test Result
+        if: always()
+        run: |
+          {
+            echo "## k6 Load Test Result"
+            echo ""
+            echo "Status: **${K6_STATUS:-unknown}** — advisory, does not block the pipeline."
+            echo ""
+            echo "Full JSON metrics are uploaded as the \`load-test-results\` artifact."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Load Test Artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: load-test-results
+          path: load-test-results.json
+          if-no-files-found: ignore

--- a/.github/workflows/behat-tests.yml
+++ b/.github/workflows/behat-tests.yml
@@ -140,31 +140,36 @@ jobs:
         run: |
           # Re-run with JUnit output for reporting — same tag-driven acceptance
           # suite as bin/behat-ci (the `ci` profile excludes @wip/@web/@skip/@api).
+          # Behat's junit formatter writes one XML file per suite INTO the --out
+          # directory, so --out must be a directory (not a file, which silently
+          # created a directory named behat-results.xml and broke the downstream
+          # steps).
+          mkdir -p behat-results
           vendor/bin/behat \
             --profile=ci \
             --suite=acceptance \
             --no-interaction \
             --format=junit \
-            --out=behat-results.xml || true
-          
-          # Ensure the file exists for the upload step
-          if [ ! -f behat-results.xml ]; then
-            echo '<?xml version="1.0" encoding="UTF-8"?><testsuites><testsuite name="Behat" errors="1"><testcase name="No results" classname="Behat"><error>No test results generated</error></testcase></testsuite></testsuites>' > behat-results.xml
+            --out=behat-results || true
+
+          # Ensure at least one result file exists for the summary/upload steps.
+          if [ -z "$(ls -A behat-results 2>/dev/null)" ]; then
+            echo '<?xml version="1.0" encoding="UTF-8"?><testsuites><testsuite name="Behat" errors="1"><testcase name="No results" classname="Behat"><error>No test results generated</error></testcase></testsuite></testsuites>' > behat-results/behat.xml
           fi
-            
+
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: behat-test-results
-          path: behat-results.xml
+          path: behat-results/
           retention-days: 30
-          
+
       - name: Test Summary
         if: always()
         uses: test-summary/action@v2
         with:
-          paths: behat-results.xml
+          paths: behat-results/*.xml
           
       - name: Debug Information
         if: failure()

--- a/.github/workflows/behat-tests.yml
+++ b/.github/workflows/behat-tests.yml
@@ -134,14 +134,18 @@ jobs:
           
       - name: Generate Test Report
         if: always()
+        env:
+          BEHAT_BASE_URL: http://127.0.0.1:8000
+          QUEUE_CONNECTION: sync
         run: |
-          # Run again with JUnit output for reporting
+          # Re-run with JUnit output for reporting — same tag-driven acceptance
+          # suite as bin/behat-ci (the `ci` profile excludes @wip/@web/@skip/@api).
           vendor/bin/behat \
+            --profile=ci \
+            --suite=acceptance \
             --no-interaction \
             --format=junit \
-            --out=behat-results.xml \
-            --tags="~@wip" \
-            features/ || true
+            --out=behat-results.xml || true
           
           # Ensure the file exists for the upload step
           if [ ! -f behat-results.xml ]; then

--- a/behat.yml
+++ b/behat.yml
@@ -7,7 +7,7 @@ default:
                 - FeatureContext
                 - LaravelFeatureContext
             filters:
-                tags: "~@web&&~@wip"
+                tags: "~@web&&~@wip&&~@api"
         api:
             paths:
                 features: features/api
@@ -55,4 +55,4 @@ ci:
                 - FeatureContext
                 - LaravelFeatureContext
             filters:
-                tags: "~@web&&~@skip&&~@wip"
+                tags: "~@web&&~@skip&&~@wip&&~@api"

--- a/bin/behat-ci
+++ b/bin/behat-ci
@@ -1,42 +1,28 @@
 #!/bin/bash
 
-# Behat CI runner - runs only implemented features without interaction
-# This prevents the undefined steps prompt in CI/CD environments
+# Behat CI runner - runs the tag-driven acceptance suite without interaction
+# (prevents the undefined-steps prompt in CI/CD environments).
+#
+# The `ci` profile's acceptance suite excludes @wip (unimplemented specs),
+# @web (promo-page specs), @skip and @api (separate suite). Implementing a
+# deferred spec is just removing its @wip tag — there is no hardcoded feature
+# filename list here to drift out of date.
 
 export BEHAT_BASE_URL="${BEHAT_BASE_URL:-http://localhost}"
 export QUEUE_CONNECTION=sync
 
-# Default to all feature files if no arguments provided
+# Default to the acceptance suite if no arguments provided
 if [ $# -eq 0 ]; then
-    # List of implemented feature files
-    FEATURES=(
-        "features/account_management.feature"
-        "features/basket_management.feature"
-    )
-    
-    # Run each feature file separately to avoid the multiple paths issue
-    EXIT_CODE=0
-    for feature in "${FEATURES[@]}"; do
-        echo "Running: $feature"
-        vendor/bin/behat \
-            --no-interaction \
-            --format=progress \
-            --no-colors \
-            --stop-on-failure \
-            "$feature"
-        
-        # Capture exit code
-        if [ $? -ne 0 ]; then
-            EXIT_CODE=1
-            # Stop on failure
-            break
-        fi
-    done
-    
-    exit $EXIT_CODE
+    exec vendor/bin/behat \
+        --profile=ci \
+        --suite=acceptance \
+        --no-interaction \
+        --format=progress \
+        --no-colors \
+        --stop-on-failure
 else
     # Run with provided arguments
-    vendor/bin/behat \
+    exec vendor/bin/behat \
         --no-interaction \
         --format=progress \
         --no-colors \

--- a/bin/check-test-coverage
+++ b/bin/check-test-coverage
@@ -25,7 +25,7 @@ declare -A CLAIMED=(
     [Console]="03-test-suite.yml integration-tests (testsuite Integration)"
     [Integration]="03-test-suite.yml integration-tests (testsuite Integration)"
     [MultiConnection]="03-test-suite.yml multi-connection-tests"
-    [Security]="04-security-tests.yml (Penetration/Authentication/API/Vulnerabilities/Cryptography/MultiTenancy)"
+    [Security]="04-security-tests.yml (explicit subdir steps + pest-rest catch-all for loose/new tests)"
     [Performance]="05-performance.yml"
     [Actions]="03-test-suite.yml unit-tests components batch"
     [Filament]="03-test-suite.yml unit-tests components batch"
@@ -60,6 +60,27 @@ if [ ${#LOOSE[@]} -gt 0 ]; then
     echo "::error::Loose test files directly under tests/ are not run by any CI batch: ${LOOSE[*]}"
     FAIL=1
 fi
+
+# --- Catch-all enforcement for directories run by explicit subpath ----------
+# Some test directories are executed by listing their subdirectories one-by-one
+# in a workflow (rather than handing the whole directory to pest). Those jobs
+# silently drop loose *Test.php files and newly-added subdirectories — exactly
+# how tests/Security/ComprehensiveSecurityTest.php went un-run for a long time.
+# For each such directory, require an exclusion-computed catch-all
+# (./bin/pest-rest <dir>) in its workflow so that class of drift cannot recur.
+declare -A SUBPATH_RUN=(
+    [tests/Security]=".github/workflows/04-security-tests.yml"
+)
+for parent in "${!SUBPATH_RUN[@]}"; do
+    wf="${SUBPATH_RUN[$parent]}"
+    if [ ! -f "$wf" ]; then
+        echo "::error::$wf (catch-all guard for $parent/) is missing."
+        FAIL=1
+    elif ! grep -q "pest-rest $parent" "$wf"; then
+        echo "::error::$wf runs $parent/ by explicit subpath but has no './bin/pest-rest $parent' catch-all — loose or newly-added tests under $parent/ would silently not run."
+        FAIL=1
+    fi
+done
 
 if [ $FAIL -eq 0 ]; then
     echo "All $(find tests -mindepth 1 -maxdepth 1 -type d | wc -l) top-level tests/ directories are claimed by a CI job."

--- a/features/api/exchange_rates.feature
+++ b/features/api/exchange_rates.feature
@@ -1,3 +1,4 @@
+@api
 Feature: Exchange Rate API
   In order to convert between currencies
   As an API consumer

--- a/features/batch_processing.feature
+++ b/features/batch_processing.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: Batch Processing
   In order to efficiently handle bulk operations
   As a system administrator

--- a/features/compliance_flows.feature
+++ b/features/compliance_flows.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: Compliance and Regulatory Flows
   In order to meet regulatory requirements
   As a financial platform

--- a/features/cross_domain_workflows.feature
+++ b/features/cross_domain_workflows.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: Cross-Domain Workflow Coordination
   In order to handle complex business processes
   As a platform with multiple bounded contexts

--- a/features/custodian_integration.feature
+++ b/features/custodian_integration.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: Custodian Integration
   In order to provide secure multi-bank services
   As a financial platform

--- a/features/error_recovery.feature
+++ b/features/error_recovery.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: Error Recovery Mechanisms
   In order to maintain system reliability
   As a financial platform

--- a/features/exchange.feature
+++ b/features/exchange.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: Exchange Trading
   In order to trade digital assets
   As a user with an account

--- a/features/external-exchange-connectors.feature
+++ b/features/external-exchange-connectors.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: External Exchange Connectors
   As a trading platform
   I need to connect to external exchanges

--- a/features/governance_voting.feature
+++ b/features/governance_voting.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: Governance and Voting
   In order to participate in platform governance
   As a stakeholder

--- a/features/kyc_compliance.feature
+++ b/features/kyc_compliance.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: KYC and Compliance
   In order to meet regulatory requirements
   As a financial platform

--- a/features/liquidity-pools.feature
+++ b/features/liquidity-pools.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: Liquidity Pool Management
   As a liquidity provider
   I want to provide liquidity to pools

--- a/features/registration.feature
+++ b/features/registration.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: User Registration
   In order to use the FinAegis platform
   As a new user

--- a/features/saga_patterns.feature
+++ b/features/saga_patterns.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: Saga Pattern Implementation
   In order to ensure system reliability and data consistency
   As a system handling distributed transactions

--- a/features/stablecoin_operations.feature
+++ b/features/stablecoin_operations.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: Stablecoin Operations
   In order to use digital stablecoins
   As a crypto-enabled user

--- a/features/transaction_reversal.feature
+++ b/features/transaction_reversal.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: Transaction Reversal
   In order to correct errors and handle disputes
   As a system operator

--- a/features/transfers.feature
+++ b/features/transfers.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: Money Transfers
   In order to send money to other accounts
   As a bank customer

--- a/features/wallet_conversion.feature
+++ b/features/wallet_conversion.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: Wallet Currency Conversion
   In order to convert between currencies
   As a user with multi-currency needs

--- a/features/wallet_e2e.feature
+++ b/features/wallet_e2e.feature
@@ -1,3 +1,4 @@
+@wip
 Feature: Wallet End-to-End User Journeys
   In order to manage my digital assets effectively
   As a wallet user

--- a/tests/k6/scenarios/load.js
+++ b/tests/k6/scenarios/load.js
@@ -15,7 +15,7 @@ import { BASE_URL, HEADERS, TEST_USER } from '../helpers/config.js';
 export function load()
 {
     // GET API root - simulates landing page discovery
-    const rootRes = http.get(`${BASE_URL} / `, { headers: HEADERS });
+    const rootRes = http.get(`${BASE_URL}/`, { headers: HEADERS });
     check(rootRes, {
         'load api root: status is 200': (r) => r.status === 200,
     });
@@ -23,7 +23,7 @@ export function load()
     sleep(1);
 
     // GET health check - simulates monitoring probe
-    const healthRes = http.get(`${BASE_URL} / monitoring / health`, { headers: HEADERS });
+    const healthRes = http.get(`${BASE_URL}/monitoring/health`, { headers: HEADERS });
     check(healthRes, {
         'load health: status is 200': (r) => r.status === 200,
     });
@@ -35,7 +35,7 @@ export function load()
         email: TEST_USER.email,
         password: TEST_USER.password,
     });
-    const loginRes = http.post(`${BASE_URL} / auth / login`, loginPayload, { headers: HEADERS });
+    const loginRes = http.post(`${BASE_URL}/auth/login`, loginPayload, { headers: HEADERS });
     check(loginRes, {
         'load login: status is 200 or 401 or 422': (r) =>
             r.status === 200 || r.status === 401 || r.status === 422,
@@ -54,7 +54,7 @@ export function load()
 
                 sleep(1);
 
-                const modulesRes = http.get(`${BASE_URL} / v2 / modules`, { headers: authHeaderSet });
+                const modulesRes = http.get(`${BASE_URL}/v2/modules`, { headers: authHeaderSet });
                 check(modulesRes, {
                     'load modules: status is 200': (r) => r.status === 200,
                 });
@@ -67,7 +67,7 @@ export function load()
     sleep(1);
 
     // GET readiness check
-    const readyRes = http.get(`${BASE_URL} / monitoring / ready`, { headers: HEADERS });
+    const readyRes = http.get(`${BASE_URL}/monitoring/ready`, { headers: HEADERS });
     check(readyRes, {
         'load ready: status is 200': (r) => r.status === 200,
     });

--- a/tests/k6/scenarios/smoke.js
+++ b/tests/k6/scenarios/smoke.js
@@ -15,7 +15,7 @@ import { BASE_URL, HEADERS } from '../helpers/config.js';
 export function smoke()
 {
     // Health check
-    const healthRes = http.get(`${BASE_URL} / monitoring / health`, { headers: HEADERS });
+    const healthRes = http.get(`${BASE_URL}/monitoring/health`, { headers: HEADERS });
     check(healthRes, {
         'health: status is 200': (r) => r.status === 200,
         'health: response time < 200ms': (r) => r.timings.duration < 200,
@@ -24,7 +24,7 @@ export function smoke()
     sleep(0.5);
 
     // Readiness check
-    const readyRes = http.get(`${BASE_URL} / monitoring / ready`, { headers: HEADERS });
+    const readyRes = http.get(`${BASE_URL}/monitoring/ready`, { headers: HEADERS });
     check(readyRes, {
         'ready: status is 200': (r) => r.status === 200,
         'ready: response time < 200ms': (r) => r.timings.duration < 200,
@@ -33,7 +33,7 @@ export function smoke()
     sleep(0.5);
 
     // Liveness check
-    const aliveRes = http.get(`${BASE_URL} / monitoring / alive`, { headers: HEADERS });
+    const aliveRes = http.get(`${BASE_URL}/monitoring/alive`, { headers: HEADERS });
     check(aliveRes, {
         'alive: status is 200': (r) => r.status === 200,
         'alive: response time < 200ms': (r) => r.timings.duration < 200,
@@ -42,7 +42,7 @@ export function smoke()
     sleep(0.5);
 
     // API root
-    const rootRes = http.get(`${BASE_URL} / `, { headers: HEADERS });
+    const rootRes = http.get(`${BASE_URL}/`, { headers: HEADERS });
     check(rootRes, {
         'api root: status is 200': (r) => r.status === 200,
         'api root: response time < 200ms': (r) => r.timings.duration < 200,

--- a/tests/k6/scenarios/stress.js
+++ b/tests/k6/scenarios/stress.js
@@ -17,10 +17,10 @@ export function stress()
 {
     // Batch concurrent requests to multiple monitoring endpoints
     const responses = http.batch([
-        ['GET', `${BASE_URL} / monitoring / health`, null, { headers: HEADERS, tags: { endpoint: 'health' } }],
-        ['GET', `${BASE_URL} / monitoring / ready`, null, { headers: HEADERS, tags: { endpoint: 'ready' } }],
-        ['GET', `${BASE_URL} / monitoring / alive`, null, { headers: HEADERS, tags: { endpoint: 'alive' } }],
-        ['GET', `${BASE_URL} / `, null, { headers: HEADERS, tags: { endpoint: 'root' } }],
+        ['GET', `${BASE_URL}/monitoring/health`, null, { headers: HEADERS, tags: { endpoint: 'health' } }],
+        ['GET', `${BASE_URL}/monitoring/ready`, null, { headers: HEADERS, tags: { endpoint: 'ready' } }],
+        ['GET', `${BASE_URL}/monitoring/alive`, null, { headers: HEADERS, tags: { endpoint: 'alive' } }],
+        ['GET', `${BASE_URL}/`, null, { headers: HEADERS, tags: { endpoint: 'root' } }],
     ]);
 
     // Check health response
@@ -50,7 +50,7 @@ export function stress()
     sleep(0.3);
 
     // Prometheus metrics endpoint (heavier response)
-    const metricsRes = http.get(`${BASE_URL} / monitoring / metrics`, { headers: HEADERS });
+    const metricsRes = http.get(`${BASE_URL}/monitoring/metrics`, { headers: HEADERS });
     check(metricsRes, {
         'stress metrics: status is 200': (r) => r.status === 200,
         'stress metrics: response time < 1000ms': (r) => r.timings.duration < 1000,
@@ -60,7 +60,7 @@ export function stress()
 
     // Rapid-fire health checks to simulate aggressive monitoring
     for (let i = 0; i < 3; i++) {
-        const rapidRes = http.get(`${BASE_URL} / monitoring / health`, { headers: HEADERS });
+        const rapidRes = http.get(`${BASE_URL}/monitoring/health`, { headers: HEADERS });
         check(rapidRes, {
             'stress rapid health: status is 200': (r) => r.status === 200,
         });


### PR DESCRIPTION
## Why

Follow-up to the CI test-execution-hole work. The previous fix proved every top-level `tests/` **directory** is *claimed* by a job — but "claimed" is not "every file actually runs." A file-by-file audit (1,194 pest files reconciled exactly against what each job selects) found genuine gaps. This PR closes them.

## What changed

| Gap found | Fix |
|---|---|
| `tests/Security/ComprehensiveSecurityTest.php` ran in **no job** (security workflow enumerated subdirs explicitly, no catch-all) | Added exclusion-computed `./bin/pest-rest tests/Security` step to `04-security-tests.yml` — **12 tests / 245 assertions now gate** (verified passing locally) |
| The coverage guard couldn't detect that gap (it only checks directory *claims*) | `bin/check-test-coverage` now requires a `pest-rest` catch-all for any subpath-enumerated directory (`SUBPATH_RUN` check) so the same drift can't recur |
| Behat ran **2 hardcoded** feature files; the rest were silently omitted | Switched to the tag-driven `ci` **acceptance suite**; tagged the 17 unimplemented specs `@wip` (explicit + auto-enabling once implemented), split the api feature out with `@api`. `bin/behat-ci` + `behat-tests.yml` aligned — no more hardcoded filename lists |
| The 2 `@group('slow')` Domain tests only ran nightly | They complete in **<9s each** (under the 180s limit) → dropped `--exclude-group=slow` from the integration job so they gate PRs |
| k6 scenario URLs were mangled by a JS formatter — `` `${BASE_URL} / monitoring / health` `` — and never hit a real endpoint | Despaced every URL in smoke/load/stress; load-test result is now surfaced in the job summary instead of being silently swallowed (stays advisory — runs against single-threaded `php artisan serve`) |

## Intentionally not changed

- **Browser/Dusk** (`tests/Browser`, 2 files): stays a documented local-only exclusion. It needs headless Chrome and the test asserts promo pages / `FinAegis` branding that are off by default in CI — enabling it as-is would just go red. Flagged for separate follow-up.
- **SQLite-gated unit tests**: the unit job runs SQLite in-memory, so ~14 MySQL-gated unit tests (tenancy) skip there; multi-connection semantics are covered by the real-MySQL `MultiConnection` job. Tracked as a known, explicit skip (tests print their skip reason).

## Verification

- `bin/check-test-coverage` passes (and fails as expected if the catch-all is removed).
- Security catch-all runs exactly `ComprehensiveSecurityTest.php` → 12 passed / 245 assertions.
- `behat --profile=ci --suite=acceptance` resolves to Account + Basket management, **0 undefined steps**.
- The 2 slow Domain tests pass in 44s total under the default config.
- All edited workflow + behat YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)