### PR TITLE
Wave 1A: GDPR coverage for blockchain_address_transactions + railgun_wallets

### DIFF
--- a/app/Domain/Compliance/Services/GdprService.php
+++ b/app/Domain/Compliance/Services/GdprService.php
@@ -19,6 +19,7 @@ use App\Domain\MobilePayment\Models\ActivityFeedItem;
 use App\Domain\MobilePayment\Models\PaymentIntent;
 use App\Domain\MobilePayment\Models\PaymentReceipt;
 use App\Domain\Payment\Models\HyperSwitchDepositIntent;
+use App\Domain\Privacy\Models\RailgunWallet;
 use App\Domain\Subscription\Models\Cue;
 use App\Domain\Subscription\Models\IapReceipt;
 use App\Domain\Subscription\Models\IapSubscription;
@@ -90,6 +91,7 @@ class GdprService
         // Wallet (v7.12+)
         'blockchain_addresses',
         'wallet_send_records',
+        'railgun_wallets',
         // Mobile payments
         'payment_intents',
         'payment_receipts',
@@ -180,7 +182,6 @@ class GdprService
         'privacy_commitments'          => self::EXCL_LEGACY,
         'privacy_transactions'         => self::EXCL_LEGACY,
         'promotions'                   => self::EXCL_LEGACY,
-        'railgun_wallets'              => self::EXCL_LEGACY,
         'recovery_backups'             => self::EXCL_LEGACY,
         'recovery_shard_cloud_backups' => self::EXCL_LEGACY,
         'referral_codes'               => 'Random referral code + counters; no personal data beyond the FK to the anonymized users row.',
@@ -668,6 +669,8 @@ class GdprService
      */
     protected function getWalletData(User $user): array
     {
+        $addressUuids = BlockchainAddress::where('user_uuid', $user->uuid)->pluck('uuid');
+
         return [
             'blockchain_addresses' => BlockchainAddress::where('user_uuid', $user->uuid)->get()->map(
                 fn (BlockchainAddress $address): array => [
@@ -694,6 +697,34 @@ class GdprService
                     'submitted_at'      => $send->submitted_at,
                     'confirmed_at'      => $send->confirmed_at,
                     'failed_at'         => $send->failed_at,
+                ]
+            )->all(),
+            // Address-linked tx history (links by address_uuid, not a user FK,
+            // so it is outside the schema coverage guard — covered here
+            // explicitly). Financial fields only; free-text metadata is omitted
+            // from the export and erased on deletion.
+            'blockchain_transactions' => DB::table('blockchain_address_transactions')
+                ->whereIn('address_uuid', $addressUuids)
+                ->orderBy('created_at')
+                ->get()
+                ->map(fn (object $tx): array => [
+                    'chain'        => $tx->chain,
+                    'type'         => $tx->type,
+                    'amount'       => $tx->amount,
+                    'fee'          => $tx->fee,
+                    'tx_hash'      => $tx->tx_hash,
+                    'from_address' => $tx->from_address,
+                    'to_address'   => $tx->to_address,
+                    'status'       => $tx->status,
+                    'created_at'   => $tx->created_at,
+                ])->all(),
+            // Non-custodial privacy wallet: the PUBLIC 0zk address (a persistent
+            // pseudonymous identifier). Seed material is never stored server-side.
+            'railgun_wallets' => RailgunWallet::where('user_id', $user->id)->get()->map(
+                fn (RailgunWallet $wallet): array => [
+                    'railgun_address' => $wallet->railgun_address,
+                    'network'         => $wallet->network,
+                    'created_at'      => $wallet->created_at,
                 ]
             )->all(),
         ];
@@ -978,6 +1009,20 @@ class GdprService
             'metadata'      => null,
             'error_message' => null,
         ]);
