### PR TITLE
Wave 0C: SOC-2 demo-mode production hard-fail (stop fabricated audit evidence)

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -420,6 +420,7 @@ MOBILE_PAYMENT_DEMO_MODE=false
 # =============================================================================
 REGTECH_ENABLED=true
 REGTECH_DEMO_MODE=false
+SOC2_DEMO_MODE=false
 REGTECH_ML_ENABLED=true
 REGTECH_ML_MODEL_VERSION=1.0.0
 

--- a/.env.zelta.example
+++ b/.env.zelta.example
@@ -584,6 +584,7 @@ MOBILE_PAYMENT_DEMO_MODE=false
 # =============================================================================
 REGTECH_ENABLED=true
 REGTECH_DEMO_MODE=false
+SOC2_DEMO_MODE=false
 REGTECH_ML_ENABLED=true
 REGTECH_ML_MODEL_VERSION=1.0.0
 

--- a/app/Console/Commands/OpsVerifyEnvCommand.php
+++ b/app/Console/Commands/OpsVerifyEnvCommand.php
@@ -154,6 +154,7 @@ class OpsVerifyEnvCommand extends Command
         $this->requireFalse(self::CATEGORY_BYPASSES, 'keymanagement.demo_mode', 'KEY_MANAGEMENT_DEMO_MODE resolves to true (config default is true) — a simulated HSM signs in place of the real cloud HSM. Set KEY_MANAGEMENT_DEMO_MODE=false explicitly.');
         $this->requireFalse(self::CATEGORY_BYPASSES, 'regtech.demo_mode', 'REGTECH_DEMO_MODE resolves to true (config default is true) — regulatory filings/screening run in demo mode. Set REGTECH_DEMO_MODE=false explicitly.');
         $this->requireFalse(self::CATEGORY_BYPASSES, 'ai.demo_mode', 'AI_DEMO_MODE resolves to true (config default is true) — AI services return canned demo output. Set AI_DEMO_MODE=false explicitly.');
+        $this->requireFalse(self::CATEGORY_BYPASSES, 'compliance-certification.soc2.demo_mode', 'SOC2_DEMO_MODE=true — the SOC 2 evidence endpoint returns fabricated audit data stamped as production (collectEvidence() also throws in prod). Set SOC2_DEMO_MODE=false.');
     }
 
     private function checkBridgeWebhookCredentials(): void

