### PR TITLE
feat(privacy): RAILGUN non-custodial Phase 1 — on-device engine-config + infra runbook

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -263,6 +263,19 @@ RAILGUN_BRIDGE_URL=http://127.0.0.1:3100
 RAILGUN_BRIDGE_SECRET=
 RAILGUN_BRIDGE_TIMEOUT=30
 
+# RAILGUN non-custodial on-device engine (served by GET /api/v1/privacy/engine-config).
+# These are PUBLIC infra endpoints the mobile app points its on-device engine at.
+# RPC URLs MUST be key-safe (a proxy or keyless endpoint) — never embed an API key,
+# the value is returned to the client. See docs/operations/railgun-infra.md.
+RAILGUN_WALLET_SOURCE=zelta
+RAILGUN_ARTIFACT_BASE_URL=
+RAILGUN_POI_NODE_URLS=                # comma-separated; our self-hosted POI aggregator(s)
+RAILGUN_BROADCASTER_ENABLED=true
+RAILGUN_RPC_ETHEREUM=
+RAILGUN_RPC_POLYGON=
+RAILGUN_RPC_ARBITRUM=
+RAILGUN_RPC_BSC=
+
 # WebAuthn / Passkey Configuration
 WEBAUTHN_RP_ID=finaegis.com
 WEBAUTHN_RP_NAME=FinAegis

--- a/.env.zelta.example
+++ b/.env.zelta.example
@@ -427,6 +427,19 @@ RAILGUN_BRIDGE_URL=http://127.0.0.1:3100
 RAILGUN_BRIDGE_SECRET=
 RAILGUN_BRIDGE_TIMEOUT=30
 
+# RAILGUN non-custodial on-device engine (served by GET /api/v1/privacy/engine-config).
+# These are PUBLIC infra endpoints the mobile app points its on-device engine at.
+# RPC URLs MUST be key-safe (a proxy or keyless endpoint) — never embed an API key,
+# the value is returned to the client. See docs/operations/railgun-infra.md.
+RAILGUN_WALLET_SOURCE=zelta
+RAILGUN_ARTIFACT_BASE_URL=
+RAILGUN_POI_NODE_URLS=                # comma-separated; our self-hosted POI aggregator(s)
+RAILGUN_BROADCASTER_ENABLED=true
+RAILGUN_RPC_ETHEREUM=
+RAILGUN_RPC_POLYGON=
+RAILGUN_RPC_ARBITRUM=
+RAILGUN_RPC_BSC=
+
 # WebAuthn / Passkey Configuration
 WEBAUTHN_RP_ID=zelta.app
 WEBAUTHN_RP_NAME=Zelta

--- a/app/Domain/Privacy/Routes/api.php
+++ b/app/Domain/Privacy/Routes/api.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Http\Controllers\Api\Privacy\DelegatedProofController;
 use App\Http\Controllers\Api\Privacy\PrivacyController;
+use App\Http\Controllers\Api\Privacy\RailgunEngineConfigController;
 use App\Http\Controllers\Api\Privacy\RailgunWalletRegistrationController;
 use Illuminate\Support\Facades\Route;
 
