### PR TITLE
Wave 0A: queue-worker coverage — restore push/transfers/webhooks/fraud + CI guard

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -198,13 +198,15 @@ return [
     'environments' => [
         'production' => [
             'supervisor-1' => [
+                'connection'      => 'redis',
+                'queue'           => ['default', 'webhooks', 'fraud-batch', 'exchange', 'proofs'],
                 'maxProcesses'    => 10,
                 'balanceMaxShift' => 1,
                 'balanceCooldown' => 3,
             ],
             'event-sourcing-supervisor-1' => [
                 'connection' => 'redis',
-                'queue'      => [env('EVENT_PROJECTOR_QUEUE_NAME')],
+                'queue'      => ['events', 'ledger', 'transactions', 'transfers', 'liquidity_pools'],
                 'balance'    => 'simple',
                 'processes'  => 1,
                 'tries'      => 3,
@@ -235,11 +237,13 @@ return [
 
         'local' => [
             'supervisor-1' => [
+                'connection'   => 'redis',
+                'queue'        => ['default', 'webhooks', 'fraud-batch', 'exchange', 'proofs'],
                 'maxProcesses' => 3,
             ],
             'event-sourcing-supervisor-1' => [
                 'connection' => 'redis',
-                'queue'      => [env('EVENT_PROJECTOR_QUEUE_NAME')],
+                'queue'      => ['events', 'ledger', 'transactions', 'transfers', 'liquidity_pools'],
                 'balance'    => 'simple',
                 'processes'  => 1,
                 'tries'      => 3,

--- a/config/queue.php
+++ b/config/queue.php
@@ -109,4 +109,34 @@ return [
         'table'    => 'failed_jobs',
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Managed Queues (worker-coverage source of truth)
+    |--------------------------------------------------------------------------
+    |
+    | Every queue application code dispatches to. tests/Feature/Ops/
+    | QueueCoverageTest.php asserts (a) no code dispatches to a queue missing
+    | from this list, and (b) etc/supervisor.conf has a worker for each entry.
+    | The event-sourcing queues (events/ledger/transactions/transfers/
+    | liquidity_pools) come from App\Values\EventQueues; the rest are ad-hoc
+    | ->onQueue('x') / $queue = 'x' targets. When you add a new one, add it
+    | here AND add a worker in etc/supervisor.conf (+ config/horizon.php).
+    |
+    */
+
+    'managed_queues' => [
+        'default',
+        'events',
+        'ledger',
+        'transactions',
+        'transfers',
+        'liquidity_pools',
+        'mobile',
+        'broadcasts',
+        'webhooks',
+        'fraud-batch',
+        'exchange',
+        'proofs',
+    ],
+
 ];

--- a/docs/10-OPERATIONS/PRODUCTION_READINESS_CHECKLIST.md
+++ b/docs/10-OPERATIONS/PRODUCTION_READINESS_CHECKLIST.md
@@ -81,7 +81,8 @@ Runbook: `docs/operations/wallet-sponsorship.md`.
 - [ ] `LOG_SLACK_WEBHOOK_URL` set — the default log stack auto-includes Slack when present, routing every `Log::critical`/`emergency` to Slack (PR #1133). `LOG_SLACK_LEVEL` defaults to `critical` (does not inherit `LOG_LEVEL`).
 - [ ] `METRICS_TOKEN` (or `METRICS_ALLOWED_IPS`) set — `MetricsAccessMiddleware` gates `/api/monitoring/{metrics,prometheus}` + `/api/metrics/prometheus`; with neither configured it **fails closed (403) in production** (PR #1133). `/health`, `/ready`, `/alive` stay public for k8s probes.
 - [ ] Error tracking (Sentry/Rollbar) + APM wired; alert thresholds set.
-- [ ] Horizon running for queues (`events`, default, notifications); failed-job handling verified.
+- [x] Queue workers cover **every** managed queue (`config/queue.php` `managed_queues`), enforced on every PR by `tests/Feature/Ops/QueueCoverageTest.php` (PR 0A). Production runs **Supervisor** off `etc/supervisor.conf` (not Horizon). **After deploying the config you MUST run on the server:** `supervisorctl reread && supervisorctl update && supervisorctl restart all`, then confirm with `supervisorctl status` that `finaegis-transfers-worker`, `finaegis-mobile-worker`, and `finaegis-aux-worker` are RUNNING — a `git pull` alone does not restart workers. Failed-job handling: `database-uuids`, 1-week retention.
+- [ ] Run `php artisan ops:verify-env` as a manual deploy step after `git pull`, **before** `migrate` — deploy is a manual `git pull` + manual artisan steps, so the `deploy.yml` gate is not in the live path and env guards (peppers, demo-modes, RAILGUN/SOC-2 provider checks) only fire when the command is run.
 
 ## 9. Data & backups
 

--- a/docs/superpowers/plans/2026-07-04-wave-0a-queue-worker-coverage.md
+++ b/docs/superpowers/plans/2026-07-04-wave-0a-queue-worker-coverage.md
@@ -1,0 +1,378 @@
+# Wave 0A — Queue-Worker Coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure every queue application code dispatches to has a consuming worker in production, and add a CI guard so it can never silently regress — fixing the live defect where transaction/security push notifications, real-time broadcasts, outbound webhooks, and fraud scans queue forever with no worker.
+
+**Architecture:** Introduce a canonical `config('queue.managed_queues')` list as the single source of truth. A Pest guard test (mirroring `tests/Feature/Compliance/GdprCoverageGuardTest.php`) asserts (a) no code dispatches to a queue missing from that list, and (b) `etc/supervisor.conf` (the live production runner) has a worker for each managed queue. Then fix `etc/supervisor.conf` (add the missing workers) and `config/horizon.php` (parity, in case the runner ever switches to Horizon).
+
+**Tech Stack:** PHP 8.4, Laravel 12, Laravel Horizon, Pest, Supervisor.
+
+## Global Constraints
+
+- No float money anywhere (bcmath) — N/A to this PR (config/tests only), but never introduce it.
+- Commits: `fix:` / `test:` / `docs:` prefix + `Co-Authored-By: Claude <noreply@anthropic.com>`.
+- Code style: `./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php` before commit.
+- Static analysis: `XDEBUG_MODE=off vendor/bin/phpstan analyse --memory-limit=2G` must stay clean (Level 8).
+- Branch: continue on `wave-0-production-readiness` (already holds the spec + this plan). This becomes the Wave-0A PR. Later items (0B/0C/0D) branch fresh off `main` after 0A merges.
+- Authoritative live worker config is `etc/supervisor.conf` (owner runs Supervisor; the Helm/Horizon path is NOT deployed).
+- Canonical queue set (verified 2026-07-04 — the only queues application code dispatches to): `default, events, ledger, transactions, liquidity_pools, mobile, broadcasts, webhooks, fraud-batch, exchange, proofs`. (`transfers` has no producer — deliberately excluded.)
+
+---
+
+### Task 1: Canonical `managed_queues` + failing coverage guard
+
+**Files:**
+- Modify: `config/queue.php` (add `managed_queues` before the closing `];`, after the `failed` block ~line 110)
+- Create: `tests/Feature/Ops/QueueCoverageTest.php`
+
+**Interfaces:**
+- Produces: `config('queue.managed_queues')` → `array<int,string>` of canonical queue names, consumed by the guard test and available to any future config.
+
+- [ ] **Step 1: Add the `managed_queues` config block**
+
+In `config/queue.php`, immediately before the final `];`, add:
+
+```php
+    /*
+    |--------------------------------------------------------------------------
+    | Managed Queues (worker-coverage source of truth)
+    |--------------------------------------------------------------------------
+    |
+    | Every queue application code dispatches to. tests/Feature/Ops/
+    | QueueCoverageTest.php asserts (a) no code dispatches to a queue missing
+    | from this list, and (b) etc/supervisor.conf has a worker for each entry.
+    | When you add a new ->onQueue('x') or a $queue = 'x' on a ShouldQueue
+    | class, add 'x' here AND add a worker in etc/supervisor.conf (and
+    | config/horizon.php for parity).
+    |
+    */
+
+    'managed_queues' => [
+        'default',
+        'events',
+        'ledger',
+        'transactions',
+        'liquidity_pools',
+        'mobile',
+        'broadcasts',
+        'webhooks',
+        'fraud-batch',
+        'exchange',
+        'proofs',
+    ],
+```
+
+- [ ] **Step 2: Write the failing guard test**
+
+Create `tests/Feature/Ops/QueueCoverageTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Queue-worker coverage guard (mirrors tests/Feature/Compliance/GdprCoverageGuardTest.php).
+ *
+ * Every queue application code dispatches to (via ->onQueue('x') or a
+ * $queue = 'x' property on a ShouldQueue listener/job) MUST (1) be declared
+ * in config('queue.managed_queues') and (2) have a consuming worker in
+ * etc/supervisor.conf — the production runner. Catches the class of bug where
+ * a new listener queues to a name no worker consumes (e.g. push notifications
+ * on the 'mobile' queue silently never delivered).
+ */
+
+/** @return array<string,string> queue name => first file that dispatches to it */
+function dispatchedQueues(): array
+{
+    $appDir = dirname(__DIR__, 3) . '/app';
+    $found = [];
+    $rii = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($appDir, FilesystemIterator::SKIP_DOTS)
+    );
+    /** @var SplFileInfo $file */
+    foreach ($rii as $file) {
+        if ($file->getExtension() !== 'php') {
+            continue;
+        }
+        $code = (string) file_get_contents($file->getPathname());
+        if (preg_match_all('/onQueue\(\s*[\'"]([a-z0-9_\-]+)[\'"]\s*\)/i', $code, $m)) {
+            foreach ($m[1] as $q) {
+                $found[$q] ??= $file->getPathname();
+            }
+        }
+        if (preg_match_all('/\$queue\s*=\s*[\'"]([a-z0-9_\-]+)[\'"]/', $code, $m)) {
+            foreach ($m[1] as $q) {
+                $found[$q] ??= $file->getPathname();
+            }
+        }
+    }
+
+    return $found;
+}
+
+/** @return array<int,string> queue names consumed by etc/supervisor.conf */
+function supervisorConsumedQueues(): array
+{
+    $conf = (string) file_get_contents(dirname(__DIR__, 3) . '/etc/supervisor.conf');
+    $queues = [];
+    foreach (preg_split('/\R/', $conf) ?: [] as $line) {
+        if (! str_contains($line, 'queue:work')) {
+            continue;
+        }
+        if (preg_match('/--queue=([a-z0-9_,\-]+)/i', $line, $m)) {
+            foreach (explode(',', $m[1]) as $q) {
+                $queues[] = $q;
+            }
+        } else {
+            $queues[] = 'default'; // bare `queue:work` consumes 'default'
+        }
+    }
+
+    return array_values(array_unique($queues));
+}
+
+it('declares every dispatched queue in config queue.managed_queues', function () {
+    /** @var array<int,string> $managed */
+    $managed = config('queue.managed_queues');
+    expect($managed)->toBeArray()->not->toBeEmpty();
+
+    $undeclared = array_keys(array_filter(
+        dispatchedQueues(),
+        fn (string $file, string $queue) => ! in_array($queue, $managed, true),
+        ARRAY_FILTER_USE_BOTH
+    ));
+
+    if ($undeclared !== []) {
+        $this->fail('Queues dispatched to but missing from config(queue.managed_queues): ' . implode(', ', $undeclared));
+    }
+    expect($undeclared)->toBe([]);
+});
+
+it('has a supervisor worker for every managed queue', function () {
+    /** @var array<int,string> $managed */
+    $managed  = config('queue.managed_queues');
+    $consumed = supervisorConsumedQueues();
+
+    $uncovered = array_values(array_diff($managed, $consumed));
+
+    if ($uncovered !== []) {
+        $this->fail('Managed queues with NO worker in etc/supervisor.conf (jobs queue forever): ' . implode(', ', $uncovered));
+    }
+    expect($uncovered)->toBe([]);
+});
+```
+
+- [ ] **Step 3: Run the guard — verify it FAILS on the supervisor gap**
+
+Run: `./vendor/bin/pest tests/Feature/Ops/QueueCoverageTest.php`
+Expected: the first test PASSES (managed_queues covers all dispatched queues); the second test FAILS with
+`Managed queues with NO worker in etc/supervisor.conf (jobs queue forever): mobile, broadcasts, webhooks, fraud-batch, exchange, proofs`
+
+- [ ] **Step 4: Commit the source-of-truth + failing guard**
+
+```bash
+git add config/queue.php tests/Feature/Ops/QueueCoverageTest.php
+git commit -m "test: queue-worker coverage guard + managed_queues source of truth
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Add the missing Supervisor workers (makes the live path correct)
+
+**Files:**
+- Modify: `etc/supervisor.conf` (add 2 program blocks; extend the `[group:finaegis-workers]` list)
+
+**Interfaces:**
+- Consumes: the queue names from Task 1's `managed_queues`.
+- Produces: Supervisor programs consuming `mobile` (dedicated) and `broadcasts,webhooks,fraud-batch,exchange,proofs` (combined).
+
+- [ ] **Step 1: Append two worker programs**
+
+In `etc/supervisor.conf`, after the `[program:finaegis-liquidity-pools-worker]` block (before `[group:finaegis-workers]`), insert:
+
+```ini
+[program:finaegis-mobile-worker]
+process_name=%(program_name)s_%(process_num)02d
+command=php /home/yozaz/www/finaegis/core-banking-prototype-laravel/artisan queue:work --queue=mobile --sleep=3 --tries=3 --max-time=3600
+autostart=true
+autorestart=true
+stopasgroup=true
+killasgroup=true
+user=yozaz
+numprocs=2
+redirect_stderr=true
+stdout_logfile=/home/yozaz/www/finaegis/core-banking-prototype-laravel/storage/logs/mobile-worker.log
+stopwaitsecs=3600
+
+[program:finaegis-aux-worker]
+process_name=%(program_name)s_%(process_num)02d
+command=php /home/yozaz/www/finaegis/core-banking-prototype-laravel/artisan queue:work --queue=broadcasts,webhooks,fraud-batch,exchange,proofs --sleep=3 --tries=3 --max-time=3600
+autostart=true
+autorestart=true
+stopasgroup=true
+killasgroup=true
+user=yozaz
+numprocs=2
+redirect_stderr=true
+stdout_logfile=/home/yozaz/www/finaegis/core-banking-prototype-laravel/storage/logs/aux-worker.log
+stopwaitsecs=3600
+```
+
+- [ ] **Step 2: Extend the worker group**
+
+Replace the `[group:finaegis-workers]` `programs=` line with:
+
+```ini
+programs=finaegis-events-worker,finaegis-ledger-worker,finaegis-transactions-worker,finaegis-default-worker,finaegis-liquidity-pools-worker,finaegis-mobile-worker,finaegis-aux-worker
+```
+
+- [ ] **Step 3: Run the guard — verify it PASSES**
+
+Run: `./vendor/bin/pest tests/Feature/Ops/QueueCoverageTest.php`
+Expected: both tests PASS (every managed queue now has a supervisor worker).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add etc/supervisor.conf
+git commit -m "fix: consume mobile/broadcasts/webhooks/fraud-batch/exchange/proofs queues
+
+Adds Supervisor workers for the six queues that had no consumer, restoring
+push notifications, real-time broadcasts, outbound webhooks, and fraud scans.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Fix `config/horizon.php` for parity (no live impact, prevents future footgun)
+
+**Files:**
+- Modify: `config/queue.php` — N/A. `config/horizon.php` production + local `environments`.
+
+**Interfaces:**
+- Consumes: the managed queue set. Produces: Horizon supervisors that cover the same set, so a future switch to `php artisan horizon` is already correct.
+
+- [ ] **Step 1: Replace the null-bound ES supervisor + widen supervisor-1 (production block)**
+
+In `config/horizon.php`, in `environments.production`, change `event-sourcing-supervisor-1`'s `queue` from `[env('EVENT_PROJECTOR_QUEUE_NAME')]` to the explicit list, and change `supervisor-1` to name its queues (it currently inherits `['default']` from defaults):
+
+```php
+        'production' => [
+            'supervisor-1' => [
+                'connection'      => 'redis',
+                'queue'           => ['default', 'webhooks', 'fraud-batch', 'exchange', 'proofs'],
+                'maxProcesses'    => 10,
+                'balanceMaxShift' => 1,
+                'balanceCooldown' => 3,
+            ],
+            'event-sourcing-supervisor-1' => [
+                'connection' => 'redis',
+                'queue'      => ['events', 'ledger', 'transactions', 'liquidity_pools'],
+                'balance'    => 'simple',
+                'processes'  => 1,
+                'tries'      => 3,
+            ],
+```
+
+(Leave `broadcasts-supervisor` and `mobile-supervisor` unchanged — they already cover `broadcasts` and `mobile`.)
+
+- [ ] **Step 2: Mirror the ES fix in the local block**
+
+In `environments.local`, change `event-sourcing-supervisor-1`'s `queue` from `[env('EVENT_PROJECTOR_QUEUE_NAME')]` to `['events', 'ledger', 'transactions', 'liquidity_pools']`.
+
+- [ ] **Step 3: Verify config still loads + guard still green**
+
+Run: `php artisan config:clear && php -r "require 'vendor/autoload.php'; \$app = require 'bootstrap/app.php'; \$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap(); echo json_encode(config('horizon.environments.production.event-sourcing-supervisor-1.queue'));"`
+Expected: `["events","ledger","transactions","liquidity_pools"]`
+Run: `./vendor/bin/pest tests/Feature/Ops/QueueCoverageTest.php`
+Expected: both tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add config/horizon.php
+git commit -m "fix: config/horizon.php parity — explicit ES queues, no null-bound supervisor
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Docs — deploy notes, checklist, ops:verify-env manual step
+
+**Files:**
+- Modify: `docs/10-OPERATIONS/PRODUCTION_READINESS_CHECKLIST.md` (§8 queues)
+- Modify: `docs/superpowers/specs/2026-07-04-wave-0-production-readiness-blockers-design.md` (mark 0A done — optional)
+
+- [ ] **Step 1: Update the readiness checklist §8**
+
+In `docs/10-OPERATIONS/PRODUCTION_READINESS_CHECKLIST.md`, replace the Horizon line under "## 8. Observability & alerting" with:
+
+```markdown
+- [x] Queue workers cover **every** managed queue (`config/queue.php` `managed_queues`), enforced by `tests/Feature/Ops/QueueCoverageTest.php`. Production runs Supervisor off `etc/supervisor.conf` — **after deploying this config you MUST run on the server:** `supervisorctl reread && supervisorctl update && supervisorctl restart all`, then confirm with `supervisorctl status` that `finaegis-mobile-worker` and `finaegis-aux-worker` are RUNNING. A repo edit alone does not restart workers.
+- [ ] Run `php artisan ops:verify-env` as a manual deploy step after `git pull`, before `migrate` (deploy is manual `git pull` + artisan steps; the `deploy.yml` gate is not in the live path, so env guards only fire when run).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/10-OPERATIONS/PRODUCTION_READINESS_CHECKLIST.md
+git commit -m "docs: queue-coverage checklist + supervisorctl apply step + ops:verify-env manual gate
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Full gate, post-phase-review, PR
+
+- [ ] **Step 1: Run the full local quality gate**
+
+```bash
+./vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php
+XDEBUG_MODE=off vendor/bin/phpstan analyse --memory-limit=2G
+./vendor/bin/pest tests/Feature/Ops/QueueCoverageTest.php
+```
+Expected: cs-fixer clean, PHPStan no new errors, guard green. Commit any cs-fixer changes.
+
+- [ ] **Step 2: Run post-phase-review** (project workflow requirement before a phase PR). Address any critical/important findings.
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push -u origin wave-0-production-readiness
+gh pr create --title "Wave 0A: queue-worker coverage — restore push/webhooks/fraud + CI guard" \
+  --body "$(cat <<'EOF'
+## Wave 0A — queue-worker coverage (live defect)
+
+Production Supervisor consumed only events/ledger/transactions/default/liquidity_pools, so `mobile` (transaction + security-alert push), `broadcasts`, `webhooks`, `fraud-batch`, `exchange`, and `proofs` jobs queued forever with no worker. Fixes that and guards against regression.
+
+- `config/queue.php`: `managed_queues` source of truth
+- `tests/Feature/Ops/QueueCoverageTest.php`: fails if any dispatched queue lacks a managed entry or a supervisor worker
+- `etc/supervisor.conf`: dedicated `mobile` worker + combined `aux` worker
+- `config/horizon.php`: parity (explicit ES queues; no null-bound supervisor)
+
+**Deploy step (manual):** on the server `supervisorctl reread && supervisorctl update && supervisorctl restart all`, then `supervisorctl status`.
+
+Spec: docs/superpowers/specs/2026-07-04-wave-0-production-readiness-blockers-design.md
+Plan: docs/superpowers/plans/2026-07-04-wave-0a-queue-worker-coverage.md
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Watch CI green, then merge** (`gh pr checks <n> --watch`; require total ≥ 15 before trusting — known false-green race). Merge when green.
+
+## Self-Review
+
+**Spec coverage:** 0A spec section → Tasks 1-4 (managed_queues + guard = spec approach step 1&5; supervisor.conf = step 2; horizon parity = step 4; server apply + ops:verify-env note = docs). ✅ Covered. `transfers` correctly excluded (no producer). Path-parameterisation dropped from 0A scope (YAGNI — existing workers already use the path; noted as follow-up).
+
+**Placeholder scan:** No TBD/TODO; all code shown in full; exact commands + expected output present. ✅
+
+**Type consistency:** `dispatchedQueues(): array<string,string>`, `supervisorConsumedQueues(): array<int,string>`, `config('queue.managed_queues'): array<int,string>` — used consistently across both tests. ✅

--- a/docs/superpowers/plans/2026-07-04-wave-0a-queue-worker-coverage.md
+++ b/docs/superpowers/plans/2026-07-04-wave-0a-queue-worker-coverage.md
@@ -376,3 +376,11 @@ EOF
 **Placeholder scan:** No TBD/TODO; all code shown in full; exact commands + expected output present. ✅
 
 **Type consistency:** `dispatchedQueues(): array<string,string>`, `supervisorConsumedQueues(): array<int,string>`, `config('queue.managed_queues'): array<int,string>` — used consistently across both tests. ✅
+
+## Execution notes (deviations from the drafted plan)
+
+Two corrections found while verifying against real code before committing:
+
+1. **`transfers` is a real uncovered money queue.** The plan draft said `transfers` had "no producer" — wrong. `MoneyTransferred`, `AssetTransferred`, and `TransferThresholdReached` all set `$queue = EventQueues::TRANSFERS->value` (`app/Values/EventQueues.php`). The initial regex missed it because the queue is an **enum reference, not a quoted literal**. So `transfers` was added to `managed_queues` and given its own dedicated Supervisor worker (money-projection isolation). The true uncovered set was **7** queues, not 6.
+2. **The guard is enum-aware.** `dispatchedQueues()` seeds from `EventQueues::cases()` (the event-sourcing source of truth) in addition to scanning quoted `onQueue('x')`/`$queue = 'x'` literals — otherwise any future ES event on a new enum case would escape the guard.
+3. PHPStan: `expect(...)->toBeArray()->not->toBeEmpty()` trips the Pest generics extension; split into `->toBeArray()` + `->toContain('default')`.

--- a/docs/superpowers/specs/2026-07-04-wave-0-production-readiness-blockers-design.md
+++ b/docs/superpowers/specs/2026-07-04-wave-0-production-readiness-blockers-design.md
@@ -1,0 +1,158 @@
+# Wave 0 — Production-Readiness Go-Live Blockers (Design Spec)
+
+**Date:** 2026-07-04
+**Status:** Proposed — awaiting review
+**Owner:** Platform / Ops
+**Source:** 10-dimension fresh evidence audit of v7.16.0 (2026-07-04). Supersedes nothing; feeds `docs/10-OPERATIONS/PRODUCTION_READINESS_CHECKLIST.md`.
+
+---
+
+## 1. Context
+
+A fresh, evidence-based production-readiness audit of the repo (branch `main`, v7.16.0) reached a two-part verdict:
+
+- **Zelta (the shipping mobile wallet)** is *conditionally* go-live-ready. The core money engineering is genuinely careful (bcmath, integer minor-units, idempotent + signature-verified webhooks, tokenised cards / clean SAQ-A footprint, real Apple JWS validation, real GDPR export/erasure with processor fan-out, non-custodial Wallet Send). The blockers are a small number of **default-config / honesty** gaps, not correctness bugs.
+- **FinAegis (the "core banking platform")** is a *reference implementation*: all seven financial standards (ISO 20022, ISO 8583, SWIFT, Open Banking, SEPA, US rails, Interledger) are message-construction or demo-stub with **zero live connectivity**, all correctly disabled in Zelta production — but the public README markets compliance certifications the project does not hold.
+
+The product owner has decided: **reposition FinAegis as an open-source reference/education platform** (not invest to make the standards operational) and **fix the honesty copy**.
+
+This spec covers **Wave 0 only**: the four go-live blockers that must ship before a defensible Zelta soft launch. Each is an independent, isolated PR.
+
+## 2. Scope
+
+**In scope (Wave 0):** four PRs — queue-worker coverage; RAILGUN custody-neutral production default; SOC-2 demo-mode production hard-fail; README/site honesty relabel + reference-platform positioning.
+
+**Explicit non-goals (deferred, tracked for later waves):**
+- Stripe *web* `DepositController` double-credit / webhook backstop — **P1, Wave 1** (confirmed: the mobile client uses **Bridge + IAP only**, not this path, so it is not a launch blocker).
+- GDPR `blockchain_address_transactions` coverage; `railgun_wallets` exclusion justification — Wave 1.
+- Backups (`BACKUP_DISK=s3`, restore drill, RPO), Sentry/APM — Wave 1.
+- Developer/API doc drift (SDK "not published" banner, `api.finaegis.org`→`api.zelta.app`, OpenAPI 7.16 regen, PyPI license) — Wave 2.
+- Operator CLI name collisions, dead-code removal (RAILGUN Phase-3, CQRS bus, dead saga), god-controller splits, PHPStan baseline burn-down, MySQL component tests — Wave 3.
+- Making any financial standard operational — **not doing** (reposition decision). Wave 4 = positioning only.
+
+## 3. Wave-0 items
+
+### 0A — Queue-worker coverage (P0, data integrity)
+
+**Problem.** Async projections and jobs are dispatched to queues that **no worker consumes**, on both deployment topologies — a silent money-projection / job-loss failure.
+
+**Evidence (current state).**
+- Queue names actually in use (authoritative union): `default`, `events`, `ledger`, `transactions`, `transfers`, `liquidity_pools`, `mobile`, `broadcasts`, `webhooks`, `fraud-batch`, `exchange`, `proofs`. (`grep onQueue()` + `$queue` literals + event queue overrides; event-sourcing money events set their own queues — e.g. `MoneyAdded`→`transactions`, `AccountCreated`→`ledger`, `MoneyTransferred`→`transfers`, `BasePoolEvent`→`liquidity_pools`.)
+- **Horizon / K8s path** (`config/horizon.php:199-234`, `helm/finaegis/templates/deployment-horizon.yaml`): production supervisors cover only `default`, `broadcasts`, `mobile`, and `event-sourcing-supervisor-1` which binds `[env('EVENT_PROJECTOR_QUEUE_NAME')]` — **unset in every env template → `[null]`**. So `events/ledger/transactions/transfers/liquidity_pools` (all ES money projections) have **no consumer** on K8s. One supervisor bound to one env var structurally cannot cover the 5 distinct ES queues anyway.
+- **VM / supervisor path** (`etc/supervisor.conf`): programs cover `events`, `ledger`, `transactions`, `default`, `liquidity_pools` — but **omit** `transfers`, `webhooks`, `fraud-batch`, `mobile`, `broadcasts`, `exchange`, `proofs`.
+- **Consumed by NEITHER topology:** `transfers`, `webhooks`, `fraud-batch`, `exchange`, `proofs`. (`transfers` carries money events; `fraud-batch` carries the scheduled fraud scan → fraud detection is silently dead; `webhooks` carries all outbound webhook deliveries.)
+
+**Desired state.** Every queue that any code dispatches to has at least one consumer in whichever topology is deployed, and a CI test fails if that ever regresses.
+
+**Approach.**
+1. Establish the canonical queue inventory as a single constant (e.g. `config/queue.php` `'managed_queues' => [...]` or a `QueueNames` enum) — the source of truth both topologies and the CI guard read.
+2. **`config/horizon.php`** (production + local): replace the single `event-sourcing-supervisor-1` `[env('EVENT_PROJECTOR_QUEUE_NAME')]` binding with an explicit queue list covering the 5 ES queues, and add supervisors/queues for `transfers`, `webhooks`, `fraud-batch`, `exchange`, `proofs`. Keep `EVENT_PROJECTOR_QUEUE_NAME` working as an override if set, but default to the explicit list so a null env var can never silently drop projections.
+3. **`etc/supervisor.conf`**: add the missing programs (`transfers`, `webhooks`, `fraud-batch`, `mobile`, `broadcasts`, `exchange`, `proofs`) so the VM path is also complete. Remove the hardcoded absolute path assumption or parameterise it.
+4. **Env templates**: set `EVENT_PROJECTOR_QUEUE_NAME` appropriately (or document it as an optional override now that the config no longer depends on it).
+5. **CI guard** (`tests/Feature/Ops/QueueCoverageTest.php`): enumerate every `onQueue('x')` / `$queue = 'x'` / event queue-override literal in `app/`, and assert each appears in the canonical inventory AND is covered by ≥1 Horizon supervisor queue array. (Optional companion: assert `etc/supervisor.conf` coverage too, gated on whether the VM path is still used.)
+
+**Tests.** The `QueueCoverageTest` guard (fails on any uncovered queue); a Horizon config-parse smoke test.
+
+**Open question for the plan:** confirm which topology is actually deployed (Helm vs VM). The durable fix makes both correct + adds the CI guard regardless, so this does not block the PR — it only decides which topology the CI guard treats as authoritative.
+
+---
+
+### 0B — RAILGUN custody-neutral production default (P0, custody honesty)
+
+**Problem.** The *custodial* RAILGUN privacy path is wired and **enabled by both production env templates**, deriving every user's privacy seed server-side from `app.key` — textbook custody, directly contradicting the "non-custodial" product claim. It is inert today only because the bridge sidecar is not deployed and no wallets are funded (operational happenstance, not a code control).
+
+**Evidence (current state).**
+- `config/privacy.php:17` → `'provider' => env('ZK_PROVIDER', 'demo')`.
+- `.env.production.example:240` and `.env.zelta.example:404` → `ZK_PROVIDER=railgun`.
+- `PrivacyController::isRailgunMode()` (`PrivacyController.php:44`) gates the custodial money-movement methods (`shield`/`unshield`/`privateTransfer`/`getViewingKey` + proof endpoints) at `:588,:670,:773,:863,:958,:1041,:1273,:1351` into `RailgunPrivacyService`, whose `generateMnemonic()` derives the seed via `hash_hmac('sha512', user->id, app.key)`.
+- The non-custodial Phase-1 endpoints (`POST /privacy/wallet/register`, `GET /privacy/engine-config`, `POST /privacy/rpc/{network}`) are **separate** routes, not gated by `ZK_PROVIDER`, and must stay live.
+
+**Desired state.** Production ships custody-neutral: (a) `ZK_PROVIDER` is not `railgun`, and (b) the custodial money-movement privacy endpoints **cannot execute in production regardless of env value** — they return `501 Not Implemented` — until the on-device non-custodial flow (Phase 2/3) is the sole path. The non-custodial registration / engine-config / RPC endpoints remain fully functional.
+
+**Approach.**
+1. Change `ZK_PROVIDER=railgun` → `ZK_PROVIDER=demo` in `.env.production.example:240` and `.env.zelta.example:404` (aligns with the `config/privacy.php` default and removes server-side seed derivation).
+2. Add a hard production guard on the **custodial subset only** (shield / unshield / private-transfer / viewing-key / delegated-proof). Preferred: route-level middleware on the custodial route group returning `501 CUSTODIAL_PRIVACY_DISABLED` when `app()->environment('production')`, so it is impossible to re-enable by flipping an env var. Do **not** guard the non-custodial `wallet/register`, `engine-config`, `rpc` routes.
+3. Extend the existing `ops:verify-env` "RAILGUN provider consistency" check to **FAIL in production** if `ZK_PROVIDER=railgun`.
+4. Do **not** attempt to "fix" custodial shield (per the standing CLAUDE.md guidance — shield moves on-device; a server-derived shield key would re-cement custody).
+
+**Tests.** Feature test: custodial privacy endpoints return `501` under `APP_ENV=production`; non-custodial `register`/`engine-config`/`rpc` still return `200/expected`. Env-verify test: `ops:verify-env` fails when `ZK_PROVIDER=railgun` in production.
+
+**Note.** This is safe — there are no funded custodial wallets. It converts a "deliberately un-deployed" state into an enforced one, and is the natural precursor to the Wave-3 Phase-3 removal of the custodial bridge / `DelegatedProofService` / `encrypted_mnemonic`.
+
+---
+
+### 0C — SOC-2 demo-mode production hard-fail (P0, dangerous default)
+
+**Problem.** The SOC-2 compliance-evidence tooling **fabricates audit evidence by default**, and the default is not overridden anywhere — a production deploy serving the evidence endpoint returns invented data stamped `'app_env' => 'production'`, which is actively dangerous if shown to an auditor or customer.
+
+**Evidence (current state).**
+- `config/compliance-certification.php:30` → `'demo_mode' => env('SOC2_DEMO_MODE', true)` (**defaults true**).
+- `SOC2_DEMO_MODE` is **absent from every env template** (only `REGTECH_DEMO_MODE=false` is set, at `.env.production.example:418` / `.env.zelta.example:582`).
+- `ComplianceCertificationController` demo-branches (`:396,:432,:468,:546,:584`) → `EvidenceCollectionService::getDemoEvidence()` returns hardcoded fake data stamped production.
+
+**Desired state.** In production it is impossible to serve fabricated compliance evidence. Demo mode is opt-in, off by default, and rejected in production.
+
+**Approach.**
+1. `config/compliance-certification.php:30` → default `false`.
+2. Add `SOC2_DEMO_MODE=false` to `.env.production.example` and `.env.zelta.example` (next to `REGTECH_DEMO_MODE`).
+3. Hard-fail: when `app()->environment('production')`, force `demo_mode` off (config-resolution guard) and/or make the controller demo branch `abort(404)` in production, so the flag cannot be re-enabled by env.
+4. `ops:verify-env`: FAIL in production if `SOC2_DEMO_MODE=true` (mirrors the existing `REGTECH_DEMO_MODE` / `AI_DEMO_MODE` / `KEY_MANAGEMENT_DEMO_MODE` checks).
+
+**Tests.** Feature test: the evidence endpoint under `APP_ENV=production` does **not** return demo/fabricated data (returns real evidence or `404`). Env-verify test: fails on `SOC2_DEMO_MODE=true` in production.
+
+---
+
+### 0D — README / site honesty relabel + reference-platform positioning (P0, truth-in-labelling)
+
+**Problem.** The always-public README markets **SOC 2 Type II** and **PCI DSS** as achieved certifications, and presents the seven financial standards as operational rails. None of the certifications are held; the standards are reference implementations disabled in production. For a regulated fintech this is a legal/reputational exposure.
+
+**Evidence (current state).**
+- `README.md:28` → "Regulatory compliance | Built-in KYC/AML, **SOC 2, PCI DSS**, GDPR (v3.5.0)".
+- `README.md:36` → "Compliance certification | **SOC 2 Type II**, PCI DSS readiness, …".
+- Standards rows present ISO 20022 / SWIFT / Open Banking / etc. as capabilities.
+- Honesty caveat exists but is buried at `README.md:427`.
+- Promo pages (`resources/views/security.blade.php`, `compliance.blade.php`, `welcome.blade.php`) — some already hedged ("Compliance-Ready", "Compatible"), but `security.blade.php:160` titles a card "SOC 2 Type II Compliance". These are `SHOW_PROMO_PAGES`-gated (not served in Zelta prod), so **README is the priority.**
+
+**Desired state.** Public copy accurately positions FinAegis as an **open-source reference/education platform** and Zelta as the product; describes standards as **reference message implementations** (not operational rails / not scheme-certified); describes compliance as **readiness tooling / audit scaffolding, not held certifications**; states plainly that no third-party SOC 2 or PCI certification is held; and keeps the genuinely-good story visible (real GDPR engine, real message-layer engineering, clean tokenised-card PCI footprint / SAQ-A eligibility).
+
+**Approach.**
+1. `README.md`: rewrite lines 28 & 36 and the standards rows to honest language; add a prominent "Status & positioning" note near the top (reference-implementation vs certified/operational); elevate the `:427` caveat next to the claims.
+2. `resources/views/security.blade.php`: "SOC 2 Type II Compliance" → "SOC 2 Type II **Readiness Tooling**"; PCI copy → "SAQ-A eligible via tokenised Stripe rail; no cardholder data stored."
+3. `resources/views/compliance.blade.php`, `welcome.blade.php`: standards → "reference implementations"; RegTech → "report-format validators / adapters (no live regulator connectivity; not a licensed CASP/ARM)."
+4. Run the `post-phase-review` skill before opening the PR (per project workflow) to catch copy/SEO/cross-page consistency.
+
+**Tests.** None (copy). Optional: a doc-lint asserting the README no longer contains "SOC 2 Type II" adjacent to "certification" without the caveat.
+
+## 4. Sequencing & PR plan
+
+Four independent PRs (touch disjoint files → safe to parallelise; `post-phase-review` before each per project workflow):
+
+| PR | Title | Files (primary) | Risk |
+|----|-------|-----------------|------|
+| 0A | `fix(ops): consume every dispatched queue + CI coverage guard` | `config/horizon.php`, `etc/supervisor.conf`, `config/queue.php`, `helm/…/deployment-horizon.yaml`, `tests/Feature/Ops/QueueCoverageTest.php`, env templates | Low-Med (infra config) |
+| 0B | `fix(privacy): custody-neutral production default + 501 guard on custodial endpoints` | `.env.*.example`, custodial route group + middleware, `ops:verify-env`, tests | Low |
+| 0C | `fix(compliance): SOC-2 demo-mode off by default + production hard-fail` | `config/compliance-certification.php`, `ComplianceCertificationController`, `.env.*.example`, `ops:verify-env`, tests | Low |
+| 0D | `docs(honesty): reference-platform positioning + truthful compliance/standards copy` | `README.md`, `resources/views/{security,compliance,welcome}.blade.php` | Low (copy) |
+
+0C and 0D are the same "compliance-honesty" theme and may be co-reviewed, but stay separate PRs (code vs copy).
+
+## 5. Testing strategy
+
+- Every code PR (0A/0B/0C) adds a failing-first test that encodes the fix and a matching `ops:verify-env` assertion where applicable.
+- Full gate before each merge: `php-cs-fixer` → PHPStan L8 (`XDEBUG_MODE=off`) → `pest --parallel` incl. the new tests; MultiConnection job green.
+- 0A's `QueueCoverageTest` becomes a permanent regression guard against future queue-name drift.
+
+## 6. Rollback / risk
+
+- 0A: config-only; rollback = revert. Risk is *under*-provisioning workers (mitigated by the coverage test) — no data mutation.
+- 0B/0C: turn risky behaviour off; rollback = revert env value. No data mutation.
+- 0D: copy only.
+- None of the four touches money-movement code paths; all are default/config/copy changes.
+
+## 7. Definition of done (Wave 0)
+
+- Every dispatched queue has a consumer on the deployed topology; CI guard green.
+- Production cannot run the custodial RAILGUN money path (501) and does not default to `ZK_PROVIDER=railgun`; `ops:verify-env` enforces it.
+- Production cannot serve fabricated SOC-2 evidence; `ops:verify-env` enforces it.
+- README + promo copy make no unqualified certification/operational-rail claim; FinAegis is positioned as a reference/OSS platform.
+- `PRODUCTION_READINESS_CHECKLIST.md` updated to reflect the closed items.

--- a/docs/superpowers/specs/2026-07-04-wave-0-production-readiness-blockers-design.md
+++ b/docs/superpowers/specs/2026-07-04-wave-0-production-readiness-blockers-design.md
@@ -18,6 +18,12 @@ The product owner has decided: **reposition FinAegis as an open-source reference
 
 This spec covers **Wave 0 only**: the four go-live blockers that must ship before a defensible Zelta soft launch. Each is an independent, isolated PR.
 
+## 1a. Deployment context (confirmed with owner, 2026-07-04)
+
+- **Deploy is a manual `git pull` on a single server** + manual `php artisan migrate` / `config:cache` / `route:cache` / `queue:restart`. The repo's `deploy.yml` GitHub Action (which runs `ops:verify-env` before `migrate`) is **not** the live deploy path.
+- **Implication:** `ops:verify-env` does **not** currently gate production deploys, so the env guards this spec adds in 0B/0C (and those from the June remediation) only fire if the owner runs them. **Ops action (fold into the deploy runbook):** add `php artisan ops:verify-env` as a mandatory manual step after `git pull`, before `migrate` — or wire a deploy hook. Cheap, high-value; makes every 0B/0C guard actually enforce.
+- **Workers run under Supervisor** (`etc/supervisor.conf`) — see 0A; this is why 0A is a *live* production defect, not a latent one.
+
 ## 2. Scope
 
 **In scope (Wave 0):** four PRs — queue-worker coverage; RAILGUN custody-neutral production default; SOC-2 demo-mode production hard-fail; README/site honesty relabel + reference-platform positioning.
@@ -32,28 +38,35 @@ This spec covers **Wave 0 only**: the four go-live blockers that must ship befor
 
 ## 3. Wave-0 items
 
-### 0A — Queue-worker coverage (P0, data integrity)
+### 0A — Queue-worker coverage (P0, **live in production now**)
 
-**Problem.** Async projections and jobs are dispatched to queues that **no worker consumes**, on both deployment topologies — a silent money-projection / job-loss failure.
+**Problem.** `ShouldQueue` listeners/jobs are dispatched to queues the deployed Supervisor does **not** consume, so the work queues forever. Confirmed with the owner (2026-07-04): production runs **Supervisor** off `etc/supervisor.conf`, which consumes only `events, ledger, transactions, default, liquidity_pools`.
 
-**Evidence (current state).**
-- Queue names actually in use (authoritative union): `default`, `events`, `ledger`, `transactions`, `transfers`, `liquidity_pools`, `mobile`, `broadcasts`, `webhooks`, `fraud-batch`, `exchange`, `proofs`. (`grep onQueue()` + `$queue` literals + event queue overrides; event-sourcing money events set their own queues — e.g. `MoneyAdded`→`transactions`, `AccountCreated`→`ledger`, `MoneyTransferred`→`transfers`, `BasePoolEvent`→`liquidity_pools`.)
-- **Horizon / K8s path** (`config/horizon.php:199-234`, `helm/finaegis/templates/deployment-horizon.yaml`): production supervisors cover only `default`, `broadcasts`, `mobile`, and `event-sourcing-supervisor-1` which binds `[env('EVENT_PROJECTOR_QUEUE_NAME')]` — **unset in every env template → `[null]`**. So `events/ledger/transactions/transfers/liquidity_pools` (all ES money projections) have **no consumer** on K8s. One supervisor bound to one env var structurally cannot cover the 5 distinct ES queues anyway.
-- **VM / supervisor path** (`etc/supervisor.conf`): programs cover `events`, `ledger`, `transactions`, `default`, `liquidity_pools` — but **omit** `transfers`, `webhooks`, `fraud-batch`, `mobile`, `broadcasts`, `exchange`, `proofs`.
-- **Consumed by NEITHER topology:** `transfers`, `webhooks`, `fraud-batch`, `exchange`, `proofs`. (`transfers` carries money events; `fraud-batch` carries the scheduled fraud scan → fraud detection is silently dead; `webhooks` carries all outbound webhook deliveries.)
+**Live blast radius (verified 2026-07-04).** Everything dispatched to an uncovered queue is currently unprocessed in production:
+- `mobile` → **transaction push notifications** (`SendTransactionPushNotificationListener`), **security-alert pushes** (`SendSecurityAlertListener`), mobile audit log (`LogMobileAuditEventListener`) — all `implements ShouldQueue`, all wired in `app/Providers/EventServiceProvider.php:43,72`. **For a mobile wallet this is the single most user-visible defect in the audit: push is not being delivered.**
+- `broadcasts` → `BroadcastEventListener` (ShouldQueue) — real-time WebSocket updates not broadcast.
+- `webhooks` → `WebhookService.php:77` dispatches `ProcessWebhookDelivery` — outbound webhooks not delivered.
+- `fraud-batch` → `ProcessAnomalyBatchJob` (ShouldQueue) — scheduled fraud scans dead.
+- `exchange` → `CheckArbitrageOpportunitiesJob` (exchange feature; lower impact).
+- `proofs` → `GenerateDelegatedProofJob` (custodial RAILGUN; disabled by 0B anyway).
+- `transfers` → no active producer found — inventory only, no action.
 
-**Desired state.** Every queue that any code dispatches to has at least one consumer in whichever topology is deployed, and a CI test fails if that ever regresses.
+(`config/horizon.php` is even more incomplete — its ES supervisor binds `[env('EVENT_PROJECTOR_QUEUE_NAME')]` = `[null]` — but Horizon is **not** the deployed runner, so that's a parity/future fix, not the live bug.)
+
+**Caveat to confirm on the box.** The repo's `etc/supervisor.conf` is a template with a hardcoded `/home/yozaz/www/finaegis/core-banking-prototype-laravel/artisan` path; the running config lives in the server's `/etc/supervisor/conf.d/`. Run `supervisorctl status` on the server to confirm the actual worker set — the live config may already differ from the repo file.
+
+**Desired state.** Every queue any code dispatches to has a Supervisor worker; a CI guard fails if a new `onQueue()`/`$queue` literal ever lacks a consumer; `config/horizon.php` is also made correct for parity.
 
 **Approach.**
-1. Establish the canonical queue inventory as a single constant (e.g. `config/queue.php` `'managed_queues' => [...]` or a `QueueNames` enum) — the source of truth both topologies and the CI guard read.
-2. **`config/horizon.php`** (production + local): replace the single `event-sourcing-supervisor-1` `[env('EVENT_PROJECTOR_QUEUE_NAME')]` binding with an explicit queue list covering the 5 ES queues, and add supervisors/queues for `transfers`, `webhooks`, `fraud-batch`, `exchange`, `proofs`. Keep `EVENT_PROJECTOR_QUEUE_NAME` working as an override if set, but default to the explicit list so a null env var can never silently drop projections.
-3. **`etc/supervisor.conf`**: add the missing programs (`transfers`, `webhooks`, `fraud-batch`, `mobile`, `broadcasts`, `exchange`, `proofs`) so the VM path is also complete. Remove the hardcoded absolute path assumption or parameterise it.
-4. **Env templates**: set `EVENT_PROJECTOR_QUEUE_NAME` appropriately (or document it as an optional override now that the config no longer depends on it).
-5. **CI guard** (`tests/Feature/Ops/QueueCoverageTest.php`): enumerate every `onQueue('x')` / `$queue = 'x'` / event queue-override literal in `app/`, and assert each appears in the canonical inventory AND is covered by ≥1 Horizon supervisor queue array. (Optional companion: assert `etc/supervisor.conf` coverage too, gated on whether the VM path is still used.)
+1. Canonical queue inventory as a single source of truth (a `QueueNames` enum or `config/queue.php` `managed_queues`), read by both configs and the CI guard.
+2. **`etc/supervisor.conf` (primary — the live runner):** add programs for `mobile`, `broadcasts`, `webhooks`, `fraud-batch`, `exchange` (and `proofs` until 0B lands); parameterise the hardcoded app path so the file is portable across checkouts.
+3. **Server apply step (must be in the PR deploy notes):** copy the updated config into `/etc/supervisor/conf.d/` and run `supervisorctl reread && supervisorctl update && supervisorctl restart all`. A repo edit alone does **not** change running workers.
+4. **`config/horizon.php` (parity):** replace `[env('EVENT_PROJECTOR_QUEUE_NAME')]` with an explicit list of the 5 ES queues + add the missing queues, so a future switch to Horizon is already correct.
+5. **CI guard** (`tests/Feature/Ops/QueueCoverageTest.php`): enumerate every `onQueue('x')` / `$queue = 'x'` / event queue override in `app/` and assert each is in the inventory AND covered by a Supervisor program — fails the build on any uncovered queue.
 
-**Tests.** The `QueueCoverageTest` guard (fails on any uncovered queue); a Horizon config-parse smoke test.
+**Immediate mitigation (out-of-band, recommended today):** add `queue:work --queue=mobile` (+ `broadcasts`, `webhooks`, `fraud-batch`, `exchange`) programs on the server now and `supervisorctl reread && supervisorctl update` — this restores push notifications immediately, ahead of the full PR.
 
-**Open question for the plan:** confirm which topology is actually deployed (Helm vs VM). The durable fix makes both correct + adds the CI guard regardless, so this does not block the PR — it only decides which topology the CI guard treats as authoritative.
+**Tests.** `QueueCoverageTest` (fails on any uncovered queue); a smoke test that both configs parse and cover the inventory.
 
 ---
 
@@ -129,7 +142,7 @@ Four independent PRs (touch disjoint files → safe to parallelise; `post-phase-
 
 | PR | Title | Files (primary) | Risk |
 |----|-------|-----------------|------|
-| 0A | `fix(ops): consume every dispatched queue + CI coverage guard` | `config/horizon.php`, `etc/supervisor.conf`, `config/queue.php`, `helm/…/deployment-horizon.yaml`, `tests/Feature/Ops/QueueCoverageTest.php`, env templates | Low-Med (infra config) |
+| 0A | `fix(ops): consume every dispatched queue + CI coverage guard` | **`etc/supervisor.conf` (primary/live)**, `config/horizon.php` (parity), `config/queue.php`, `tests/Feature/Ops/QueueCoverageTest.php` + **server-side `supervisorctl reread/update` step** | Med — restores live-broken push/webhooks/fraud; needs server apply |
 | 0B | `fix(privacy): custody-neutral production default + 501 guard on custodial endpoints` | `.env.*.example`, custodial route group + middleware, `ops:verify-env`, tests | Low |
 | 0C | `fix(compliance): SOC-2 demo-mode off by default + production hard-fail` | `config/compliance-certification.php`, `ComplianceCertificationController`, `.env.*.example`, `ops:verify-env`, tests | Low |
 | 0D | `docs(honesty): reference-platform positioning + truthful compliance/standards copy` | `README.md`, `resources/views/{security,compliance,welcome}.blade.php` | Low (copy) |

--- a/etc/supervisor.conf
+++ b/etc/supervisor.conf
@@ -63,6 +63,45 @@ redirect_stderr=true
 stdout_logfile=/home/yozaz/www/finaegis/core-banking-prototype-laravel/storage/logs/liquidity-pools-worker.log
 stopwaitsecs=3600
 
+[program:finaegis-transfers-worker]
+process_name=%(program_name)s_%(process_num)02d
+command=php /home/yozaz/www/finaegis/core-banking-prototype-laravel/artisan queue:work --queue=transfers --sleep=3 --tries=3 --max-time=3600
+autostart=true
+autorestart=true
+stopasgroup=true
+killasgroup=true
+user=yozaz
+numprocs=2
+redirect_stderr=true
+stdout_logfile=/home/yozaz/www/finaegis/core-banking-prototype-laravel/storage/logs/transfers-worker.log
+stopwaitsecs=3600
+
+[program:finaegis-mobile-worker]
+process_name=%(program_name)s_%(process_num)02d
+command=php /home/yozaz/www/finaegis/core-banking-prototype-laravel/artisan queue:work --queue=mobile --sleep=3 --tries=3 --max-time=3600
+autostart=true
+autorestart=true
+stopasgroup=true
+killasgroup=true
+user=yozaz
+numprocs=2
+redirect_stderr=true
+stdout_logfile=/home/yozaz/www/finaegis/core-banking-prototype-laravel/storage/logs/mobile-worker.log
+stopwaitsecs=3600
+
+[program:finaegis-aux-worker]
+process_name=%(program_name)s_%(process_num)02d
+command=php /home/yozaz/www/finaegis/core-banking-prototype-laravel/artisan queue:work --queue=broadcasts,webhooks,fraud-batch,exchange,proofs --sleep=3 --tries=3 --max-time=3600
+autostart=true
+autorestart=true
+stopasgroup=true
+killasgroup=true
+user=yozaz
+numprocs=2
+redirect_stderr=true
+stdout_logfile=/home/yozaz/www/finaegis/core-banking-prototype-laravel/storage/logs/aux-worker.log
+stopwaitsecs=3600
+
 [group:finaegis-workers]
-programs=finaegis-events-worker,finaegis-ledger-worker,finaegis-transactions-worker,finaegis-default-worker,finaegis-liquidity-pools-worker
+programs=finaegis-events-worker,finaegis-ledger-worker,finaegis-transactions-worker,finaegis-default-worker,finaegis-liquidity-pools-worker,finaegis-transfers-worker,finaegis-mobile-worker,finaegis-aux-worker
 priority=999

--- a/tests/Feature/Ops/QueueCoverageTest.php
+++ b/tests/Feature/Ops/QueueCoverageTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Values\EventQueues;
+
+/**
+ * Queue-worker coverage guard (mirrors tests/Feature/Compliance/GdprCoverageGuardTest.php).
+ *
+ * Every queue application code dispatches to MUST (1) be declared in
+ * config('queue.managed_queues') and (2) have a consuming worker in
+ * etc/supervisor.conf — the production runner. Catches the class of bug where
+ * a new listener/job queues to a name no worker consumes (e.g. push
+ * notifications on the 'mobile' queue, or transfer projections on 'transfers',
+ * silently never processed).
+ *
+ * Dispatched queues are discovered from: (a) every App\Values\EventQueues case
+ * (the event-sourcing source of truth — events set $queue = EventQueues::X->value),
+ * and (b) quoted ->onQueue('x') / $queue = 'x' literals across app/.
+ */
+
+/** @return array<string,string> queue name => where it is dispatched from */
+function dispatchedQueues(): array
+{
+    $found = [];
+
+    // (a) event-sourcing queues — the enum is the canonical source of truth
+    foreach (EventQueues::cases() as $case) {
+        $found[$case->value] = 'App\\Values\\EventQueues';
+    }
+
+    // (b) quoted onQueue('x') / $queue = 'x' targets across app/
+    $appDir = dirname(__DIR__, 3) . '/app';
+    $rii = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($appDir, FilesystemIterator::SKIP_DOTS)
+    );
+    /** @var SplFileInfo $file */
+    foreach ($rii as $file) {
+        if ($file->getExtension() !== 'php') {
+            continue;
+        }
+        $code = (string) file_get_contents($file->getPathname());
+        if (preg_match_all('/onQueue\(\s*[\'"]([a-z0-9_\-]+)[\'"]\s*\)/i', $code, $m)) {
+            foreach ($m[1] as $q) {
+                $found[$q] ??= $file->getPathname();
+            }
+        }
+        if (preg_match_all('/\$queue\s*=\s*[\'"]([a-z0-9_\-]+)[\'"]/', $code, $m)) {
+            foreach ($m[1] as $q) {
+                $found[$q] ??= $file->getPathname();
+            }
+        }
+    }
+
+    return $found;
+}
+
+/** @return array<int,string> queue names consumed by etc/supervisor.conf */
+function supervisorConsumedQueues(): array
+{
+    $conf = (string) file_get_contents(dirname(__DIR__, 3) . '/etc/supervisor.conf');
+    $queues = [];
+    foreach (preg_split('/\R/', $conf) ?: [] as $line) {
+        if (! str_contains($line, 'queue:work')) {
+            continue;
+        }
+        if (preg_match('/--queue=([a-z0-9_,\-]+)/i', $line, $m)) {
+            foreach (explode(',', $m[1]) as $q) {
+                $queues[] = $q;
+            }
+        } else {
+            $queues[] = 'default'; // a bare `queue:work` consumes the 'default' queue
+        }
+    }
+
+    return array_values(array_unique($queues));
+}
+
+it('declares every dispatched queue in config queue.managed_queues', function () {
+    /** @var array<int,string> $managed */
+    $managed = config('queue.managed_queues');
+    expect($managed)->toBeArray();
+    expect($managed)->toContain('default');
+
+    $undeclared = array_keys(array_filter(
+        dispatchedQueues(),
+        fn (string $file, string $queue): bool => ! in_array($queue, $managed, true),
+        ARRAY_FILTER_USE_BOTH
+    ));
+
+    if ($undeclared !== []) {
+        $this->fail('Queues dispatched to but missing from config(queue.managed_queues): ' . implode(', ', $undeclared));
+    }
+    expect($undeclared)->toBe([]);
+});
+
+it('has a supervisor worker for every managed queue', function () {
+    /** @var array<int,string> $managed */
+    $managed = config('queue.managed_queues');
+    $consumed = supervisorConsumedQueues();
+
+    $uncovered = array_values(array_diff($managed, $consumed));
+
+    if ($uncovered !== []) {
+        $this->fail('Managed queues with NO worker in etc/supervisor.conf (jobs queue forever): ' . implode(', ', $uncovered));
+    }
+    expect($uncovered)->toBe([]);
+});


### PR DESCRIPTION
## Wave 0A — queue-worker coverage (live production defect)

Part of the Wave 0 production-readiness program (spec + plan included in this branch). Ships the first and most urgent go-live blocker from the 2026-07-04 audit.

### The defect
Production runs **Supervisor** off `etc/supervisor.conf`, which consumed only `events, ledger, transactions, default, liquidity_pools`. Every `ShouldQueue` listener/job on any other queue was **queued but never processed**:

| Queue | Unprocessed work | Impact |
|-------|------------------|--------|
| `mobile` | transaction + security-alert push (`SendTransactionPushNotificationListener`, `SendSecurityAlertListener`) | 🔴 core wallet feature dead |
| `transfers` | transfer projections (`MoneyTransferred`, `AssetTransferred`, `TransferThresholdReached`) | 🔴 money read-models stale |
| `broadcasts` | real-time WebSocket updates | live UI stale |
| `webhooks` | outbound webhook delivery | integrations never fire |
| `fraud-batch` | scheduled anomaly scans | fraud detection off |
| `exchange`, `proofs` | arbitrage checks, delegated proofs | lower impact |

### The fix
- `config/queue.php` → `managed_queues`: single source of truth for every dispatched queue.
- `tests/Feature/Ops/QueueCoverageTest.php`: enum-aware guard (seeds from `App\Values\EventQueues` + scans `onQueue()`/`$queue` literals) — **fails CI** if any dispatched queue lacks a `managed_queues` entry or a Supervisor worker. Red→green TDD.
- `etc/supervisor.conf`: dedicated `transfers` worker (money projections), dedicated `mobile` worker (push latency), combined `aux` worker (`broadcasts,webhooks,fraud-batch,exchange,proofs`).
- `config/horizon.php`: parity (explicit ES queue list incl. `transfers`; no more `[env('EVENT_PROJECTOR_QUEUE_NAME')]` → `[null]`).

### ⚠️ Required manual deploy step
`etc/supervisor.conf` is a template — a `git pull` does **not** restart workers. On the server after deploy:
```
supervisorctl reread && supervisorctl update && supervisorctl restart all
supervisorctl status   # confirm finaegis-{transfers,mobile,aux}-worker are RUNNING
```

Spec: `docs/superpowers/specs/2026-07-04-wave-0-production-readiness-blockers-design.md`
Plan: `docs/superpowers/plans/2026-07-04-wave-0a-queue-worker-coverage.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)