### PR TITLE
fix: stop custodian:sync-balances + basket:calculate-performance failing in production

### DIFF
--- a/app/Domain/Basket/Console/Commands/CalculateBasketPerformance.php
+++ b/app/Domain/Basket/Console/Commands/CalculateBasketPerformance.php
@@ -44,9 +44,19 @@ class CalculateBasketPerformance extends Command
         $baskets = $query->get();
 
         if ($baskets->isEmpty()) {
-            $this->error('No active baskets found to process.');
+            // An explicit --basket that resolves to nothing is a real error
+            // (typo or misconfiguration) and must surface a non-zero exit code.
+            if ($basketCode) {
+                $this->error("Basket with code '{$basketCode}' not found.");
 
-            return 1;
+                return 1;
+            }
+
+            // A scheduled bulk run with no active baskets is a no-op, not a
+            // failure — returning non-zero made the scheduler log it as failed.
+            $this->info('No active baskets to process.');
+
+            return 0;
         }
 
         $this->info("Processing performance for {$baskets->count()} basket(s)...");

--- a/app/Domain/Custodian/Models/CustodianAccount.php
+++ b/app/Domain/Custodian/Models/CustodianAccount.php
@@ -6,6 +6,7 @@ namespace App\Domain\Custodian\Models;
 
 use App\Domain\Account\Models\Account;
 use App\Domain\Shared\Traits\UsesTenantConnection;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -30,6 +31,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property array|null $metadata
  * @property int|null $last_known_balance
  * @property \Illuminate\Support\Carbon|null $last_synced_at
+ * @property string|null $sync_status
+ * @property string|null $sync_error
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  *
@@ -100,6 +103,8 @@ class CustodianAccount extends Model
         'metadata',
         'last_known_balance',
         'last_synced_at',
