### PR TITLE
feat(cards): FinCard integration Phase 1 — client, webhook, config foundations

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -405,6 +405,26 @@ MARQETA_WEBHOOK_SECRET=
 MARQETA_WEBHOOK_USERNAME=
 MARQETA_WEBHOOK_PASSWORD=
 
+# FinCard (FinHub BFF, finhub.cloud) — prefunded stored-value virtual cards.
+# Set CARD_ISSUER=fincard to activate. Auth is a session-JWT login (no outbound
+# request signing on our side). Inbound webhooks are RSA-signed — the platform
+# public key is REQUIRED in production or webhooks are rejected. ops:verify-env
+# FAILs when CARD_ISSUER=fincard and any of TENANT_ID/USERNAME/PASSWORD/
+# WEBHOOK_PUBLIC_KEY are empty.
+# base_url per docs.finhub.cloud: sandbox https://sandbox.finhub.cloud/... ,
+# integration https://api-beta.finhub.cloud/... , prod https://api.finhub.cloud/...
+FINCARD_BASE_URL=https://api.finhub.cloud/api/v2.1/fincard/virtual
+FINCARD_TENANT_ID=
+FINCARD_ORG_ID=
+FINCARD_USER_ID=
+FINCARD_USERNAME=
+FINCARD_PASSWORD=
+FINCARD_FORWARDED_FROM=zelta
+# RSA public key (PEM, or base64-of-PEM, or single-line with \n) from FinCard.
+FINCARD_WEBHOOK_PUBLIC_KEY=
+FINCARD_DEFAULT_CARD_TYPE_ID=
+FINCARD_DEFAULT_COIN_KEY=USDT_TRC20
+
 # =============================================================================
 # MOBILE PAYMENT
 # =============================================================================

--- a/.env.zelta.example
+++ b/.env.zelta.example
@@ -569,6 +569,24 @@ MARQETA_WEBHOOK_SECRET=
 MARQETA_WEBHOOK_USERNAME=
 MARQETA_WEBHOOK_PASSWORD=
 
+# FinCard (FinHub BFF, finhub.cloud) — prefunded stored-value virtual cards.
+# Set CARD_ISSUER=fincard to activate. Auth is a session-JWT login (no outbound
+# request signing on our side). Inbound webhooks are RSA-signed — the platform
+# public key is REQUIRED in production or webhooks are rejected. ops:verify-env
+# FAILs when CARD_ISSUER=fincard and any of TENANT_ID/USERNAME/PASSWORD/
+# WEBHOOK_PUBLIC_KEY are empty.
+FINCARD_BASE_URL=https://api.finhub.cloud/api/v2.1/fincard/virtual
+FINCARD_TENANT_ID=
+FINCARD_ORG_ID=
+FINCARD_USER_ID=
+FINCARD_USERNAME=
+FINCARD_PASSWORD=
+FINCARD_FORWARDED_FROM=zelta
+# RSA public key (PEM, or base64-of-PEM, or single-line with \n) from FinCard.
+FINCARD_WEBHOOK_PUBLIC_KEY=
+FINCARD_DEFAULT_CARD_TYPE_ID=
+FINCARD_DEFAULT_COIN_KEY=USDT_TRC20
+
 # =============================================================================
 # MOBILE PAYMENT
 # =============================================================================

