### PR TITLE
chore(release): v7.16.0 — non-custodial RAILGUN privacy (backend) + iOS AASA fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to the FinAegis Core Banking Platform will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.16.0] - 2026-06-21
+
+**Non-custodial RAILGUN privacy — backend migration.** Moves the RAILGUN privacy stack toward the platform's non-custodial model (the device holds all keys, like Wallet Send): the backend stops holding wallet seeds and becomes a set of support services for an on-device engine. The user-facing private-transaction flow ships once the mobile on-device engine lands — this release is the backend groundwork. Also fixes the iOS Apple App Site Association file that broke passkeys and universal links.
+
+### Added
+- **Non-custodial RAILGUN design** (`docs/superpowers/specs/2026-06-20-railgun-noncustodial-design.md`) — proving cannot be delegated without surrendering custody, so the device proves on-device (embedded engine + native prover) and the backend is reduced to support services
+- `POST /api/v1/privacy/wallet/register` — the device registers its **public** `0zk` address; the server stores no seed (`railgun_wallets.encrypted_mnemonic` is now nullable). Idempotent per (user, address); 409 on a cross-user address; 422 on a malformed address / unsupported network
+- `GET /api/v1/privacy/engine-config` — on-device engine bootstrap with SDK-exact shapes (`FallbackProviderJsonConfig`, `NetworkName` incl. bsc → `BNB_Chain`, POI node URLs, `TXIDVersion`) for `startRailgunEngine` + `loadProvider`
+- `POST /api/v1/privacy/rpc/{network}` — signed-URL JSON-RPC proxy that keeps the provider API key server-side: method whitelist (reads + `eth_sendRawTransaction`, batch-aware), per-user rate limiter, short-lived signed URLs minted by engine-config
+- `ops:verify-env` `privacy.railgun.providers` guard — fails the deploy gate when `ZK_PROVIDER`/`MERKLE_PROVIDER` disagree on railgun, or railgun mode lacks `RAILGUN_BRIDGE_SECRET`
+- Ops runbook `docs/operations/railgun-infra.md` (self-hosted POI node + artifact mirror + key-safe RPC) and the rewritten mobile integration guide `docs/RAILGUN_MOBILE_INTEGRATION.md`
+
+### Fixed
+- **iOS Apple App Site Association** (`/.well-known/apple-app-site-association`) served an empty Apple Team ID prefix (`.com.zelta.wallet`), breaking iOS passkey sign-in and the `/pay` + `/verify` universal links. `config/mobile.php` now defaults to the canonical team id (`V6JGV96RCA`) so an unset/empty env can't reproduce it
+- RAILGUN OpenAPI network enum advertised `base` (unsupported by RAILGUN) — corrected to `ethereum/polygon/arbitrum/bsc`
+
+### Security
+- RPC proxy hardened via an adversarial security review: the upstream provider API key no longer leaks into logs (Guzzle exception messages); signed-URL TTL is capped (default 300s, max 900s); the rate limiter is keyed on the signed user id (not shared per-IP); and an empty-batch (`[]`) whitelist bypass was closed
+
+### Changed
+- RAILGUN privacy is **mid-migration**: the legacy server-side custodial bridge + `app.key`-derived seed remain in place until the on-device path ships (mobile in progress). The custodial shield-422 path was deliberately left unfixed rather than cementing custody
+
 ## [7.15.0] - 2026-06-03
 
 **Bridge.xyz fiat ramp.** Bridge.xyz becomes the primary v1 fiat ↔ stablecoin rail — bank transfers in, USDC on Polygon out — with KYC, virtual accounts, and the ADR-0006 developer-fee markup mechanism. Also ships the landing-page truth-pass and wires HyperSwitch into the real deposit flow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,22 @@ Primary v1 fiat ↔ stablecoin rail (bank transfers in/out, USDC on Polygon). Do
 | VA never gets created after KYC approval | User had no Polygon `blockchain_addresses` row at KYC-completion time. `BlockchainAddressBridgeObserver` auto-retries when the address is registered; if the row already exists, run `php artisan bridge:inspect-user --email=X` to confirm state and re-trigger by deleting + re-creating the address (or call `BridgePostKycHandler::tryProvisionVirtualAccount` from tinker) |
 | Cross-domain ordering | KycServiceProvider attaches a second observer on `BlockchainAddress` (separate from Wallet/BlockchainAddressObserver which handles Helius/Solana sync). The two observers fire independently; don't merge their concerns |
 