@@ -29,6 +30,10 @@ Route::prefix('v1/privacy')->name('api.privacy.')->group(function () {
         // Non-custodial wallet registration — device registers its public 0zk
         // address; no seed material is ever sent or stored (Phase 1).
         Route::post('/wallet/register', RailgunWalletRegistrationController::class)->name('wallet.register');
+
+        // On-device engine bootstrap — config for startRailgunEngine + loadProvider
+        // pointed at our self-hosted infra (POI node, artifact mirror, RPC).
+        Route::get('/engine-config', RailgunEngineConfigController::class)->name('engine-config');
 
         Route::get('/merkle-root', [PrivacyController::class, 'getMerkleRoot'])->name('merkle-root');
         Route::post('/merkle-path', [PrivacyController::class, 'getMerklePath'])->middleware('throttle:10,1')->name('merkle-path');

--- a/app/Http/Controllers/Api/Privacy/RailgunEngineConfigController.php
+++ b/app/Http/Controllers/Api/Privacy/RailgunEngineConfigController.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\Privacy;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use OpenApi\Attributes as OA;
+
+/**
+ * Non-custodial RAILGUN on-device engine bootstrap (Phase 1).
+ *
+ * The mobile app runs @railgun-community/wallet on-device and holds all keys.
+ * This endpoint hands the device the parameters it needs to point at OUR
+ * self-hosted infra:
+ *   - poi_node_urls           → startRailgunEngine(..., poiNodeURLs)
+ *   - networks[].fallback_provider_config → loadProvider(config, networkName)
+ *   - artifact_base_url        → the app's OWN ArtifactStore.get() implementation
+ *                                fetches mirrored artifacts from here on a cache
+ *                                miss. NOTE: the v9 SDK hardcodes its IPFS gateway
+ *                                and does NOT consume this — it is honored only by
+ *                                app-side ArtifactStore code, not startRailgunEngine.
+ *
+ * NOT returned (device-constructed): the LevelDB instance, the ArtifactStore, and
+ * shouldDebug — those are positional startRailgunEngine args the device supplies.
+ *
+ * Shapes mirror the SDK exactly (FallbackProviderJsonConfig, NetworkName values,
+ * TXIDVersion). No secrets are returned: RPC URLs must be key-safe, and any URL
+ * that appears to embed a credential is dropped defensively (see rpcUrlIsUnsafe).
+ */
+class RailgunEngineConfigController extends Controller
+{
+    /**
+     * Canonical RAILGUN network metadata. NetworkName values match the SDK enum
+     * (@railgun-community/shared-models): note bsc → "BNB_Chain".
+     *
+     * @var array<string, array{name: string, chain_id: int}>
+     */
+    private const NETWORK_META = [
+        'ethereum' => ['name' => 'Ethereum', 'chain_id' => 1],
+        'polygon'  => ['name' => 'Polygon', 'chain_id' => 137],
+        'arbitrum' => ['name' => 'Arbitrum', 'chain_id' => 42161],
+        'bsc'      => ['name' => 'BNB_Chain', 'chain_id' => 56],
+    ];
+
+    #[OA\Get(
+        path: '/api/v1/privacy/engine-config',
+        operationId: 'getRailgunEngineConfig',
+        summary: 'On-device RAILGUN engine bootstrap config',
+        description: 'Returns the parameters the on-device RAILGUN engine needs to point at our self-hosted infra (POI node, artifact mirror, RPC). No secrets; RPC URLs are key-safe.',
+        security: [['sanctum' => []]],
+        tags: ['Privacy'],
+        responses: [new OA\Response(response: 200, description: 'Engine bootstrap config')],
+    )]
+    public function __invoke(Request $request): JsonResponse
+    {
+        /** @var array<int, string> $enabled */
+        $enabled = (array) config('privacy.railgun.networks', []);
+        /** @var array<string, string> $rpcUrls */
+        $rpcUrls = (array) config('privacy.railgun.engine.rpc_urls', []);
+
+        $networks = [];
+
+        foreach ($enabled as $key) {
+            $meta = self::NETWORK_META[$key] ?? null;
+            $rpcUrl = trim((string) ($rpcUrls[$key] ?? ''));
+
+            // Omit networks we can't actually serve a provider for — the device
+            // would otherwise build a loadProvider config with an empty URL.
+            if ($meta === null || $rpcUrl === '') {
+                continue;
+            }
+
+            // Defense-in-depth: this URL is returned to every authenticated
+            // client, so a provider API key embedded in it would leak. Drop the
+            // network (graceful, same as an empty URL) rather than serve a key.
+            if ($this->rpcUrlIsUnsafe($rpcUrl)) {
+                Log::warning('RAILGUN engine-config: dropping RPC URL that appears to embed a credential', ['network' => $key]);
+
+                continue;
+            }
+
+            $networks[] = [
+                'key'          => $key,
+                'network_name' => $meta['name'],
+                'chain_id'     => $meta['chain_id'],
+                // Directly consumable by loadProvider() — FallbackProviderJsonConfig.
+                'fallback_provider_config' => [
+                    'chainId'   => $meta['chain_id'],
+                    'providers' => [[
+                        'provider'        => $rpcUrl,
+                        'priority'        => 1,
+                        'weight'          => 2,
+                        'maxLogsPerBatch' => 1,
+                        'stallTimeout'    => 2500,
+                    ]],
+                ],
+            ];
+        }
+
+        return response()->json([
+            'success' => true,
+            'data'    => [
+                'wallet_source'        => (string) config('privacy.railgun.engine.wallet_source', 'zelta'),
+                'txid_version'         => (string) config('privacy.railgun.engine.txid_version', 'V2_PoseidonMerkle'),
+                'use_native_artifacts' => (bool) config('privacy.railgun.engine.use_native_artifacts', true),
+                'artifact_base_url'    => (string) config('privacy.railgun.engine.artifact_base_url', ''),
+                'poi_node_urls'        => array_values((array) config('privacy.railgun.engine.poi_node_urls', [])),
+                'broadcaster_enabled'  => (bool) config('privacy.railgun.engine.broadcaster_enabled', true),
+                'networks'             => $networks,
+            ],
+        ]);
+    }
+
+    /**
+     * Heuristic guard against an operator misconfiguring a credential-bearing RPC
+     * URL (the value is served to every client). High precision, low false-positive:
+     * matches a credential query param, or an Alchemy/Infura-style key embedded in
+     * a /v2|/v3 path segment. A key-safe proxy like https://rpc.zelta.app/polygon
+     * passes cleanly.
+     */
+    private function rpcUrlIsUnsafe(string $url): bool
+    {
+        if (preg_match('/[?&](api[-_]?key|apikey|key|token|secret|auth|access[-_]?token)=/i', $url) === 1) {
+            return true;
+        }
+
+        // /v2/<long opaque token> or /v3/<...> — the canonical provider key-in-path.
+        return preg_match('~/v[23]/[A-Za-z0-9_-]{24,}~', $url) === 1;
+    }
+}

