### PR TITLE
fix(ios): restore Apple Team ID prefix in AASA appID (V6JGV96RCA)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -395,7 +395,10 @@ MOBILE_MAX_BIOMETRIC_FAILURES=5
 MOBILE_BIOMETRIC_BLOCK_MINUTES=30
 
 # Mobile App Store — Passkey & Deep Links (.well-known files)
-MOBILE_APPLE_TEAM_ID=
+# Apple Team ID for the AASA appID prefix (public, non-secret). Defaults to the
+# canonical Zelta team id in config/mobile.php when left blank — override only
+# for a different signing team. Leaving this empty must NOT produce ".com.zelta.wallet".
+MOBILE_APPLE_TEAM_ID=V6JGV96RCA
 MOBILE_ANDROID_SHA256_FINGERPRINT=
 
 # =============================================================================

--- a/config/mobile.php
+++ b/config/mobile.php
@@ -307,7 +307,12 @@ return [
     |
     */
 
-    'apple_team_id' => env('MOBILE_APPLE_TEAM_ID', ''),
+    // Apple Team ID is a public, non-secret value (it is served in the public
+    // AASA file), so the canonical prefix is baked in as the default. The `?:`
+    // ensures an unset OR empty env override both fall back to the real team id,
+    // preventing the empty-prefix (".com.zelta.wallet") bug that breaks iOS
+    // passkeys + universal links. Set MOBILE_APPLE_TEAM_ID to override per build.
+    'apple_team_id' => env('MOBILE_APPLE_TEAM_ID') ?: 'V6JGV96RCA',
 
     'android_sha256_fingerprint' => env('MOBILE_ANDROID_SHA256_FINGERPRINT', ''),
 ];

