### PR TITLE
Wave 2: fix developer/API doc drift (SDK banner, base URL, OpenAPI 7.16, PyPI license)

### DIFF
--- a/app/Http/Controllers/Api/Documentation/OpenApiDoc.php
+++ b/app/Http/Controllers/Api/Documentation/OpenApiDoc.php
@@ -8,7 +8,7 @@ use OpenApi\Attributes as OA;
 // then run `php artisan l5-swagger:generate` and commit the regenerated
 // storage/api-docs/api-docs.json — CI's "OpenAPI Drift Check" fails otherwise.
 #[OA\Info(
-    version: '7.15.0',
+    version: '7.16.0',
     title: 'Zelta API',
     description: 'Core banking API — stablecoin-powered virtual cards, non-custodial wallet, AI agent card issuance, ISO 20022, Open Banking, US Payment Rails, Interledger, and Microfinance. Built with Laravel 12, featuring 61 DDD domains, event sourcing, CQRS, and privacy-preserving architecture.',
     contact: new OA\Contact(email: 'support@finaegis.org', name: 'Zelta Support'),

--- a/docs/01-VISION/SUB_PRODUCTS_OVERVIEW.md
+++ b/docs/01-VISION/SUB_PRODUCTS_OVERVIEW.md
@@ -275,7 +275,7 @@ Each sub-product can be independently enabled or disabled:
 
 ### Technical Integration
 - **Developer Portal**: developers.finaegis.org
-- **API Documentation**: api.finaegis.org
+- **API Documentation**: api.zelta.app
 - **Support**: support@finaegis.org
 
 ### Regulatory and Compliance

--- a/docs/04-API/API_VOTING_ENDPOINTS.md
+++ b/docs/04-API/API_VOTING_ENDPOINTS.md
@@ -568,12 +568,12 @@ Use the following cURL commands to test the endpoints:
 
 ```bash
 # Get active polls
-curl -X GET https://api.finaegis.org/api/voting/polls \
+curl -X GET https://api.zelta.app/api/voting/polls \
   -H "Authorization: Bearer {token}" \
   -H "Accept: application/json"
 
 # Submit vote
-curl -X POST https://api.finaegis.org/api/voting/polls/{uuid}/vote \
+curl -X POST https://api.zelta.app/api/voting/polls/{uuid}/vote \
   -H "Authorization: Bearer {token}" \
   -H "Content-Type: application/json" \
   -d '{

--- a/docs/04-API/REST_API_REFERENCE.md
+++ b/docs/04-API/REST_API_REFERENCE.md
@@ -900,10 +900,10 @@ Paginated responses include metadata:
 {
   "data": [...],
   "links": {
-    "first": "https://api.finaegis.org/accounts?page=1",
-    "last": "https://api.finaegis.org/accounts?page=10",
+    "first": "https://api.zelta.app/accounts?page=1",
+    "last": "https://api.zelta.app/accounts?page=10",
     "prev": null,
-    "next": "https://api.finaegis.org/accounts?page=2"
+    "next": "https://api.zelta.app/accounts?page=2"
   },
   "meta": {
     "current_page": 1,

--- a/docs/06-DEVELOPMENT/MOBILE_APP_PLANNING.md
+++ b/docs/06-DEVELOPMENT/MOBILE_APP_PLANNING.md
@@ -425,7 +425,7 @@ npm install victory-native react-native-svg
 import axios, { AxiosInstance } from 'axios';
 import * as SecureStore from 'expo-secure-store';
 
-const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'https://api.finaegis.org';
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'https://api.zelta.app';
 
 class ApiClient {
   private client: AxiosInstance;

--- a/docs/09-DEVELOPER/API-EXAMPLES.md
+++ b/docs/09-DEVELOPER/API-EXAMPLES.md
@@ -17,20 +17,20 @@ This document provides practical examples of integrating with the FinAegis API i
 ### cURL Example
 ```bash
 # Get API status
-curl https://api.finaegis.org/v2/status
+curl https://api.zelta.app/v2/status
 
 # Get GCU information
-curl https://api.finaegis.org/v2/gcu
+curl https://api.zelta.app/v2/gcu
 
 # Authenticated request
 curl -H "Authorization: Bearer YOUR_TOKEN" \