--- a/config/privacy.php
+++ b/config/privacy.php
@@ -305,5 +305,34 @@ return [
         'bridge_secret'  => env('RAILGUN_BRIDGE_SECRET'),
         'bridge_timeout' => (int) env('RAILGUN_BRIDGE_TIMEOUT', 30),
         'networks'       => ['ethereum', 'polygon', 'arbitrum', 'bsc'],
+
+        /*
+        | Non-custodial on-device engine bootstrap (Phase 1).
+        |
+        | Served verbatim to the mobile app by GET /api/v1/privacy/engine-config
+        | so the device can configure startRailgunEngine + loadProvider against
+        | OUR self-hosted infra (POI node, artifact mirror, RPC). The device holds
+        | all keys; these are only public infra endpoints. RPC URLs MUST be
+        | key-safe (a proxy or keyless endpoint) — never embed a provider API key.
+        */
+        'engine' => [
+            // walletSource: <=16 chars, lowercase (RAILGUN constraint).
+            'wallet_source'        => env('RAILGUN_WALLET_SOURCE', 'zelta'),
+            'txid_version'         => 'V2_PoseidonMerkle',
+            'use_native_artifacts' => true, // TRUE for mobile (native Groth16 prover)
+            'artifact_base_url'    => (string) env('RAILGUN_ARTIFACT_BASE_URL', ''),
+            'poi_node_urls'        => array_values(array_filter(array_map(
+                'trim',
+                explode(',', (string) env('RAILGUN_POI_NODE_URLS', '')),
+            ))),
+            'broadcaster_enabled' => (bool) env('RAILGUN_BROADCASTER_ENABLED', true),
+            // Device-facing per-network RPC URLs (key-safe: proxy or keyless).
+            'rpc_urls' => [
+                'ethereum' => (string) env('RAILGUN_RPC_ETHEREUM', ''),
+                'polygon'  => (string) env('RAILGUN_RPC_POLYGON', ''),
+                'arbitrum' => (string) env('RAILGUN_RPC_ARBITRUM', ''),
+                'bsc'      => (string) env('RAILGUN_RPC_BSC', ''),
+            ],
+        ],
     ],
 ];