--- a/app/Console/Commands/OpsVerifyEnvCommand.php
+++ b/app/Console/Commands/OpsVerifyEnvCommand.php
@@ -246,13 +246,14 @@ class OpsVerifyEnvCommand extends Command
         }
 
         if (config('cardissuance.default_issuer') === 'fincard') {
-            $missing = [];
-            foreach ([
+            $required = [
                 'FINCARD_TENANT_ID'          => 'cardissuance.issuers.fincard.tenant_id',
                 'FINCARD_USERNAME'           => 'cardissuance.issuers.fincard.username',
                 'FINCARD_PASSWORD'           => 'cardissuance.issuers.fincard.password',
                 'FINCARD_WEBHOOK_PUBLIC_KEY' => 'cardissuance.issuers.fincard.webhook_public_key',
-            ] as $env => $key) {
+            ];
+            $missing = [];
+            foreach ($required as $env => $key) {
                 if ($this->configString($key) === '') {
                     $missing[] = $env;
                 }

--- a/app/Console/Commands/OpsVerifyEnvCommand.php
+++ b/app/Console/Commands/OpsVerifyEnvCommand.php
@@ -245,6 +245,34 @@ class OpsVerifyEnvCommand extends Command
             $this->add(self::CATEGORY_CONDITIONAL, 'hyperswitch.credentials', self::SKIP, 'HYPERSWITCH_ENABLED=false — Stripe remains the deposit rail.');
         }
 
+        if (config('cardissuance.default_issuer') === 'fincard') {
+            $missing = [];
+            foreach ([
+                'FINCARD_TENANT_ID'          => 'cardissuance.issuers.fincard.tenant_id',
+                'FINCARD_USERNAME'           => 'cardissuance.issuers.fincard.username',
+                'FINCARD_PASSWORD'           => 'cardissuance.issuers.fincard.password',
+                'FINCARD_WEBHOOK_PUBLIC_KEY' => 'cardissuance.issuers.fincard.webhook_public_key',
+            ] as $env => $key) {
+                if ($this->configString($key) === '') {
+                    $missing[] = $env;
+                }
+            }
+
+            if ($missing !== []) {
+                $this->add(self::CATEGORY_CONDITIONAL, 'fincard.credentials', self::FAIL, sprintf(
+                    'CARD_ISSUER=fincard but %s empty — the card issuer cannot authenticate to FinCard%s.',
+                    implode(', ', $missing),
+                    in_array('FINCARD_WEBHOOK_PUBLIC_KEY', $missing, true)
+                        ? ' and inbound webhooks would be rejected as unverifiable'
+                        : '',
+                ));
+            } else {
+                $this->add(self::CATEGORY_CONDITIONAL, 'fincard.credentials', self::PASS);
+            }
+        } else {
+            $this->add(self::CATEGORY_CONDITIONAL, 'fincard.credentials', self::SKIP, 'CARD_ISSUER is not fincard.');
+        }
+
         if ($solanaSponsor->isEnabled()) {
             try {
                 $address = $solanaSponsor->publicKeyBase58();

--- a/app/Domain/CardIssuance/Http/Controllers/FinCardWebhookController.php
+++ b/app/Domain/CardIssuance/Http/Controllers/FinCardWebhookController.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\CardIssuance\Http\Controllers;
+
+use App\Domain\Subscription\Models\ProcessedWebhookEvent;
+use App\Http\Controllers\Controller;
+use App\Infrastructure\FinCard\FinCardWebhookVerifier;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use OpenApi\Attributes as OA;
+use Throwable;
+
+/**
+ * Dedicated webhook endpoint for FinCard (FinHub) platform events.
+ *
+ * FinCard fires card-lifecycle, authorization, 3DS, cardholder-KYC, work-order
+ * and crypto-wallet events to a single configured URL. Authentication is by
+ * RSA signature (SHA256withRSA over the raw body) — not Sanctum — verified via
+ * {@see FinCardWebhookVerifier}. The platform retries on any non-success reply,
+ * so processing is idempotent (dedupe on `processed_webhook_events`, keyed by
+ * the event's order/trade number) and a handled event acknowledges with
+ * `{"success": true}` — the exact body FinCard expects to stop retrying.
+ *
+ * Configure the FinCard dashboard to POST to:
+ *   https://<your-domain>/api/v1/webhooks/fincard
+ *
+ * Phase 1 stands up verification, dedupe and acknowledgement. Per-category
+ * side effects (KYC state, account credit, card state, transaction sync) are
+ * wired in later phases at the marked extension point — precise routing depends
+ * on confirming the production event envelope against the sandbox.
+ *
+ * @see docs/superpowers/specs/2026-07-06-fincard-card-issuing-design.md §9
+ */
+class FinCardWebhookController extends Controller
+{
+    public function __construct(
+        private readonly FinCardWebhookVerifier $verifier,
+    ) {
+    }
+
+    #[OA\Post(
+        path: '/api/v1/webhooks/fincard',
+        operationId: 'v1FinCardWebhook',
+        tags: ['FinCard Webhooks'],
+        summary: 'FinCard (FinHub) platform event webhook',
+        description: 'RSA-signature-verified (SHA256withRSA over the raw body, base64) against FinCard\'s platform public key. Accepts the X-FC-SIGNATURE or X-WSB-SIGNATURE header. Idempotent via processed_webhook_events.',
+    )]
+    #[OA\Response(response: 200, description: 'Event accepted (or ignored as duplicate)')]
+    #[OA\Response(response: 401, description: 'Invalid signature')]
+    #[OA\Response(response: 400, description: 'Invalid payload')]
+    public function handle(Request $request): JsonResponse
+    {
+        $rawBody = $request->getContent();
+
+        $signature = FinCardWebhookVerifier::signatureFrom(
+            static fn (string $name): ?string => $request->header($name),
+        );
+
+        if (! $this->verifier->verify($rawBody, $signature)) {
+            Log::warning('FinCard webhook: invalid signature');
+
+            return response()->json(['success' => false, 'error' => 'Invalid signature'], 401);
+        }
+
+        $payload = json_decode($rawBody, true);
+        if (! is_array($payload)) {
+            Log::error('FinCard webhook: invalid JSON body');
+
+            return response()->json(['success' => false, 'error' => 'Invalid payload'], 400);
+        }
+
+        $eventId = $this->extractEventId($payload);
+        $eventType = (string) ($payload['eventType'] ?? $payload['type'] ?? '');
+
+        if ($eventId === '' || $eventType === '') {
+            Log::warning('FinCard webhook: missing event id or type', ['type' => $eventType]);
+
+            return response()->json(['success' => false, 'error' => 'Missing event id or type'], 400);
+        }
+
+        // Event-level idempotency via the shared table, keyed on FinCard's
+        // order/trade number so platform retries are safe.
+        $row = ProcessedWebhookEvent::firstOrCreate(
+            ['provider' => 'fincard', 'event_id' => $eventId],
+            ['event_type' => $eventType, 'processed_at' => now()],
+        );
+
+        if (! $row->wasRecentlyCreated) {
+            Log::info('FinCard webhook: duplicate event ignored', [
+                'event_id'   => $eventId,
+                'event_type' => $eventType,
+            ]);
+
+            return response()->json(['success' => true], 200);
+        }
+
+        try {
+            $this->dispatchEvent($eventType, $payload);
+        } catch (Throwable $e) {
+            // Don't surface to FinCard — they retry, and the dedupe row prevents
+            // double-application. Operators see the failure in logs.
+            Log::error('FinCard webhook: handler threw', [
+                'event_id'   => $eventId,
+                'event_type' => $eventType,
+                'exception'  => $e->getMessage(),
+            ]);
+        }
+
+        return response()->json(['success' => true], 200);
+    }
+
+    /**
+     * Extension point for per-phase handlers (KYC, funding, card state,
+     * transaction sync). Phase 1 records the event for observability and
+     * acknowledges it.
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    private function dispatchEvent(string $eventType, array $payload): void
+    {
+        Log::info('FinCard webhook received', [
+            'event_type' => $eventType,
+            // Never log `data` — it may carry PAN / PII.
+        ]);
+    }
+
+    /**
+     * FinCard's idempotency identifiers are the order/trade numbers; fall back
+     * to an explicit event id if present.
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    private function extractEventId(array $payload): string
+    {
+        $data = is_array($payload['data'] ?? null) ? $payload['data'] : [];
+
+        foreach (['orderNo', 'tradeNo', 'eventId', 'id'] as $key) {
+            $candidate = (string) ($payload[$key] ?? $data[$key] ?? '');
+            if ($candidate !== '') {
+                return $candidate;
+            }
+        }
+
+        return '';
+    }
+}

--- a/app/Domain/CardIssuance/Routes/api.php
+++ b/app/Domain/CardIssuance/Routes/api.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Domain\CardIssuance\Http\Controllers\FinCardWebhookController;
 use App\Domain\CardIssuance\Http\Controllers\WaitlistDepositController;
 use App\Domain\CardIssuance\Webhooks\CardWaitlistWebhookController;
 use App\Http\Controllers\Api\CardIssuance\CardController;
@@ -61,6 +62,15 @@ Route::prefix('v1/cardholders')->name('api.cardholders.')->middleware(['auth:san
     Route::post('/', [CardholderController::class, 'store'])->name('store');
     Route::get('/{id}', [CardholderController::class, 'show'])->name('show');
 });
+
+// FinCard (FinHub) platform webhook — single endpoint for card lifecycle,
+// authorization, 3DS, cardholder-KYC, work-order and crypto-wallet events.
+// Authenticated by RSA signature inside the controller (not Sanctum); FinCard
+// retries on non-success, so processing is idempotent via
+// processed_webhook_events (provider='fincard').
+Route::post('v1/webhooks/fincard', [FinCardWebhookController::class, 'handle'])
+    ->middleware('api.rate_limit:webhook')
+    ->name('api.v1.webhooks.fincard');
 
 // Card issuer webhook endpoints (CRITICAL: <2000ms latency budget)
 Route::prefix('webhooks/card-issuer')->name('api.webhooks.card.')

--- a/app/Infrastructure/FinCard/FinCardApiException.php
+++ b/app/Infrastructure/FinCard/FinCardApiException.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\FinCard;
+
+use RuntimeException;
+
+/**
+ * Raised when a FinCard (FinHub BFF) RPC call fails.
+ *
+ * FinCard returns an RPC envelope `{ success, code, msg, data }`. A business
+ * failure arrives as HTTP 200 with `success=false` (carrying an integer `code`
+ * and a human `msg`); a transport/gateway failure arrives as a non-2xx status.
+ * Both surface here so the call site can map FinCard's `code` onto our own
+ * `ERR_CARDS_*` responses without re-parsing the envelope.
+ *
+ * The FinCard business-code catalogue is not published (open item, see the
+ * design spec §14) — `$apiCode` is preserved verbatim for that mapping once we
+ * have it, and for operator log correlation in the meantime.
+ */
+final class FinCardApiException extends RuntimeException
+{
+    public function __construct(
+        string $message,
+        public readonly ?int $apiCode = null,
+        public readonly ?int $httpStatus = null,
+        public readonly string $path = '',
+    ) {
+        parent::__construct($message);
+    }
+
+    public static function business(string $path, ?int $apiCode, string $msg): self
+    {
+        return new self(
+            sprintf('FinCard %s failed (code %s): %s', $path, $apiCode ?? 'null', $msg !== '' ? $msg : 'no message'),
+            apiCode: $apiCode,
+            path: $path,
+        );
+    }
+
+    public static function transport(string $path, int $httpStatus): self
+    {
+        return new self(
+            sprintf('FinCard %s returned HTTP %d', $path, $httpStatus),
+            httpStatus: $httpStatus,
+            path: $path,
+        );
+    }
+
+    public static function malformed(string $path): self
+    {
+        return new self(
+            sprintf('FinCard %s returned a malformed (non-object) response', $path),
+            path: $path,
+        );
+    }
+}

--- a/app/Infrastructure/FinCard/FinCardClient.php
+++ b/app/Infrastructure/FinCard/FinCardClient.php
@@ -1,0 +1,317 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\FinCard;
+
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Thin HTTP wrapper around the FinCard Virtual Card BFF API (finhub.cloud).
+ *
+ * Lives in app/Infrastructure/* (like BridgeClient) because both the
+ * CardIssuance adapter and the webhook controller consume it.
+ *
+ * Transport model (from docs.finhub.cloud/paas/fincard-virtual):
+ *  - RPC-over-POST: every call is a POST with a JSON body, including reads.
+ *    An empty body is sent as `{}` (not `[]`).
+ *  - Response envelope: `{ success: bool, code: int, msg: string, data: ... }`.
+ *    A business failure is HTTP 200 with `success=false`; both that and a
+ *    non-2xx transport failure raise {@see FinCardApiException}.
+ *  - Auth: a JWT bearer obtained from a session login (1h expiry, NO refresh
+ *    token) — cached until near-expiry and re-minted on a 401, mirroring the
+ *    OndatoService pattern. We do NOT sign outbound requests: the mock's
+ *    `X-WSB-SIGNATURE` is a Playground placeholder; FinHub's BFF performs the
+ *    RSA signing to its upstream. Inbound webhooks ARE signed — see
+ *    {@see FinCardWebhookVerifier}.
+ *  - Context headers required on every call: X-Tenant-ID, X-Forwarded-For
+ *    (end-user IP), X-Forwarded-From (our service name), platform, deviceId.
+ *
+ * @see docs/superpowers/specs/2026-07-06-fincard-card-issuing-design.md
+ */
+final class FinCardClient
+{
+    private const CACHE_TOKEN_KEY = 'fincard:jwt';
+
+    /** Session JWT lifetime is 3600s; cache with a 5-minute safety buffer. */
+    private const TOKEN_TTL_BUFFER_SECONDS = 300;
+
+    private const REQUEST_TIMEOUT_SECONDS = 30;
+
+    public function __construct(
+        private readonly string $baseUrl,
+        private readonly string $tenantId,
+        private readonly string $orgId,
+        private readonly string $userId,
+        private readonly string $username,
+        private readonly string $password,
+        private readonly string $forwardedFrom = 'zelta',
+    ) {
+    }
+
+    public static function fromConfig(): self
+    {
+        /** @var array<string, mixed> $cfg */
+        $cfg = (array) config('cardissuance.issuers.fincard', []);
+
+        return new self(
+            baseUrl: rtrim((string) ($cfg['base_url'] ?? 'https://sandbox.finhub.cloud/api/v2.1/fincard/virtual'), '/'),
+            tenantId: (string) ($cfg['tenant_id'] ?? ''),
+            orgId: (string) ($cfg['org_id'] ?? ''),
+            userId: (string) ($cfg['user_id'] ?? ''),
+            username: (string) ($cfg['username'] ?? ''),
+            password: (string) ($cfg['password'] ?? ''),
+            forwardedFrom: (string) ($cfg['forwarded_from'] ?? 'zelta'),
+        );
+    }
+
+    // ── Auth ─────────────────────────────────────────────────────────────
+
+    /**
+     * Return a cached session JWT, minting a fresh one on a cache miss.
+     */
+    public function getAccessToken(): string
+    {
+        $cached = Cache::get(self::CACHE_TOKEN_KEY);
+        if (is_string($cached) && $cached !== '') {
+            return $cached;
+        }
+
+        return $this->login();
+    }
+
+    /**
+     * Perform the session login and cache the JWT until near-expiry.
+     */
+    public function login(): string
+    {
+        $url = $this->host() . "/api/v2.1/admin/organization/{$this->orgId}/users/{$this->userId}/sessions";
+
+        $response = Http::asJson()
+            ->timeout(self::REQUEST_TIMEOUT_SECONDS)
+            ->withHeaders(['X-Tenant-ID' => $this->tenantId])
+            ->post($url, [
+                'username' => $this->username,
+                'password' => $this->password,
+            ]);
+
+        if ($response->failed()) {
+            Log::error('FinCard login failed', ['status' => $response->status()]);
+
+            throw FinCardApiException::transport('/sessions', $response->status());
+        }
+
+        $body = $response->json();
+        // The token may sit at the top level or inside `data` depending on the
+        // tenant/gateway version, so accept both (mirrors the mock's test script).
+        $token = '';
+        $expiresIn = 3600;
+        if (is_array($body)) {
+            $data = is_array($body['data'] ?? null) ? $body['data'] : $body;
+            $token = (string) ($body['accessToken'] ?? $data['accessToken'] ?? '');
+            $expiresIn = (int) ($body['expiresIn'] ?? $data['expiresIn'] ?? 3600);
+        }
+
+        if ($token === '') {
+            throw FinCardApiException::business('/sessions', null, 'login response contained no accessToken');
+        }
+
+        $ttl = max($expiresIn - self::TOKEN_TTL_BUFFER_SECONDS, 60);
+        Cache::put(self::CACHE_TOKEN_KEY, $token, $ttl);
+
+        return $token;
+    }
+
+    // ── Common / reference data (Phase 1) ────────────────────────────────
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function getRegions(array $context = []): array
+    {
+        return $this->rpc('/common/region', [], $context);
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function getCities(string $regionCode, array $context = []): array
+    {
+        return $this->rpc('/common/v2/city', ['regionCode' => $regionCode], $context);
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function getMobileAreaCodes(array $context = []): array
+    {
+        return $this->rpc('/common/mobileAreaCode', [], $context);
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function getOccupations(array $context = []): array
+    {
+        return $this->rpc('/card/holder/occupations', [], $context);
+    }
+
+    /**
+     * Supported card types / BINs for the tenant.
+     *
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function getCardTypes(array $context = []): array
+    {
+        return $this->rpc('/card/v2/cardTypes', [], $context);
+    }
+
+    /**
+     * Supported crypto deposit coins — the runtime source of truth for the
+     * dynamic coin set (do not hard-code USDC support).
+     *
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function getCoins(array $context = []): array
+    {
+        return $this->rpc('/wallet/v2/coins', [], $context);
+    }
+
+    // ── Core RPC ─────────────────────────────────────────────────────────
+
+    /**
+     * POST an RPC call and return the decoded envelope.
+     *
+     * Re-authenticates once on a 401 (expired/invalidated token) before giving
+     * up, so a stale cached JWT self-heals without failing the caller.
+     *
+     * @param  array<string, mixed>  $params
+     * @param  array<string, mixed>  $context  platform / device_id / forwarded_for overrides
+     * @return array<string, mixed>
+     */
+    public function rpc(string $path, array $params = [], array $context = [], bool $isRetry = false): array
+    {
+        $response = Http::asJson()
+            ->timeout(self::REQUEST_TIMEOUT_SECONDS)
+            ->retry(2, 500, $this->shouldRetry(...), throw: false)
+            ->withToken($this->getAccessToken())
+            ->withHeaders($this->contextHeaders($context))
+            ->withBody($this->encodeBody($params), 'application/json')
+            ->post($this->baseUrl . $path);
+
+        if ($response->status() === 401 && ! $isRetry) {
+            Cache::forget(self::CACHE_TOKEN_KEY);
+
+            return $this->rpc($path, $params, $context, isRetry: true);
+        }
+
+        return $this->decode($response, $path);
+    }
+
+    // ── Internals ────────────────────────────────────────────────────────
+
+    /**
+     * Retry transient failures only — connection errors and 5xx. A 4xx (incl.
+     * 401) is returned immediately so rpc() can re-authenticate rather than
+     * replay a doomed request with the same stale token. Retrying is safe for
+     * mutating calls because they carry a client `merchantOrderNo` idempotency
+     * key.
+     */
+    private function shouldRetry(Throwable $exception): bool
+    {
+        if ($exception instanceof ConnectionException) {
+            return true;
+        }
+
+        return $exception instanceof RequestException
+            && ($exception->response->serverError());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(Response $response, string $path): array
+    {
+        if ($response->failed()) {
+            // Never log the body — it may carry PAN / PII.
+            Log::warning('FinCard API transport failure', [
+                'path'   => $path,
+                'status' => $response->status(),
+            ]);
+
+            throw FinCardApiException::transport($path, $response->status());
+        }
+
+        $decoded = $response->json();
+        if (! is_array($decoded)) {
+            throw FinCardApiException::malformed($path);
+        }
+
+        if (($decoded['success'] ?? null) !== true) {
+            $code = isset($decoded['code']) ? (int) $decoded['code'] : null;
+            $msg = (string) ($decoded['msg'] ?? '');
+            Log::warning('FinCard API business failure', [
+                'path' => $path,
+                'code' => $code,
+                'msg'  => $msg,
+            ]);
+
+            throw FinCardApiException::business($path, $code, $msg);
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array<string, string>
+     */
+    private function contextHeaders(array $context): array
+    {
+        return [
+            'X-Tenant-ID'      => $this->tenantId,
+            'X-Forwarded-For'  => (string) ($context['forwarded_for'] ?? '127.0.0.1'),
+            'X-Forwarded-From' => $this->forwardedFrom,
+            'platform'         => (string) ($context['platform'] ?? 'web'),
+            'deviceId'         => (string) ($context['device_id'] ?? 'zelta-server'),
+        ];
+    }
+
+    /**
+     * Serialize the RPC body, sending an empty payload as `{}` (FinCard rejects
+     * a bare `[]`).
+     *
+     * @param  array<string, mixed>  $params
+     */
+    private function encodeBody(array $params): string
+    {
+        return $params === [] ? '{}' : (string) json_encode($params);
+    }
+
+    /**
+     * Scheme + host of the API (the admin/session login lives outside the
+     * /fincard/virtual base path).
+     */
+    private function host(): string
+    {
+        $parts = parse_url($this->baseUrl);
+        $scheme = $parts['scheme'] ?? 'https';
+        $host = $parts['host'] ?? 'sandbox.finhub.cloud';
+        $port = isset($parts['port']) ? ':' . $parts['port'] : '';
+
+        return "{$scheme}://{$host}{$port}";
+    }
+}

--- a/app/Infrastructure/FinCard/FinCardWebhookVerifier.php
+++ b/app/Infrastructure/FinCard/FinCardWebhookVerifier.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\FinCard;
+
+/**
+ * Verifies a FinCard (FinHub) webhook signature.
+ *
+ * Per docs.finhub.cloud/paas/fincard-virtual/webhooks, every webhook carries a
+ * signature header containing `SHA256withRSA(rawResponseBody)`, base64-encoded,
+ * verified against FinCard's platform RSA public key. Unlike Bridge there is no
+ * timestamp element — the signature is over the raw body alone.
+ *
+ * Header name: FinCard's own materials disagree — the narrative webhooks page
+ * uses `X-FC-SIGNATURE`, the API reference and the mock use `X-WSB-SIGNATURE`.
+ * We accept EITHER (see {@see signatureFrom}); which one production actually
+ * sends is an open item to confirm with FinCard (design spec §14), as is
+ * obtaining the public key itself.
+ *
+ * Fail-closed: with no public key configured we accept in non-production (so the
+ * dev loop works against Playground) and hard-fail in production rather than
+ * trust an unsigned webhook — the same idiom as {@see \App\Infrastructure\Bridge\BridgeWebhookVerifier}.
+ */
+final class FinCardWebhookVerifier
+{
+    /** Webhook signature header names FinCard may send, in preference order. */
+    public const SIGNATURE_HEADERS = ['X-FC-SIGNATURE', 'X-WSB-SIGNATURE'];
+
+    private readonly string $publicKey;
+
+    public function __construct(string $publicKey = '')
+    {
+        $this->publicKey = self::normalizePublicKey($publicKey);
+    }
+
+    public static function fromConfig(): self
+    {
+        return new self((string) config('cardissuance.issuers.fincard.webhook_public_key', ''));
+    }
+
+    public function verify(string $rawBody, string $signature): bool
+    {
+        if ($this->publicKey === '') {
+            // No key configured: accept in non-prod (Playground dev loop),
+            // hard-fail in production rather than trust an unsigned webhook.
+            return ! app()->environment('production');
+        }
+
+        if ($signature === '') {
+            return false;
+        }
+
+        $binarySignature = base64_decode($signature, true);
+        if ($binarySignature === false || $binarySignature === '') {
+            return false;
+        }
+
+        $publicKey = openssl_pkey_get_public($this->publicKey);
+        if ($publicKey === false) {
+            return false;
+        }
+
+        return openssl_verify($rawBody, $binarySignature, $publicKey, OPENSSL_ALGO_SHA256) === 1;
+    }
+
+    /**
+     * Resolve the signature value from whichever header FinCard sent.
+     *
+     * @param  callable(string): (string|null)  $headerLookup  case-insensitive header reader
+     */
+    public static function signatureFrom(callable $headerLookup): string
+    {
+        foreach (self::SIGNATURE_HEADERS as $name) {
+            $value = (string) ($headerLookup($name) ?? '');
+            if ($value !== '') {
+                return $value;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Accept the public key as raw PEM, a single-line env value with escaped
+     * `\n`, or a base64-encoded PEM blob. Returns '' when nothing usable is set.
+     */
+    private static function normalizePublicKey(string $raw): string
+    {
+        $raw = trim($raw);
+        if ($raw === '') {
+            return '';
+        }
+
+        if (strlen($raw) >= 2) {
+            $quote = $raw[0];
+            if (($quote === '"' || $quote === "'") && str_ends_with($raw, $quote)) {
+                $raw = trim(substr($raw, 1, -1));
+            }
+        }
+
+        if (! str_contains($raw, "\n") && str_contains($raw, '\\n')) {
+            $raw = str_replace('\\n', "\n", $raw);
+        }
+
+        if (! str_contains($raw, '-----BEGIN')) {
+            $decoded = base64_decode($raw, true);
+            if ($decoded !== false && str_contains($decoded, '-----BEGIN')) {
+                $raw = trim($decoded);
+            }
+        }
+
+        return $raw;
+    }
+}

--- a/app/Providers/CardIssuanceServiceProvider.php
+++ b/app/Providers/CardIssuanceServiceProvider.php
@@ -7,6 +7,8 @@ namespace App\Providers;
 use App\Domain\CardIssuance\Adapters\DemoCardIssuerAdapter;
 use App\Domain\CardIssuance\Adapters\MarqetaCardIssuerAdapter;
 use App\Domain\CardIssuance\Contracts\CardIssuerInterface;
+use App\Infrastructure\FinCard\FinCardClient;
+use App\Infrastructure\FinCard\FinCardWebhookVerifier;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 
@@ -33,6 +35,14 @@ class CardIssuanceServiceProvider extends ServiceProvider
                 default => new DemoCardIssuerAdapter(),
             };
         });
+
+        // FinCard infrastructure — the outbound client and the inbound webhook
+        // verifier. Bound as singletons so the cached session JWT is shared
+        // across a request lifecycle. The `fincard` CardIssuerInterface match
+        // arm is added when the adapter lands (later phases); Phase 1 only needs
+        // the client (reference data) and the verifier (webhook endpoint).
+        $this->app->singleton(FinCardClient::class, static fn () => FinCardClient::fromConfig());
+        $this->app->singleton(FinCardWebhookVerifier::class, static fn () => FinCardWebhookVerifier::fromConfig());
     }
 
     /**
@@ -49,6 +59,17 @@ class CardIssuanceServiceProvider extends ServiceProvider
             && empty(config('cardissuance.issuers.marqeta.hmac_secret'))
         ) {
             Log::debug('Marqeta HMAC secret not configured — sandbox mode, webhook signature validation relaxed');
+        }
+
+        // FinCard webhooks are RSA-signed; without the platform public key the
+        // verifier fails closed in production (rejecting every event). Warn loudly
+        // so a misconfigured deploy is caught. ops:verify-env FAILs on this too.
+        if (
+            $this->app->environment('production')
+            && config('cardissuance.default_issuer') === 'fincard'
+            && empty(config('cardissuance.issuers.fincard.webhook_public_key'))
+        ) {
+            Log::warning('FinCard webhook public key not configured — all inbound FinCard webhooks will be rejected in production');
         }
     }
 }

--- a/config/cardissuance.php
+++ b/config/cardissuance.php
@@ -19,7 +19,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | The card issuer provider to use. Supported: "demo", "marqeta", "lithic",
-    | "stripe_issuing"
+    | "stripe_issuing", "fincard"
     |
     */
 
@@ -58,6 +58,25 @@ return [
             'driver'         => 'stripe_issuing',
             'api_key'        => env('STRIPE_SECRET'),
             'webhook_secret' => env('STRIPE_ISSUING_WEBHOOK_SECRET'),
+        ],
+
+        // FinCard (FinHub BFF, finhub.cloud) — prefunded stored-value virtual
+        // cards. Auth is a session-JWT login (no request signing on our side;
+        // FinHub's BFF signs to its upstream). Inbound webhooks are RSA-signed
+        // and verified with `webhook_public_key`.
+        // @see docs/superpowers/specs/2026-07-06-fincard-card-issuing-design.md
+        'fincard' => [
+            'driver'               => 'fincard',
+            'base_url'             => env('FINCARD_BASE_URL', 'https://sandbox.finhub.cloud/api/v2.1/fincard/virtual'),
+            'tenant_id'            => env('FINCARD_TENANT_ID'),
+            'org_id'               => env('FINCARD_ORG_ID'),
+            'user_id'              => env('FINCARD_USER_ID'),
+            'username'             => env('FINCARD_USERNAME'),
+            'password'             => env('FINCARD_PASSWORD'),
+            'forwarded_from'       => env('FINCARD_FORWARDED_FROM', 'zelta'),
+            'webhook_public_key'   => env('FINCARD_WEBHOOK_PUBLIC_KEY', ''),
+            'default_card_type_id' => env('FINCARD_DEFAULT_CARD_TYPE_ID'),
+            'default_coin_key'     => env('FINCARD_DEFAULT_COIN_KEY', 'USDT_TRC20'),
         ],
     ],
 

--- a/docs/FINCARD_MOBILE_INTEGRATION.md
+++ b/docs/FINCARD_MOBILE_INTEGRATION.md
@@ -1,0 +1,181 @@
+# FinCard Cards — Mobile Integration Spec
+
+Audience: Zelta mobile developers (iOS / Android). This is the contract for the
+crypto- and fiat-funded virtual card product backed by FinCard. It describes the
+end-to-end flows, the `/api/v1/cards/*` HTTP surface, realtime events, and state
+machines so the app can be built in parallel with the backend.
+
+- **Backend design:** `docs/superpowers/specs/2026-07-06-fincard-card-issuing-design.md`
+- **Status legend per endpoint:** 🟢 available now · 🟡 in progress · ⚪ planned (phase noted). Phase 1 (backend foundations) ships no new mobile endpoints; the mobile surface lands across phases 2–4. Build against this contract; treat ⚪ fields marked *(pending FinCard)* as subject to final confirmation of FinCard's response schemas.
+
+---
+
+## 1. Product model (what to build)
+
+A **virtual card** the user funds from a prefunded balance and spends online. Two custody hops the UI must make legible:
+
+- The user's **crypto stays self-custodial** in their Zelta wallet until they choose to fund a card.
+- **Funding a card moves value into FinCard's custody** (a per-user "card account"). This is inherent to cards — surface it plainly at the funding step.
+
+The user journey is four stages, each gated on the previous:
+
+```
+KYC (cardholder)  →  Fund account  →  Open card  →  Use & manage
+   pass_audit         balance > 0      active         spend / freeze / topup
+```
+
+v1 is **virtual cards only**, viewed in-app (no Apple/Google Pay, no physical cards).
+
+---
+
+## 2. Conventions
+
+Identical to the rest of the Zelta mobile API:
+
+- **Auth:** `Authorization: Bearer <sanctum_token>` (the token from `/api/v1/auth/privy-login`). Every card endpoint requires it.
+- **Success:** `{ "success": true, "data": { ... } }` (or `data: [ ... ]` for lists).
+- **Error:** `{ "success": false, "error": { "code": "ERR_CARDS_00x", "message": "…" } }`. HTTP status carries the class (401/403/404/409/422/429). Branch on `error.code`, not the message.
+- **Bodies are snake_case** (e.g. `card_id`, `coin_key`, `amount_cents`).
+- **Idempotency:** POST/PATCH/DELETE require an `Idempotency-Key` HTTP header (UUID or 16–255 `[A-Za-z0-9_-]`). Reusing a key replays the first response; same key + different body → `409`.
+- **Lists** return `data: [...]` plus `pagination: { next_cursor, has_more, total }`. Query with `?cursor=…&limit=…` (limit ≤ 100, default 20).
+- **KYC gate:** issuance/spend endpoints require completed Zelta KYC (`require.kyc`) *and* a `pass_audit` FinCard cardholder; a missing FinCard cardholder returns `ERR_CARDS_403_KYC` (see §7).
+
+---
+
+## 3. Money & amounts
+
+All amounts are **integer minor units** in the field's currency: `amount_cents` (USD cents for card/account balances). Never send floats. Card balances are USD (FinCard converts crypto deposits to USD on receipt). When you show a crypto deposit amount, use the wallet's native decimals; when you show a card/account balance, it's USD cents.
+
+---
+
+## 4. End-to-end flows
+
+### 4.1 KYC / cardholder onboarding ⚪ (phase 2)
+
+FinCard requires its own KYC — richer than the app's existing profile. Prefill what you can; collect the rest.
+
+1. `GET /v1/cards/onboarding` → returns a prefilled draft (name, DOB, nationality, address from the Zelta profile) **plus the field schema** the user must complete: `occupations` list, allowed `id_types` (`PASSPORT`, `DLN`, `GOVERNMENT_ISSUED_ID_CARD`), and the required financial fields (`annual_salary`, `expected_monthly_volume`, `account_purpose`, `gender`).
+2. Capture **three photos** and upload each: `POST /v1/cards/kyc/documents` (multipart, `type` = `id_front` | `id_back` | `selfie`) → returns `{ file_id }`. A selfie is mandatory.
+3. `POST /v1/cardholders` with the full field set + the three `file_id`s → creates the cardholder; response `kyc_status: "in_review"`, `kyc_stage: "admin"`.
+4. Poll `GET /v1/cardholders/{id}` **or** listen for the WebSocket events in §6. Approval is two-stage (`admin` → `channel`). Only `kyc_status: "verified"` (`pass_audit`) unlocks card creation. `rejected` carries `kyc_rejection_reason`.
+
+> Restricted countries are rejected up front with `ERR_CARDS_422_COUNTRY`. The full FinCard field list and photo requirements are *(pending FinCard)* final confirmation; `GET /v1/cards/onboarding` is the source of truth at runtime — render from it, don't hard-code the field set.
+
+### 4.2 Funding ⚪ (phase 3 crypto, phase 5 fiat)
+
+**Crypto (recommended, reuses the wallet):**
+1. `GET /v1/cards/account/coins` → supported deposit coins (e.g. `USDT_TRC20`, `USDT_BEP20`) with `chain`, `min_deposit`, `confirmations`, `deposit_fee`. Render from this — the set is dynamic; do not assume USDC.
+2. `POST /v1/cards/account/deposit-address` `{ coin_key }` → `{ address, chain, coin_key, min_deposit, confirmations }`.
+3. User sends that stablecoin from their **existing Zelta wallet** to `address` (normal wallet send). Show the min amount and confirmation count.
+4. On credit, the backend emits `fincard.account.funded` (§6) and the account balance updates. FinCard converts to USD (a fee applies); show that the credited USD may be less than the crypto sent.
+
+**Fiat (phase 5):** routes through the existing Bridge ramp; exact UX TBD pending the fiat-funding rail (*open item*). Treat as a later addition.
+
+### 4.3 Open & use a card ⚪ (phase 4)
+
+1. `GET /v1/cards/reference/card-types` → available products (`card_type_id`, network, currency).
+2. `POST /v1/cards` `{ card_type_id, amount_cents, cardholder_id }` (+ `Idempotency-Key`) → opens a card, moving `amount_cents` from the account onto the card. Response is the card object (§5.2), `status: "active"`.
+3. `GET /v1/cards/{card_id}/sensitive` → **ephemeral** PAN/CVV/expiry for display or manual entry. Never cache or persist these; fetch on demand behind a biometric re-auth and clear from memory after display.
+4. Manage: `POST /v1/cards/{card_id}/topup`, `/withdraw`, `/freeze`, `DELETE /{card_id}/freeze` (unfreeze), `DELETE /{card_id}` (cancel, biometric-gated).
+5. `GET /v1/cards/{card_id}/transactions?type=purchase` for history (types: `purchase`, `auth`, `fee`, `3ds`, `refund`).
+
+---
+
+## 5. Data shapes
+
+### 5.1 Account
+```json
+{ "account_id": "…", "currency": "USD", "balance_cents": 12345, "status": "active" }
+```
+
+### 5.2 Card
+```json
+{
+  "card_id": "…",
+  "last4": "4242",
+  "network": "visa",
+  "status": "active",
+  "currency": "USD",
+  "balance_cents": 5000,
+  "label": "Travel",
+  "expires_at": "2029-05-31",
+  "created_at": "2026-07-06T12:00:00Z"
+}
+```
+`status` ∈ `pending | active | frozen | cancelled | expired` (see §8). `network` ∈ `visa | mastercard | discover`.
+
+### 5.3 Sensitive details (ephemeral — never persist)
+```json
+{ "pan": "4242424242424242", "cvv": "123", "expiry": "05/29", "cardholder_name": "JANE SMITH" }
+```
+
+### 5.4 Transaction
+```json
+{
+  "transaction_id": "…", "card_id": "…", "type": "purchase",
+  "merchant_name": "ACME", "merchant_category": "5411",
+  "amount_cents": 1999, "currency": "USD", "status": "settled",
+  "transacted_at": "2026-07-06T12:34:56Z"
+}
+```
+`status` ∈ `pending | settled | declined | reversed`. Field names for FinCard-specific transaction streams (auth/fee/3ds) are *(pending FinCard)* final schema confirmation.
+
+---
+
+## 6. Realtime events (WebSocket)
+
+Subscribe to the private channel `private-user.{userId}` (the same channel the app already authorizes). Card events:
+
+| Event name | When | Payload |
+|---|---|---|
+| `fincard.kyc.status_changed` | KYC stage/decision changes | `{ cardholder_id, kyc_status, kyc_stage, rejection_reason? }` |
+| `fincard.account.funded` | A deposit credits the account | `{ account_id, balance_cents, credited_cents, coin_key? }` |
+| `card.state_changed` | Card created / frozen / cancelled / balance change | `{ card_id, status, balance_cents }` |
+
+Push notifications (FCM/APNs) fire on the **terminal KYC states** (`verified`, `rejected`) and on **inbound funding**, mirroring the wallet's transaction-received pattern. Use the WebSocket for live in-app updates and push for background. All ⚪ phase 2–4.
+
+---
+
+## 7. Error codes
+
+Card endpoints use the `ERR_CARDS_*` family (registered in `config/error_codes.php`). Handle at minimum:
+
+| Code | HTTP | Meaning / UX |
+|---|---|---|
+| `ERR_CARDS_403_KYC` | 403 | No verified FinCard cardholder yet → route to onboarding |
+| `ERR_CARDS_409_KYC_PENDING` | 409 | KYC still under review → show pending state |
+| `ERR_CARDS_422_COUNTRY` | 422 | User's country is restricted by FinCard |
+| `ERR_CARDS_422_INSUFFICIENT_FUNDS` | 422 | Account/card balance too low → prompt to fund |
+| `ERR_CARDS_404` | 404 | Card / resource not found |
+| `ERR_VALIDATION_001/003` | 422 | Missing/invalid `Idempotency-Key` or body |
+| `ERR_IDEMPOTENCY_409` | 409 | Same key, different body |
+| (rate limit) | 429 | Too many card operations → back off |
+
+Exact final code list is confirmed as endpoints land per phase; the shape (`{success:false, error:{code,message}}`) is stable.
+
+---
+
+## 8. Card status state machine
+
+```
+pending ──▶ active ──▶ frozen ──▶ active
+                │          │
+                ▼          ▼
+            cancelled   cancelled     (also: active/frozen ──▶ expired)
+```
+`frozen` is reversible (unfreeze → `active`); `cancelled` and `expired` are terminal. FinCard's `blocked` state maps to `frozen` with a distinct reason surfaced in `card.state_changed`.
+
+KYC: `in_review (admin)` → `in_review (channel)` → `verified` | `rejected`. Only `verified` allows opening cards.
+
+---
+
+## 9. What mobile needs from backend before building each screen
+
+| Screen | Blocked on backend phase |
+|---|---|
+| Card onboarding / KYC | Phase 2 (`/onboarding`, `/kyc/documents`, `/cardholders`) |
+| Fund with crypto | Phase 3 (`/account`, `/account/coins`, `/account/deposit-address`) |
+| Card list / open / manage / sensitive | Phase 4 (`/cards*`, `/sensitive`, `/topup`, `/withdraw`) |
+| Fund with fiat | Phase 5 (Bridge path) |
+
+Each phase ships with its OpenAPI (`/api/documentation`) regenerated, so request/response schemas are always live there. When a phase merges, diff this doc against the generated spec for the authoritative field list.

--- a/docs/partners/FinCard_BFF_Virtual_Card_API_Test_Tenant_Mock_postman_collection.json
+++ b/docs/partners/FinCard_BFF_Virtual_Card_API_Test_Tenant_Mock_postman_collection.json
@@ -1,0 +1,2066 @@
+{
+  "info": {
+    "_postman_id": "d0ca3622-0721-47ef-b2d4-78603c71aac5",
+    "name": "FinCard BFF - Virtual_Card_API_Test_Tenant",
+    "description": "Complete API collection for the FinCard Virtual Card BFF.\n\nBase path: /api/v2.1/fincard/virtual\n\n**Quick Start:**\n1. Import the companion environment file `FinCard-BFF.postman_environment.json`\n2. Run **🔐 Auth / Login** — bearerToken is auto-saved\n3. Run **💰 Account / Create Shared Account** — accountId is auto-saved\n4. Run **👤 Card Holder / Create Cardholder V2** — holderId is auto-saved\n5. Run **💳 Card / Create Card V2** — cardId is auto-saved\n\nAll subsequent requests use those saved variables automatically.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "54502770",
+    "_collection_link": "https://go.postman.co/collection/54502770-d0ca3622-0721-47ef-b2d4-78603c71aac5?source=collection_link"
+  },
+  "item": [
+    {
+      "name": "🔐 Auth",
+      "item": [
+        {
+          "name": "Login",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "const r = pm.response.json();",
+                  "const token = (r && r.accessToken) || (r && r.data && r.data.accessToken);",
+                  "if (token) {",
+                  "  pm.collectionVariables.set('bearerToken', token);",
+                  "  pm.test('Login successful — token saved', () => pm.response.to.have.status(200));",
+                  "  console.log('✅ bearerToken saved:', token.substring(0, 40) + '...');",
+                  "} else {",
+                  "  pm.test('Login failed — no token in response', () => false);",
+                  "}"
+                ],
+                "type": "text/javascript",
+                "packages": {},
+                "requests": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "noauth"
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Tenant-ID",
+                "value": "{{tenantId}}"
+              },
+              {
+                "key": "X-Forwarded-For",
+                "value": "127.0.0.1"
+              },
+              {
+                "key": "platform",
+                "value": "web"
+              },
+              {
+                "key": "deviceId",
+                "value": "postman-device-001"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"username\": \"cards_test@fincard-test.finhub.cloud\",\n  \"password\": \"Cards@Test2025!\"\n  }",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/admin/organization/e5b82d4f-9a3c-5f6b-c0e2-8d7f4a3b2c19/users/a7d04f6b-1c5e-7b8d-e2a4-0f9b6c5d4e3b/sessions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "admin",
+                "organization",
+                "e5b82d4f-9a3c-5f6b-c0e2-8d7f4a3b2c19",
+                "users",
+                "a7d04f6b-1c5e-7b8d-e2a4-0f9b6c5d4e3b",
+                "sessions"
+              ]
+            }
+          },
+          "response": []
+        }
+      ],
+      "description": "Authentication endpoints"
+    },
+    {
+      "name": "🌐 Common",
+      "item": [
+        {
+          "name": "Country / Region List",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/common/region",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "common",
+                "region"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "City List",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"regionCode\": \"US\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/common/city",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "common",
+                "city"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "City List V2 (hierarchical)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"regionCode\": \"US\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/common/v2/city",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "common",
+                "v2",
+                "city"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Mobile Area Code List",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/common/mobileAreaCode",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "common",
+                "mobileAreaCode"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "File Upload",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "category",
+                  "value": "card",
+                  "type": "text"
+                },
+                {
+                  "key": "file",
+                  "type": "file",
+                  "value": null
+                },
+                {
+                  "key": "fileName",
+                  "value": "id-front.jpg",
+                  "type": "text"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/common/file/upload",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "common",
+                "file",
+                "upload"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Submit Work Order",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const r = pm.response.json();",
+                  "if (r && r.success && r.orderNo) {",
+                  "  pm.collectionVariables.set('workOrderNo', r.orderNo);",
+                  "  console.log('✅ workOrderNo saved:', r.orderNo);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"merchantOrderNo\": \"WORK{{$timestamp}}001\",\n  \"title\": \"Card Activation Request\",\n  \"target\": \"5533700000000000\",\n  \"tradeType\": \"CARD_ACTIVE\",\n  \"content\": \"Please activate the card\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/work/submit",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "work",
+                "submit"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Work Order List",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"pageNum\": 1,\n  \"pageSize\": 10\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/work/list",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "work",
+                "list"
+              ]
+            }
+          },
+          "response": []
+        }
+      ],
+      "description": "Reference data: regions, cities, mobile codes, file upload, work orders"
+    },
+    {
+      "name": "💰 Account",
+      "item": [
+        {
+          "name": "Assets (Account Info)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/account/info",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "account",
+                "info"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Account List",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"pageNum\": 1,\n  \"pageSize\": 10,\n  \"accountType\": \"MARGIN\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/account/list",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "account",
+                "list"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Single Account Query",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"accountId\": \"{{accountId}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/account/single/query",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "account",
+                "single",
+                "query"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Ledger Transactions",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"accountId\": \"{{accountId}}\",\n  \"pageNum\": 1,\n  \"pageSize\": 20\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/account/transaction",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "account",
+                "transaction"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Shared Account",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const r = pm.response.json();",
+                  "const id = r && r.data && r.data.accountId;",
+                  "if (id) {",
+                  "  const existing = pm.collectionVariables.get('accountId');",
+                  "  if (!existing) {",
+                  "    pm.collectionVariables.set('accountId', id);",
+                  "    console.log('✅ accountId saved:', id);",
+                  "  } else {",
+                  "    pm.collectionVariables.set('accountId2', id);",
+                  "    console.log('✅ accountId2 saved:', id);",
+                  "  }",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"accountName\": \"My Shared Account\",\n  \"currency\": \"USD\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/account/create",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "account",
+                "create"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Fund Transfer",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"type\": \"TRANSFER\",\n  \"merchantOrderNo\": \"XFER{{$timestamp}}001\",\n  \"fromAccountId\": \"{{accountId}}\",\n  \"toAccountId\": \"{{accountId2}}\",\n  \"amount\": 10,\n  \"currency\": \"USD\",\n  \"description\": \"Internal transfer\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/account/transfer",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "account",
+                "transfer"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Wallet Deposit (Deprecated)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"accountId\": \"{{accountId}}\",\n  \"amount\": 100,\n  \"currency\": \"USD\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/account/walletDeposit",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "account",
+                "walletDeposit"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Wallet Deposit Transactions (Deprecated)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"accountId\": \"{{accountId}}\",\n  \"pageNum\": 1,\n  \"pageSize\": 20\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/account/walletDepositTransaction",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "account",
+                "walletDepositTransaction"
+              ]
+            }
+          },
+          "response": []
+        }
+      ],
+      "description": "Account management: info, list, create, transfer, wallet deposit"
+    },
+    {
+      "name": "💎 Wallet V2",
+      "item": [
+        {
+          "name": "Coin List",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/wallet/v2/coins",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "wallet",
+                "v2",
+                "coins"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Wallet Address",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"coinKey\": \"USDT_TRC20\",\n  \"accountId\": \"{{accountId}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/wallet/v2/create",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "wallet",
+                "v2",
+                "create"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Wallet Address List",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"pageNum\": 1,\n  \"pageSize\": 20\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/wallet/v2/addressList",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "wallet",
+                "v2",
+                "addressList"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Wallet Transaction History",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"pageNum\": 1,\n  \"pageSize\": 20\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/wallet/v2/transaction",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "wallet",
+                "v2",
+                "transaction"
+              ]
+            }
+          },
+          "response": []
+        }
+      ],
+      "description": "Crypto wallet: coins, deposit addresses, transaction history"
+    },
+    {
+      "name": "👤 Card Holder",
+      "item": [
+        {
+          "name": "Cardholder Occupations",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/holder/occupations",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "holder",
+                "occupations"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Cardholder (Deprecated)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const r = pm.response.json();",
+                  "const id = r && r.data && r.data.cardholderId;",
+                  "if (id) { pm.collectionVariables.set('holderId', id); console.log('✅ holderId saved:', id); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"firstName\": \"John\",\n  \"lastName\": \"Doe\",\n  \"birthday\": \"1990-01-15\",\n  \"nationality\": \"US\",\n  \"phone\": \"5551234567\",\n  \"phoneCountryCode\": \"+1\",\n  \"email\": \"john.doe@example.com\",\n  \"country\": \"US\",\n  \"state\": \"NY\",\n  \"city\": \"New York\",\n  \"address\": \"123 Main St\",\n  \"zipCode\": \"10001\",\n  \"idType\": \"PASSPORT\",\n  \"idNumber\": \"A1234567\",\n  \"idFrontFileId\": \"{{fileId}}\",\n  \"idBackFileId\": \"{{fileId}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/holder/create",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "holder",
+                "create"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Cardholder (Deprecated)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"cardholderId\": \"{{holderId}}\",\n  \"address\": \"456 Updated Street\",\n  \"city\": \"Los Angeles\",\n  \"state\": \"CA\",\n  \"zipCode\": \"90001\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/holder/update",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "holder",
+                "update"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Cardholder V2",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const r = pm.response.json();",
+                  "const id = r && r.data && r.data.cardholderId;",
+                  "if (id) { pm.collectionVariables.set('holderId', id); console.log('✅ holderId saved:', id); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"firstName\": \"Jane\",\n  \"lastName\": \"Smith\",\n  \"birthday\": \"1992-03-20\",\n  \"nationality\": \"US\",\n  \"phone\": \"5559876543\",\n  \"phoneCountryCode\": \"+1\",\n  \"email\": \"jane.smith@example.com\",\n  \"country\": \"US\",\n  \"state\": \"CA\",\n  \"city\": \"Los Angeles\",\n  \"address\": \"456 Oak Avenue\",\n  \"zipCode\": \"90001\",\n  \"idType\": \"NATIONAL_ID\",\n  \"idNumber\": \"B9876543\",\n  \"idFrontFileId\": \"{{fileId}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/holder/v2/create",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "holder",
+                "v2",
+                "create"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Cardholder V2",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"cardholderId\": \"{{holderId}}\",\n  \"address\": \"789 New Boulevard\",\n  \"city\": \"Chicago\",\n  \"state\": \"IL\",\n  \"zipCode\": \"60601\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/holder/v2/update",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "holder",
+                "v2",
+                "update"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Cardholder List",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"pageNum\": 1,\n  \"pageSize\": 20\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/holder/list",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "holder",
+                "list"
+              ]
+            }
+          },
+          "response": []
+        }
+      ],
+      "description": "Cardholder management: create, update, list"
+    },
+    {
+      "name": "💳 Card",
+      "item": [
+        {
+          "name": "Support Bins (Card Types)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/v2/cardTypes",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "v2",
+                "cardTypes"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Card (Deprecated)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const r = pm.response.json();",
+                  "const id = r && r.data && (r.data.cardNo || r.data.cardId);",
+                  "if (id) { pm.collectionVariables.set('cardId', id); console.log('✅ cardId saved:', id); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"merchantOrderNo\": \"CARD{{$timestamp}}001\",\n  \"cardTypeId\": 111001,\n  \"amount\": 200,\n  \"accountId\": \"{{accountId}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/openCard",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "openCard"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Card V2",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const r = pm.response.json();",
+                  "const id = r && r.data && (r.data.cardNo || r.data.cardId);",
+                  "if (id) { pm.collectionVariables.set('cardId', id); console.log('✅ cardId saved:', id); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"merchantOrderNo\": \"CARD{{$timestamp}}002\",\n  \"cardTypeId\": 111001,\n  \"amount\": 200,\n  \"accountId\": \"{{accountId}}\",\n  \"holderId\": \"{{holderId}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/v2/openCard",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "v2",
+                "openCard"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Card Info",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"cardId\": \"{{cardId}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/info",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "info"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Card Info Sensitive",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"cardId\": \"{{cardId}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/info/sensitive",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "info",
+                "sensitive"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Card Balance",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"cardId\": \"{{cardId}}\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/balance",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "balance"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Card List",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"pageNum\": 1,\n  \"pageSize\": 20,\n  \"status\": \"Normal\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/list",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "list"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Card Note",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"cardId\": \"{{cardId}}\",\n  \"merchantOrderNo\": \"UPD{{$timestamp}}001\",\n  \"remark\": \"My primary travel card\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/v2/updateNote",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "v2",
+                "updateNote"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Card Settings",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"cardId\": \"{{cardId}}\",\n  \"merchantOrderNo\": \"UPD{{$timestamp}}002\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/v2/update",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "v2",
+                "update"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Freeze Card",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"cardId\": \"{{cardId}}\",\n  \"merchantOrderNo\": \"FRZ{{$timestamp}}001\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/v2/freeze",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "v2",
+                "freeze"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "UnFreeze Card",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"cardId\": \"{{cardId}}\",\n  \"merchantOrderNo\": \"UFZ{{$timestamp}}001\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/v2/unfreeze",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "v2",
+                "unfreeze"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Deposit to Card",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"cardId\": \"{{cardId}}\",\n  \"merchantOrderNo\": \"DEP{{$timestamp}}001\",\n  \"amount\": 50\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/deposit",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "deposit"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Withdraw from Card",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"cardId\": \"{{cardId}}\",\n  \"merchantOrderNo\": \"WDR{{$timestamp}}001\",\n  \"amount\": 10\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/withdraw",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "withdraw"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Cancel Card",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"cardId\": \"{{cardId}}\",\n  \"merchantOrderNo\": \"CXL{{$timestamp}}001\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/cancel",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "cancel"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Activate Card (physical)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"merchantOrderNo\": \"ACT{{$timestamp}}001\",\n  \"cardId\": \"phys-card-001\",\n  \"pin\": \"123456\",\n  \"activationCode\": \"ACT000001\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/activate",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "activate"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update PIN (physical)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"cardId\": \"phys-card-001\",\n  \"merchantOrderNo\": \"PIN{{$timestamp}}001\",\n  \"oldPin\": \"123456\",\n  \"newPin\": \"654321\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/updatePin",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "updatePin"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Card Purchase Transactions",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"cardId\": \"{{cardId}}\",\n  \"pageNum\": 1,\n  \"pageSize\": 20\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/purchase/transaction",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "purchase",
+                "transaction"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Card Operation Transactions",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"cardId\": \"{{cardId}}\",\n  \"pageNum\": 1,\n  \"pageSize\": 20\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/transaction",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "transaction"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Card Operation Transactions V2",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"cardId\": \"{{cardId}}\",\n  \"pageNum\": 1,\n  \"pageSize\": 20\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/v2/transaction",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "v2",
+                "transaction"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Card Authorization Transactions",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"cardId\": \"{{cardId}}\",\n  \"pageNum\": 1,\n  \"pageSize\": 20\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/authorize/transaction",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "authorize",
+                "transaction"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Card Auth Fee Transactions",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"cardId\": \"{{cardId}}\",\n  \"pageNum\": 1,\n  \"pageSize\": 20\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/auth/fee/transaction",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "auth",
+                "fee",
+                "transaction"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Card 3DS Transactions",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"cardId\": \"{{cardId}}\",\n  \"pageNum\": 1,\n  \"pageSize\": 20\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/card/3ds/transaction",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "card",
+                "3ds",
+                "transaction"
+              ]
+            }
+          },
+          "response": []
+        }
+      ],
+      "description": "Card lifecycle: create, info, balance, operations, transactions"
+    },
+    {
+      "name": "🔔 Webhook",
+      "item": [
+        {
+          "name": "Webhook Callback",
+          "request": {
+            "auth": {
+              "type": "noauth"
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-WSB-SIGNATURE",
+                "value": "valid_signature_12345",
+                "description": "Playground mode: use 'valid_signature_12345'. Production: HMAC-RSA from FinCard platform."
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"eventId\": \"evt-{{$randomUUID}}\",\n  \"eventType\": \"card_create\",\n  \"tenantId\": \"{{tenantId}}\",\n  \"createTime\": {{$timestamp}},\n  \"data\": {\n    \"cardId\": \"{{cardId}}\",\n    \"status\": \"Normal\",\n    \"amount\": 200,\n    \"currency\": \"USD\"\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v2.1/fincard/virtual/webhook/callback",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v2.1",
+                "fincard",
+                "virtual",
+                "webhook",
+                "callback"
+              ]
+            }
+          },
+          "response": []
+        }
+      ],
+      "description": "Receive FinCard platform event notifications"
+    }
+  ],
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      {
+        "key": "token",
+        "value": "{{bearerToken}}",
+        "type": "string"
+      }
+    ]
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "requests": {},
+        "exec": [
+          "pm.request.headers.upsert({ key: 'X-Tenant-ID',     value: pm.collectionVariables.get('tenantId') || 'fc4d0001-0000-0000-0000-000000000001' });",
+          "pm.request.headers.upsert({ key: 'X-Forwarded-For', value: '127.0.0.1' });",
+          "pm.request.headers.upsert({ key: 'X-Forwarded-From',value: 'postman' });",
+          "pm.request.headers.upsert({ key: 'platform',        value: 'web' });",
+          "pm.request.headers.upsert({ key: 'deviceId',        value: 'postman-device-001' });"
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "packages": {},
+        "requests": {},
+        "exec": [
+          ""
+        ]
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "https://sandbox.finhub.cloud"
+    },
+    {
+      "key": "tenantId",
+      "value": "fc4d0001-0000-0000-0000-000000000001"
+    },
+    {
+      "key": "bearerToken",
+      "value": ""
+    },
+    {
+      "key": "cardId",
+      "value": ""
+    },
+    {
+      "key": "accountId",
+      "value": ""
+    },
+    {
+      "key": "accountId2",
+      "value": ""
+    },
+    {
+      "key": "holderId",
+      "value": ""
+    },
+    {
+      "key": "fileId",
+      "value": "mock-file-id-001"
+    },
+    {
+      "key": "workOrderNo",
+      "value": ""
+    }
+  ]
+}

