### PR TITLE
feat(privacy): RAILGUN non-custodial Phase 1 — wallet registration + mobile guide

### DIFF
--- a/app/Domain/Privacy/Routes/api.php
+++ b/app/Domain/Privacy/Routes/api.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Http\Controllers\Api\Privacy\DelegatedProofController;
 use App\Http\Controllers\Api\Privacy\PrivacyController;
+use App\Http\Controllers\Api\Privacy\RailgunWalletRegistrationController;
 use Illuminate\Support\Facades\Route;
 
 Route::prefix('v1/privacy')->name('api.privacy.')->group(function () {
@@ -25,6 +26,10 @@ Route::prefix('v1/privacy')->name('api.privacy.')->group(function () {
 
     // Authenticated endpoints
     Route::middleware(['auth:sanctum', 'throttle:60,1'])->group(function () {
+        // Non-custodial wallet registration — device registers its public 0zk
+        // address; no seed material is ever sent or stored (Phase 1).
+        Route::post('/wallet/register', RailgunWalletRegistrationController::class)->name('wallet.register');
+
         Route::get('/merkle-root', [PrivacyController::class, 'getMerkleRoot'])->name('merkle-root');
         Route::post('/merkle-path', [PrivacyController::class, 'getMerklePath'])->middleware('throttle:10,1')->name('merkle-path');
         Route::post('/verify-commitment', [PrivacyController::class, 'verifyCommitment'])->middleware('throttle:10,1')->name('verify-commitment');

--- a/app/Http/Controllers/Api/Privacy/RailgunWalletRegistrationController.php
+++ b/app/Http/Controllers/Api/Privacy/RailgunWalletRegistrationController.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Privacy;
+
+use App\Domain\Privacy\Models\RailgunWallet;
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use OpenApi\Attributes as OA;
+
+/**
+ * Non-custodial RAILGUN wallet registration (Phase 1).
+ *
+ * In the non-custodial model the device creates the 0zk wallet locally (seed +
+ * spending key + viewing key never leave the device) and registers only its
+ * PUBLIC 0zk address here — for activity-feed mirroring, push notifications and
+ * scan hints. The backend stores no seed: encrypted_mnemonic stays null.
+ */
+class RailgunWalletRegistrationController extends Controller
+{
+    #[OA\Post(
+        path: '/api/v1/privacy/wallet/register',
+        operationId: 'registerRailgunWallet',
+        summary: 'Register a non-custodial RAILGUN 0zk address',
+        description: 'The device creates the RAILGUN wallet locally and registers only its public 0zk address. No seed material is sent or stored.',
+        security: [['sanctum' => []]],
+        tags: ['Privacy'],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['railgun_address', 'network'],
+                properties: [
+                    new OA\Property(property: 'railgun_address', type: 'string', example: '0zk1q...'),
+                    new OA\Property(property: 'network', type: 'string', enum: ['ethereum', 'polygon', 'arbitrum', 'bsc']),
+                ],
+            ),
+        ),
+        responses: [
+            new OA\Response(response: 200, description: 'Registered'),
+            new OA\Response(response: 409, description: 'Address already registered to another user'),
+            new OA\Response(response: 422, description: 'Validation error'),
+        ],
+    )]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        if (! $user instanceof User) {
+            return response()->json(['success' => false, 'error' => ['code' => 'UNAUTHENTICATED', 'message' => 'Authentication required.']], 401);
+        }
+
+        $validated = $request->validate([
+            'railgun_address' => ['required', 'string', 'min:20', 'max:128', 'regex:/^0zk1[a-z0-9]+$/'],
+            'network'         => ['required', 'string', Rule::in(config('privacy.railgun.networks', ['ethereum', 'polygon', 'arbitrum', 'bsc']))],
+        ]);
+
+        $address = $validated['railgun_address'];
+
+        $existing = RailgunWallet::where('railgun_address', $address)->first();
+
+        if ($existing !== null && $existing->user_id !== $user->id) {
+            return response()->json([
+                'success' => false,
+                'error'   => [
+                    'code'    => 'ADDRESS_ALREADY_REGISTERED',
+                    'message' => 'This RAILGUN address is already registered to another account.',
+                ],
+            ], 409);
+        }
+
+        // encrypted_mnemonic is intentionally NOT set — non-custodial wallets
+        // hold the seed on-device only.
+        $wallet = RailgunWallet::updateOrCreate(
+            ['user_id' => $user->id, 'railgun_address' => $address],
+            ['network' => $validated['network'], 'status' => RailgunWallet::STATUS_ACTIVE],
+        );
+
+        return response()->json([
+            'success' => true,
+            'data'    => [
+                'railgun_address' => $wallet->railgun_address,
+                'network'         => $wallet->network,
+                'status'          => $wallet->status,
+                'custodial'       => false,
+                'registered_at'   => $wallet->updated_at->toIso8601String(),
+            ],
+        ]);
+    }
+}

--- a/database/migrations/2026_06_20_120000_make_railgun_wallet_mnemonic_nullable.php
+++ b/database/migrations/2026_06_20_120000_make_railgun_wallet_mnemonic_nullable.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Phase 1 of the non-custodial RAILGUN migration.
+ *
+ * Non-custodial wallets are created on-device; the backend stores only the
+ * PUBLIC 0zk address (via POST /api/v1/privacy/wallet/register) and never holds
+ * seed material. Make encrypted_mnemonic nullable so a registered wallet can
+ * exist with no server-held seed. The legacy custodial path still sets it until
+ * it is removed in Phase 3.
+ */
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('railgun_wallets', function (Blueprint $table) {
+            $table->text('encrypted_mnemonic')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('railgun_wallets', function (Blueprint $table) {
+            $table->text('encrypted_mnemonic')->nullable(false)->change();
+        });
+    }
+};

--- a/docs/RAILGUN_MOBILE_INTEGRATION.md
+++ b/docs/RAILGUN_MOBILE_INTEGRATION.md
@@ -1,0 +1,60 @@
+# RAILGUN Mobile Integration — Start Here
+
+> Replaces the stale `docs/archive/RAILGUN_MOBILE_HANDOVER.md`. Full architecture
+> in `docs/superpowers/specs/2026-06-20-railgun-noncustodial-design.md`.
+
+## TL;DR
+
+RAILGUN privacy is going **non-custodial** (device holds the keys, like Wallet Send via Privy). The backend already exposes a stable REST surface under `/api/v1/privacy/*` (Sanctum bearer, no extra KYC). **You can build the entire privacy UI today against demo mode** — then swap in the on-device engine as it lands. The single biggest risk is the on-device prover; **run the spike (below) first.**
+
+## 1. Start today — build UI against demo mode
+
+Set the backend env to `ZK_PROVIDER=demo` (the default). Every endpoint returns well-formed data with no real on-chain semantics, so you can build and wire the whole flow:
+
+- Auth: the normal Sanctum bearer token (same as the rest of the app). No extra step.
+- `GET /api/v1/privacy/networks` — **authoritative** list of supported chains. Always read this; never hardcode. (Production/railgun = `ethereum, polygon, arbitrum, bsc` — **not** Base.)
+- `GET /balances`, `GET /total-balance`, `GET /transactions`
+- `POST /shield`, `POST /unshield`, `POST /transfer` — **dual-mode**: in demo mode they return a delegated-proof job `{status:'queued', progress:0}`; in railgun mode they return `{status:'transaction_ready', transaction:{to,data,value}, gas_estimate, railgun_address:'0zk...'}`. Handle both shapes (or branch on `status`).
+- `PUT /transactions/{id}/tx-hash` — record the on-chain hash after you broadcast.
+
+> ⚠️ Do **not** rely on `GET /viewing-key` — it's a server-side SHA-256 stub, not a real RAILGUN viewing key. In the non-custodial model the viewing key is device-held and you decrypt balances locally.
+
+## 2. The non-custodial target (what changes)
+
+The contract **inverts**: instead of the server building + proving your transaction, the **device** does it. The backend becomes support services.
+
+| The device does | The backend provides (no keys) |
+|---|---|
+| derive seed (from a Privy signature), hold spending + viewing keys | `POST /wallet/register` — register your **public** `0zk` address |
+| run `@railgun-community/wallet` v10 in an embedded Node runtime + native Groth16 prover | merkle/commitment feed (scan acceleration) |
+| generate shield/unshield/transfer proofs **on-device** (~20–30s) | artifact CDN mirror, self-hosted POI node, RPC proxy |
+| derive `shieldPrivateKey` = `keccak256(privySign(getShieldPrivateKeySignatureMessage()))` | activity-feed mirror (sees only public EVM txs) |
+| decrypt balances with the viewing key | broadcaster info / gas |
+
+### New: `POST /api/v1/privacy/wallet/register` (live now, Phase 1)
+After creating the wallet on-device, register its public address:
+```http
+POST /api/v1/privacy/wallet/register
+Authorization: Bearer <sanctum>
+{ "railgun_address": "0zk1...", "network": "polygon" }
+→ 200 { "success": true, "data": { "railgun_address": "0zk1...", "network": "polygon", "custodial": false, "registered_at": "..." } }
+```
+Idempotent per (user, address). The backend stores **no seed** — `encrypted_mnemonic` is null for registered wallets. `409 ADDRESS_ALREADY_REGISTERED` if the address belongs to another account; `422` on a malformed `0zk` address or unsupported network.
+
+## 3. Spike FIRST (de-risk the biggest unknown)
+
+Before building the on-device path, prove it works on a real device:
+
+1. Stand up `nodejs-mobile-react-native` + `@railgun-community/wallet` **v10** + the native Groth16 prover (`@railgun-privacy/native-prover`) + `leveldown-nodejs-mobile` + an `fs`-backed artifact store. (Reference: the Railway Wallet repo — it's RN + embedded Node.)
+2. Create a wallet and **prove one testnet shield end-to-end** on a physical phone. Measure proof time + memory.
+3. **Confirm Privy signature determinism:** sign the same fixed message with the Privy embedded wallet across app restarts/devices and assert the signature bytes are identical (RFC-6979). This decides the seed model — deterministic ⇒ signature-derived seed (no backup); if not ⇒ standard backed-up BIP-39 fallback.
+
+If 1–3 pass, the rest is integration. If the prover is too slow/heavy on target devices, raise it early — there is **no** server-proving fallback in a non-custodial design.
+
+## 4. Gotchas
+
+- **Networks:** read `GET /networks`; case-sensitive; Base is not supported by RAILGUN.
+- **POI standby:** newly shielded funds are unshield-only for ~1h until the on-device POI proof validates. Design the UX for it.
+- **Artifacts:** ~50MB+ of circuit artifacts download on demand (from our mirror). Plan first-use latency + a progress UI.
+- **Proving UX:** 20–30s on slow devices; must survive backgrounding.
+- **Don't trust the archived handover** — its merkle endpoint paths are the bridge's internal routes, not the Laravel API.

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -36707,6 +36707,61 @@
                 ]
             }
         },
