### PR TITLE
fix(web): guard team-aware nav against null currentTeam

### DIFF
--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -306,7 +306,10 @@
 
             <div class="hidden sm:flex sm:items-center sm:ms-6">
                 <!-- Teams Dropdown -->
-                @if (Laravel\Jetstream\Jetstream::hasTeamFeatures())
+                {{-- currentTeam can be null for users provisioned outside the team-creating
+                     signup paths (e.g. an interrupted signup). Guard the dereferences below
+                     so a team-less user degrades gracefully instead of 500ing on every page. --}}
+                @if (Laravel\Jetstream\Jetstream::hasTeamFeatures() && Auth::user()->currentTeam)
                     <div class="ms-3 relative">
                         <x-dropdown align="right" width="60">
                             <x-slot name="trigger">
@@ -513,7 +516,7 @@
                 </form>
 
                 <!-- Team Management -->
-                @if (Laravel\Jetstream\Jetstream::hasTeamFeatures())
+                @if (Laravel\Jetstream\Jetstream::hasTeamFeatures() && Auth::user()->currentTeam)
                     <div class="border-t border-gray-200 dark:border-gray-600"></div>
 
                     <div class="block px-4 py-2 text-xs text-gray-400">


### PR DESCRIPTION
## Context

While diagnosing a partner report — new-email sign-in via the web Privy email-OTP flow (`/login`) returns **500 Server Error** after the OTP step, while an existing email correctly shows the "already registered" warning — I confirmed a latent robustness bug in the shared navigation.

## Root cause of the crash class

`resources/views/navigation-menu.blade.php` gated its desktop and responsive **Teams** sections only on `Jetstream::hasTeamFeatures()`, then dereferenced `Auth::user()->currentTeam->{name,id,is_business_organization}` unguarded (lines 315 / 332 / 336-337 / 524).

Because the nav renders on **every authenticated web page**, any team-less user hits:

```
Attempt to read property "name" on null (View: navigation-menu.blade.php)
```

→ a hard **500** on the post-login dashboard (and every other page). Reproduced against real MariaDB.

Team-less users can arise from: a Privy signup interrupted after the `users` row is inserted but before team provisioning, users created outside the team-creating paths, or a user whose team was deleted.

## Fix

Add `&& Auth::user()->currentTeam` to both section guards. A team-less user's nav now simply omits the team dropdown instead of crashing.

## Verification

Rendering the dashboard as a team-less user:
- **Before:** `ViewException: Attempt to read property "name" on null`
- **After:** renders HTML (no exception)

## Scope / notes

- Defense-in-depth. The controller-level `ensurePersonalTeam()` (shipped v7.14.1) remains the primary guarantee that new Privy users get a team; this just makes the view layer resilient if a user is ever team-less for any reason.
- Blade-only change; no PHP/logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)