--- a/routes/web.php
+++ b/routes/web.php
@@ -288,15 +288,17 @@ Route::get('/legal/delete-account', function () {
 
 // Apple App Site Association — enables passkey AutoFill + Universal Links on iOS 16+
 Route::get('/.well-known/apple-app-site-association', function () {
+    $appId = config('mobile.apple_team_id') . '.com.zelta.wallet';
+
     return response()->json([
         'webcredentials' => [
-            'apps' => [config('mobile.apple_team_id', 'REPLACE_TEAM_ID') . '.com.zelta.wallet'],
+            'apps' => [$appId],
         ],
         'applinks' => [
             'apps'    => [],
             'details' => [
                 [
-                    'appID' => config('mobile.apple_team_id', 'REPLACE_TEAM_ID') . '.com.zelta.wallet',
+                    'appID' => $appId,
                     'paths' => ['/pay/*', '/verify/*'],
                 ],
             ],

--- a/tests/Feature/WellKnown/AppleAppSiteAssociationTest.php
+++ b/tests/Feature/WellKnown/AppleAppSiteAssociationTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+// Regression coverage for the Apple App Site Association (AASA) file.
+//
+// Apple is strict: the appID must be "<TeamID>.<BundleID>". A missing/empty
+// team-id prefix (".com.zelta.wallet") silently breaks iOS passkey sign-in and
+// the /pay + /verify universal links. These tests pin the team-id prefix and
+// guard against the empty-prefix regression.
+
+const AASA_BUNDLE_ID = 'com.zelta.wallet';
+const AASA_DEFAULT_TEAM_ID = 'V6JGV96RCA';
+
+it('serves the AASA file at the exact path with a JSON content type and no redirect', function () {
+    $response = $this->get('/.well-known/apple-app-site-association');
+
+    $response->assertOk(); // 200 directly, not a 3xx redirect
+    expect($response->headers->get('Content-Type'))->toContain('application/json');
+});
+
+it('serves an appID with a non-empty Apple Team ID prefix', function () {
+    $payload = $this->get('/.well-known/apple-app-site-association')->json();
+
+    $appId = $payload['applinks']['details'][0]['appID'];
+    $webcred = $payload['webcredentials']['apps'][0];
+
+    // The empty-prefix bug produced ".com.zelta.wallet" — guard both fields.
+    expect($appId)->not->toStartWith('.');
+    expect($webcred)->not->toStartWith('.');
+
+    expect($appId)->toBe(AASA_DEFAULT_TEAM_ID . '.' . AASA_BUNDLE_ID);
+    expect($webcred)->toBe(AASA_DEFAULT_TEAM_ID . '.' . AASA_BUNDLE_ID);
+});
+
+it('declares the /pay and /verify universal-link paths', function () {
+    $payload = $this->get('/.well-known/apple-app-site-association')->json();
+
+    expect($payload['applinks']['details'][0]['paths'])->toBe(['/pay/*', '/verify/*']);
+    expect($payload['applinks']['apps'])->toBe([]);
+});
+
+it('respects an explicit Apple Team ID override from config', function () {
+    config(['mobile.apple_team_id' => 'ABCDE12345']);
+
+    $payload = $this->get('/.well-known/apple-app-site-association')->json();
+
+    expect($payload['applinks']['details'][0]['appID'])->toBe('ABCDE12345.' . AASA_BUNDLE_ID);
+    expect($payload['webcredentials']['apps'][0])->toBe('ABCDE12345.' . AASA_BUNDLE_ID);
+});


### PR DESCRIPTION
## Problem

`https://zelta.app/.well-known/apple-app-site-association` was served with an **empty Apple Team ID prefix** — `\".com.zelta.wallet\"` instead of `\"V6JGV96RCA.com.zelta.wallet\"`. Apple is strict about the `appID` format (`<TeamID>.<BundleID>`); an empty prefix silently breaks:

- iOS **passkey sign-in** (`webcredentials:zelta.app`)
- the **`/pay/*` and `/verify/*` universal links**

### Root cause

The route (`routes/web.php:290`) built the appID from `config('mobile.apple_team_id')`, which resolves to `env('MOBILE_APPLE_TEAM_ID', '')` — an **empty-string default**. Production never set `MOBILE_APPLE_TEAM_ID`, so the prefix collapsed to `''`. The `'REPLACE_TEAM_ID'` second arg to `config()` never fired because the config key always exists (it just resolved to `''`).

## Fix

- **`config/mobile.php`** — bake the canonical, **public, non-secret** Team ID `V6JGV96RCA` as the default via `env('MOBILE_APPLE_TEAM_ID') ?: 'V6JGV96RCA'`. The `?:` covers both an **unset** and an **empty-string** env override, so the empty-prefix bug cannot recur. An explicitly-set `MOBILE_APPLE_TEAM_ID` still overrides for other signing teams.
- **`routes/web.php`** — compute `$appId` once (was duplicated across both fields) and drop the dead `REPLACE_TEAM_ID` arg.
- **`.env.example`** — set the documented value + a comment explaining the invariant.
- **`tests/Feature/WellKnown/AppleAppSiteAssociationTest.php`** — new regression coverage pinning the prefix and asserting the appID **never starts with `.`**. The old smoke test only checked status + content-type, which is why this shipped undetected.

## Verified locally (simulated production, env var unset)

```
HTTP Status: 200
Content-Type: application/json
Redirect?: no
{\"webcredentials\":{\"apps\":[\"V6JGV96RCA.com.zelta.wallet\"]},\"applinks\":{\"apps\":[],\"details\":[{\"appID\":\"V6JGV96RCA.com.zelta.wallet\",\"paths\":[\"/pay/*\",\"/verify/*\"]}]}}
```

Requirements met: exact path (no `.json`), `application/json`, HTTP 200 with no redirect, served from apex via the existing route. (JSON key order is `webcredentials`/`applinks` as before — Apple parses JSON, order is irrelevant; only the prefix changed.)

- ✅ `pest tests/Feature/WellKnown/AppleAppSiteAssociationTest.php tests/Smoke/HealthCheckSmokeTest.php` → 11 passed
- ✅ php-cs-fixer clean
- ✅ PHPStan: no new errors on changed lines (pre-existing baseline debt only)

## Post-merge / deploy notes

1. Deploy runs `config:cache`, so the new default takes effect after the standard deploy.
2. **Belt-and-suspenders:** also set `MOBILE_APPLE_TEAM_ID=V6JGV96RCA` in the production `.env` (the code default already makes the served file correct regardless).
3. After deploy, verify the raw file: \`curl -i https://zelta.app/.well-known/apple-app-site-association\`.
4. Apple's CDN copy (\`https://app-site-association.cdn-apple.com/a/v1/zelta.app\`) refreshes on Apple's own schedule (can lag up to ~24h) — not under our control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)