+        "/api/v1/privacy/wallet/register": {
+            "post": {
+                "tags": [
+                    "Privacy"
+                ],
+                "summary": "Register a non-custodial RAILGUN 0zk address",
+                "description": "The device creates the RAILGUN wallet locally and registers only its public 0zk address. No seed material is sent or stored.",
+                "operationId": "registerRailgunWallet",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "railgun_address",
+                                    "network"
+                                ],
+                                "properties": {
+                                    "railgun_address": {
+                                        "type": "string",
+                                        "example": "0zk1q..."
+                                    },
+                                    "network": {
+                                        "type": "string",
+                                        "enum": [
+                                            "ethereum",
+                                            "polygon",
+                                            "arbitrum",
+                                            "bsc"
+                                        ]
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Registered"
+                    },
+                    "409": {
+                        "description": "Address already registered to another user"
+                    },
+                    "422": {
+                        "description": "Validation error"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
         "/api/monitoring/projector-health": {
             "get": {
                 "tags": [

--- a/tests/Feature/Api/Privacy/RailgunWalletRegistrationTest.php
+++ b/tests/Feature/Api/Privacy/RailgunWalletRegistrationTest.php
@@ -33,9 +33,8 @@ it('registers a non-custodial wallet and stores NO seed material', function () {
         ->assertJsonPath('data.railgun_address', validRailgunAddress())
         ->assertJsonPath('data.network', 'polygon');
 
-    $wallet = RailgunWallet::where('railgun_address', validRailgunAddress())->first();
-    expect($wallet)->not->toBeNull()
-        ->and($wallet->user_id)->toBe($this->user->id)
+    $wallet = RailgunWallet::where('railgun_address', validRailgunAddress())->firstOrFail();
+    expect($wallet->user_id)->toBe($this->user->id)
         ->and($wallet->getAttributes()['encrypted_mnemonic'] ?? null)->toBeNull(); // raw column — no server-held seed
 });
 

--- a/tests/Feature/Api/Privacy/RailgunWalletRegistrationTest.php
+++ b/tests/Feature/Api/Privacy/RailgunWalletRegistrationTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Privacy\Models\RailgunWallet;
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+
+// Phase 1 of the non-custodial RAILGUN migration: the device creates the 0zk
+// wallet locally and registers only its PUBLIC address with the backend (for
+// activity-feed mirroring / push / scan hints). The server NEVER receives or
+// stores seed material — encrypted_mnemonic stays null for registered wallets.
+
+// bech32m-shaped public RAILGUN address (no secret); length 114 ≤ column max 128.
+function validRailgunAddress(): string
+{
+    return '0zk1' . str_repeat('q', 110);
+}
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    Sanctum::actingAs($this->user, ['read', 'write', 'delete']);
+});
+
+it('registers a non-custodial wallet and stores NO seed material', function () {
+    $response = $this->postJson('/api/v1/privacy/wallet/register', [
+        'railgun_address' => validRailgunAddress(),
+        'network'         => 'polygon',
+    ]);
+
+    $response->assertOk()
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.railgun_address', validRailgunAddress())
+        ->assertJsonPath('data.network', 'polygon');
+
+    $wallet = RailgunWallet::where('railgun_address', validRailgunAddress())->first();
+    expect($wallet)->not->toBeNull()
+        ->and($wallet->user_id)->toBe($this->user->id)
+        ->and($wallet->getAttributes()['encrypted_mnemonic'] ?? null)->toBeNull(); // raw column — no server-held seed
+});
+
+it('is idempotent — re-registering updates the network without duplicating', function () {
+    $this->postJson('/api/v1/privacy/wallet/register', ['railgun_address' => validRailgunAddress(), 'network' => 'polygon'])->assertOk();
+    $this->postJson('/api/v1/privacy/wallet/register', ['railgun_address' => validRailgunAddress(), 'network' => 'arbitrum'])->assertOk();
+
+    $wallets = RailgunWallet::where('railgun_address', validRailgunAddress())->get();
+    expect($wallets)->toHaveCount(1)
+        ->and($wallets->first()->network)->toBe('arbitrum');
+});
+
+it('rejects a malformed 0zk address', function () {
+    $this->postJson('/api/v1/privacy/wallet/register', [
+        'railgun_address' => 'not-a-railgun-address',
+        'network'         => 'polygon',
+    ])->assertStatus(422)->assertJsonValidationErrors('railgun_address');
+});
+
+it('rejects an unsupported network', function () {
+    $this->postJson('/api/v1/privacy/wallet/register', [
+        'railgun_address' => validRailgunAddress(),
+        'network'         => 'base', // RAILGUN does not support Base
+    ])->assertStatus(422)->assertJsonValidationErrors('network');
+});
+
+it('refuses to register an address already owned by another user', function () {
+    $other = User::factory()->create();
+    RailgunWallet::create([
+        'user_id'         => $other->id,
+        'railgun_address' => validRailgunAddress(),
+        'network'         => 'polygon',
+        'status'          => 'active',
+    ]);
+
+    $this->postJson('/api/v1/privacy/wallet/register', [
+        'railgun_address' => validRailgunAddress(),
+        'network'         => 'polygon',
+    ])->assertStatus(409)->assertJsonPath('error.code', 'ADDRESS_ALREADY_REGISTERED');
+});
+
+it('requires authentication', function () {
+    app('auth')->forgetGuards();
+
+    $this->postJson('/api/v1/privacy/wallet/register', [
+        'railgun_address' => validRailgunAddress(),
+        'network'         => 'polygon',
+    ])->assertUnauthorized();
+});


### PR DESCRIPTION
First backend increment of the approved non-custodial RAILGUN migration ([design spec](../blob/main/docs/superpowers/specs/2026-06-20-railgun-noncustodial-design.md), shipped in #1153).

## Why

In the non-custodial model the **device** creates the 0zk wallet locally — seed, spending key, and viewing key never leave the device — and registers only its **public** `0zk` address with the backend (for activity-feed mirroring / push / scan hints). This adds that primitive. It's needed regardless of how the Phase-2 mobile spike resolves the seed model, so it carries **no rework risk**.

## Changes

- **`POST /api/v1/privacy/wallet/register`** (`auth:sanctum`) — device registers its public `0zk` address + network.
  - Idempotent per `(user, address)`.
  - `409 ADDRESS_ALREADY_REGISTERED` if the address belongs to another account.
  - `422` on a malformed `0zk` address or unsupported network (validated against `config('privacy.railgun.networks')` — Base rejected).
  - **Stores no seed** — `encrypted_mnemonic` stays null for registered wallets (asserted in tests via the raw column).
- **Migration** — make `railgun_wallets.encrypted_mnemonic` nullable so non-custodial wallets need no server-held seed. The legacy custodial path still sets it until removed in Phase 3.
- **`docs/RAILGUN_MOBILE_INTEGRATION.md`** — fresh "start here" for the mobile dev (build UI against demo mode today; the de-risking spike checklist; the non-custodial target contract). Replaces the stale archived handover.

## Verification
- ✅ `pest tests/Feature/Api/Privacy/` → **96 passed** (incl. 6 new registration tests; existing custodial `RailgunIntegrationTest` still green — the nullable migration is non-breaking)
- ✅ php-cs-fixer clean · PHPStan: no errors · api-docs.json regenerated (`APP_URL=localhost`)

## Not in scope (later phases)
Merkle/commitment indexer, artifact CDN mirror, self-hosted POI node (Phase 1 cont.); on-device engine (Phase 2); strip custodial bridge + `DelegatedProofService` + `encrypted_mnemonic` column (Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)