--- a/docs/superpowers/specs/2026-07-06-fincard-card-issuing-design.md
+++ b/docs/superpowers/specs/2026-07-06-fincard-card-issuing-design.md
@@ -1,0 +1,282 @@
+# FinCard Card Issuing — Integration Design
+
+- **Status:** Approved (design shape) 2026-07-06 — implementation in phases.
+- **Partner:** FinCard Virtual Card BFF, operated by FinHub (`finhub.cloud`, a SEPA Cyber Technologies group product).
+- **Source artifacts:** `docs/partners/FinCard_BFF_Virtual_Card_API_Test_Tenant_Mock_postman_collection.json` (mock test-tenant collection); public docs at `https://docs.finhub.cloud/paas/fincard-virtual/`.
+- **Related:** `config/cardissuance.php` (issuer registry), `app/Domain/CardIssuance/` (existing domain), ADR-0005/0006 (Bridge), `docs/operations/bridge-ramp.md` (partner-ops precedent).
+
+---
+
+## 1. Summary & decisions
+
+FinCard is the card-issuing partner Zelta will use to launch its virtual card product. It is a **prefunded, stored-value virtual card program** — architecturally different from the JIT-funded issuers (Marqeta/Lithic/Stripe Issuing) the existing `CardIssuerInterface` was designed around. FinCard holds a per-tenant fiat "account" ledger that we fund (with crypto or fiat), and cards spend from a balance moved onto them; authorization happens inside FinCard and is reported to us by webhook.
+
+Product decisions (locked 2026-07-06):
+
+| Decision | Choice |
+|---|---|
+| **Funding** | Both crypto (USDT from the user's Zelta wallet) **and** fiat (via the existing Bridge ramp). Crypto ships first (unblocked); fiat second. |
+| **KYC** | Dedicated FinCard KYC, prefilled from the user's Zelta profile. No reliance on third-party KYC passthrough (FinCard performs its own verification). |
+| **v1 scope** | Virtual cards only, viewed in-app. **No** Apple/Google Pay tokenization, **no** physical cards. |
+| **Custody** | One FinCard account per Zelta user. |
+
+The integration extends the existing `CardIssuance` domain rather than creating a new one: FinCard becomes `CARD_ISSUER=fincard`, a new adapter + a companion funding contract + local persistence + a webhook handler.
+
+---
+
+## 2. What FinCard is (corrected from public docs)
+
+The mock collection is a stale, simplified subset of FinCard's real API. The authoritative facts, from `docs.finhub.cloud/paas/fincard-virtual/`:
+
+- **BFF/aggregator model.** "FinHub BFF" (`/api/v2.1/fincard/virtual/...`) wraps an upstream "FinCard Virtual" card platform. FinHub is an EU BaaS marketplace (SEPA Cyber Technologies, Bulgaria/UK); it is **not** the license holder — the upstream issuer / BIN sponsor is not publicly disclosed (open item).
+- **RPC-over-POST.** Every call is a `POST` with a JSON body, including reads and lists (`pageNum`/`pageSize`). Client idempotency key is `merchantOrderNo` on mutating calls.
+- **Response envelope:** `{ "success": bool, "code": int, "msg": string, "data": ... }` (note `msg`, not `message`).
+- **Base URLs:** sandbox `https://sandbox.finhub.cloud/api/v2.1/fincard/virtual`; integration/beta `https://api-beta.finhub.cloud/...`; production `https://api.finhub.cloud/...`.
+- **Four resource layers:** Cardholder (KYC identity) → Account (fiat USD ledger) → Card (spendable balance, opened against an account + cardholder). Wallet-V2 (crypto deposit) credits an Account.
+- **Card networks:** Visa, Mastercard, Discover. v1 uses whatever virtual BIN(s) the tenant is provisioned for (`card/v2/cardTypes`).
+
+### 2.1 Authentication (outbound: us → FinHub BFF)
+
+- **We do NOT sign outbound requests.** The `X-WSB-SIGNATURE` header in the mock is a **Playground placeholder** (`valid_signature_12345`). The RSA signing that reaches the upstream FinCard production API is performed **inside FinHub's BFF**, not by us. Playground/sandbox tenants accept the placeholder; Integration tenants have FinHub sign on our behalf.
+- **Auth = JWT bearer.** Obtained via `POST /api/v2.1/admin/organization/{orgId}/users/{userId}/sessions` with `{username, password}` → `data.accessToken`. Token `expiresIn: 3600` (1 hour), **no refresh token** → cache and re-login before expiry.
+- **Required context headers on every call:** `Authorization: Bearer <jwt>`, `Content-Type: application/json`, `X-Tenant-ID`, `X-Forwarded-For` (end-user IP), `X-Forwarded-From` (originating service name), `platform` (`web`|`ios`|`android`), `deviceId`.
+
+### 2.2 Webhooks (inbound: FinCard → us)
+
+- **Signature is RSA, inbound only.** Each webhook carries `SHA256withRSA(rawBody)` base64-encoded, verified against FinCard's **platform RSA public key**. This is the same shape as the existing `BridgeWebhookVerifier` (asymmetric RSA over the raw body) and is copy-and-adapt.
+- **Header name is ambiguous** in FinCard's own materials: `X-FC-SIGNATURE` (narrative webhooks page) vs `X-WSB-SIGNATURE` (API reference + mock). Our verifier will **accept either header** and this must be confirmed with FinCard (open item), along with obtaining the public key.
+- **Retries + idempotency.** The platform retries failed deliveries; we must process idempotently keyed on `orderNo`/`tradeNo` and reply `{"success": true}`.
+- **Event catalog (8 categories).** The real `type` values differ from the mock's `card_create`:
+  - *Card operation:* `create`, `deposit`, `withdraw`, `Freeze`, `UnFreeze`, `cancel`, `blocked`, `overdraft_statement`
+  - *Card authorization (spend):* `auth`, `refund`, `verification`, `Void`
+  - *Card auth fee:* `maintain_fee`, `card_patch_fee`, `card_patch_cross_border`
+  - *Card 3DS:* `third_3ds_otp`, `auth_url`, `activation_code`
+  - *Activate (physical):* `card_activated` *(out of v1 scope)*
+  - *Cardholder:* `wait_audit`, `under_review`, `pass_audit`, `reject`
+  - *Work order:* `processing`, `success`, `fail`
+  - *Wallet V2 (crypto):* `DEPOSIT`, `WITHDRAW`
+
+### 2.3 KYC (heavier than the mock)
+
+Cardholder-V2 create requires far more than the mock body:
+`firstName`, `lastName`, `gender`, `birthday`, `nationality` (ISO-2), `occupation` (from `card/holder/occupations`), `annualSalary`, `expectedMonthlyVolume`, `accountPurpose`, `phone` + `phoneCountryCode`, `email`, full address, `idType` (`PASSPORT` | `DLN` | `GOVERNMENT_ISSUED_ID_CARD` — **not** the mock's `NATIONAL_ID`), `idNumber`, `issueDate`, `idNoExpiryDate`, **three uploaded photos** (`idFrontId`, `idBackId`, and a selfie/hold `idHoldId`), and `ipAddress`.
+
+Approval is **two-stage**: `admin` (FinHub platform review) → `channel` (bank review), surfaced as cardholder webhooks `wait_audit → pass_audit | under_review | reject`. **Cards can only be created after `pass_audit`.** FinCard maintains a restricted-country list (enforced by them; we mirror a check to fail fast).
+
+### 2.4 Crypto funding
+
+`wallet/v2/create` with a `coinKey` returns a per-coin deposit **address**; the user deposits stablecoin; FinCard **converts crypto → USD** on receipt (fees `feeRate%` + `fixedFee`; ~38 confirmations for TRC20) and credits the merchant account, firing a wallet `DEPOSIT` webhook. Documented coins are `USDT_TRC20` and `USDT_BEP20`; **USDC is not confirmed** — the live set comes from `wallet/v2/coins` (fields: `coinKey, chain, enableDeposit, confirmations, depositFee, minDepositAmount, maxDepositAmount, …`), which we treat as the runtime source of truth.
+
+---
+
+## 3. Architecture
+
+FinCard extends the existing `app/Domain/CardIssuance/` domain. Three seams are added.
+
+### 3.1 Infrastructure client — `app/Infrastructure/FinCard/`
+
+Placed in `Infrastructure` (like `app/Infrastructure/Bridge/`) because both the domain adapter and the webhook controller consume it.
+
+- **`FinCardClient`** — the outbound HTTP layer.
+  - `fromConfig()` factory reading `config('cardissuance.issuers.fincard.*')`.
+  - Cached JWT session auth mirroring `OndatoService::getAccessToken()`: `Cache::get('fincard:jwt')` → on miss, `POST .../sessions`, cache for ~55 min (`expiresIn - 300s`), re-login on a `401`/expiry.
+  - A single private `rpc(string $path, array $params, array $context): array` that POSTs to `{base_url}{path}`, injects the bearer + context headers, `->timeout(30)->retry(2, 500, throw: false)`, and decodes the `{success, code, msg, data}` envelope — throwing `FinCardApiException` (carrying `code` + `msg`) on `success=false` or transport failure, logging `path/code/msg` first (never the body — it holds PII/PAN).
+  - Typed public methods per endpoint group (auth, common/reference, account, wallet, cardholder, card).
+  - `X-Forwarded-For`/`deviceId`/`platform` are passed **per call** from the originating mobile request context (not static), so FinCard's fraud/geo signals reflect the real end user.
+- **`FinCardWebhookVerifier`** — RSA verification, modeled on `BridgeWebhookVerifier`: `openssl_verify($rawBody, base64_decode($sig), $publicKey, OPENSSL_ALGO_SHA256) === 1`, accepting `X-FC-SIGNATURE` or `X-WSB-SIGNATURE`, with the "accept in non-prod, fail closed in production" idiom when no key is configured.
+- **`FinCardApiException`** — carries FinCard's business `code` + `msg` for mapping to our `ERR_CARDS_*` responses.
+
+### 3.2 Domain contracts & adapter — `app/Domain/CardIssuance/`
+
+- **`FinCardCardIssuerAdapter implements CardIssuerInterface`** — satisfies the existing 9-method lifecycle contract (`createCard`, `freezeCard`, `unfreezeCard`, `cancelCard`, `getCard`, `listUserCards`, `getTransactions`, `getName`). `getProvisioningData()` throws `UnsupportedCardOperationException` (no Apple/Google Pay in v1). This keeps `CardProvisioningService`, the GraphQL mutations, and the existing `CardController` lifecycle routes working through the standard seam.
+- **`FinCardFundingInterface`** (new companion contract) — the prefunded operations the base interface cannot express:
+  `createCardholder`, `uploadKycDocument`, `getCardholder`, `createAccount`, `getAccountBalance`, `listAccountTransactions`, `createDepositAddress`, `listCoins`, `openCard`, `topUpCard`, `withdrawFromCard`, `getCardBalance`, `getSensitiveCardDetails`, `getPurchaseTransactions`, `get3dsTransactions`. `FinCardCardIssuerAdapter` implements this too; other issuers do not.
+- **`FinCardCardService`** — orchestration + **local persistence** (the crux). The current adapter/`VirtualCard` path never writes `cards`/`cardholders`; FinCard entities are long-lived and must be mapped to Zelta users. This service wraps the adapter, persists to the tables in §4, enforces our own limits, dispatches domain events, and is what the new mobile controllers depend on.
+
+### 3.3 Selection & wiring
+
+- `config/cardissuance.php` gains a `fincard` issuer stanza; `CardIssuanceServiceProvider::register()` gains a `'fincard' => new FinCardCardIssuerAdapter(FinCardClient::fromConfig(), ...)` match arm and binds `FinCardFundingInterface`.
+- `ValidateWebhookSignature` gains a `fincard` arm **or** (preferred) FinCard gets its own webhook route with a dedicated controller that calls `FinCardWebhookVerifier` directly (cleaner, since FinCard's RSA scheme differs from the Marqeta basic-auth arm).
+
+---
+
+## 4. Data model
+
+Reuse existing partner hooks and add FinCard-specific persistence. All sensitive material uses Laravel's `encrypted`/`encrypted:array` cast over `text` columns.
+
+### New tables
+
+- **`fincard_accounts`** — one per user.
+  `id` (uuid), `user_id` (FK), `fincard_account_id` (unique, indexed), `currency` (default `USD`), `balance_cents` (bigint), `status`, `created_at`/`updated_at`. `UsesTenantConnection`.
+- **`fincard_deposit_addresses`** — crypto deposit addresses.
+  `id` (uuid), `user_id` (FK), `fincard_account_id`, `coin_key` (e.g. `USDT_TRC20`), `chain`, `address` (indexed), `min_deposit_cents` nullable, `created_at`/`updated_at`. Unique `(user_id, coin_key)`.
+
+### Extend existing tables (new migrations)
+
+- **`cardholders`** — add `kyc_stage` (`admin`|`channel`|null), `kyc_rejection_reason` (nullable), and store the extended KYC attributes inside the existing encrypted `verification_data` blob (no new plaintext PII columns). `issuer_cardholder_id` already exists → FinCard `holderId`.
+- **`cards`** — add `balance_cents` (bigint, nullable), `fincard_account_id` (nullable, indexed), `merchant_order_no` (nullable, for idempotent open/reconcile). `issuer_card_token` already exists → FinCard `cardId`; `issuer` = `fincard`.
+
+### Reuse
+
+- **`card_transactions`** — purchase/auth/3DS history, upserted by `CardTransactionSyncService` keyed on `external_id` (FinCard `orderNo`/`tradeNo`). Add `type` (`purchase`|`auth`|`fee`|`3ds`|`refund`) to distinguish streams.
+- **`processed_webhook_events`** — dedupe with `provider='fincard'`, `event_id = orderNo` (or `tradeNo`). No new table.
+
+---
+
+## 5. Auth & session management
+
+`FinCardClient` holds no long-lived secret beyond the service-account `username`/`password` and `org`/`user`/`tenant` IDs (all from env/config). The JWT is cached in Redis under `fincard:jwt` with a TTL of `min(expiresIn, 3600) - 300` seconds. A `401` from any RPC triggers a single transparent re-login + retry (guarded against infinite loops). Concurrent cache-miss logins are de-duplicated with a short lock (`Cache::lock('fincard:jwt:login', 10)`) so a burst of requests doesn't spawn many logins.
+
+---
+
+## 6. Funding flows
+
+### 6.1 Crypto (ships first, non-custodial upstream)
+
+1. User has a `pass_audit` cardholder and a FinCard account (§7, §8).
+2. Mobile requests a deposit address → `FinCardCardService::getOrCreateDepositAddress(user, coinKey)` → `wallet/v2/create` → persisted in `fincard_deposit_addresses`, returned to mobile with the chain, min amount, and confirmations.
+3. User sends USDT from their **existing Zelta TRON/BSC wallet** (self-custody) to that address using the wallet they already have.
+4. FinCard converts crypto→USD, credits the account, fires a wallet `DEPOSIT` webhook → we update `fincard_accounts.balance_cents`, dispatch `FinCardAccountFunded`, broadcast + push.
+5. User opens a card (moves USD from account→card) or tops up an existing card.
+
+### 6.2 Fiat (ships second — one open dependency)
+
+The user's fiat enters through the **existing Bridge ramp**. FinCard's documented account-funding rails are **crypto-in and inter-account transfer only** — there is no documented direct fiat-into-account endpoint. So the default design routes fiat as a **treasury operation**: Bridge fiat → USDC/USDT → deposited to the FinCard account via the same crypto rail. **Open item:** confirm with FinCard whether a merchant account can be funded with fiat directly (bank wire / settlement rail); if so, the fiat path simplifies and skips the stablecoin hop. Because of this dependency, fiat funding is sequenced after crypto.
+
+### 6.3 Money handling
+
+All amounts are integer minor units (`*_cents`) end to end; conversions use `bcmath` (`bcmul`/`bcdiv`), never float. FinCard returns decimal strings — normalize with `bcadd($v, '0', 2)` before converting to cents. Deposit crediting follows the HyperSwitch webhook discipline: dedupe/claim on the default connection, then credit balances on the tenant connection in a **separate** transaction (cross-connection transactions self-deadlock); the credited amount always comes from the webhook's settled figure reconciled against our record, never blind trust.
+
+---
+
+## 7. KYC / cardholder flow
+
+1. **Prefill.** Mobile opens the card-onboarding flow; backend returns a prefilled cardholder draft from the Zelta profile (name, DOB, nationality, address) plus the FinCard-required-field schema (occupation list from `card/holder/occupations`, ID types, financial fields).
+2. **Document upload.** Each of the three photos is uploaded via FinCard `common/file/upload` → returns a `fileId`; we hold the ids transiently (not the images).
+3. **Create cardholder.** `card/holder/v2/create` with the full field set → `holderId`; persist to `cardholders` (`issuer_cardholder_id`, `kyc_status='in_review'`, `kyc_stage='admin'`).
+4. **Approval tracking.** Cardholder webhooks drive `kyc_status`/`kyc_stage`: `under_review` → still pending; `pass_audit` → `verified` (card creation unlocked); `reject` → `rejected` + `kyc_rejection_reason`. Each transition broadcasts on `private-user.{userId}` (`fincard.kyc.*`) and sends a push on the terminal states.
+5. **Restricted country** is checked before submission to fail fast with a clear error.
+
+Prefill reduces friction but the user still supplies FinCard-specific fields and a live selfie; we do not claim third-party KYC passthrough.
+
+---
+
+## 8. Card lifecycle
+
+Gated on a `pass_audit` cardholder + a funded account.
+
+- **Open card** — `card/v2/openCard` (`cardTypeId`, `amount`, `accountId`, `holderId`, `merchantOrderNo`) → persist `cards` row (`issuer_card_token`, `balance_cents`, `fincard_account_id`, `status='active'`). `create` webhook confirms.
+- **Read** — card info, **sensitive details** (PAN/CVV via `card/info/sensitive`, returned ephemerally to mobile over TLS, never persisted plaintext), balance, list.
+- **Control** — freeze / unfreeze / cancel (map FinCard status ↔ our `CardStatus`).
+- **Fund movement** — top-up (`card/deposit`) and withdraw (`card/withdraw`) between account and card.
+- **Transactions** — purchase, operation, authorization, auth-fee, and 3DS streams synced via webhooks (primary) + `CardTransactionSyncService::pollAndSync()` (reconciliation backstop).
+
+### Status mapping (FinCard → `CardStatus`)
+
+`Normal → active`, frozen states → `frozen`, `cancel`/closed → `cancelled`, pending open → `pending`, `blocked` → `frozen` (with a distinct reason surfaced). Networks fold into the existing `CardNetwork` enum (extend with `discover` if a Discover BIN is provisioned).
+
+---
+
+## 9. Webhooks
+
+- **Route:** `POST /api/v1/webhooks/fincard` (public, `api.rate_limit:webhook`, no Sanctum — authenticated by signature), matching the Bridge/HyperSwitch route shape.
+- **Controller flow** (Bridge/HyperSwitch discipline): read raw body → `FinCardWebhookVerifier::verify()` (401 on fail) → decode → extract event `type` + `orderNo`/`tradeNo` → `ProcessedWebhookEvent::firstOrCreate(['provider'=>'fincard','event_id'=>$orderNo])`; if not `wasRecentlyCreated`, reply `{"success":true}` (duplicate) → dispatch by category to a handler → reply `{"success":true}`. Handlers run in `try/catch`, log-and-swallow (the dedupe row + FinCard's own retry guard against loss), and apply state inside `DB::transaction` + `lockForUpdate` on the target row, with slow side-effects (push/broadcast) **outside** the transaction.
+- **Handlers by category:** cardholder → KYC state; wallet `DEPOSIT`/`WITHDRAW` → account balance; card-op `create/deposit/withdraw/Freeze/UnFreeze/cancel/blocked` → card state + balance; auth/refund/verification/Void + auth-fee + 3DS → `card_transactions` via `CardTransactionSyncService`.
+
+---
+
+## 10. Mobile API surface
+
+New/extended `/api/v1/cards/*` and `/api/v1/cardholders/*` endpoints. Conventions (from the existing mobile surface): `{success, data}` success envelope; `ErrorResponse::make('ERR_CARDS_*', …)` errors (register new codes in `config/error_codes.php`; `ERR_CARDS_001..006` already exist); **snake_case** bodies (match existing `CardController`); `Idempotency-Key` header + `idempotency.required` on writes; `require.kyc` (Zelta-level) on the group, plus a FinCard-KYC gate in-service; list responses add `pagination:{next_cursor,has_more,total}`; `#[OA\*]` annotations regenerated via `l5-swagger:generate`.
+
+| Method & path | Purpose |
+|---|---|
+| `GET /v1/cards/onboarding` | Prefilled cardholder draft + FinCard field schema (occupations, id types) |
+| `POST /v1/cards/kyc/documents` | Upload an ID photo → `fileId` (front/back/selfie) |
+| `POST /v1/cardholders` | Create FinCard cardholder (extends existing) |
+| `GET /v1/cardholders/{id}` | Cardholder + KYC stage/status |
+| `GET /v1/cards/reference/card-types` | Supported card types (BINs) |
+| `GET /v1/cards/account` | FinCard account + balance |
+| `POST /v1/cards/account/deposit-address` | Get/create a crypto deposit address (`coin_key`) |
+| `GET /v1/cards/account/coins` | Supported deposit coins (live from FinCard) |
+| `GET /v1/cards` | List the user's cards *(exists)* |
+| `POST /v1/cards` | Open a card *(exists — routed to FinCard)* |
+| `GET /v1/cards/{cardId}` | Card info *(exists)* |
+| `GET /v1/cards/{cardId}/sensitive` | Ephemeral PAN/CVV |
+| `GET /v1/cards/{cardId}/balance` | Card balance |
+| `POST /v1/cards/{cardId}/topup` | Move funds account→card |
+| `POST /v1/cards/{cardId}/withdraw` | Move funds card→account |
+| `POST /v1/cards/{cardId}/freeze` · `DELETE .../freeze` | Freeze / unfreeze *(exists)* |
+| `DELETE /v1/cards/{cardId}` | Cancel *(exists — biometric-gated)* |
+| `GET /v1/cards/{cardId}/transactions` | Purchase history *(exists — extend with type filter)* |
+
+Realtime: card/KYC/funding state changes raise domain events → queued listener dispatches a `CardStateChanged`/`FinCardKycStatusChanged`/`FinCardAccountFunded` broadcast on `private-user.{userId}` and calls `PushNotificationService::sendToUser(...)` (respecting notification preferences), matching the wallet/payments pattern.
+
+A separate **mobile-developer spec** (`docs/mobile/FINCARD_CARD_INTEGRATION.md`) documents request/response bodies, error codes, socket events, and the end-to-end flow for the app team.
+
+---
+
+## 11. Config, env & ops
+
+`config/cardissuance.php` `issuers.fincard`:
+
+```php
+'fincard' => [
+    'driver'              => 'fincard',
+    'base_url'            => env('FINCARD_BASE_URL', 'https://sandbox.finhub.cloud/api/v2.1/fincard/virtual'),
+    'tenant_id'           => env('FINCARD_TENANT_ID'),
+    'org_id'              => env('FINCARD_ORG_ID'),
+    'user_id'             => env('FINCARD_USER_ID'),
+    'username'            => env('FINCARD_USERNAME'),
+    'password'            => env('FINCARD_PASSWORD'),
+    'forwarded_from'      => env('FINCARD_FORWARDED_FROM', 'zelta'),
+    'webhook_public_key'  => env('FINCARD_WEBHOOK_PUBLIC_KEY', ''),
+    'default_card_type_id'=> env('FINCARD_DEFAULT_CARD_TYPE_ID'),
+    'default_coin_key'    => env('FINCARD_DEFAULT_COIN_KEY', 'USDT_TRC20'),
+],
+```
+
+Env keys mirrored into `.env.production.example` and `.env.zelta.example` (a `# FinCard` block). `OpsVerifyEnvCommand::checkConditional()` gains a FinCard block: when `CARD_ISSUER=fincard`, FAIL if `tenant_id`/`username`/`password`/`webhook_public_key` are empty (matching the HyperSwitch conditional). `CardIssuanceServiceProvider::boot()` logs a production warning when the webhook public key is missing.
+
+---
+
+## 12. Security & compliance
+
+- **PCI:** PAN/CVV from `card/info/sensitive` are relayed to mobile ephemerally over TLS and **never persisted** (not even encrypted-at-rest); no logging of card bodies. If FinCard offers a hosted/tokenized sensitive-data channel, prefer it (open item).
+- **PII:** KYC attributes live only in the encrypted `verification_data` blob; ID images are never stored (only transient `fileId`s). Webhook/RPC logging is restricted to `path/code/msg`, never bodies.
+- **Custody note:** funding a card moves value from the user's self-custody wallet into FinCard's custody — inherent to cards and made explicit in-product. Until deposit, funds remain non-custodial.
+- **Idempotency & races:** `merchantOrderNo` on every mutating FinCard call; `processed_webhook_events` on inbound; `lockForUpdate` on balance mutations; cross-connection credit kept out of the claim transaction.
+- **Restricted countries** checked pre-submission.
+
+---
+
+## 13. Delivery phases (one PR each)
+
+1. **Foundations** — `FinCardClient` (auth/session/RPC/context headers), `FinCardApiException`, `FinCardWebhookVerifier`, config stanza + env + `ops:verify-env` conditional + provider wiring, webhook route/controller skeleton, reference-data passthrough (regions/cities/occupations/card-types/coins). Unblocked against sandbox Playground. *(This session.)*
+2. **KYC / cardholder** — file upload, Cardholder-V2 create, approval webhooks + state machine, mobile onboarding/KYC endpoints, prefill, restricted-country check.
+3. **Account + crypto funding** — per-user account provisioning, deposit-address create, wallet `DEPOSIT`/`WITHDRAW` webhook credit, balance endpoints.
+4. **Card lifecycle** — open/get/sensitive/balance/freeze/unfreeze/cancel/top-up/withdraw + transaction sync (purchase/auth/fee/3DS) + realtime/push.
+5. **Fiat funding + polish** — Bridge→FinCard treasury path (pending the fiat-rail confirmation), Filament admin visibility, OpenAPI regen, reconciliation cron, docs.
+
+---
+
+## 14. Open dependencies (to confirm with FinCard — none block phases 1–2)
+
+1. Production webhook **header name** (`X-FC-SIGNATURE` vs `X-WSB-SIGNATURE`) and the **RSA public key** for verification.
+2. FinCard-PaaS **business error `code` catalog** (the `code` integer values and meanings).
+3. Authoritative **supported-coin list**, min/max deposit, and **FX rate methodology** (pull live from `wallet/v2/coins`; confirm FX).
+4. Whether an account can be **funded with fiat directly** (determines whether the fiat path needs the stablecoin hop).
+5. **Upstream issuer / BIN sponsor identity** and the regulatory license under which cards are issued.
+6. Formal confirmation that FinCard **performs its own KYC** (no third-party passthrough) and the review SLA.
+7. Production **credentials** (org/user/tenant IDs, service-account username/password) and Integration-tenant onboarding.
+
+---
+
+## 15. Testing strategy
+
+- **Unit:** `FinCardClient` envelope decode + error mapping + token caching/re-login (HTTP faked); `FinCardWebhookVerifier` RSA verify (fixture keypair) incl. both header names and the fail-closed-in-prod path; status/network mapping.
+- **Feature:** mobile endpoints (auth, validation, envelopes, idempotency, KYC gating) with the FinCard client faked.
+- **Webhook:** signed-payload dedupe + each event category's state transition; replay returns duplicate; malformed/wrong-signature → 401.
+- **MultiConnection:** account-credit + card-balance writes against real MySQL (tenant connection), asserting no cross-connection deadlock and the `account_balances.asset_code → assets.code` FK is seeded.
+- **Money:** bcmath/cents assertions; no float paths.
+```

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -24,6 +24,27 @@
         }
     ],
     "paths": {
+        "/api/v1/webhooks/fincard": {
+            "post": {
+                "tags": [
+                    "FinCard Webhooks"
+                ],
+                "summary": "FinCard (FinHub) platform event webhook",
+                "description": "RSA-signature-verified (SHA256withRSA over the raw body, base64) against FinCard's platform public key. Accepts the X-FC-SIGNATURE or X-WSB-SIGNATURE header. Idempotent via processed_webhook_events.",
+                "operationId": "v1FinCardWebhook",
+                "responses": {
+                    "200": {
+                        "description": "Event accepted (or ignored as duplicate)"
+                    },
+                    "401": {
+                        "description": "Invalid signature"
+                    },
+                    "400": {
+                        "description": "Invalid payload"
+                    }
+                }
+            }
+        },
         "/api/v1/subscription/iap/verify": {
             "post": {
                 "tags": [
@@ -62342,6 +62363,10 @@
         {
             "name": "X402 Protocol",
             "description": "HTTP 402 Payment Protocol - native micropayments for APIs"
+        },
+        {
+            "name": "FinCard Webhooks",
+            "description": "FinCard Webhooks"
         },
         {
             "name": "Subscription",

--- a/tests/Feature/Api/FinCard/FinCardWebhookEndpointTest.php
+++ b/tests/Feature/Api/FinCard/FinCardWebhookEndpointTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * Endpoint tests for POST /api/v1/webhooks/fincard.
+ *
+ * Verifies the Phase-1 webhook contract: RSA-signature auth, JSON validation,
+ * idempotent dedupe on processed_webhook_events, and the `{"success": true}`
+ * acknowledgement FinCard expects to stop retrying.
+ */
+
+declare(strict_types=1);
+
+use App\Domain\Subscription\Models\ProcessedWebhookEvent;
+use App\Infrastructure\FinCard\FinCardWebhookVerifier;
+
+/**
+ * @return array{0: string, 1: string} [privatePem, publicPem]
+ */
+function fincardEndpointKeypair(): array
+{
+    $res = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+    if ($res === false) {
+        throw new RuntimeException('openssl_pkey_new failed');
+    }
+    openssl_pkey_export($res, $priv);
+    $details = openssl_pkey_get_details($res);
+
+    return [(string) $priv, (string) ($details['key'] ?? '')];
+}
+
+function fincardEndpointSign(string $body, string $priv): string
+{
+    openssl_sign($body, $sig, $priv, OPENSSL_ALGO_SHA256);
+
+    return base64_encode($sig);
+}
+
+/**
+ * Build the PHP `$server` array carrying a signature header for the call().
+ *
+ * @return array<string, string>
+ */
+function fincardWebhookServer(string $header, string $value): array
+{
+    return [
+        'CONTENT_TYPE'                                       => 'application/json',
+        'HTTP_' . str_replace('-', '_', strtoupper($header)) => $value,
+    ];
+}
+
+beforeEach(function () {
+    [$priv, $pub] = fincardEndpointKeypair();
+    $this->finCardPriv = $priv;
+    // Inject a verifier with a known key so the signed fixture verifies.
+    $this->app->instance(FinCardWebhookVerifier::class, new FinCardWebhookVerifier($pub));
+});
+
+it('accepts a validly signed event, records it, and acknowledges success', function () {
+    $body = (string) json_encode(['eventType' => 'create', 'data' => ['orderNo' => 'ord-123', 'cardId' => 'c1']]);
+    $sig = fincardEndpointSign($body, $this->finCardPriv);
+
+    $this->call('POST', '/api/v1/webhooks/fincard', [], [], [], fincardWebhookServer('X-FC-SIGNATURE', $sig), $body)
+        ->assertOk()
+        ->assertExactJson(['success' => true]);
+
+    expect(ProcessedWebhookEvent::where('provider', 'fincard')->where('event_id', 'ord-123')->count())->toBe(1);
+});
+
+it('accepts the signature under the legacy X-WSB-SIGNATURE header too', function () {
+    $body = (string) json_encode(['eventType' => 'deposit', 'data' => ['orderNo' => 'ord-wsb']]);
+    $sig = fincardEndpointSign($body, $this->finCardPriv);
+
+    $this->call('POST', '/api/v1/webhooks/fincard', [], [], [], fincardWebhookServer('X-WSB-SIGNATURE', $sig), $body)
+        ->assertOk()
+        ->assertExactJson(['success' => true]);
+});
+
+it('is idempotent across duplicate deliveries', function () {
+    $body = (string) json_encode(['eventType' => 'create', 'data' => ['orderNo' => 'ord-dup']]);
+    $sig = fincardEndpointSign($body, $this->finCardPriv);
+    $server = fincardWebhookServer('X-FC-SIGNATURE', $sig);
+
+    $this->call('POST', '/api/v1/webhooks/fincard', [], [], [], $server, $body)->assertOk()->assertExactJson(['success' => true]);
+    $this->call('POST', '/api/v1/webhooks/fincard', [], [], [], $server, $body)->assertOk()->assertExactJson(['success' => true]);
+
+    expect(ProcessedWebhookEvent::where('provider', 'fincard')->where('event_id', 'ord-dup')->count())->toBe(1);
+});
+
+it('rejects an invalid signature with 401', function () {
+    $body = (string) json_encode(['eventType' => 'create', 'data' => ['orderNo' => 'ord-x']]);
+
+    $this->call('POST', '/api/v1/webhooks/fincard', [], [], [], fincardWebhookServer('X-FC-SIGNATURE', base64_encode('garbage')), $body)
+        ->assertStatus(401);
+
+    expect(ProcessedWebhookEvent::where('event_id', 'ord-x')->exists())->toBeFalse();
+});
+
+it('rejects a validly signed but identifier-less payload with 400', function () {
+    $body = (string) json_encode(['data' => []]);
+    $sig = fincardEndpointSign($body, $this->finCardPriv);
+
+    $this->call('POST', '/api/v1/webhooks/fincard', [], [], [], fincardWebhookServer('X-FC-SIGNATURE', $sig), $body)
+        ->assertStatus(400);
+});

--- a/tests/Feature/Api/FinCard/FinCardWebhookVerifierTest.php
+++ b/tests/Feature/Api/FinCard/FinCardWebhookVerifierTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * Tests for FinCardWebhookVerifier.
+ *
+ * FinCard signs webhooks with SHA256withRSA over the RAW body (no timestamp
+ * wrapper), base64-encoded, delivered in either the X-FC-SIGNATURE or
+ * X-WSB-SIGNATURE header. The public key is FinCard's platform key.
+ */
+
+declare(strict_types=1);
+
+use App\Infrastructure\FinCard\FinCardWebhookVerifier;
+
+/**
+ * @return array{0: string, 1: string} [privatePem, publicPem]
+ */
+function finCardTestKeypair(): array
+{
+    $res = openssl_pkey_new([
+        'private_key_bits' => 2048,
+        'private_key_type' => OPENSSL_KEYTYPE_RSA,
+    ]);
+    if ($res === false) {
+        throw new RuntimeException('openssl_pkey_new failed: ' . openssl_error_string());
+    }
+
+    openssl_pkey_export($res, $privatePem);
+    $details = openssl_pkey_get_details($res);
+    if ($details === false) {
+        throw new RuntimeException('openssl_pkey_get_details failed');
+    }
+
+    return [(string) $privatePem, (string) $details['key']];
+}
+
+/** Produce a valid base64 SHA256withRSA signature over the raw body. */
+function signFinCard(string $body, string $privatePem): string
+{
+    $ok = openssl_sign($body, $rawSig, $privatePem, OPENSSL_ALGO_SHA256);
+    if ($ok === false) {
+        throw new RuntimeException('openssl_sign failed: ' . openssl_error_string());
+    }
+
+    return base64_encode($rawSig);
+}
+
+it('accepts a valid RSA signature over the raw body', function () {
+    [$priv, $pub] = finCardTestKeypair();
+    $body = '{"eventType":"create","data":{"cardId":"c1"}}';
+
+    $verifier = new FinCardWebhookVerifier($pub);
+
+    expect($verifier->verify($body, signFinCard($body, $priv)))->toBeTrue();
+});
+
+it('rejects a tampered body', function () {
+    [$priv, $pub] = finCardTestKeypair();
+    $body = '{"eventType":"create"}';
+    $sig = signFinCard($body, $priv);
+
+    $verifier = new FinCardWebhookVerifier($pub);
+
+    expect($verifier->verify($body . ' ', $sig))->toBeFalse();
+});
+
+it('rejects a signature made with the wrong key', function () {
+    [$privAttacker] = finCardTestKeypair();
+    [, $pubReal] = finCardTestKeypair();
+    $body = '{"eventType":"create"}';
+
+    $verifier = new FinCardWebhookVerifier($pubReal);
+
+    expect($verifier->verify($body, signFinCard($body, $privAttacker)))->toBeFalse();
+});
+
+it('rejects an empty or non-base64 signature', function () {
+    [, $pub] = finCardTestKeypair();
+    $verifier = new FinCardWebhookVerifier($pub);
+
+    expect($verifier->verify('{}', ''))->toBeFalse()
+        ->and($verifier->verify('{}', '!!!not base64!!!'))->toBeFalse();
+});
+
+it('accepts any request in non-production when no key is configured (dev passthrough)', function () {
+    $verifier = new FinCardWebhookVerifier('');
+
+    expect($verifier->verify('{}', 'anything'))->toBeTrue();
+});
+
+it('fails closed in production when no key is configured', function () {
+    $original = app()->environment();
+    app()->detectEnvironment(fn () => 'production');
+
+    try {
+        $verifier = new FinCardWebhookVerifier('');
+        expect($verifier->verify('{}', 'anything'))->toBeFalse();
+    } finally {
+        app()->detectEnvironment(fn () => $original);
+    }
+});
+
+it('normalizes a base64-encoded PEM public key', function () {
+    [$priv, $pub] = finCardTestKeypair();
+    $body = '{"eventType":"create"}';
+
+    // FinCard's key pasted as a single-line base64 blob (a friendly .env form).
+    $verifier = new FinCardWebhookVerifier(base64_encode($pub));
+
+    expect($verifier->verify($body, signFinCard($body, $priv)))->toBeTrue();
+});
+
+it('resolves the signature from either header name', function () {
+    // X-FC-SIGNATURE preferred.
+    expect(FinCardWebhookVerifier::signatureFrom(fn (string $h): ?string => match ($h) {
+        'X-FC-SIGNATURE' => 'fc-sig',
+        default          => null,
+    }))->toBe('fc-sig');
+
+    // Falls back to X-WSB-SIGNATURE.
+    expect(FinCardWebhookVerifier::signatureFrom(fn (string $h): ?string => match ($h) {
+        'X-WSB-SIGNATURE' => 'wsb-sig',
+        default           => null,
+    }))->toBe('wsb-sig');
+
+    // Neither present → empty.
+    expect(FinCardWebhookVerifier::signatureFrom(fn (string $h): ?string => null))->toBe('');
+});

--- a/tests/Unit/Infrastructure/FinCard/FinCardClientTest.php
+++ b/tests/Unit/Infrastructure/FinCard/FinCardClientTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Infrastructure\FinCard;
+
+use App\Infrastructure\FinCard\FinCardApiException;
+use App\Infrastructure\FinCard\FinCardClient;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class FinCardClientTest extends TestCase
+{
+    private FinCardClient $client;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['cache.default' => 'array']);
+        Cache::flush();
+
+        $this->client = new FinCardClient(
+            baseUrl: 'https://sandbox.finhub.cloud/api/v2.1/fincard/virtual',
+            tenantId: 'tenant-1',
+            orgId: 'ORG',
+            userId: 'USER',
+            username: 'svc',
+            password: 'pw',
+            forwardedFrom: 'zelta',
+        );
+    }
+
+    /**
+     * @return array<string, \GuzzleHttp\Promise\PromiseInterface>
+     */
+    private function loginFake(string $token = 'jwt-abc', int $expiresIn = 3600): array
+    {
+        return [
+            'sandbox.finhub.cloud/api/v2.1/admin/*' => Http::response([
+                'success' => true,
+                'code'    => 0,
+                'msg'     => 'ok',
+                'data'    => ['accessToken' => $token, 'expiresIn' => $expiresIn],
+            ]),
+        ];
+    }
+
+    public function test_login_caches_token_and_reuses_it(): void
+    {
+        Http::fake($this->loginFake('jwt-xyz'));
+
+        $this->assertSame('jwt-xyz', $this->client->getAccessToken());
+        // Second call must hit the cache, not the network.
+        $this->assertSame('jwt-xyz', $this->client->getAccessToken());
+
+        $adminCalls = collect(Http::recorded())
+            ->filter(fn (array $pair): bool => str_contains($pair[0]->url(), '/admin/'))
+            ->count();
+        $this->assertSame(1, $adminCalls, 'login should be performed once and then cached');
+    }
+
+    public function test_get_card_types_sends_bearer_and_context_headers(): void
+    {
+        Http::fake(array_merge($this->loginFake(), [
+            'sandbox.finhub.cloud/api/v2.1/fincard/virtual/card/v2/cardTypes' => Http::response([
+                'success' => true,
+                'code'    => 0,
+                'msg'     => 'ok',
+                'data'    => ['records' => [['cardTypeId' => 111001]]],
+            ]),
+        ]));
+
+        $result = $this->client->getCardTypes();
+
+        $this->assertTrue($result['success']);
+        $this->assertSame(111001, $result['data']['records'][0]['cardTypeId']);
+
+        Http::assertSent(function ($request): bool {
+            if (! str_contains($request->url(), '/card/v2/cardTypes')) {
+                return false;
+            }
+
+            return $request->hasHeader('Authorization', 'Bearer jwt-abc')
+                && $request->hasHeader('X-Tenant-ID', 'tenant-1')
+                && $request->hasHeader('X-Forwarded-From', 'zelta')
+                && $request->hasHeader('platform', 'web')
+                && $request->hasHeader('deviceId', 'zelta-server');
+        });
+    }
+
+    public function test_context_overrides_are_forwarded(): void
+    {
+        Http::fake(array_merge($this->loginFake(), [
+            'sandbox.finhub.cloud/api/v2.1/fincard/virtual/*' => Http::response([
+                'success' => true, 'code' => 0, 'msg' => 'ok', 'data' => [],
+            ]),
+        ]));
+
+        $this->client->getOccupations([
+            'platform'      => 'ios',
+            'device_id'     => 'device-42',
+            'forwarded_for' => '203.0.113.9',
+        ]);
+
+        Http::assertSent(fn ($request): bool => $request->hasHeader('platform', 'ios')
+            && $request->hasHeader('deviceId', 'device-42')
+            && $request->hasHeader('X-Forwarded-For', '203.0.113.9'));
+    }
+
+    public function test_rpc_throws_on_business_failure(): void
+    {
+        Http::fake(array_merge($this->loginFake(), [
+            'sandbox.finhub.cloud/api/v2.1/fincard/virtual/*' => Http::response([
+                'success' => false,
+                'code'    => 2003,
+                'msg'     => 'invalid region',
+                'data'    => null,
+            ]),
+        ]));
+
+        try {
+            $this->client->getCities('ZZ');
+            $this->fail('expected FinCardApiException');
+        } catch (FinCardApiException $e) {
+            $this->assertSame(2003, $e->apiCode);
+            $this->assertStringContainsString('invalid region', $e->getMessage());
+        }
+    }
+
+    public function test_rpc_throws_on_transport_failure(): void
+    {
+        Http::fake(array_merge($this->loginFake(), [
+            'sandbox.finhub.cloud/api/v2.1/fincard/virtual/*' => Http::response(['x' => 'y'], 503),
+        ]));
+
+        try {
+            $this->client->getCoins();
+            $this->fail('expected FinCardApiException');
+        } catch (FinCardApiException $e) {
+            $this->assertSame(503, $e->httpStatus);
+        }
+    }
+
+    public function test_rpc_reauthenticates_once_on_401(): void
+    {
+        Http::fake(array_merge($this->loginFake(), [
+            'sandbox.finhub.cloud/api/v2.1/fincard/virtual/*' => Http::sequence()
+                ->push(['success' => false, 'msg' => 'expired'], 401)
+                ->push(['success' => true, 'code' => 0, 'msg' => 'ok', 'data' => ['records' => []]], 200),
+        ]));
+
+        $result = $this->client->getCardTypes();
+
+        $this->assertTrue($result['success']);
+
+        // A fresh login happens on the initial miss AND after the 401 forgets it.
+        $adminCalls = collect(Http::recorded())
+            ->filter(fn (array $pair): bool => str_contains($pair[0]->url(), '/admin/'))
+            ->count();
+        $this->assertSame(2, $adminCalls);
+    }
+
+    public function test_empty_body_is_serialized_as_json_object(): void
+    {
+        Http::fake(array_merge($this->loginFake(), [
+            'sandbox.finhub.cloud/api/v2.1/fincard/virtual/*' => Http::response([
+                'success' => true, 'code' => 0, 'msg' => 'ok', 'data' => [],
+            ]),
+        ]));
+
+        $this->client->getCoins();
+
+        Http::assertSent(function ($request): bool {
+            if (! str_contains($request->url(), '/wallet/v2/coins')) {
+                return false;
+            }
+
+            // FinCard rejects a bare `[]`; an empty payload must be `{}`.
+            return $request->body() === '{}';
+        });
+    }
+
+    public function test_login_without_token_in_response_throws(): void
+    {
+        Http::fake([
+            'sandbox.finhub.cloud/api/v2.1/admin/*' => Http::response([
+                'success' => true, 'code' => 0, 'msg' => 'ok', 'data' => [],
+            ]),
+        ]);
+
+        $this->expectException(FinCardApiException::class);
+        $this->client->login();
+    }
+}


### PR DESCRIPTION
## FinCard card-issuing — Phase 1 (Foundations)

Introduces **FinCard** (finhub.cloud, a SEPA Cyber Technologies BaaS) as Zelta's card-issuing partner. FinCard is a **prefunded stored-value virtual card program** — architecturally different from the JIT-funded issuers (Marqeta/Lithic) the existing `CardIssuerInterface` was built for — so it needs a funding/account layer, local persistence, and RSA webhooks. This PR lays the foundations; the mobile-facing surface lands across follow-up phases.

Design spec: `docs/superpowers/specs/2026-07-06-fincard-card-issuing-design.md`
Mobile contract: `docs/FINCARD_MOBILE_INTEGRATION.md`

### What's in this PR

**Infrastructure — `app/Infrastructure/FinCard/`**
- **`FinCardClient`** — RPC-over-POST wrapper. Cached session-JWT auth (1h, no refresh token → re-login on `401`), required context headers (`X-Tenant-ID`, `X-Forwarded-For`/`-From`, `platform`, `deviceId`), `{success,code,msg,data}` envelope decode, and Phase-1 reference-data reads (regions/cities/occupations/card-types/coins). Retries **only** transient failures (connection + 5xx); a `401` falls through to re-auth rather than replaying a doomed request with a stale token.
- **`FinCardWebhookVerifier`** — `SHA256withRSA`-over-raw-body verification, accepts `X-FC-SIGNATURE` or `X-WSB-SIGNATURE`, fails closed in production when no key is configured (Bridge verifier idiom).
- **`FinCardApiException`** — preserves FinCard's business `code` for future `ERR_CARDS_*` mapping.

**Webhook** — `POST /api/v1/webhooks/fincard`: verify → dedupe (`processed_webhook_events`, `provider='fincard'`) → acknowledge `{"success":true}` (the body FinCard needs to stop retrying). Per-category handlers (KYC/funding/card/tx-sync) are a marked extension point for later phases.

**Wiring** — `config/cardissuance.php` `fincard` stanza; provider singletons + prod webhook-key warning; `ops:verify-env` FAILs when `CARD_ISSUER=fincard` and credentials/webhook key are missing; `# FinCard` env block in both `.env.production.example` and `.env.zelta.example`.

Off by default — `CARD_ISSUER` stays `marqeta`; nothing activates until FinCard credentials are set.

### Tests (21 passing)
- **Client:** token caching + reuse, context-header injection, envelope success + business-failure + transport-failure mapping, **401 re-auth** (caught a real bug — see below), `{}` empty-body serialization, tokenless-login guard.
- **Verifier:** valid/tampered/wrong-key RSA, dual header names, empty/non-base64 rejection, base64-PEM normalization, dev-passthrough vs prod fail-closed.
- **Webhook endpoint:** signed-accept + record, dual header, idempotent dedupe, `401` bad signature, `400` identifier-less.

Existing `OpsVerifyEnvCommandTest` still green (no regression). PHPStan L8 + php-cs-fixer clean.

> **Bug found & fixed during testing:** Laravel's `retry(…, throw: false)` still retries on 4xx, which silently replayed requests with the same expired token and masked the re-auth path. Fixed with a `when` predicate that retries only connection errors + 5xx (safe given `merchantOrderNo` idempotency), letting `401` reach the re-auth logic.

### Roadmap (one PR per phase)
1. **Foundations** ← this PR
2. KYC / cardholder (file upload, Cardholder-V2, approval webhooks, mobile onboarding)
3. Account + crypto funding (per-user account, USDT deposit address, `DEPOSIT` webhook credit)
4. Card lifecycle (open/sensitive/balance/freeze/topup/withdraw + transaction sync)
5. Fiat funding (Bridge path) + Filament admin + OpenAPI + reconciliation

### Open items to confirm with FinCard (none block phases 1–2)
- Production webhook **header name** (`X-FC-SIGNATURE` vs `X-WSB-SIGNATURE`) + their **RSA public key**.
- Business **error-code catalog** (the `code` integers).
- Authoritative **coin list** + min/max + FX methodology (pull live from `wallet/v2/coins`).
- Whether a FinCard account can be **funded with fiat directly** (determines the phase-5 fiat path).
- Upstream **issuer / BIN sponsor** identity + license; confirmation FinCard performs its **own KYC** (no third-party passthrough).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
