### PR TITLE
Wave 1D: block local-only backups in prod + correct RPO claim

### DIFF
--- a/app/Console/Commands/OpsVerifyEnvCommand.php
+++ b/app/Console/Commands/OpsVerifyEnvCommand.php
@@ -386,11 +386,11 @@ class OpsVerifyEnvCommand extends Command
     }
 
     /**
-     * Backup destination sanity (WARN-level — never blocks). Cheap config
-     * checks only: the nightly `backup:run --only-db` job (routes/console.php)
-     * writes to the disks in backup.backup.destination.disks; verify the
-     * disks exist in config/filesystems.php and warn when dumps would stay
-     * on the local box. No live S3 call — that's the restore drill's job.
+     * Backup destination sanity. Cheap config checks only: the nightly
+     * `backup:run --only-db` job (routes/console.php) writes to the disks in
+     * backup.backup.destination.disks. A local-ONLY destination in production
+     * FAILs the gate (dumps die with the box — no offsite copy); other issues
+     * (empty/undefined disk) WARN. No live S3 call — that's the restore drill.
      */
     private function checkBackupDestination(): void
     {
@@ -420,7 +420,12 @@ class OpsVerifyEnvCommand extends Command
         }
 
         if ($disks === ['local']) {
-            $this->add(self::CATEGORY_CONDITIONAL, 'backup.destination', self::WARN, 'Backup destination is the local disk only — database dumps never leave the box. Set BACKUP_DISK=s3 (+ bucket credentials) in production and run one restore drill.');
+            // Local-only dumps die with the box (no offsite copy): block a
+            // production deploy; warn (non-blocking) outside production.
+            $result = ($this->laravel->environment('production') || (bool) $this->option('strict'))
+                ? self::FAIL
+                : self::WARN;
+            $this->add(self::CATEGORY_CONDITIONAL, 'backup.destination', $result, 'Backup destination is the local disk only — database dumps never leave the box. Set BACKUP_DISK=s3 (+ bucket credentials) in production and run one restore drill.');
 
             return;
         }

--- a/docs/10-OPERATIONS/OPERATIONAL_RUNBOOK.md
+++ b/docs/10-OPERATIONS/OPERATIONAL_RUNBOOK.md
@@ -620,7 +620,7 @@ php artisan event-sourcing:replay --from=<event-id>
 | Scenario | RTO | RPO | Priority |
 |----------|-----|-----|----------|
 | Complete Outage | 4 hours | 1 hour | P1 |
-| Database Failure | 2 hours | 15 minutes | P1 |
+| Database Failure | 2 hours | **24h** (nightly `backup:run` dump; PITR/binlog shipping required for a lower RPO) | P1 |
 | Application Failure | 30 minutes | N/A | P2 |
 | Region Failure | 8 hours | 1 hour | P1 |
 

--- a/tests/Feature/Console/OpsVerifyEnvCommandTest.php
+++ b/tests/Feature/Console/OpsVerifyEnvCommandTest.php
@@ -50,6 +50,7 @@ function opsVerifyEnvAllGoodConfig(): void
         'services.helius.api_key'          => 'test-helius-key',
         'mobile.attestation.enabled'       => false,
         'privy.web_login_enabled'          => false,
+        'backup.backup.destination.disks'  => ['s3'],
 
         // files — the repo ships storage/app/apple/AppleRootCA-G3.cer, whose
         // sha256 matches the default pinned fingerprint in config/subscription.php.
@@ -162,17 +163,28 @@ it('blocks the deploy in production when Bridge is routed but has no credentials
         ->assertExitCode(1);
 });
 
-it('only warns (never blocks) when the backup destination is the local disk', function (): void {
+it('blocks the deploy in production when backups stay on the local disk only', function (): void {
     opsVerifyEnvAllGoodConfig();
     config(['backup.backup.destination.disks' => ['local']]);
     app()->detectEnvironment(fn () => 'production');
 
-    // Note: a single output line only satisfies ONE expectsOutputToContain
-    // (Mockery consumes the first matching expectation), so assert the most
-    // specific substring of the WARN line.
     $this->artisan('ops:verify-env')
         ->expectsOutputToContain('Backup destination is the local disk only')
-        ->assertExitCode(0);
+        ->assertExitCode(1);
+});
+
+it('only warns (never blocks) about a local-only backup disk outside production', function (): void {
+    opsVerifyEnvAllGoodConfig();
+    config(['backup.backup.destination.disks' => ['local']]);
+    // testing env (non-production) → WARN, non-blocking.
+
+    $exitCode = Artisan::call('ops:verify-env', ['--json' => true]);
+    $decoded = json_decode(Artisan::output(), true);
+    $check = collect($decoded['checks'])->firstWhere('name', 'backup.destination');
+
+    expect($exitCode)->toBe(0)
+        ->and($check)->not->toBeNull()
+        ->and($check['result'])->toBe('WARN');
 });
 
 it('only warns (never blocks) when the backup destination disk is not defined in filesystems', function (): void {


### PR DESCRIPTION
## Wave 1D — backup-destination deploy gate + honest RPO

- **`ops:verify-env` now FAILs** (was WARN) in production/`--strict` when the backup destination is the local disk only — DB dumps that never leave the box are worthless in a box-loss disaster. Forces `BACKUP_DISK=s3` (+ creds) before a prod deploy passes the gate. Still WARN (non-blocking) outside production so local dev isn't disrupted.
- **`OPERATIONAL_RUNBOOK.md` RPO corrected** from an unbacked "15 minutes" to the real **~24h** (nightly `backup:run` dump), noting PITR/binlog shipping is required for a lower RPO.

Tests: the local-disk case now asserts a block (exit 1) in production and a non-blocking WARN outside it; the all-good baseline sets an `s3` destination so the happy path stays green.

Note: this is the gate; the operator still must set `BACKUP_DISK=s3` + run one restore drill (production checklist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)