--- a/docs/RAILGUN_MOBILE_INTEGRATION.md
+++ b/docs/RAILGUN_MOBILE_INTEGRATION.md
@@ -41,6 +41,28 @@ Authorization: Bearer <sanctum>
 ```
 Idempotent per (user, address). The backend stores **no seed** — `encrypted_mnemonic` is null for registered wallets. `409 ADDRESS_ALREADY_REGISTERED` if the address belongs to another account; `422` on a malformed `0zk` address or unsupported network.
 
+### New: `GET /api/v1/privacy/engine-config` (live now, Phase 1)
+Fetch this once at startup to configure the on-device engine against our self-hosted infra. The shapes are **directly consumable** by the SDK:
+```http
+GET /api/v1/privacy/engine-config  (Authorization: Bearer <sanctum>)
+→ data: {
+    "wallet_source": "zelta",                 // startRailgunEngine arg (≤16 chars)
+    "txid_version": "V2_PoseidonMerkle",
+    "use_native_artifacts": true,             // mobile → native Groth16 prover
+    "artifact_base_url": "https://...",        // YOUR ArtifactStore.get() fetches mirrored artifacts from here (see note)
+    "poi_node_urls": ["https://..."],          // startRailgunEngine(..., poiNodeURLs)
+    "networks": [
+      { "key":"polygon", "network_name":"Polygon", "chain_id":137,
+        "fallback_provider_config": { "chainId":137, "providers":[{ "provider":"https://...", "priority":1, "weight":2, "maxLogsPerBatch":1, "stallTimeout":2500 }] } }
+    ]
+  }
+```
+Pass `network_name` (the exact SDK `NetworkName`) + `fallback_provider_config` straight to `loadProvider(config, networkName)`, and `poi_node_urls` to `startRailgunEngine`. A network with no configured RPC (or one that looks like it embeds a credential) is omitted. `bsc` → `network_name: "BNB_Chain"`.
+
+> ⚠️ **`artifact_base_url` is NOT consumed by the SDK.** The v9 engine hardcodes its own IPFS artifact gateway. To use our mirror, your **ArtifactStore `get()`/`exists()` implementation** must fetch from `artifact_base_url` on a cache miss (and `store()` it) — that's the only hook. If you don't, artifacts come from the SDK's pinned gateway and our mirror is unused.
+>
+> **Device-constructed (not in this payload):** the LevelDB instance, the `ArtifactStore`, and `shouldDebug` are positional `startRailgunEngine` args you build on-device — the endpoint intentionally doesn't return them.
+
 ## 3. Spike FIRST (de-risk the biggest unknown)
 
 Before building the on-device path, prove it works on a real device:

--- a/docs/operations/railgun-infra.md
+++ b/docs/operations/railgun-infra.md
@@ -1,0 +1,46 @@
+# RAILGUN Non-Custodial Infra — Ops Runbook
+
+For the non-custodial RAILGUN wallet (design: `docs/superpowers/specs/2026-06-20-railgun-noncustodial-design.md`). The mobile app runs the RAILGUN engine **on-device** and holds all keys; the backend only points it at our **self-hosted support infra** via `GET /api/v1/privacy/engine-config`. None of these services hold keys or see private transactions.
+
+Three services to stand up (decision: self-host, not public RAILGUN infra):
+
+## 1. POI aggregator node → `RAILGUN_POI_NODE_URLS`
+
+Run `Railgun-Community/private-proof-of-innocence` (a Node service; IPFS-like — anyone can run one). The on-device engine generates its own POI proof and talks to this node to sync lists / validate merkleroots — it is **not** a prover-on-your-behalf and holds no keys.
+
+- Deploy the node (its own host; persistent volume for its DB).
+- Set `RAILGUN_POI_NODE_URLS=https://poi.zelta.app` (comma-separated for multiple, in priority order).
+- The device passes these to `startRailgunEngine(..., poiNodeURLs)`.
+- **Note:** until a node is healthy, mainnet shields stay in the ~1h "unshield-only standby" longer. Monitor it like any prod dependency.
+
+## 2. Artifact mirror → `RAILGUN_ARTIFACT_BASE_URL`
+
+The device downloads Groth16 circuit artifacts (~50MB+ total, on demand) for proving. Mirror RAILGUN's content-addressed artifacts (from `assets.railgun.org` / IPFS) onto our CDN for reliability + first-use latency.
+
+- Sync the artifact set to a CDN bucket (content-addressed paths preserved).
+- Set `RAILGUN_ARTIFACT_BASE_URL=https://cdn.zelta.app/railgun-artifacts`.
+- **mobile uses the native (`.dat`) artifacts** (`use_native_artifacts=true`).
+- ⚠️ The v9 SDK hardcodes its own IPFS artifact gateway and does **not** read this URL. The mirror is only used if the **mobile app's `ArtifactStore.get()`** fetches from it on a cache miss — a client-side responsibility (documented in `docs/RAILGUN_MOBILE_INTEGRATION.md`). Leaving `RAILGUN_ARTIFACT_BASE_URL` empty is harmless (the app falls back to the SDK's pinned gateway).
+
+## 3. Per-chain RPC → `RAILGUN_RPC_{ETHEREUM,POLYGON,ARBITRUM,BSC}`
+
+The device reads chain state + syncs the merkle tree through these. They are returned to the client in `engine-config.networks[].fallback_provider_config`, so:
+
+> 🔒 **RPC URLs MUST be key-safe.** Never put a provider API key in `RAILGUN_RPC_*` — the value is served to every authenticated client. Use a keyless endpoint or a server-side RPC proxy that injects the key. (A dedicated `/privacy/rpc/{network}` proxy is a planned follow-up PR; until then, point these at keyless/proxy URLs.)
+
+- Set one per supported chain; a chain with an **empty** RPC URL is **omitted** from `engine-config` (the app won't offer it).
+- RAILGUN supports `ethereum/polygon/arbitrum/bsc` only — **not** Base.
+
+## 4. Broadcaster → `RAILGUN_BROADCASTER_ENABLED`
+
+Broadcasters relay gas-paying meta-txs over the public Waku network (they never hold user tokens/keys). Default `true` (use the public network). Self-signing from the user's Privy EOA is the fallback (needs the EOA to hold gas). Reconcile with the Pimlico sponsorship used by Wallet Send in Phase 2.
+
+## Verify
+
+```bash
+# As an authenticated mobile user (Sanctum bearer):
+curl -s https://<host>/api/v1/privacy/engine-config -H "Authorization: Bearer <token>" | jq .data
+```
+Confirm: `poi_node_urls` non-empty, `artifact_base_url` set, and one `networks[]` entry per chain that has an RPC URL, each with a `fallback_provider_config` (chainId + providers[0].provider = your key-safe RPC URL). `bsc` maps to `network_name: "BNB_Chain"`.
+
+`php artisan ops:verify-env` also gates the legacy bridge's `privacy.railgun.providers` consistency (Phase 0).

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -36707,6 +36707,26 @@
                 ]
             }
         },