+
+        // blockchain_address_transactions: on-chain financial records
+        // (Art. 17(3)(b)) — amounts/hashes/addresses retained; free-text
+        // metadata (webhook notes/labels) erased. Scoped via the user's
+        // addresses (the table links by address_uuid, not a user FK).
+        $addressUuids = BlockchainAddress::where('user_uuid', $user->uuid)->pluck('uuid');
+        DB::table('blockchain_address_transactions')
+            ->whereIn('address_uuid', $addressUuids)
+            ->update(['metadata' => null]);
+
+        // railgun_wallets: the 0zk address is a persistent pseudonymous identity
+        // tied to the user; no funded custodial wallets exist. Delete on erasure
+        // to sever the identifier (any legacy encrypted_mnemonic goes with it).
+        RailgunWallet::where('user_id', $user->id)->delete();
     }
 
     /**

--- a/tests/Feature/Compliance/GdprWalletPrivacyErasureTest.php
+++ b/tests/Feature/Compliance/GdprWalletPrivacyErasureTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Compliance\Services\GdprService;
+use App\Domain\Privacy\Models\RailgunWallet;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+
+// Wave 1A — blockchain_address_transactions (address-linked financial PII that
+// escaped the user-FK schema coverage guard) and railgun_wallets (a pseudonymous
+// 0zk identity) are now covered by GDPR export + erasure. The schema guard
+// cannot see the tx table (no user FK), so this asserts the behaviour directly.
+
+it('exports and erases blockchain transactions and railgun wallets', function () {
+    Http::fake(); // fresh user has no processor links; keep any fan-out offline
+
+    $user = User::factory()->create();
+    $addressUuid = (string) Str::uuid();
+
+    DB::table('blockchain_addresses')->insert([
+        'uuid'       => $addressUuid,
+        'user_uuid'  => $user->uuid,
+        'chain'      => 'solana',
+        'address'    => 'SoLtEsT1111111111111111111111111111111111111',
+        'public_key' => 'test-pk',
+        'is_active'  => true,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    DB::table('blockchain_address_transactions')->insert([
+        'uuid'         => (string) Str::uuid(),
+        'address_uuid' => $addressUuid,
+        'tx_hash'      => 'txhash-abc',
+        'type'         => 'receive',
+        'amount'       => '1.5',
+        'fee'          => '0',
+        'from_address' => 'FROMADDR',
+        'to_address'   => 'SoLtEsT1111111111111111111111111111111111111',
+        'chain'        => 'solana',
+        'status'       => 'confirmed',
+        'metadata'     => json_encode(['note' => 'private memo']),
+        'created_at'   => now(),
+        'updated_at'   => now(),
+    ]);
+
+    DB::table('railgun_wallets')->insert([
+        'id'                 => (string) Str::uuid(),
+        'user_id'            => $user->id,
+        'railgun_address'    => '0zk-test-' . $user->id,
+        'encrypted_mnemonic' => null,
+        'created_at'         => now(),
+        'updated_at'         => now(),
+    ]);
+
+    $service = app(GdprService::class);
+
+    // Export includes the tx history and the 0zk address.
+    $export = json_encode($service->exportUserData($user));
+    expect($export)->toContain('txhash-abc');
+    expect($export)->toContain('0zk-test-' . $user->id);
+
+    // Erasure strips the tx free-text metadata and deletes the railgun row.
+    $service->deleteUserData($user);
+
+    $metadata = DB::table('blockchain_address_transactions')
+        ->where('address_uuid', $addressUuid)
+        ->value('metadata');
+    expect($metadata)->toBeNull();
+    expect(RailgunWallet::where('user_id', $user->id)->exists())->toBeFalse();
+});


### PR DESCRIPTION
## Wave 1A — close two GDPR coverage gaps (P1 + P2)

First Wave 1 (P1) item from the audit.

- **`blockchain_address_transactions` (P1)** — links by `address_uuid`, not a user FK, so the schema coverage guard never saw it. A full table of on-chain financial history + free-text `metadata` was **absent from Art. 15/20 export** and **survived Art. 17 erasure**. Now: exported (financial fields, scoped via the user's addresses) and `metadata`-nulled on erasure. A dedicated regression test asserts both (the schema guard structurally can't).
- **`railgun_wallets` (P2)** — was `EXCLUDED` with a factually wrong "legacy" justification; it's the current v7.16 non-custodial feature storing a persistent pseudonymous `0zk` address tied to `user_id`. Moved to `COVERED`: address exported, row deleted on erasure.

Guard intact (railgun_wallets is user-FK → passes the "no stale" check; blockchain_address_transactions stays out of the constants since it has no user FK — handled in code + the new test). Existing `GdprServiceTest` (10 tests) + `GdprCoverageGuardTest` (7) still green.

Note: the guard's user-FK-column heuristic still can't see other address/account-linked tables — a broader guard enhancement is a follow-up (kept out of scope to avoid flagging many tables for triage at once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)