+## RAILGUN Non-Custodial Privacy (v7.16.0+)
+
+RAILGUN privacy is **mid-migration** from custodial (v5.6.0 server-side bridge, seed = `hash_hmac(userId, app.key)`) to **non-custodial** (device holds all keys, like Wallet Send). Proving can't be delegated without surrendering custody, so the device proves on-device (embedded `@railgun-community/wallet` v10 + native Groth16 prover, Railway-style); the backend is reduced to support services. Design: `docs/superpowers/specs/2026-06-20-railgun-noncustodial-design.md`. Mobile guide: `docs/RAILGUN_MOBILE_INTEGRATION.md`. Infra runbook: `docs/operations/railgun-infra.md`.
+
+- **Backend support endpoints** (all under `/api/v1/privacy/*`, `auth:sanctum`): `POST /wallet/register` (device registers its PUBLIC `0zk` address — server stores NO seed; `railgun_wallets.encrypted_mnemonic` is nullable), `GET /engine-config` (SDK-exact bootstrap: `FallbackProviderJsonConfig`, `NetworkName`, POI node URLs, `TXIDVersion` — directly consumable by `startRailgunEngine`/`loadProvider`).
+- **RPC proxy**: `POST /api/v1/privacy/rpc/{network}` is authed by a **signed URL** (not Sanctum — the SDK's `loadProvider` takes a plain URL string, no header injection). `engine-config` mints it when `RAILGUN_RPC_UPSTREAM_*` is set; the key stays server-side. Method-whitelisted (reads + `eth_sendRawTransaction`), per-user `railgun-rpc` limiter keyed on the signed `u`.
+- **Status**: backend Phase 0 + Phase 1 shipped; the on-device engine (mobile) is gated on a de-risking spike (incl. a Privy signature-determinism check that decides the seed model). Phase 3 will strip the custodial bridge + `DelegatedProofService` + `encrypted_mnemonic` — safe since there are no funded wallets yet.
+
+| Pitfall | Fix |
+|---|---|
+| `artifact_base_url` from engine-config doesn't work | The v9/v10 SDK **hardcodes its IPFS artifact gateway** — `startRailgunEngine` does NOT consume `artifact_base_url`. The mirror is only used if the app's OWN `ArtifactStore.get()` fetches from it on a cache miss |
+| `base` network rejected in railgun mode | RAILGUN supports `ethereum/polygon/arbitrum/bsc` only (bsc → `NetworkName` `"BNB_Chain"`). `GET /networks` is the runtime source of truth; the OpenAPI enum was corrected in v7.16.0 |
+| Provider API key in `RAILGUN_RPC_*` | That value is served to clients. Use `RAILGUN_RPC_UPSTREAM_*` (proxied, key server-side) instead; `engine-config` defensively drops a client RPC URL that looks like it embeds a credential |
+| RPC proxy returns 403 mid-session | The signed URL expired (TTL capped [60,900]s). The app must **refetch `engine-config`** and rebuild the provider |
+| Editing custodial shield to "make it work" | Don't — the custodial shield-422 is deliberately unfixed; shield moves on-device in Phase 2. Adding a server-derived `shieldPrivateKey` would re-cement custody |
+
 ## Notes
 
 - Feature pages: only visible when `SHOW_PROMO_PAGES=true` (demo mode); production shows app landing page only

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ FinAegis provides the foundation for building digital banking applications. The 
 | Plugin Marketplace | Manager, loader, sandbox, security scanner (v4.0.0) |
 | Event streaming | Redis Streams publisher/consumer, live dashboard (v5.0.0) |
 | API monetization | x402 protocol: HTTP-native micropayments with USDC on Base (v5.2.0) |
-| Privacy protocol | RAILGUN SDK integration: shield/unshield/transfer with Merkle proofs (v5.6.0) |
+| Privacy protocol | RAILGUN shield/unshield/transfer with Merkle proofs (v5.6.0); non-custodial backend migration — public-address registration, on-device engine config, signed-URL RPC proxy (v7.16.0) |
 | Mobile gamification | Rewards system: quests, XP/levels, points shop, streaks (v5.7.0) |
 | Fiat on/off ramp | Stripe Bridge with async webhook processing and provider-agnostic session management (v5.12.0) |
 | Design system v2 | Complete frontend overhaul with consistent typography, dark heroes (v5.12.0) |

--- a/docs/VERSION_ROADMAP.md
+++ b/docs/VERSION_ROADMAP.md
@@ -3257,6 +3257,29 @@ Findings #1-2 fixed in v7.1.1, findings #3-15 fixed in this release:
 
 ---
 
+## Version 7.16.0 — Non-Custodial RAILGUN Privacy (Backend) (June 2026)
+
+**Theme**: Migrate the RAILGUN privacy stack to the platform's non-custodial model (the device holds all keys, like Wallet Send). Proving cannot be delegated without surrendering custody, so the device proves on-device and the backend becomes support services. This release is the **backend groundwork** — the user-facing private-transaction flow ships once the mobile on-device engine lands. Also fixes the iOS AASA file that broke passkeys + universal links.
+
+### Delivered Features
+- Non-custodial design (`docs/superpowers/specs/2026-06-20-railgun-noncustodial-design.md`) — embedded on-device engine + native Groth16 prover (Railway-style); the legacy server-side custodial bridge + `app.key`-derived seed are retained only until the on-device path ships (Phase 3 teardown).
+- `POST /api/v1/privacy/wallet/register` (#1154) — the device registers its **public** `0zk` address; the server holds no seed (`railgun_wallets.encrypted_mnemonic` made nullable). Idempotent per (user, address); 409 cross-user; 422 malformed/unsupported.
+- `GET /api/v1/privacy/engine-config` (#1155) — on-device engine bootstrap with SDK-exact shapes (`FallbackProviderJsonConfig`, `NetworkName` incl. bsc → `BNB_Chain`, POI node URLs, `TXIDVersion`) for `startRailgunEngine` + `loadProvider`.
+- `POST /api/v1/privacy/rpc/{network}` (#1156) — signed-URL JSON-RPC proxy keeping the provider key server-side: method whitelist (reads + `eth_sendRawTransaction`, batch-aware), per-user limiter, short-lived signed URLs minted by engine-config.
+- Phase 0 custody-neutral fixes (#1153) — `ops:verify-env` `privacy.railgun.providers` consistency guard; OpenAPI network enum corrected (`base` → `ethereum/polygon/arbitrum/bsc`); env discoverability docs.
+- iOS Apple App Site Association fix (#1152) — the served file had an empty Apple Team ID prefix (`.com.zelta.wallet`), breaking iOS passkeys + the `/pay`/`/verify` universal links; the canonical team id is now the config default.
+- Docs — ops runbook `docs/operations/railgun-infra.md` (self-hosted POI node + artifact mirror + key-safe RPC) and rewritten `docs/RAILGUN_MOBILE_INTEGRATION.md`.
+
+### Scope Notes
+- **Backend only.** The on-device engine (mobile) is a separate workstream gated on a de-risking spike (embedded Node + native prover + Privy signature-determinism check, which decides the seed model). No user-facing private-transaction claim is made in this release.
+- The two adversarial verification passes caught real issues before merge: `artifact_base_url` is inert against the v9 SDK (it hardcodes its IPFS gateway), and the RPC proxy leaked the upstream provider key into logs — both fixed.
+
+### Required Configuration
+- For railgun mode: `ZK_PROVIDER=railgun` + `MERKLE_PROVIDER=railgun` + a non-empty `RAILGUN_BRIDGE_SECRET` (now gated by `ops:verify-env`).
+- For the on-device engine support services: `RAILGUN_POI_NODE_URLS`, `RAILGUN_ARTIFACT_BASE_URL`, and either `RAILGUN_RPC_UPSTREAM_*` (preferred — proxied, key server-side) or key-safe `RAILGUN_RPC_*`. See `docs/operations/railgun-infra.md`.
+
+---
+
 ## Version 7.15.0 — Bridge.xyz Fiat Ramp (June 2026)
 
 **Theme**: Bridge.xyz becomes the primary v1 fiat ↔ stablecoin rail — bank transfers in, USDC on Polygon — with Bridge-hosted KYC, virtual accounts, and the ADR-0006 developer-fee markup mechanism. Plus a landing-page truth-pass and HyperSwitch wired into the real deposit flow.
@@ -3427,5 +3450,5 @@ Embeddable JS widget that renders Zelta's 402 payment flow inside the partner's 
 
 ---
 
-*Document Version: 7.15.0*
-*Updated: June 3, 2026 (v7.15.0 Bridge.xyz fiat ramp — Bridge KYC, virtual accounts, developer-fee markup, HyperSwitch deposit wiring)*
+*Document Version: 7.16.0*
+*Updated: June 21, 2026 (v7.16.0 non-custodial RAILGUN privacy backend — wallet-register, on-device engine-config, signed-URL RPC proxy, Phase 0 custody-neutral fixes, iOS AASA fix)*

--- a/resources/views/changelog.blade.php
+++ b/resources/views/changelog.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'Changelog | ' . config('brand.name', 'Zelta'),
-        'description' => 'Release history for the Zelta core banking platform. Track every feature shipped, bug fixed, and improvement made — v7.0 through v7.15.0.',
+        'description' => 'Release history for the Zelta core banking platform. Track every feature shipped, bug fixed, and improvement made — v7.0 through v7.16.0.',
         'keywords' => 'changelog, release notes, updates, ' . config('brand.name', 'Zelta') . ', version history, core banking',
     ])
 
@@ -43,6 +43,20 @@
 
             @php
                 $releases = [
+                    [
+                        'version' => 'v7.16.0',
+                        'date' => 'June 21, 2026',
+                        'label' => 'Non-Custodial RAILGUN Privacy — Backend Migration',
+                        'label_color' => 'violet',
+                        'badge_color' => 'bg-violet-100 text-violet-700 border-violet-200',
+                        'dot_color' => 'bg-violet-500',
+                        'items' => [
+                            'Non-custodial RAILGUN privacy (backend) — the RAILGUN privacy stack is moving to the platform\'s non-custodial model: the device holds all keys and proves on-device, and the backend stops holding wallet seeds. Proving cannot be delegated without surrendering custody, so the on-device engine does it; the backend becomes a set of support services. The user-facing private-transaction flow ships once the mobile on-device engine lands — this release is the backend groundwork.',
+                            'New privacy endpoints — <code>POST /api/v1/privacy/wallet/register</code> registers the device\'s <strong>public</strong> <code>0zk</code> address (the server stores no seed); <code>GET /api/v1/privacy/engine-config</code> returns SDK-exact bootstrap for the on-device engine (provider config, POI node URLs, networks); and <code>POST /api/v1/privacy/rpc/{network}</code> is a signed-URL JSON-RPC proxy that keeps the provider API key server-side with a method whitelist and per-user rate limiting.',
+                            'iOS deep-link &amp; passkey fix — the <code>/.well-known/apple-app-site-association</code> file was served with an empty Apple Team ID prefix (<code>.com.zelta.wallet</code>), which broke iOS passkey sign-in and the <code>/pay</code> + <code>/verify</code> universal links. The Team ID prefix is now baked in so an unset env can\'t reproduce it.',
+                            'Deploy-gate &amp; ops hardening — <code>ops:verify-env</code> now fails when the privacy providers are inconsistently configured, an ops runbook documents the self-hosted POI node + artifact mirror + key-safe RPC, and an adversarial security review of the RPC proxy closed a provider-key-in-logs leak and tightened its signed-URL token model.',
+                        ],
+                    ],
                     [
                         'version' => 'v7.15.0',
                         'date' => 'June 3, 2026',


### PR DESCRIPTION
Release notes for **v7.16.0**, covering this cycle's merged work: the RAILGUN non-custodial backend migration (#1153–#1156) and the iOS AASA fix (#1152).

## Framing: honest infra release

The RAILGUN non-custodial work is **backend-only** — the user-facing private-transaction flow ships once the mobile on-device engine lands (gated on a de-risking spike). So this release records the backend groundwork **without** claiming non-custodial private payments are live for users. No public marketing pages were touched (per the agreed scope).

## Files

- **`CHANGELOG.md`** — `[7.16.0]` entry (Added / Fixed / Security / Changed)
- **`docs/VERSION_ROADMAP.md`** — v7.16.0 section + footer bump
- **`resources/views/changelog.blade.php`** — public changelog block (renders, HTTP 200) + SEO range → v7.16.0
- **`README.md`** — privacy feature row notes the non-custodial backend migration
- **`CLAUDE.md`** — new `RAILGUN Non-Custodial Privacy (v7.16.0+)` section (endpoints, custodial→non-custodial status, pitfalls)

## Post-phase review
- ✅ Cross-page version consistency (CHANGELOG / ROADMAP / changelog page / README / CLAUDE.md all v7.16.0; dates all 2026-06-21)
- ✅ Copywriting accuracy — framed as "backend migration / mid-migration", no over-claim
- ✅ No stale "latest = v7.15.0" references; public changelog page renders
- ✅ Changelog block reuses an existing Tailwind color (violet) — no purge risk

## After merge
Tag `v7.16.0` on `main` + create the GitHub release (notes = the CHANGELOG entry). The README version badge is a dynamic GitHub-release shield, so it picks up the tag automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)