--- a/app/Domain/Compliance/Services/Certification/EvidenceCollectionService.php
+++ b/app/Domain/Compliance/Services/Certification/EvidenceCollectionService.php
@@ -10,6 +10,7 @@ use App\Domain\Compliance\Models\ComplianceEvidence;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
+use RuntimeException;
 
 /**
  * SOC 2 Evidence Collection Service.
@@ -30,7 +31,11 @@ class EvidenceCollectionService
      */
     public function collectEvidence(string $period, string $type = 'all'): array
     {
-        if (config('compliance-certification.soc2.demo_mode', true)) {
+        if (config('compliance-certification.soc2.demo_mode', false)) {
+            if (app()->environment('production')) {
+                throw new RuntimeException('SOC 2 demo evidence is disabled in production: SOC2_DEMO_MODE=true would return fabricated audit data stamped as production. Set SOC2_DEMO_MODE=false and use real evidence collection.');
+            }
+
             return $this->getDemoEvidence($period);
         }
 

--- a/config/compliance-certification.php
+++ b/config/compliance-certification.php
@@ -26,8 +26,10 @@ return [
     */
 
     'soc2' => [
-        // When enabled, SOC 2 checks run in demonstration mode (no real audit trail)
-        'demo_mode' => env('SOC2_DEMO_MODE', true),
+        // When enabled, SOC 2 checks run in demonstration mode (fabricated audit
+        // data). Defaults to FALSE — must never be on in production; the evidence
+        // collector throws in prod and ops:verify-env blocks the deploy.
+        'demo_mode' => env('SOC2_DEMO_MODE', false),
 
         // Number of days to retain audit evidence artifacts
         'evidence_retention_days' => (int) env('SOC2_EVIDENCE_RETENTION_DAYS', 365),

--- a/tests/Feature/Compliance/Soc2DemoModeProductionTest.php
+++ b/tests/Feature/Compliance/Soc2DemoModeProductionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Compliance\Services\Certification\EvidenceCollectionService;
+
+// Wave 0C — the SOC 2 evidence collector must never return fabricated demo
+// evidence in production (the audit found it returned hardcoded data stamped
+// 'app_env' => 'production'). In prod it throws; outside prod (demo on) it
+// returns the demo dataset for local/reference use.
+
+it('throws instead of returning fabricated SOC 2 evidence in production', function (): void {
+    config(['compliance-certification.soc2.demo_mode' => true]);
+    $this->app->detectEnvironment(fn () => 'production');
+
+    expect(fn () => app(EvidenceCollectionService::class)->collectEvidence('2026-Q1'))
+        ->toThrow(RuntimeException::class);
+});
+
+it('returns demo SOC 2 evidence outside production when demo mode is on', function (): void {
+    config(['compliance-certification.soc2.demo_mode' => true]);
+    // testing env (non-production) — demo dataset is fine for local/reference.
+
+    $evidence = app(EvidenceCollectionService::class)->collectEvidence('2026-Q1');
+
+    $this->assertIsArray($evidence);
+    $this->assertNotEmpty($evidence);
+});

--- a/tests/Feature/Console/OpsVerifyEnvCommandTest.php
+++ b/tests/Feature/Console/OpsVerifyEnvCommandTest.php
@@ -39,9 +39,10 @@ function opsVerifyEnvAllGoodConfig(): void
             'fixed_exchange_rates' => false,
             'auto_approve'         => false,
         ],
-        'keymanagement.demo_mode' => false,
-        'regtech.demo_mode'       => false,
-        'ai.demo_mode'            => false,
+        'keymanagement.demo_mode'                 => false,
+        'regtech.demo_mode'                       => false,
+        'ai.demo_mode'                            => false,
+        'compliance-certification.soc2.demo_mode' => false,
 
         // conditional
         'hyperswitch.enabled'              => false,
@@ -91,6 +92,16 @@ it('blocks the deploy in production when the Apple JWS verification bypass is on
 
     $this->artisan('ops:verify-env')
         ->expectsOutputToContain('apple_jws_verification_bypass')
+        ->assertExitCode(1);
+});
+
+it('blocks the deploy in production when SOC2_DEMO_MODE is on (fabricated evidence)', function (): void {
+    opsVerifyEnvAllGoodConfig();
+    config(['compliance-certification.soc2.demo_mode' => true]);
+    app()->detectEnvironment(fn () => 'production');
+
+    $this->artisan('ops:verify-env')
+        ->expectsOutputToContain('compliance-certification.soc2.demo_mode')
         ->assertExitCode(1);
 });
 


### PR DESCRIPTION
## Wave 0C — SOC-2 demo-mode can no longer fabricate audit evidence in production

Third Wave 0 blocker. `SOC2_DEMO_MODE` defaulted to **true** and was unset in every env file, so a default production deploy served **fabricated SOC 2 audit evidence stamped `app_env => production`** (`EvidenceCollectionService::getDemoEvidence`) — actively dangerous if shown to an auditor/customer.

### Changes (defense in depth)
1. **Default flipped to `false`** (`config/compliance-certification.php`) + `SOC2_DEMO_MODE=false` added to both prod env templates — no fabrication by default.
2. **Runtime throw at the source** — `EvidenceCollectionService::collectEvidence()` throws in production if demo mode is somehow on, instead of returning fabricated data. (Runtime-enforced because the deploy is a manual `git pull`; `demo_mode` is read in ~12 places, so the source-level guard is the reliable chokepoint for the evidence path.)
3. **Deploy gate** — `ops:verify-env` now FAILs in production (or `--strict`) when `SOC2_DEMO_MODE=true`, alongside the existing REGTECH/AI/KEY_MANAGEMENT demo-mode checks.

### Tests
- `Soc2DemoModeProductionTest` — collector throws in prod; returns demo dataset outside prod.
- `OpsVerifyEnvCommandTest` — new SOC-2 FAIL case; `SOC2_DEMO_MODE=false` added to the all-good baseline.

Note: aligns with the reposition of the compliance suite as reference/readiness tooling (0D relabels the public copy). Residual: the non-evidence demo *reports* (classification/key-rotation) still honor the flag outside the evidence path — acceptable since the flag now defaults false and the deploy gate catches an explicit enable.

Spec: docs/superpowers/specs/2026-07-04-wave-0-production-readiness-blockers-design.md (0C)

🤖 Generated with [Claude Code](https://claude.com/claude-code)