### PR TITLE
Wave 0B: RAILGUN custody-neutral production default + 501 guard

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -237,7 +237,11 @@ KEY_MANAGEMENT_DEMO_MODE=false
 # =============================================================================
 # PRIVACY / ZK
 # =============================================================================
-ZK_PROVIDER=railgun
+# ZK_PROVIDER: keep 'demo' in production. 'railgun' enables the CUSTODIAL
+# server-side-seed path (seed derived from app.key) — blocked by ops:verify-env
+# in prod, and the custodial shield/unshield/transfer/viewing-key endpoints
+# hard-return 501 regardless. Non-custodial privacy is on-device (engine-config).
+ZK_PROVIDER=demo
 ZK_PROOF_VALIDITY_DAYS=90
 PRIVACY_AUDIT_LOGGING=true
 POI_RENEWAL_THRESHOLD=30

--- a/.env.zelta.example
+++ b/.env.zelta.example
@@ -401,7 +401,11 @@ KEY_MANAGEMENT_DEMO_MODE=false
 # =============================================================================
 # PRIVACY / ZK
 # =============================================================================
-ZK_PROVIDER=railgun
+# ZK_PROVIDER: keep 'demo' in production. 'railgun' enables the CUSTODIAL
+# server-side-seed path (seed derived from app.key) — blocked by ops:verify-env
+# in prod, and the custodial shield/unshield/transfer/viewing-key endpoints
+# hard-return 501 regardless. Non-custodial privacy is on-device (engine-config).
+ZK_PROVIDER=demo
 ZK_PROOF_VALIDITY_DAYS=90
 PRIVACY_AUDIT_LOGGING=true
 POI_RENEWAL_THRESHOLD=30

--- a/app/Console/Commands/OpsVerifyEnvCommand.php
+++ b/app/Console/Commands/OpsVerifyEnvCommand.php
@@ -339,6 +339,17 @@ class OpsVerifyEnvCommand extends Command
         $zkRailgun = $zk === 'railgun';
         $merkleRailgun = $merkle === 'railgun';
 