+        "/api/v1/privacy/engine-config": {
+            "get": {
+                "tags": [
+                    "Privacy"
+                ],
+                "summary": "On-device RAILGUN engine bootstrap config",
+                "description": "Returns the parameters the on-device RAILGUN engine needs to point at our self-hosted infra (POI node, artifact mirror, RPC). No secrets; RPC URLs are key-safe.",
+                "operationId": "getRailgunEngineConfig",
+                "responses": {
+                    "200": {
+                        "description": "Engine bootstrap config"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
         "/api/v1/privacy/wallet/register": {
             "post": {
                 "tags": [

--- a/tests/Feature/Api/Privacy/RailgunEngineConfigTest.php
+++ b/tests/Feature/Api/Privacy/RailgunEngineConfigTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+
+// Phase 1: device-facing bootstrap for the on-device RAILGUN engine. The mobile
+// app calls GET /engine-config to configure startRailgunEngine + loadProvider
+// against OUR self-hosted infra (POI node, artifact mirror, RPC). Shapes mirror
+// the @railgun-community SDK exactly (FallbackProviderJsonConfig, NetworkName,
+// poiNodeURLs[]) so the payload is directly consumable.
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    Sanctum::actingAs($this->user, ['read', 'write', 'delete']);
+
+    config([
+        'privacy.railgun.networks'                 => ['ethereum', 'polygon', 'arbitrum', 'bsc'],
+        'privacy.railgun.engine.wallet_source'     => 'zelta',
+        'privacy.railgun.engine.artifact_base_url' => 'https://cdn.zelta.app/railgun-artifacts',
+        'privacy.railgun.engine.poi_node_urls'     => ['https://poi.zelta.app'],
+        'privacy.railgun.engine.rpc_urls'          => [
+            'ethereum' => '',                              // not configured → omitted
+            'polygon'  => 'https://rpc.zelta.app/polygon',
+            'arbitrum' => 'https://rpc.zelta.app/arbitrum',
+            'bsc'      => 'https://rpc.zelta.app/bsc',
+        ],
+    ]);
+});
+
+it('returns the on-device engine bootstrap config', function () {
+    $response = $this->getJson('/api/v1/privacy/engine-config');
+
+    $response->assertOk()
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.wallet_source', 'zelta')
+        ->assertJsonPath('data.txid_version', 'V2_PoseidonMerkle')
+        ->assertJsonPath('data.use_native_artifacts', true)
+        ->assertJsonPath('data.artifact_base_url', 'https://cdn.zelta.app/railgun-artifacts')
+        ->assertJsonPath('data.poi_node_urls', ['https://poi.zelta.app']);
+});
+
+it('emits a SDK-shaped fallback_provider_config per configured network', function () {
+    $data = $this->getJson('/api/v1/privacy/engine-config')->json('data');
+
+    $polygon = collect($data['networks'])->firstWhere('key', 'polygon');
+    expect($polygon)->not->toBeNull()
+        ->and($polygon['network_name'])->toBe('Polygon')
+        ->and($polygon['chain_id'])->toBe(137)
+        ->and($polygon['fallback_provider_config']['chainId'])->toBe(137)
+        ->and($polygon['fallback_provider_config']['providers'][0]['provider'])->toBe('https://rpc.zelta.app/polygon')
+        ->and($polygon['fallback_provider_config']['providers'][0])->toHaveKeys(['priority', 'weight', 'provider']);
+});
+
+it('maps bsc to the SDK NetworkName BNB_Chain / chain 56', function () {
+    $data = $this->getJson('/api/v1/privacy/engine-config')->json('data');
+
+    $bsc = collect($data['networks'])->firstWhere('key', 'bsc');
+    expect($bsc['network_name'])->toBe('BNB_Chain')
+        ->and($bsc['chain_id'])->toBe(56);
+});
+
+it('omits networks that have no configured RPC URL', function () {
+    $data = $this->getJson('/api/v1/privacy/engine-config')->json('data');
+
+    $keys = collect($data['networks'])->pluck('key')->all();
+    expect($keys)->not->toContain('ethereum') // rpc url was empty
+        ->and($keys)->toContain('polygon');
+});
+
+it('omits a network whose RPC URL appears to embed a credential (key-safety guard)', function () {
+    config(['privacy.railgun.engine.rpc_urls' => [
+        'ethereum' => 'https://eth-mainnet.g.alchemy.com/v2/SECRETKEY1234567890abcdef1234', // key in path
+        'polygon'  => 'https://rpc.zelta.app/polygon',                                       // safe proxy
+        'arbitrum' => 'https://rpc.example.com/arb?apikey=leakedsecret',                      // key in query
+        'bsc'      => '',
+    ]]);
+
+    $data = $this->getJson('/api/v1/privacy/engine-config')->json('data');
+
+    // Only the key-safe proxy URL is served; credential-bearing URLs are dropped.
+    expect(collect($data['networks'])->pluck('key')->all())->toBe(['polygon']);
+});
+
+it('requires authentication', function () {
+    app('auth')->forgetGuards();
+
+    $this->getJson('/api/v1/privacy/engine-config')->assertUnauthorized();
+});


### PR DESCRIPTION
Second Phase 1 increment of the non-custodial RAILGUN migration ([design](../blob/main/docs/superpowers/specs/2026-06-20-railgun-noncustodial-design.md)). Backend is deployed and the app is being built, so the on-device engine now needs a way to point at our infra.

## What

- **`GET /api/v1/privacy/engine-config`** (`auth:sanctum`) — the device fetches this once to configure `startRailgunEngine` + `loadProvider` against our **self-hosted** POI node, artifact mirror, and key-safe RPC. Returns `wallet_source`, `txid_version`, `use_native_artifacts`, `artifact_base_url`, `poi_node_urls`, and per enabled network `{ key, network_name, chain_id, fallback_provider_config }`. Networks with no RPC URL are omitted.
  - **Shapes verified against the installed SDK** (`@railgun-community/{wallet,shared-models}` `.d.ts` + our own `engine.ts`): `FallbackProviderJsonConfig`, `NetworkName` (bsc → `"BNB_Chain"`), `TXIDVersion` — directly consumable.
- **`config/privacy.php`** `railgun.engine` block (env-driven) + env examples.
- **`docs/operations/railgun-infra.md`** — runbook to stand up the self-hosted POI node + artifact mirror + key-safe RPC (decision #2).
- **`docs/RAILGUN_MOBILE_INTEGRATION.md`** — documents engine-config consumption.

## Hardened by an adversarial verification pass

I ran a 2-dimension review (contract-completeness vs the SDK + code/security), each finding adversarially verified against source. It caught **two real issues, both fixed before this PR**:

1. **`artifact_base_url` is inert against the v9 SDK** — the engine hardcodes its IPFS artifact gateway with no override hook. Corrected the docblock + guide to state the field is honored only by the app's own `ArtifactStore.get()` (cache-miss fetch from our mirror), not by `startRailgunEngine`; also documented that `db`/`artifactStore`/`shouldDebug` are device-constructed.
2. **RPC key-safety was ops-convention only** — added a code guard (`rpcUrlIsUnsafe`) that drops + logs any RPC URL embedding a credential (query key, or `/v2|/v3` key-in-path), so a misconfigured provider key never reaches a client.

The review also **confirmed** the field shapes are correct and that the worried-about "missing" fields (quickSync URL, contract addresses, chain type) are correctly omitted — the SDK bakes those in.

## Verification
- ✅ `pest` engine-config + registration → **12 passed** (incl. the key-safety guard test)
- ✅ php-cs-fixer clean · PHPStan clean · api-docs regenerated (`APP_URL=localhost`)

## Next (Phase 1 cont.)
Merkle/commitment indexer (quickSync source) + the `/privacy/rpc/{network}` proxy are follow-ups. Phase 2 = the mobile on-device engine spike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)