### PR TITLE
Wave 1B: fix CLI command-name collisions (partner:api-key:*, voting:setup)

### DIFF
--- a/app/Console/Commands/PartnerApiKeyCreateCommand.php
+++ b/app/Console/Commands/PartnerApiKeyCreateCommand.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Str;
 
 class PartnerApiKeyCreateCommand extends Command
 {
-    protected $signature = 'partner:api-key create {partner} {--scopes=read,write : Comma-separated API scopes}';
+    protected $signature = 'partner:api-key:create {partner} {--scopes=read,write : Comma-separated API scopes}';
 
     protected $description = 'Create an API key for a partner';
 

--- a/app/Console/Commands/PartnerApiKeyListCommand.php
+++ b/app/Console/Commands/PartnerApiKeyListCommand.php
@@ -8,7 +8,7 @@ use Illuminate\Console\Command;
 
 class PartnerApiKeyListCommand extends Command
 {
-    protected $signature = 'partner:api-key list {partner}';
+    protected $signature = 'partner:api-key:list {partner}';
 
     protected $description = 'List API keys for a partner';
 
@@ -22,7 +22,7 @@ class PartnerApiKeyListCommand extends Command
         $partnerId = $this->argument('partner');
         $partnerStr = is_string($partnerId) ? $partnerId : '';
         $this->info("API keys for partner: {$partnerStr}");
-        $this->line('No API keys found. Use partner:api-key create to generate one.');
+        $this->line('No API keys found. Use partner:api-key:create to generate one.');
 
         return self::SUCCESS;
     }

--- a/app/Console/Commands/PartnerApiKeyRevokeCommand.php
+++ b/app/Console/Commands/PartnerApiKeyRevokeCommand.php
@@ -8,7 +8,7 @@ use Illuminate\Console\Command;
 
 class PartnerApiKeyRevokeCommand extends Command
 {
-    protected $signature = 'partner:api-key revoke {key_id}';
+    protected $signature = 'partner:api-key:revoke {key_id}';
 
     protected $description = 'Revoke a specific API key';
 

--- a/app/Console/Commands/PartnerApiKeyRotateCommand.php
+++ b/app/Console/Commands/PartnerApiKeyRotateCommand.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Str;
 
 class PartnerApiKeyRotateCommand extends Command
 {
-    protected $signature = 'partner:api-key rotate {partner}';
+    protected $signature = 'partner:api-key:rotate {partner}';
 
     protected $description = 'Rotate the API key for a partner (invalidates old key)';
 

--- a/app/Domain/Governance/Console/Commands/SetupVotingPolls.php
+++ b/app/Domain/Governance/Console/Commands/SetupVotingPolls.php
@@ -14,7 +14,7 @@ class SetupVotingPolls extends Command
      *
      * @var string
      */
-    protected $signature = 'voting:setup 
+    protected $signature = 'voting:setup-batch
                             {--month= : Setup voting for a specific month (YYYY-MM)}
                             {--year= : Setup all monthly polls for a year}';
 

--- a/docs/VERSION_ROADMAP.md
+++ b/docs/VERSION_ROADMAP.md
@@ -2901,7 +2901,7 @@ Based on competitive analysis of 19 worldwide open-source core banking platforms
 - **Sandbox Reset** — Clean state reset with re-seeding
 - **Webhook Testing** — Test payload generation for 5 event types, webhook replay with HMAC signatures
 - **Webhook Delivery Routes** — Event listing, test payload, delivery log endpoints
-- **API Key Management** — CLI commands: `partner:api-key {create,rotate,revoke,list}`
+- **API Key Management** — CLI commands: `partner:api-key:{create,rotate,revoke,list}`
 - **Sandbox CLI** — `partner:sandbox:{create,reset}` with profile selection
 
 ### Mobile Compatibility Fixes

--- a/tests/Feature/Console/CliCommandCollisionTest.php
+++ b/tests/Feature/Console/CliCommandCollisionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Artisan;
+
+// Wave 1B — the four partner:api-key subcommands previously all declared the
+// signature 'partner:api-key <action> …'. Symfony takes the first whitespace
+// token as the command NAME, so all four registered as 'partner:api-key' and
+// create/list/rotate were unreachable. Colon-separated names fix it. Same class
+// of bug for the two 'voting:setup' commands.
+
+it('registers each partner:api-key subcommand as a distinct command', function () {
+    $commands = array_keys(Artisan::all());
+
+    foreach ([
+        'partner:api-key:create',
+        'partner:api-key:list',
+        'partner:api-key:rotate',
+        'partner:api-key:revoke',
+    ] as $name) {
+        $this->assertContains($name, $commands, "Command {$name} is not registered");
+    }
+
+    // The old colliding bare name must no longer exist.
+    $this->assertNotContains('partner:api-key', $commands);
+});
+
+it('registers both voting setup commands under distinct names', function () {
+    $commands = array_keys(Artisan::all());
+
+    $this->assertContains('voting:setup', $commands);
+    $this->assertContains('voting:setup-batch', $commands);
+});

--- a/tests/Feature/Console/CliCommandCollisionTest.php
+++ b/tests/Feature/Console/CliCommandCollisionTest.php
@@ -13,12 +13,14 @@ use Illuminate\Support\Facades\Artisan;
 it('registers each partner:api-key subcommand as a distinct command', function () {
     $commands = array_keys(Artisan::all());
 
-    foreach ([
+    $expected = [
         'partner:api-key:create',
         'partner:api-key:list',
         'partner:api-key:rotate',
         'partner:api-key:revoke',
-    ] as $name) {
+    ];
+
+    foreach ($expected as $name) {
         $this->assertContains($name, $commands, "Command {$name} is not registered");
     }
 

--- a/tests/Unit/Console/Commands/PartnerApiKeyCreateCommandTest.php
+++ b/tests/Unit/Console/Commands/PartnerApiKeyCreateCommandTest.php
@@ -13,20 +13,20 @@ it('command class exists and extends Illuminate Command', function (): void {
     expect($command)->toBeInstanceOf(Illuminate\Console\Command::class);
 });
 
-it('has correct command name partner:api-key', function (): void {
+it('has correct command name partner:api-key:create', function (): void {
     $command = new PartnerApiKeyCreateCommand();
 
-    expect($command->getName())->toBe('partner:api-key');
+    expect($command->getName())->toBe('partner:api-key:create');
 });
 
-it('signature definition contains partner:api-key create {partner}', function (): void {
+it('signature definition contains partner:api-key:create {partner}', function (): void {
     $command = new PartnerApiKeyCreateCommand();
     $ref = new ReflectionClass($command);
     $prop = $ref->getProperty('signature');
     $prop->setAccessible(true);
     $signature = (string) $prop->getValue($command);
 
-    expect($signature)->toContain('partner:api-key create {partner}');
+    expect($signature)->toContain('partner:api-key:create {partner}');
 });
 
 it('has a non-empty description', function (): void {


### PR DESCRIPTION
## Wave 1B — unreachable operator CLI commands

The four `partner:api-key <action> …` commands all declared `partner:api-key` as their name (Symfony takes the first whitespace token as the command name), so only one registered and **create/list/rotate were unreachable** — operators couldn't manage partner API keys via the documented CLI. Renamed to `partner:api-key:create|list|rotate|revoke`.

Same class of bug: two commands declared `voting:setup`, one shadowing the other. The scheduled next-month command (`routes/console.php` monthly) keeps `voting:setup`; the YYYY-MM/`--year` batch variant becomes `voting:setup-batch`.

Regression test (`CliCommandCollisionTest`) asserts each subcommand registers distinctly and the old bare `partner:api-key` name is gone. Doc reference in VERSION_ROADMAP updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)