+        // Custody-neutral in production (Wave 0B): ZK_PROVIDER=railgun enables the
+        // CUSTODIAL money path (isRailgunMode → server-side seed derived from
+        // app.key). Forbidden in production regardless of the rest of the stack —
+        // privacy is non-custodial / on-device, and the custodial shield/unshield/
+        // transfer/viewing-key endpoints hard-return 501 in prod.
+        if ($zkRailgun && ($this->laravel->environment('production') || (bool) $this->option('strict'))) {
+            $this->add(self::CATEGORY_CONDITIONAL, 'privacy.railgun.custody', self::FAIL, 'ZK_PROVIDER=railgun enables the custodial RAILGUN path (server-side seed derived from app.key) — forbidden in production. Set ZK_PROVIDER=demo. Privacy is non-custodial/on-device; the custodial shield/unshield/transfer/viewing-key endpoints hard-return 501 in prod regardless.');
+
+            return;
+        }
+
         if (! $zkRailgun && ! $merkleRailgun) {
             $this->add(self::CATEGORY_CONDITIONAL, 'privacy.railgun.providers', self::SKIP, sprintf(
                 'Privacy stack in demo mode (ZK_PROVIDER=%s, MERKLE_PROVIDER=%s) — no real RAILGUN privacy.',

--- a/app/Domain/Privacy/Routes/api.php
+++ b/app/Domain/Privacy/Routes/api.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Api\Privacy\PrivacyController;
 use App\Http\Controllers\Api\Privacy\RailgunEngineConfigController;
 use App\Http\Controllers\Api\Privacy\RailgunRpcProxyController;
 use App\Http\Controllers\Api\Privacy\RailgunWalletRegistrationController;
+use App\Http\Middleware\RejectCustodialPrivacyInProduction;
 use Illuminate\Support\Facades\Route;
 
 Route::prefix('v1/privacy')->name('api.privacy.')->group(function () {
@@ -53,7 +54,7 @@ Route::prefix('v1/privacy')->name('api.privacy.')->group(function () {
 
         // Delegated Proof Generation (v2.6.0)
         Route::post('/delegated-proof', [DelegatedProofController::class, 'requestProof'])
-            ->middleware('transaction.rate_limit:delegated_proof')
+            ->middleware([RejectCustodialPrivacyInProduction::class, 'transaction.rate_limit:delegated_proof'])
             ->name('delegated-proof.request');
         Route::get('/delegated-proof/{jobId}', [DelegatedProofController::class, 'getProofStatus'])
             ->name('delegated-proof.status');
@@ -72,21 +73,23 @@ Route::prefix('v1/privacy')->name('api.privacy.')->group(function () {
 
         // Shield/Unshield/Transfer operations
         Route::post('/shield', [PrivacyController::class, 'shield'])
-            ->middleware('transaction.rate_limit:delegated_proof')
+            ->middleware([RejectCustodialPrivacyInProduction::class, 'transaction.rate_limit:delegated_proof'])
             ->name('shield');
         Route::post('/unshield', [PrivacyController::class, 'unshield'])
-            ->middleware('transaction.rate_limit:delegated_proof')
+            ->middleware([RejectCustodialPrivacyInProduction::class, 'transaction.rate_limit:delegated_proof'])
             ->name('unshield');
         Route::post('/transfer', [PrivacyController::class, 'privateTransfer'])
-            ->middleware('transaction.rate_limit:delegated_proof')
+            ->middleware([RejectCustodialPrivacyInProduction::class, 'transaction.rate_limit:delegated_proof'])
             ->name('transfer');
 
         // Viewing key
-        Route::get('/viewing-key', [PrivacyController::class, 'getViewingKey'])->name('viewing-key');
+        Route::get('/viewing-key', [PrivacyController::class, 'getViewingKey'])
+            ->middleware(RejectCustodialPrivacyInProduction::class)
+            ->name('viewing-key');
 
         // Proof of Innocence
         Route::post('/proof-of-innocence', [PrivacyController::class, 'generateProofOfInnocence'])
-            ->middleware('transaction.rate_limit:delegated_proof')
+            ->middleware([RejectCustodialPrivacyInProduction::class, 'transaction.rate_limit:delegated_proof'])
             ->name('proof-of-innocence.generate');
         Route::get('/proof-of-innocence/{proofId}/verify', [PrivacyController::class, 'verifyProofOfInnocence'])
             ->name('proof-of-innocence.verify');

--- a/app/Http/Middleware/RejectCustodialPrivacyInProduction.php
+++ b/app/Http/Middleware/RejectCustodialPrivacyInProduction.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Hard-disables the CUSTODIAL RAILGUN privacy endpoints in production.
+ *
+ * The custodial shield/unshield/transfer/viewing-key path derives a user's
+ * privacy spending seed server-side from app.key — textbook custody, and the
+ * opposite of the non-custodial product model. Privacy moves on-device (the
+ * RAILGUN engine + native prover, bootstrapped via GET /privacy/engine-config).
+ * These endpoints must never run in production, regardless of ZK_PROVIDER, so
+ * this returns 501. Non-production keeps them reachable so tests/local can
+ * exercise the inert demo path.
+ *
+ * Enforcement is at runtime (not just ops:verify-env) because production deploys
+ * here are a manual `git pull` and the env gate is not guaranteed to run.
+ *
+ * See docs/superpowers/specs/2026-07-04-wave-0-production-readiness-blockers-design.md (0B).
+ */
+class RejectCustodialPrivacyInProduction
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (app()->environment('production')) {
+            return response()->json([
+                'success' => false,
+                'error'   => 'CUSTODIAL_PRIVACY_DISABLED',
+                'message' => 'Custodial privacy operations are disabled. Privacy is non-custodial and moves on-device via the RAILGUN engine (GET /api/v1/privacy/engine-config).',
+            ], Response::HTTP_NOT_IMPLEMENTED);
+        }
+
+        return $next($request);
+    }
+}

--- a/tests/Feature/Console/OpsVerifyEnvCommandTest.php
+++ b/tests/Feature/Console/OpsVerifyEnvCommandTest.php
@@ -94,6 +94,16 @@ it('blocks the deploy in production when the Apple JWS verification bypass is on
         ->assertExitCode(1);
 });
 
+it('blocks the deploy in production when ZK_PROVIDER=railgun (custodial privacy path)', function (): void {
+    opsVerifyEnvAllGoodConfig();
+    config(['privacy.zk.provider' => 'railgun']);
+    app()->detectEnvironment(fn () => 'production');
+
+    $this->artisan('ops:verify-env')
+        ->expectsOutputToContain('privacy.railgun.custody')
+        ->assertExitCode(1);
+});
+
 it('blocks the deploy in production when HyperSwitch is enabled without a webhook secret', function (): void {
     opsVerifyEnvAllGoodConfig();
     config([
@@ -249,35 +259,45 @@ it('skips the privacy provider check when the stack is in demo mode', function (
         ->and($check['result'])->toBe('SKIP');
 });
 
-it('blocks the deploy when ZK_PROVIDER and MERKLE_PROVIDER disagree on railgun', function (): void {
+// Wave 0B: in production the custodial RAILGUN path is forbidden outright
+// (privacy is non-custodial/on-device), so ZK_PROVIDER=railgun blocks with a
+// `privacy.railgun.custody` FAIL that preempts the consistency/secret checks.
+// Those checks remain as non-blocking diagnostics OUTSIDE production.
+
+it('flags inconsistent railgun providers as a non-blocking FAIL outside production', function (): void {
     opsVerifyEnvAllGoodConfig();
     config([
         'privacy.zk.provider'           => 'railgun',
         'privacy.merkle.provider'       => 'demo',
         'privacy.railgun.bridge_secret' => 'a-secret',
     ]);
-    app()->detectEnvironment(fn () => 'production');
+    // Not production/strict → custody rule does not fire; consistency check reports FAIL (non-blocking).
 
-    $this->artisan('ops:verify-env')
-        ->expectsOutputToContain('privacy.railgun.providers')
-        ->assertExitCode(1);
+    $exitCode = Artisan::call('ops:verify-env', ['--json' => true]);
+    $check = collect(json_decode(Artisan::output(), true)['checks'])->firstWhere('name', 'privacy.railgun.providers');
+
+    expect($exitCode)->toBe(0)
+        ->and($check)->not->toBeNull()
+        ->and($check['result'])->toBe('FAIL');
 });
 
-it('blocks the deploy when railgun mode is on but RAILGUN_BRIDGE_SECRET is empty', function (): void {
+it('flags railgun mode without a bridge secret as a non-blocking FAIL outside production', function (): void {
     opsVerifyEnvAllGoodConfig();
     config([
         'privacy.zk.provider'           => 'railgun',
         'privacy.merkle.provider'       => 'railgun',
         'privacy.railgun.bridge_secret' => '',
     ]);
-    app()->detectEnvironment(fn () => 'production');
 
-    $this->artisan('ops:verify-env')
-        ->expectsOutputToContain('RAILGUN_BRIDGE_SECRET')
-        ->assertExitCode(1);
+    $exitCode = Artisan::call('ops:verify-env', ['--json' => true]);
+    $check = collect(json_decode(Artisan::output(), true)['checks'])->firstWhere('name', 'privacy.railgun.providers');
+
+    expect($exitCode)->toBe(0)
+        ->and($check)->not->toBeNull()
+        ->and($check['result'])->toBe('FAIL');
 });
 
-it('passes the privacy provider check when both are railgun with a bridge secret', function (): void {
+it('blocks railgun in production even with a bridge secret (custodial path forbidden)', function (): void {
     opsVerifyEnvAllGoodConfig();
     config([
         'privacy.zk.provider'           => 'railgun',
@@ -287,8 +307,9 @@ it('passes the privacy provider check when both are railgun with a bridge secret
     app()->detectEnvironment(fn () => 'production');
 
     $exitCode = Artisan::call('ops:verify-env', ['--json' => true]);
-    $check = collect(json_decode(Artisan::output(), true)['checks'])->firstWhere('name', 'privacy.railgun.providers');
+    $check = collect(json_decode(Artisan::output(), true)['checks'])->firstWhere('name', 'privacy.railgun.custody');
 
-    expect($exitCode)->toBe(0)
-        ->and($check['result'])->toBe('PASS');
+    expect($exitCode)->toBe(1)
+        ->and($check)->not->toBeNull()
+        ->and($check['result'])->toBe('FAIL');
 });

--- a/tests/Feature/Privacy/CustodialPrivacyDisabledInProductionTest.php
+++ b/tests/Feature/Privacy/CustodialPrivacyDisabledInProductionTest.php
@@ -5,13 +5,11 @@ declare(strict_types=1);
 use App\Models\User;
 use Laravel\Sanctum\Sanctum;
 
-/**
- * Wave 0B — the custodial RAILGUN money-movement/key endpoints (server-side
- * seed derivation from app.key) are hard-disabled (501) in production,
- * regardless of ZK_PROVIDER; privacy is non-custodial / on-device. Outside
- * production they stay reachable so tests/local can exercise the inert demo
- * path. Mirrors the both-sides pattern used for account-flag bypass tests.
- */
+// Wave 0B — the custodial RAILGUN money-movement/key endpoints (server-side
+// seed derivation from app.key) are hard-disabled (501) in production,
+// regardless of ZK_PROVIDER; privacy is non-custodial / on-device. Outside
+// production they stay reachable so tests/local can exercise the inert demo
+// path. Mirrors the both-sides pattern used for account-flag bypass tests.
 it('returns 501 for custodial privacy endpoints in production', function (string $method, string $uri) {
     $this->app->detectEnvironment(fn () => 'production');
     Sanctum::actingAs(User::factory()->create(), ['read', 'write', 'delete']);

--- a/tests/Feature/Privacy/CustodialPrivacyDisabledInProductionTest.php
+++ b/tests/Feature/Privacy/CustodialPrivacyDisabledInProductionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+
+/**
+ * Wave 0B — the custodial RAILGUN money-movement/key endpoints (server-side
+ * seed derivation from app.key) are hard-disabled (501) in production,
+ * regardless of ZK_PROVIDER; privacy is non-custodial / on-device. Outside
+ * production they stay reachable so tests/local can exercise the inert demo
+ * path. Mirrors the both-sides pattern used for account-flag bypass tests.
+ */
+it('returns 501 for custodial privacy endpoints in production', function (string $method, string $uri) {
+    $this->app->detectEnvironment(fn () => 'production');
+    Sanctum::actingAs(User::factory()->create(), ['read', 'write', 'delete']);
+
+    $this->json($method, $uri, [])
+        ->assertStatus(501)
+        ->assertJson(['error' => 'CUSTODIAL_PRIVACY_DISABLED']);
+})->with([
+    ['post', '/api/v1/privacy/shield'],
+    ['post', '/api/v1/privacy/unshield'],
+    ['post', '/api/v1/privacy/transfer'],
+    ['get', '/api/v1/privacy/viewing-key'],
+    ['post', '/api/v1/privacy/proof-of-innocence'],
+    ['post', '/api/v1/privacy/delegated-proof'],
+]);
+
+it('does not block custodial privacy endpoints outside production', function () {
+    Sanctum::actingAs(User::factory()->create(), ['read', 'write', 'delete']);
+
+    // testing env (default): the guard must NOT fire — any non-501 confirms the env gate.
+    $status = $this->json('post', '/api/v1/privacy/shield', [])->status();
+
+    $this->assertNotSame(501, $status);
+});
+
+it('keeps the non-custodial engine-config endpoint reachable in production', function () {
+    $this->app->detectEnvironment(fn () => 'production');
+    Sanctum::actingAs(User::factory()->create(), ['read', 'write', 'delete']);
+
+    // The non-custodial on-device bootstrap must NOT be swept up by the guard.
+    $status = $this->getJson('/api/v1/privacy/engine-config')->status();
+
+    $this->assertNotSame(501, $status);
+});


### PR DESCRIPTION
## Wave 0B — RAILGUN custody-neutral in production

Second Wave 0 go-live blocker. The custodial RAILGUN privacy path derives every user's spending seed **server-side from `app.key`** (`RailgunPrivacyService::generateMnemonic`) — textbook custody, and the opposite of the "non-custodial" product claim. It was **enabled by both prod env templates** (`ZK_PROVIDER=railgun`), inert only because the bridge sidecar isn't deployed. This makes custody-neutral the enforced default.

### Changes (defense in depth — the deploy is a manual `git pull`, so no single control is enough)
1. **Runtime 501 guard** (`RejectCustodialPrivacyInProduction` middleware) on the custodial subset — `shield`, `unshield`, `transfer`, `viewing-key`, `proof-of-innocence`, `delegated-proof`. Returns `501 CUSTODIAL_PRIVACY_DISABLED` in production regardless of `ZK_PROVIDER`. The non-custodial `wallet/register`, `engine-config`, and signed `rpc/{network}` endpoints stay live.
2. **Config default** flipped to `ZK_PROVIDER=demo` in `.env.production.example` + `.env.zelta.example`.
3. **Deploy gate** — `ops:verify-env` now FAILs in production (or `--strict`) when `ZK_PROVIDER=railgun`, preempting the consistency/secret checks (which remain non-blocking diagnostics outside prod).

### Tests
- `CustodialPrivacyDisabledInProductionTest` — 6 custodial routes → 501 in prod; not blocked outside prod; `engine-config` stays reachable in prod.
- `OpsVerifyEnvCommandTest` — new custody FAIL case; consistency/secret cases repointed to non-prod diagnostics.

Safe: there are no funded custodial wallets. This converts a "deliberately un-deployed" state into an enforced one, and is the precursor to the Phase-3 removal of the custodial bridge / `DelegatedProofService` / `encrypted_mnemonic`.

Spec: docs/superpowers/specs/2026-07-04-wave-0-production-readiness-blockers-design.md (0B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)