-     https://api.finaegis.org/v2/accounts
+     https://api.zelta.app/v2/accounts
 ```
 
 ### JavaScript/Node.js Quick Start
 ```javascript
 // Using fetch (Node.js 18+ or browser)
-const response = await fetch('https://api.finaegis.org/v2/gcu');
+const response = await fetch('https://api.zelta.app/v2/gcu');
 const gcuInfo = await response.json();
 console.log(`Current GCU value: ${gcuInfo.data.symbol}${gcuInfo.data.current_value}`);
 ```
@@ -44,7 +44,7 @@ const axios = require('axios');
 class FinAegisClient {
   constructor(apiKey) {
     this.client = axios.create({
-      baseURL: 'https://api.finaegis.org/v2',
+      baseURL: 'https://api.zelta.app/v2',
       headers: {
         'Authorization': `Bearer ${apiKey}`,
         'Content-Type': 'application/json'
@@ -69,7 +69,7 @@ import os
 
 class FinAegisClient:
     def __init__(self, api_key):
-        self.base_url = 'https://api.finaegis.org/v2'
+        self.base_url = 'https://api.zelta.app/v2'
         self.headers = {
             'Authorization': f'Bearer {api_key}',
             'Content-Type': 'application/json'
@@ -96,7 +96,7 @@ class FinAegisClient {
     
     public function __construct($apiKey) {
         $this->client = new Client([
-            'base_uri' => 'https://api.finaegis.org/v2/',
+            'base_uri' => 'https://api.zelta.app/v2/',
             'headers' => [
                 'Authorization' => 'Bearer ' . $apiKey,
                 'Content-Type' => 'application/json'
@@ -121,7 +121,7 @@ $accounts = $client->getAccounts();
 async function createAndFundAccount(userEmail, initialDeposit) {
   try {
     // Step 1: Create account
-    const accountResponse = await fetch('https://api.finaegis.org/v2/accounts', {
+    const accountResponse = await fetch('https://api.zelta.app/v2/accounts', {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${API_KEY}`,
@@ -142,7 +142,7 @@ async function createAndFundAccount(userEmail, initialDeposit) {
 
     // Step 2: Fund account with GCU
     const depositResponse = await fetch(
-      `https://api.finaegis.org/v2/accounts/${account.data.uuid}/deposit`,
+      `https://api.zelta.app/v2/accounts/${account.data.uuid}/deposit`,
       {
         method: 'POST',
         headers: {
@@ -180,7 +180,7 @@ class MultiCurrencyAccount:
     def __init__(self, api_key, account_uuid):
         self.api_key = api_key
         self.account_uuid = account_uuid
-        self.base_url = 'https://api.finaegis.org/v2'
+        self.base_url = 'https://api.zelta.app/v2'
     
     async def get_all_balances(self):
         async with aiohttp.ClientSession() as session:
@@ -258,7 +258,7 @@ function GCUVotingComponent({ apiKey }) {
   }, []);
 
   const fetchActivePolls = async () => {
-    const response = await fetch('https://api.finaegis.org/v2/gcu/governance/active-polls');
+    const response = await fetch('https://api.zelta.app/v2/gcu/governance/active-polls');
     const data = await response.json();
     setActivePolls(data.data);
   };
@@ -271,7 +271,7 @@ function GCUVotingComponent({ apiKey }) {
       return;
     }
 
-    const response = await fetch(`https://api.finaegis.org/v2/polls/${pollId}/vote`, {
+    const response = await fetch(`https://api.zelta.app/v2/polls/${pollId}/vote`, {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${apiKey}`,
@@ -392,7 +392,7 @@ export default {
   },
   methods: {
     async fetchGCUInfo() {
-      const response = await fetch('https://api.finaegis.org/v2/gcu');
+      const response = await fetch('https://api.zelta.app/v2/gcu');
       const data = await response.json();
       
       this.currentValue = data.data.current_value;
@@ -402,7 +402,7 @@ export default {
     
     async fetchAndDrawChart() {
       const response = await fetch(
-        'https://api.finaegis.org/v2/gcu/value-history?period=7d&interval=hourly'
+        'https://api.zelta.app/v2/gcu/value-history?period=7d&interval=hourly'
       );
       const data = await response.json();
       
@@ -451,7 +451,7 @@ interface DistributionResult {
 class BankDistributionService {
   constructor(
     private apiKey: string,
-    private baseUrl: string = 'https://api.finaegis.org/v2'
+    private baseUrl: string = 'https://api.zelta.app/v2'
   ) {}
 
   async distributeDeposit(
@@ -902,7 +902,7 @@ const fetch = require('node-fetch');
 class FinAegisClient {
   constructor(apiKey) {
     this.apiKey = apiKey;
-    this.baseUrl = 'https://api.finaegis.org/v2';
+    this.baseUrl = 'https://api.zelta.app/v2';
     
     // Connection pooling
     this.agent = new Agent({
@@ -1070,7 +1070,7 @@ class HealthChecker {
   async checkAPI() {
     try {
       const start = Date.now();
-      const response = await fetch('https://api.finaegis.org/v2/status');
+      const response = await fetch('https://api.zelta.app/v2/status');
       const data = await response.json();
       
       return {

--- a/docs/09-DEVELOPER/API-INTEGRATION-GUIDE.md
+++ b/docs/09-DEVELOPER/API-INTEGRATION-GUIDE.md
@@ -14,15 +14,15 @@ This guide provides comprehensive documentation for integrating with the FinAegi
 - API Key: your_api_key_here
 - API Secret: your_api_secret_here
 - Environment URLs:
-  - Sandbox: https://sandbox-api.finaegis.org
-  - Production: https://api.finaegis.org
+  - Sandbox: https://sandbox-api.zelta.app
+  - Production: https://api.zelta.app
 ```
 
 ### 2. Make Your First Request
 
 ```bash
 # Get account information
-curl -X GET https://sandbox-api.finaegis.org/v2/accounts \
+curl -X GET https://sandbox-api.zelta.app/v2/accounts \
   -H "Authorization: Bearer your_api_key_here" \
   -H "Content-Type: application/json"
 ```
@@ -31,7 +31,7 @@ curl -X GET https://sandbox-api.finaegis.org/v2/accounts \
 
 ```bash
 # Register a webhook endpoint
-curl -X POST https://sandbox-api.finaegis.org/v2/webhooks \
+curl -X POST https://sandbox-api.zelta.app/v2/webhooks \
   -H "Authorization: Bearer your_api_key_here" \
   -H "Content-Type: application/json" \
   -d '{
@@ -291,7 +291,7 @@ GET /v2/exchange-rates/{from}/{to}
 
 1. **Register Endpoint**
 ```bash
-curl -X POST https://api.finaegis.org/v2/webhooks \
+curl -X POST https://api.zelta.app/v2/webhooks \
   -H "Authorization: Bearer your_api_key" \
   -H "Content-Type: application/json" \
   -d '{
@@ -485,7 +485,7 @@ client.webhooks.listen(3000, (event) => {
 
 ### Sandbox Environment
 
-- Base URL: `https://sandbox-api.finaegis.org`
+- Base URL: `https://sandbox-api.zelta.app`
 - Test API keys available in dashboard
 - Simulated bank responses
 - Accelerated time for testing recurring features

--- a/docs/09-DEVELOPER/README.md
+++ b/docs/09-DEVELOPER/README.md
@@ -26,7 +26,7 @@ All API requests require authentication using Laravel Sanctum tokens:
 
 ```bash
 # Get auth token
-curl -X POST https://api.finaegis.org/api/login \
+curl -X POST https://api.zelta.app/api/login \
   -H "Content-Type: application/json" \
   -d '{"email": "user@example.com", "password": "password"}'
 ```
@@ -34,7 +34,7 @@ curl -X POST https://api.finaegis.org/api/login \
 ### 2. Making API Calls
 ```bash
 # Get account balance
-curl -X GET https://api.finaegis.org/api/accounts/{uuid}/balance \
+curl -X GET https://api.zelta.app/api/accounts/{uuid}/balance \
   -H "Authorization: Bearer {token}"
 ```
 
@@ -113,14 +113,14 @@ npx openapi-to-postmanv2 -s storage/api-docs/api-docs.json \
 ```
 
 ### Test Environment
-- Base URL: `https://test-api.finaegis.org`
+- Base URL: `https://test-api.zelta.app`
 - Test credentials available upon request
 - Rate limits: 100 requests per minute
 
 ## Support
 
 ### Developer Resources
-- API Documentation: https://api.finaegis.org/documentation
+- API Documentation: https://api.zelta.app/documentation
 - Status Page: https://status.finaegis.org
 - Developer Forum: https://developers.finaegis.org
 

--- a/docs/09-DEVELOPER/SDK-GUIDE.md
+++ b/docs/09-DEVELOPER/SDK-GUIDE.md
@@ -15,8 +15,8 @@ Welcome to the FinAegis API SDK documentation. This guide will help you integrat
 ## Getting Started
 
 ### Base URLs
-- **Production**: `https://api.finaegis.org/v2`
-- **Sandbox**: `https://sandbox.api.finaegis.org/v2`
+- **Production**: `https://api.zelta.app/v2`
+- **Sandbox**: `https://sandbox.api.zelta.app/v2`
 
 ### API Version
 Current version: `2.0.0`

--- a/docs/13-AI-FRAMEWORK/05-API-Reference.md
+++ b/docs/13-AI-FRAMEWORK/05-API-Reference.md
@@ -2,7 +2,7 @@
 
 ## Base URL
 ```
-https://api.finaegis.org/api/ai
+https://api.zelta.app/api/ai
 ```
 
 ## Authentication
@@ -420,7 +420,7 @@ POST /api/ai/mcp/tools/register
 ### Connect to WebSocket
 
 ```javascript
-const socket = new WebSocket('wss://api.finaegis.org/ai/ws');
+const socket = new WebSocket('wss://api.zelta.app/ai/ws');
 
 socket.onopen = () => {
   // Authenticate
@@ -493,7 +493,7 @@ import { FinAegisAI } from '@finaegis/ai-sdk';
 
 const ai = new FinAegisAI({
   apiKey: 'your-api-key',
-  baseUrl: 'https://api.finaegis.org'
+  baseUrl: 'https://api.zelta.app'
 });
 
 // Send message
@@ -515,7 +515,7 @@ from finaegis import AIClient
 
 client = AIClient(
     api_key='your-api-key',
-    base_url='https://api.finaegis.org'
+    base_url='https://api.zelta.app'
 )
 
 # Send message
@@ -538,7 +538,7 @@ use FinAegis\AI\Client;
 
 $client = new Client([
     'api_key' => 'your-api-key',
-    'base_url' => 'https://api.finaegis.org'
+    'base_url' => 'https://api.zelta.app'
 ]);
 
 // Send message

--- a/resources/views/developers/sdks.blade.php
+++ b/resources/views/developers/sdks.blade.php
@@ -225,7 +225,7 @@
             <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                 <div class="flex items-start gap-3">
                     <svg class="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                    <p class="text-sm text-amber-800"><strong>SDKs are included in the FinAegis monorepo.</strong> They are not published to npm, Packagist, or PyPI. Install from the repository source after cloning the project.</p>
+                    <p class="text-sm text-amber-800"><strong>The FinAegis SDKs are published to public registries.</strong> Install from npm, Packagist, or PyPI with the commands below — or build from the monorepo source.</p>
                 </div>
             </div>
         </div>

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -17,7 +17,7 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Libraries :: Python Modules",
-        "License :: OSI Approved :: MIT License",
+        "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -11,7 +11,7 @@
             "name": "Apache 2.0",
             "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
         },
-        "version": "7.15.0"
+        "version": "7.16.0"
     },
     "servers": [
         {


### PR DESCRIPTION
## Wave 2 — developer/API accuracy

Closes the doc-drift the audit flagged (all developer-facing, low-risk):
- **SDK page** (`developers/sdks.blade.php`): the amber banner claimed the SDKs are **not** published to npm/Packagist/PyPI — false (they are, and the same page said so two lines down). Corrected.
- **Base URL**: `api.finaegis.org` → `api.zelta.app` across `docs/09-DEVELOPER`, `docs/04-API`, `docs/13-AI-FRAMEWORK`, `docs/01-VISION`, `docs/06-DEVELOPMENT` — the shipped SDK/CLI already default to `api.zelta.app`, so the docs were wrong.
- **OpenAPI**: `info.version` 7.15.0 → 7.16.0 + regenerated `storage/api-docs/api-docs.json` (keeps the CI drift gate green).
- **PyPI**: `setup.py` license classifier MIT → Apache-2.0 (the repo is Apache-2.0; the published PyPI artifact misstated it).

Follow-up left for the SDK owner: the JSON-LD on the SDK page still names `@finaegis/payment-sdk` (npm "future") — a product-naming decision, not drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)