+        'sync_status',
+        'sync_error',
     ];
 
     /**
@@ -154,6 +159,22 @@ class CustodianAccount extends Model
     public function scopeForCustodian($query, string $custodianName)
     {
         return $query->where('custodian_name', $custodianName);
+    }
+
+    /**
+     * Scope a query to accounts that need synchronization: never synced, or
+     * last synced more than five minutes ago. Mirrors the staleness window in
+     * BalanceSynchronizationService::getActiveCustodianAccounts().
+     *
+     * @param  Builder<CustodianAccount>  $query
+     * @return Builder<CustodianAccount>
+     */
+    public function scopeNeedsSynchronization(Builder $query): Builder
+    {
+        return $query->where(function ($query) {
+            $query->whereNull('last_synced_at')
+                ->orWhere('last_synced_at', '<', now()->subMinutes(5));
+        });
     }
 
     /**

--- a/app/Domain/Custodian/Services/BalanceSynchronizationService.php
+++ b/app/Domain/Custodian/Services/BalanceSynchronizationService.php
@@ -77,7 +77,7 @@ class BalanceSynchronizationService
             }
 
             // Get custodian connector
-            $connector = $this->custodianRegistry->getConnector($custodianAccount->custodian_id);
+            $connector = $this->custodianRegistry->getConnector($custodianAccount->custodian_name);
 
             if (! $connector->isAvailable()) {
                 $this->recordSyncResult($custodianAccount, 'failed', 'Custodian not available');
@@ -86,7 +86,7 @@ class BalanceSynchronizationService
             }
 
             // Get account info from custodian
-            $accountInfo = $connector->getAccountInfo($custodianAccount->external_account_id);
+            $accountInfo = $connector->getAccountInfo($custodianAccount->custodian_account_id);
 
             // Update balances
             $this->updateAccountBalances($custodianAccount, $accountInfo);
@@ -139,7 +139,7 @@ class BalanceSynchronizationService
             ->get();
 
         foreach ($custodianAccounts as $custodianAccount) {
-            $results[$custodianAccount->custodian_id] = $this->synchronizeAccountBalance($custodianAccount);
+            $results[$custodianAccount->custodian_name] = $this->synchronizeAccountBalance($custodianAccount);
         }
 
         return $results;
@@ -181,7 +181,9 @@ class BalanceSynchronizationService
     {
         DB::transaction(
             function () use ($custodianAccount, $accountInfo) {
-                $account = Account::findOrFail($custodianAccount->account_uuid);
+                // account_uuid is the accounts.uuid column, not the (bigint) PK,
+                // so look it up by uuid rather than Account::findOrFail().
+                $account = Account::where('uuid', $custodianAccount->account_uuid)->firstOrFail();
 
                 foreach ($accountInfo->balances as $assetCode => $amountInCents) {
                     $currentBalance = $account->getBalance($assetCode);
@@ -202,7 +204,7 @@ class BalanceSynchronizationService
                         event(
                             new AccountBalanceUpdated(
                                 accountUuid: $account->uuid,
-                                custodianId: $custodianAccount->custodian_id,
+                                custodianId: $custodianAccount->custodian_name,
                                 assetCode: $assetCode,
                                 previousBalance: $currentBalance,
                                 newBalance: $amountInCents,
@@ -214,7 +216,7 @@ class BalanceSynchronizationService
                             'Account balance updated',
                             [
                                 'account_uuid'     => $account->uuid,
-                                'custodian_id'     => $custodianAccount->custodian_id,
+                                'custodian_id'     => $custodianAccount->custodian_name,
                                 'asset_code'       => $assetCode,
                                 'previous_balance' => $currentBalance,
                                 'new_balance'      => $amountInCents,
@@ -250,8 +252,8 @@ class BalanceSynchronizationService
         $this->syncResults['details'][] = [
             'custodian_account_id' => $custodianAccount->id,
             'account_uuid'         => $custodianAccount->account_uuid,
-            'custodian_id'         => $custodianAccount->custodian_id,
-            'external_account_id'  => $custodianAccount->external_account_id,
+            'custodian_id'         => $custodianAccount->custodian_name,
+            'external_account_id'  => $custodianAccount->custodian_account_id,
             'status'               => $status,
             'message'              => $message,
             'timestamp'            => now()->toISOString(),

--- a/database/migrations/2026_06_23_120000_add_sync_status_to_custodian_accounts_table.php
+++ b/database/migrations/2026_06_23_120000_add_sync_status_to_custodian_accounts_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Add the sync_status / sync_error columns that BalanceSynchronizationService
+     * reads and writes. They were referenced in code (success/failed status plus
+     * the failure-rate stats query) but never created by a migration, so the
+     * scheduled `custodian:sync-balances` command threw
+     * SQLSTATE[42S22] "Unknown column 'sync_status'" on MySQL every run.
+     */
+    public function up(): void
+    {
+        Schema::table('custodian_accounts', function (Blueprint $table) {
+            if (! Schema::hasColumn('custodian_accounts', 'sync_status')) {
+                $table->string('sync_status')->nullable()->after('last_synced_at');
+                $table->index('sync_status');
+            }
+
+            if (! Schema::hasColumn('custodian_accounts', 'sync_error')) {
+                $table->text('sync_error')->nullable()->after('sync_status');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('custodian_accounts', function (Blueprint $table) {
+            if (Schema::hasColumn('custodian_accounts', 'sync_status')) {
+                $table->dropIndex(['sync_status']);
+                $table->dropColumn('sync_status');
+            }
+
+            if (Schema::hasColumn('custodian_accounts', 'sync_error')) {
+                $table->dropColumn('sync_error');
+            }
+        });
+    }
+};

--- a/tests/Feature/Console/CalculateBasketPerformanceCommandTest.php
+++ b/tests/Feature/Console/CalculateBasketPerformanceCommandTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Basket\Models\BasketAsset;
+
+it('returns success when there are no active baskets to process', function () {
+    // Regression: a scheduled bulk run with nothing to do returned exit code 1,
+    // which the scheduler logged as "command failed". An empty active-basket set
+    // is a no-op, not a failure.
+    $this->artisan('basket:calculate-performance')
+        ->expectsOutputToContain('No active baskets')
+        ->assertSuccessful();
+});
+
+it('fails when a specific basket is requested but not found', function () {
+    // An explicit --basket=X that does not exist IS a real error (typo / bad
+    // config) and must keep returning a non-zero exit code.
+    $this->artisan('basket:calculate-performance', ['--basket' => 'DOES_NOT_EXIST'])
+        ->assertFailed();
+});
+
+it('processes active baskets and succeeds', function () {
+    BasketAsset::create([
+        'code'      => 'TESTGCU',
+        'name'      => 'Test Basket',
+        'type'      => 'fixed',
+        'is_active' => true,
+    ]);
+
+    $this->artisan('basket:calculate-performance')
+        ->assertSuccessful();
+});

--- a/tests/Feature/Console/SynchronizeCustodianBalancesCommandTest.php
+++ b/tests/Feature/Console/SynchronizeCustodianBalancesCommandTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Account\Models\Account;
+use App\Domain\Custodian\Contracts\ICustodianConnector;
+use App\Domain\Custodian\Models\CustodianAccount;
+use App\Domain\Custodian\Services\BalanceSynchronizationService;
+use App\Domain\Custodian\Services\CustodianRegistry;
+use App\Domain\Custodian\ValueObjects\AccountInfo;
+use App\Domain\Wallet\Services\WalletService;
+
+/*
+ * Regression for the production failure:
+ *   SQLSTATE[42S22] Unknown column 'sync_status' in 'WHERE'
+ *
+ * BalanceSynchronizationService writes sync_status / sync_error and the stats
+ * query filters on sync_status, but no migration ever created those columns.
+ *
+ * NOTE: the exact "unknown column" error only reproduces on MySQL. SQLite
+ * silently rewrites the unknown double-quoted identifier as a string literal
+ * (`WHERE 'sync_status' = 'failed'`), so it never raised. The MySQL-faithful
+ * reproduction lives in tests/MultiConnection/Custodian. This fast-suite test
+ * still guards the regression: if the column/migration disappears, the write is
+ * dropped and the count below collapses to 0.
+ */
+it('counts custodian accounts that failed to sync in the last hour', function () {
+    $account = Account::factory()->create();
+
+    CustodianAccount::factory()->create([
+        'account_uuid'   => $account->uuid,
+        'status'         => 'active',
+        'sync_status'    => 'failed',
+        'sync_error'     => 'Custodian not available',
+        'last_synced_at' => now()->subMinutes(10),
+    ]);
+
+    $stats = app(BalanceSynchronizationService::class)->getSynchronizationStats();
+
+    expect($stats['total_accounts'])->toBe(1);
+    expect($stats['failed_last_hour'])->toBe(1);
+});
+
+/*
+ * The per-account sync path read $custodianAccount->custodian_id and
+ * ->external_account_id — neither is a real column (they are custodian_name and
+ * custodian_account_id), so getConnector() received null and threw a TypeError
+ * the moment any active account existed. It also looked the account up with
+ * Account::findOrFail($account_uuid), but account_uuid maps to accounts.uuid,
+ * not the bigint PK, so the lookup threw ModelNotFoundException. This asserts
+ * the connector is asked with the real column values and the sync succeeds.
+ */
+it('syncs active accounts through the scheduled path using the real column values', function () {
+    $account = Account::factory()->create();
+
+    $custodian = CustodianAccount::factory()->create([
+        'account_uuid'         => $account->uuid,
+        'custodian_name'       => 'mock',
+        'custodian_account_id' => 'ext-acct-123',
+        'status'               => 'active',
+        'last_synced_at'       => null,
+    ]);
+
+    $connector = Mockery::mock(ICustodianConnector::class);
+    $connector->shouldReceive('isAvailable')->andReturnTrue();
+    // Proves external_account_id -> custodian_account_id: the connector is asked
+    // for the stored external id, not null.
+    $connector->shouldReceive('getAccountInfo')->once()->with('ext-acct-123')
+        ->andReturn(new AccountInfo(
+            accountId: 'ext-acct-123',
+            name: 'Mock Account',
+            status: 'active',
+            balances: [],
+        ));
+
+    $registry = Mockery::mock(CustodianRegistry::class);
+    // Proves custodian_id -> custodian_name: getConnector receives 'mock'.
+    $registry->shouldReceive('getConnector')->once()->with('mock')->andReturn($connector);
+
+    $service = new BalanceSynchronizationService($registry, app(WalletService::class));
+
+    // synchronizeAllBalances() is the scheduled (no-arg) entry point that was
+    // failing in production. Before the column fixes it would TypeError on
+    // getConnector(null) the moment an active account existed.
+    $results = $service->synchronizeAllBalances();
+
+    expect($results['synchronized'])->toBe(1);
+    expect($results['failed'])->toBe(0);
+    expect($custodian->fresh()->sync_status)->toBe('success');
+});
+
+/*
+ * `custodian:sync-balances --custodian=X` (without --force) called
+ * $query->needsSynchronization(), a scope that did not exist — every such
+ * invocation threw BadMethodCallException. This asserts the scope exists and
+ * returns only never-synced or stale (>5 min) accounts.
+ */
+it('needsSynchronization scope returns never-synced and stale accounts only', function () {
+    $make = function ($lastSyncedAt) {
+        $account = Account::factory()->create();
+
+        return CustodianAccount::factory()->create([
+            'account_uuid'   => $account->uuid,
+            'status'         => 'active',
+            'last_synced_at' => $lastSyncedAt,
+        ]);
+    };
+
+    $never = $make(null);
+    $stale = $make(now()->subMinutes(10));
+    $fresh = $make(now()->subMinute());
+
+    $ids = CustodianAccount::needsSynchronization()->pluck('id')->all();
+
+    expect($ids)->toContain($never->id);
+    expect($ids)->toContain($stale->id);
+    expect($ids)->not->toContain($fresh->id);
+});

--- a/tests/MultiConnection/Custodian/BalanceSynchronizationStatsMultiConnectionTest.php
+++ b/tests/MultiConnection/Custodian/BalanceSynchronizationStatsMultiConnectionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\MultiConnection\Custodian;
+
+use App\Domain\Account\Models\Account;
+use App\Domain\Custodian\Models\CustodianAccount;
+use App\Domain\Custodian\Services\BalanceSynchronizationService;
+use Illuminate\Support\Str;
+
+/*
+ * MySQL-faithful regression for the production failure:
+ *   SQLSTATE[42S22] Unknown column 'sync_status' in 'WHERE'
+ *
+ * BalanceSynchronizationService writes sync_status / sync_error and
+ * getSynchronizationStats() filters on sync_status, but no migration created
+ * those columns. MySQL rejects the query; SQLite silently rewrites the unknown
+ * quoted identifier as a string literal and never raises — which is why the
+ * fast suite missed it. These run on the real MySQL topology so a missing
+ * column fails loudly.
+ */
+
+it('computes sync stats without an unknown-column error when no accounts exist', function () {
+    // This is the literal production failure: the stats query runs on every
+    // scheduled invocation, and its `where('sync_status', 'failed')` count threw
+    // 42S22 even with zero custodian accounts.
+    $stats = app(BalanceSynchronizationService::class)->getSynchronizationStats();
+
+    expect($stats['total_accounts'])->toBe(0);
+    expect($stats['failed_last_hour'])->toBe(0);
+});
+
+it('counts custodian accounts that failed to sync in the last hour', function () {
+    $account = Account::factory()->create();
+
+    CustodianAccount::create([
+        'account_uuid'         => $account->uuid,
+        'custodian_name'       => 'mock',
+        'custodian_account_id' => (string) Str::uuid(),
+        'status'               => 'active',
+        'sync_status'          => 'failed',
+        'sync_error'           => 'Custodian not available',
+        'last_synced_at'       => now()->subMinutes(10),
+    ]);
+
+    $stats = app(BalanceSynchronizationService::class)->getSynchronizationStats();
+
+    expect($stats['total_accounts'])->toBe(1);
+    expect($stats['failed_last_hour'])->toBe(1);
+});


### PR DESCRIPTION
## What

Two scheduled commands were spamming production error logs. Both are fixed here, with regression tests.

### 1. `custodian:sync-balances` → `SQLSTATE[42S22] Unknown column 'sync_status'`

`BalanceSynchronizationService` writes `sync_status` / `sync_error` and `getSynchronizationStats()` filters on `sync_status`, but **no migration ever created those columns**. The stats query runs unconditionally on every invocation, so it threw every run. (Production has zero active custodian accounts, so only the stats path executed — the per-account loop body never ran.)

- **Add the missing columns** (`sync_status` indexed, `sync_error`) + model `$fillable`.

While in the same command, three latent crashes in its **per-account path** — which would re-break the job the moment one active account exists — are repaired:

| Bug | Was | Now |
|---|---|---|
| Phantom columns | `$account->custodian_id` / `->external_account_id` (don't exist → `getConnector(null)` throws an **uncatchable `TypeError`**) | `custodian_name` / `custodian_account_id` (mirrors `DailyReconciliationService`) |
| Account lookup | `Account::findOrFail($account_uuid)` (PK is bigint → `ModelNotFoundException`) | look up by the `uuid` column |
| Missing scope | `--custodian=X` called `needsSynchronization()`, which didn't exist → `BadMethodCallException` | scope added (mirrors the service's 5-min staleness window) |

### 2. `basket:calculate-performance` → `failed with exit code [1]`

The only non-zero return was the empty-basket branch, so a scheduled bulk run with **no active baskets** (a no-op) was logged as a failure.

- Return **SUCCESS** for an empty bulk run; return **FAILURE** only when an explicit `--basket=X` is not found. Mirrors the established `baskets:rebalance` convention.

## Why the tests matter

The custodian bug is **MySQL-only**: SQLite silently rewrites the unknown double-quoted identifier as a string literal (`WHERE 'sync_status' = 'failed'`), so the fast suite never caught it. The new `tests/MultiConnection/Custodian` test runs on the real MySQL topology and reproduces the **exact** production error (`Unknown column 'sync_status' in 'where clause'`).

Verified locally **RED→GREEN against real MySQL** (stood up MariaDB, dropped the columns to simulate the deployed schema → exact 42S22, re-added → green). Fast-suite guards cover the basket exit codes, the column write/read round-trip, the connector column mapping (asserted via Mockery `with('mock')` / `with('ext-acct-123')`), and the `needsSynchronization` scope.

An adversarial multi-agent review scanned every other `Schedule::command` for the same two anti-patterns (phantom column / no-op-as-failure) and found **no other instances** — scope is exactly these two commands.

## Out of scope (noted, non-fatal)
- The operator `--account` / `--custodian` paths call `synchronizeAccountBalance()` without initializing `syncResults`, emitting a non-fatal `Undefined array key` warning in production. Not part of the reported failures; the scheduled no-arg path initializes it correctly.

## Checks
- `php-cs-fixer` clean · PHPStan Level 8 clean (src + tests) · affected SQLite suites green (Console / Custodian / Basket) · full MultiConnection suite green on MySQL.