### PR TITLE
Wave 0D: honesty relabel — reference-platform positioning, truthful compliance copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@ FinAegis provides the foundation for building digital banking applications. The 
 | Building financial systems from scratch | 61 domain modules |
 | Audit trail requirements | Event sourcing with domain-specific event tables |
 | Complex multi-step transactions | Saga pattern with automatic compensation |
-| Regulatory compliance | Built-in KYC/AML, SOC 2, PCI DSS, GDPR (v3.5.0) |
+| Regulatory tooling | KYC/AML integration + GDPR export/erasure (real); SOC 2 / PCI-DSS *readiness tooling* — not third-party certified |
 | Multi-tenant SaaS deployment | Team-based tenant isolation (v2.0.0) |
 | Hardware wallet security | Ledger/Trezor support with multi-sig (v2.1.0) |
 | Mobile wallet backend | Biometric auth, passkeys, push notifications (v2.2.0+) |
 | Privacy-preserving transactions | ZK-KYC, Merkle trees, ERC-4337 gas abstraction (v2.4.0-v2.6.0) |
-| Multi-jurisdiction RegTech | MiFID II, MiCA, FATF Travel Rule, 4-jurisdiction adapters (v2.8.0) |
+| Multi-jurisdiction RegTech | MiFID II / MiCA / FATF Travel Rule *report-format validators & adapters* — no live regulator connectivity; not a licensed CASP/ARM (v2.8.0) |
 | Cross-chain & DeFi | Bridge protocols, DEX aggregation, yield optimization (v3.0.0) |
 | Modular plugin architecture | 61 domains with manifests, enable/disable, dependency resolution (v3.2.0) |
-| Compliance certification | SOC 2 Type II, PCI DSS readiness, multi-region deployment (v3.5.0) |
+| Compliance scaffolding | SOC 2 evidence helpers + a clean PCI-DSS SAQ-A footprint (tokenized cards, no PAN stored); **no certification is held** (v3.5.0) |
 | GraphQL API | Schema-first Lighthouse PHP, 45 domains, subscriptions (v4.0.0+) |
 | Event Store v2 | Domain routing (61 domains), upcasting, migration tooling (v4.0.0) |
 | Plugin Marketplace | Manager, loader, sandbox, security scanner (v4.0.0) |
@@ -424,7 +424,7 @@ This is a **demonstration platform** showcasing modern banking architecture. Use
 - Contributing to open-source fintech
 - Studying GCU as a basket currency reference
 
-**Production Readiness**: The codebase includes production-grade infrastructure (CQRS, event sourcing, multi-tenancy, GraphQL API, event streaming, 50%+ test coverage, PHPStan Level 8, 4,900+ tests). However, **a security audit and compliance review are required** before any production deployment. See [Security Policy](SECURITY.md) for vulnerability reporting.
+**Production Readiness**: The codebase includes production-grade infrastructure (CQRS, event sourcing, multi-tenancy, GraphQL API, event streaming, 50%+ test coverage, PHPStan Level 8, 4,900+ tests). However, **a security audit and compliance review are required** before any production deployment. **No third-party SOC 2 or PCI-DSS certification is held** — the compliance modules are audit-readiness tooling, and the payment-standards domains (ISO 20022, ISO 8583, SWIFT, Open Banking, SEPA, US rails, Interledger) are **reference implementations** at the message/logic layer, not live scheme connectivity or settlement. See [Security Policy](SECURITY.md) for vulnerability reporting.
 
 ---
 

--- a/resources/views/features/index.blade.php
+++ b/resources/views/features/index.blade.php
@@ -574,7 +574,7 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path>
                         </svg>
                     </div>
-                    <h3 class="text-xl font-semibold mb-3">Compliance Certification</h3>
+                    <h3 class="text-xl font-semibold mb-3">Compliance Tooling</h3>
                     <p class="text-slate-500 mb-4">
                         SOC 2 Type II and PCI DSS readiness tooling with continuous control monitoring, evidence collection, and GDPR enhanced privacy.
                     </p>

--- a/resources/views/features/iso20022.blade.php
+++ b/resources/views/features/iso20022.blade.php
@@ -327,7 +327,7 @@
                         <svg class="w-5 h-5 text-teal-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
                     </div>
                     <h3 class="font-semibold mb-2">SEPA Messaging</h3>
-                    <p class="text-sm text-slate-500">Native pain.001/pain.008 for SEPA Credit Transfers and Direct Debits. Fully compliant with EPC rulebooks.</p>
+                    <p class="text-sm text-slate-500">Native pain.001/pain.008 message generation for SEPA Credit Transfers and Direct Debits, built to the EPC rulebook formats (reference implementation — no live scheme settlement).</p>
                 </div>
                 <div class="bg-white rounded-xl p-6 border border-gray-100 shadow-sm">
                     <div class="w-10 h-10 bg-green-100 rounded-lg flex items-center justify-center mb-4">

