### PR TITLE
Wave 3: deflake AssetValuation + UserOp rate-limit tests

### DIFF
--- a/tests/Feature/Treasury/Services/AssetValuationServiceTest.php
+++ b/tests/Feature/Treasury/Services/AssetValuationServiceTest.php
@@ -20,6 +20,11 @@ class AssetValuationServiceTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+        // Isolate the cache to an in-memory array store. The shared Redis store
+        // round-trips cached numerics through strings, so a fresh portfolio value
+        // and its cached read drifted by ~1e-10 (e.g. 1006900.0 vs
+        // 1006900.0000000001) → flaky exact-equality assertions in parallel CI.
+        config(['cache.default' => 'array']);
         $this->portfolioService = app(PortfolioManagementService::class);
         $this->service = new AssetValuationService($this->portfolioService);
         Cache::flush();

--- a/tests/Unit/Domain/Relayer/Services/UserOperationSigningServiceTest.php
+++ b/tests/Unit/Domain/Relayer/Services/UserOperationSigningServiceTest.php
@@ -21,6 +21,12 @@ class UserOperationSigningServiceTest extends TestCase
     {
         parent::setUp();
 
+        // Isolate the rate limiter to an in-memory array store so parallel CI
+        // workers can't collide on a shared Redis counter, and the 10 hits stay
+        // fast enough that the decay window can't expire mid-loop (the 11th-call
+        // block was intermittently not triggered).
+        config(['cache.default' => 'array']);
+
         // Create a fresh user per test to avoid parallel CI rate limiter collisions
         $this->user = User::factory()->create();
 


### PR DESCRIPTION
## Wave 3 — deflake two intermittent tests

These two tests each failed once during this session's PR runs and passed on rerun — pure CI friction from the shared Redis cache store:
- **`AssetValuationServiceTest::test_cache_behavior`** — Redis round-trips cached numerics through strings, so a fresh portfolio value and its cached read drifted by ~1e-10 (`1006900.0` vs `1006900.0000000001`), failing exact-equality.
- **`UserOperationSigningServiceTest::test_enforces_rate_limiting`** — the rate-limiter counter could collide across parallel workers / the decay window could expire mid-loop, so the 11th-request block intermittently didn't fire.

Fix: pin both tests to an in-memory `array` cache store in `setUp()` — deterministic, no network round-trip, no cross-worker collision. Both files pass (11 + 18 tests).

Note: the deeper fix (AssetValuationService should use bcmath, not float, for money) is left as a follow-up — this PR just stops the flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)