--- a/resources/views/security.blade.php
+++ b/resources/views/security.blade.php
@@ -5,7 +5,7 @@
 @section('seo')
     @include('partials.seo', [
         'title' => 'Security - Bank-Grade Protection | ' . config('brand.name', 'Zelta'),
-        'description' => 'Zelta security architecture: HMAC integrity, HSM key management, post-quantum encryption (ML-KEM-768), ZK-KYC proofs, and WebAuthn. SOC 2 and PCI DSS ready.',
+        'description' => 'Zelta security architecture: HMAC integrity, HSM key management, post-quantum encryption (ML-KEM-768), ZK-KYC proofs, and WebAuthn. SOC 2 / PCI-DSS readiness tooling (no certification held).',
         'keywords' => config('brand.name', 'Zelta') . ' security, bank-grade security, blockchain security, secure banking, cybersecurity, data protection',
     ])
 
@@ -157,7 +157,7 @@
                     ['title' => 'Hardware Security Keys', 'desc' => 'FIDO2/WebAuthn hardware wallet support via HardwareWalletManager with Ledger and Trezor signing.', 'color' => 'slate', 'icon' => 'M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z', 'badge' => 'v2.1.0'],
                     ['title' => 'Zero-Knowledge Proofs', 'desc' => 'Privacy-preserving ZK-KYC verification, Proof of Innocence, Merkle tree commitments, and delegated proofs.', 'color' => 'teal', 'icon' => 'M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z', 'badge' => 'v2.4.0'],
                     ['title' => 'Passkey Authentication', 'desc' => 'Passwordless authentication using FIDO2 passkeys for seamless, phishing-resistant login.', 'color' => 'blue', 'icon' => 'M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z', 'badge' => 'v2.7.0'],
-                    ['title' => 'SOC 2 Type II Compliance', 'desc' => 'Continuous control monitoring, evidence collection, and audit readiness tooling.', 'color' => 'teal', 'icon' => 'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z', 'badge' => 'v3.5.0'],
+                    ['title' => 'SOC 2 Type II Readiness Tooling', 'desc' => 'Continuous control monitoring, evidence collection, and audit-readiness tooling (no certification held).', 'color' => 'teal', 'icon' => 'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z', 'badge' => 'v3.5.0'],
                     ['title' => 'WebAuthn Hardened', 'desc' => 'rpIdHash, UP/UV flags, COSE alg/curve validation, origin checking — full FIDO2 specification compliance.', 'color' => 'slate', 'icon' => 'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z', 'badge' => 'v5.9.0'],
                     ['title' => 'Scope-Based CI Enforcement', 'desc' => 'Comprehensive Sanctum ability enforcement across all test files — read/write/delete scopes validated in CI for every endpoint.', 'color' => 'blue', 'icon' => 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z', 'badge' => 'v5.12.0'],
                 ];


### PR DESCRIPTION
## Wave 0D — truth-in-labelling (public copy)

Final Wave 0 item. The always-public README presented **SOC 2 Type II** and **PCI-DSS** as achieved certifications and the payment standards as operational rails — a legal/reputational exposure for a fintech (none are held; the standards are reference implementations disabled in prod). Per the reposition decision (FinAegis = open-source reference/education platform; Zelta = the hosted product), the copy now tells the truth.

### Changes (copy only — no code, no Tailwind class changes)
- **README** "Why FinAegis" rows: *Regulatory compliance* → "Regulatory tooling … not third-party certified"; *Compliance certification* → "Compliance scaffolding … no certification is held"; *RegTech* → "report-format validators & adapters — no live regulator connectivity; not a licensed CASP/ARM".
- **README** production-readiness caveat now states plainly: **no third-party SOC 2 or PCI-DSS certification is held**, and the standards domains (ISO 20022/8583, SWIFT, Open Banking, SEPA, US rails, Interledger) are **reference implementations**, not live scheme connectivity/settlement.
- **Promo pages** (`SHOW_PROMO_PAGES`-gated): security "SOC 2 Type II Compliance" → "Readiness Tooling" + honest meta description; features "Compliance Certification" heading → "Compliance Tooling"; iso20022 "Fully compliant with EPC rulebooks" → reference-implementation wording.

Ran `post-phase-review`: welcome/about/pricing/compliance pages already use hedged language ("Compatible", "Compliance-Ready", "readiness tooling"); the two remaining feature-page overstatements were fixed here. Genuinely-earned claims kept visible (real GDPR export/erasure engine; clean tokenized-card PCI footprint).

Spec: docs/superpowers/specs/2026-07-04-wave-0-production-readiness-blockers-design.md (0D)

🤖 Generated with [Claude Code](https://claude.com/claude-code)