### PR TITLE
feat(cards): FinCard integration Phase 2 — cardholder KYC onboarding

### DIFF
--- a/app/Domain/CardIssuance/Events/Broadcast/FinCardKycStatusChanged.php
+++ b/app/Domain/CardIssuance/Events/Broadcast/FinCardKycStatusChanged.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\CardIssuance\Events\Broadcast;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Broadcast to the mobile app when a FinCard cardholder's KYC state changes
+ * (driven by FinCard cardholder webhooks). Delivered on the user's existing
+ * private channel as `fincard.kyc.status_changed`.
+ *
+ * @see docs/FINCARD_MOBILE_INTEGRATION.md §6
+ */
+final class FinCardKycStatusChanged implements ShouldBroadcast
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly int $userId,
+        public readonly string $cardholderId,
+        public readonly string $kycStatus,
+        public readonly ?string $kycStage = null,
+        public readonly ?string $rejectionReason = null,
+    ) {
+    }
+
+    /**
+     * @return array<int, PrivateChannel>
+     */
+    public function broadcastOn(): array
+    {
+        return [new PrivateChannel("user.{$this->userId}")];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'fincard.kyc.status_changed';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        return array_filter([
+            'cardholder_id'    => $this->cardholderId,
+            'kyc_status'       => $this->kycStatus,
+            'kyc_stage'        => $this->kycStage,
+            'rejection_reason' => $this->rejectionReason,
+        ], static fn ($v): bool => $v !== null);
+    }
+
+    public function broadcastWhen(): bool
+    {
+        return (bool) config('websocket.enabled', true);
+    }
+}

--- a/app/Domain/CardIssuance/Http/Controllers/FinCardWebhookController.php
+++ b/app/Domain/CardIssuance/Http/Controllers/FinCardWebhookController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Domain\CardIssuance\Http\Controllers;
 
+use App\Domain\CardIssuance\Services\FinCardCardholderService;
 use App\Domain\Subscription\Models\ProcessedWebhookEvent;
 use App\Http\Controllers\Controller;
 use App\Infrastructure\FinCard\FinCardWebhookVerifier;
@@ -36,8 +37,12 @@ use Throwable;
  */
 class FinCardWebhookController extends Controller
 {
+    /** FinCard cardholder-event types (KYC approval workflow). */
+    private const CARDHOLDER_EVENTS = ['wait_audit', 'under_review', 'pass_audit', 'reject'];
+
     public function __construct(
         private readonly FinCardWebhookVerifier $verifier,
+        private readonly FinCardCardholderService $cardholderService,
     ) {
     }
 
@@ -113,15 +118,21 @@ class FinCardWebhookController extends Controller
     }
 
     /**
-     * Extension point for per-phase handlers (KYC, funding, card state,
-     * transaction sync). Phase 1 records the event for observability and
-     * acknowledges it.
+     * Route a verified event to its per-category handler. Cardholder KYC events
+     * (Phase 2) update local KYC state; funding/card/transaction categories are
+     * wired in later phases.
      *
      * @param  array<string, mixed>  $payload
      */
     private function dispatchEvent(string $eventType, array $payload): void
     {
-        Log::info('FinCard webhook received', [
+        if (in_array($eventType, self::CARDHOLDER_EVENTS, true)) {
+            $this->cardholderService->applyKycWebhook($eventType, $payload);
+
+            return;
+        }
+
+        Log::info('FinCard webhook received (no handler yet)', [
             'event_type' => $eventType,
             // Never log `data` — it may carry PAN / PII.
         ]);

--- a/app/Domain/CardIssuance/Http/Requests/CreateFinCardCardholderRequest.php
+++ b/app/Domain/CardIssuance/Http/Requests/CreateFinCardCardholderRequest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\CardIssuance\Http\Requests;
+
+use App\Domain\CardIssuance\Support\FinCardCardholderMapper;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validates FinCard Cardholder-V2 onboarding input (snake_case).
+ *
+ * Field requirements follow FinCard's card-holders docs; exact enum values
+ * (gender, financial brackets) are pending sandbox confirmation, so those are
+ * validated as free strings rather than hard enums to avoid over-constraining
+ * an unconfirmed contract. `id_type` IS a fixed FinCard enum.
+ */
+final class CreateFinCardCardholderRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'first_name'              => ['required', 'string', 'max:100'],
+            'last_name'               => ['required', 'string', 'max:100'],
+            'gender'                  => ['required', 'string', 'max:16'],
+            'birthday'                => ['required', 'date_format:Y-m-d'],
+            'nationality'             => ['required', 'string', 'size:2'],
+            'occupation'              => ['required', 'string', 'max:100'],
+            'annual_salary'           => ['required', 'string', 'max:64'],
+            'expected_monthly_volume' => ['required', 'string', 'max:64'],
+            'account_purpose'         => ['required', 'string', 'max:255'],
+            'phone'                   => ['required', 'string', 'max:32'],
+            'phone_country_code'      => ['required', 'string', 'max:8'],
+            'email'                   => ['required', 'email', 'max:255'],
+            'country'                 => ['required', 'string', 'size:2'],
+            'state'                   => ['nullable', 'string', 'max:100'],
+            'city'                    => ['required', 'string', 'max:100'],
+            'address'                 => ['required', 'string', 'max:255'],
+            'zip_code'                => ['required', 'string', 'max:20'],
+            'id_type'                 => ['required', Rule::in(FinCardCardholderMapper::ID_TYPES)],
+            'id_number'               => ['required', 'string', 'max:64'],
+            'issue_date'              => ['nullable', 'date_format:Y-m-d'],
+            'id_expiry_date'          => ['nullable', 'date_format:Y-m-d'],
+            'id_front_file_id'        => ['required', 'string', 'max:255'],
+            'id_back_file_id'         => ['nullable', 'string', 'max:255'],
+            'id_selfie_file_id'       => ['required', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Domain/CardIssuance/Http/Requests/UploadKycDocumentRequest.php
+++ b/app/Domain/CardIssuance/Http/Requests/UploadKycDocumentRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\CardIssuance\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validates a KYC document upload (one of the three FinCard photos).
+ */
+final class UploadKycDocumentRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'type' => ['required', Rule::in(['id_front', 'id_back', 'selfie'])],
+            'file' => ['required', 'file', 'mimes:jpg,jpeg,png,pdf', 'max:10240'], // 10 MB
+        ];
+    }
+}

--- a/app/Domain/CardIssuance/Models/Cardholder.php
+++ b/app/Domain/CardIssuance/Models/Cardholder.php
@@ -20,6 +20,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property string|null $email
  * @property string|null $phone
  * @property string $kyc_status
+ * @property string|null $kyc_stage
+ * @property string|null $kyc_rejection_reason
  * @property string|null $issuer_cardholder_id
  * @property string|null $shipping_address_line1
  * @property string|null $shipping_address_line2
@@ -46,6 +48,8 @@ class Cardholder extends Model
         'email',
         'phone',
         'kyc_status',
+        'kyc_stage',
+        'kyc_rejection_reason',
         'issuer_cardholder_id',
         'shipping_address_line1',
         'shipping_address_line2',

--- a/app/Domain/CardIssuance/Routes/api.php
+++ b/app/Domain/CardIssuance/Routes/api.php
@@ -8,6 +8,7 @@ use App\Domain\CardIssuance\Webhooks\CardWaitlistWebhookController;
 use App\Http\Controllers\Api\CardIssuance\CardController;
 use App\Http\Controllers\Api\CardIssuance\CardholderController;
 use App\Http\Controllers\Api\CardIssuance\CardTransactionWebhookController;
+use App\Http\Controllers\Api\CardIssuance\FinCardOnboardingController;
 use App\Http\Controllers\Api\CardIssuance\JitFundingWebhookController;
 use Illuminate\Support\Facades\Route;
 
@@ -27,6 +28,24 @@ Route::prefix('v1/cards/waitlist')->name('api.cards.waitlist.')
 
         Route::get('/entry', [WaitlistDepositController::class, 'entry'])
             ->name('entry');
+    });
+
+// FinCard cardholder onboarding + KYC (Phase 2). Registered BEFORE the generic
+// v1/cards group so these specific paths are not swallowed by the greedy
+// /v1/cards/{cardId} route. No require.kyc here — these endpoints START the
+// FinCard KYC flow (mirrors the Bridge KYC-setup routes); card creation gates
+// on a verified cardholder later.
+Route::prefix('v1/cards')->name('api.cards.fincard.')
+    ->middleware(['auth:sanctum'])
+    ->group(function (): void {
+        Route::get('/onboarding', [FinCardOnboardingController::class, 'onboarding'])->name('onboarding');
+        Route::get('/cardholder', [FinCardOnboardingController::class, 'status'])->name('cardholder.status');
+        Route::post('/kyc/documents', [FinCardOnboardingController::class, 'uploadDocument'])
+            ->middleware('api.rate_limit:mutation')
+            ->name('kyc.documents');
+        Route::post('/cardholder', [FinCardOnboardingController::class, 'createCardholder'])
+            ->middleware(['idempotency.required', 'api.rate_limit:mutation'])
+            ->name('cardholder.create');
     });
 
 Route::prefix('v1/cards')->name('api.cards.')->group(function () {

--- a/app/Domain/CardIssuance/Services/FinCardCardholderService.php
+++ b/app/Domain/CardIssuance/Services/FinCardCardholderService.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\CardIssuance\Services;
+
+use App\Domain\CardIssuance\Events\Broadcast\FinCardKycStatusChanged;
+use App\Domain\CardIssuance\Models\Cardholder;
+use App\Domain\CardIssuance\Support\FinCardCardholderMapper;
+use App\Infrastructure\FinCard\FinCardClient;
+use App\Models\User;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Orchestrates FinCard cardholder KYC: creates the remote cardholder, persists
+ * the local Cardholder row (mapping the Zelta user ↔ FinCard holderId), and
+ * applies the two-stage approval reported by FinCard cardholder webhooks.
+ *
+ * The persistent Cardholder row is the bridge between our user and FinCard —
+ * the issuer adapter path does not persist, so this service owns it.
+ *
+ * @see docs/superpowers/specs/2026-07-06-fincard-card-issuing-design.md §3.2, §7
+ */
+final class FinCardCardholderService
+{
+    public function __construct(
+        private readonly FinCardClient $client,
+    ) {
+    }
+
+    /**
+     * The user's FinCard cardholder, if one has been created.
+     */
+    public function existingFor(User $user): ?Cardholder
+    {
+        return Cardholder::query()
+            ->where('user_id', $user->id)
+            ->whereNotNull('issuer_cardholder_id')
+            ->first();
+    }
+
+    /**
+     * Upload a KYC document to FinCard, returning the fileId to reference in
+     * createCardholder.
+     *
+     * @param  array<string, mixed>  $context
+     */
+    public function uploadDocument(string $contents, string $filename, string $mimeType, array $context = []): string
+    {
+        $response = $this->client->uploadKycDocument($contents, $filename, $mimeType, $context);
+        $data = is_array($response['data'] ?? null) ? $response['data'] : [];
+
+        return (string) ($data['fileId'] ?? $data['id'] ?? '');
+    }
+
+    /**
+     * Create the FinCard cardholder and persist the local row.
+     *
+     * @param  array<string, mixed>  $validated  snake_case onboarding fields
+     * @param  array<string, mixed>  $context    forwarded_for / platform / device_id
+     */
+    public function createCardholder(User $user, array $validated, array $context): Cardholder
+    {
+        $ip = (string) ($context['forwarded_for'] ?? '');
+        $payload = FinCardCardholderMapper::toPayload($validated, $ip);
+
+        $response = $this->client->createCardholder($payload, $context);
+        $data = is_array($response['data'] ?? null) ? $response['data'] : [];
+        $holderId = (string) ($data['holderId'] ?? $data['cardholderId'] ?? '');
+
+        return Cardholder::create([
+            'user_id'                => $user->id,
+            'first_name'             => (string) ($validated['first_name'] ?? ''),
+            'last_name'              => (string) ($validated['last_name'] ?? ''),
+            'email'                  => $validated['email'] ?? null,
+            'phone'                  => $validated['phone'] ?? null,
+            'kyc_status'             => 'in_review',
+            'kyc_stage'              => 'admin',
+            'issuer_cardholder_id'   => $holderId,
+            'shipping_address_line1' => $validated['address'] ?? null,
+            'shipping_city'          => $validated['city'] ?? null,
+            'shipping_state'         => $validated['state'] ?? null,
+            'shipping_postal_code'   => $validated['zip_code'] ?? null,
+            'shipping_country'       => $validated['country'] ?? null,
+            'verification_data'      => FinCardCardholderMapper::persistedAttributes($validated),
+        ]);
+    }
+
+    /**
+     * Apply a FinCard cardholder webhook (approval workflow) to the local row.
+     *
+     * @param  array<string, mixed>  $payload  decoded webhook body
+     */
+    public function applyKycWebhook(string $eventType, array $payload): void
+    {
+        $data = is_array($payload['data'] ?? null) ? $payload['data'] : [];
+        $holderId = (string) ($data['holderId'] ?? $data['cardholderId'] ?? $payload['holderId'] ?? '');
+
+        if ($holderId === '') {
+            Log::warning('FinCard KYC webhook without holderId', ['event' => $eventType]);
+
+            return;
+        }
+
+        $cardholder = Cardholder::query()->where('issuer_cardholder_id', $holderId)->first();
+        if (! $cardholder instanceof Cardholder) {
+            Log::warning('FinCard KYC webhook for unknown cardholder', ['holder_id' => $holderId, 'event' => $eventType]);
+
+            return;
+        }
+
+        [$status, $stage] = $this->mapEventToState($eventType);
+        $cardholder->kyc_status = $status;
+        $cardholder->kyc_stage = $stage;
+
+        if ($status === 'verified') {
+            $cardholder->verified_at = now();
+            $cardholder->kyc_rejection_reason = null;
+        } elseif ($status === 'rejected') {
+            $cardholder->kyc_rejection_reason = (string) ($data['reason'] ?? $data['rejectReason'] ?? 'Rejected by issuer');
+        }
+
+        $cardholder->save();
+
+        FinCardKycStatusChanged::dispatch(
+            (int) $cardholder->user_id,
+            (string) $cardholder->id,
+            $status,
+            $stage,
+            $status === 'rejected' ? $cardholder->kyc_rejection_reason : null,
+        );
+    }
+
+    /**
+     * Map a FinCard cardholder event type to [kyc_status, kyc_stage].
+     *
+     * @return array{0: string, 1: string|null}
+     */
+    private function mapEventToState(string $eventType): array
+    {
+        return match ($eventType) {
+            'wait_audit'   => ['in_review', 'admin'],
+            'under_review' => ['in_review', 'channel'],
+            'pass_audit'   => ['verified', 'channel'],
+            'reject'       => ['rejected', null],
+            default        => ['in_review', 'admin'],
+        };
+    }
+}

--- a/app/Domain/CardIssuance/Services/FinCardCardholderService.php
+++ b/app/Domain/CardIssuance/Services/FinCardCardholderService.php
@@ -68,22 +68,31 @@ final class FinCardCardholderService
         $data = is_array($response['data'] ?? null) ? $response['data'] : [];
         $holderId = (string) ($data['holderId'] ?? $data['cardholderId'] ?? '');
 
-        return Cardholder::create([
-            'user_id'                => $user->id,
-            'first_name'             => (string) ($validated['first_name'] ?? ''),
-            'last_name'              => (string) ($validated['last_name'] ?? ''),
-            'email'                  => $validated['email'] ?? null,
-            'phone'                  => $validated['phone'] ?? null,
-            'kyc_status'             => 'in_review',
-            'kyc_stage'              => 'admin',
-            'issuer_cardholder_id'   => $holderId,
-            'shipping_address_line1' => $validated['address'] ?? null,
-            'shipping_city'          => $validated['city'] ?? null,
-            'shipping_state'         => $validated['state'] ?? null,
-            'shipping_postal_code'   => $validated['zip_code'] ?? null,
-            'shipping_country'       => $validated['country'] ?? null,
-            'verification_data'      => FinCardCardholderMapper::persistedAttributes($validated),
-        ]);
+        // Assign attributes explicitly (rather than mass-assign an array) so the
+        // writes are type-checked against the model's @property contract.
+        $cardholder = new Cardholder();
+        $cardholder->user_id = (string) $user->id;
+        $cardholder->first_name = (string) ($validated['first_name'] ?? '');
+        $cardholder->last_name = (string) ($validated['last_name'] ?? '');
+        $cardholder->email = $this->stringOrNull($validated['email'] ?? null);
+        $cardholder->phone = $this->stringOrNull($validated['phone'] ?? null);
+        $cardholder->kyc_status = 'in_review';
+        $cardholder->kyc_stage = 'admin';
+        $cardholder->issuer_cardholder_id = $holderId;
+        $cardholder->shipping_address_line1 = $this->stringOrNull($validated['address'] ?? null);
+        $cardholder->shipping_city = $this->stringOrNull($validated['city'] ?? null);
+        $cardholder->shipping_state = $this->stringOrNull($validated['state'] ?? null);
+        $cardholder->shipping_postal_code = $this->stringOrNull($validated['zip_code'] ?? null);
+        $cardholder->shipping_country = $this->stringOrNull($validated['country'] ?? null);
+        $cardholder->verification_data = FinCardCardholderMapper::persistedAttributes($validated);
+        $cardholder->save();
+
+        return $cardholder;
+    }
+
+    private function stringOrNull(mixed $value): ?string
+    {
+        return $value === null || $value === '' ? null : (string) $value;
     }
 
     /**

--- a/app/Domain/CardIssuance/Support/FinCardCardholderMapper.php
+++ b/app/Domain/CardIssuance/Support/FinCardCardholderMapper.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\CardIssuance\Support;
+
+/**
+ * Maps validated mobile onboarding input (snake_case) into FinCard's
+ * Cardholder-V2 request shape (camelCase).
+ *
+ * Isolated here because FinCard's exact field names come from their docs
+ * (docs.finhub.cloud/paas/fincard-virtual/card-holders) and are pending
+ * confirmation against a live sandbox response — when they change, this is
+ * the ONE place to adjust. `idType` values are FinCard's enum
+ * (PASSPORT | DLN | GOVERNMENT_ISSUED_ID_CARD).
+ *
+ * @see docs/superpowers/specs/2026-07-06-fincard-card-issuing-design.md §2.3
+ */
+final class FinCardCardholderMapper
+{
+    /** ID document types FinCard accepts (non-HK regions). */
+    public const ID_TYPES = ['PASSPORT', 'DLN', 'GOVERNMENT_ISSUED_ID_CARD'];
+
+    /**
+     * ISO-3166 alpha-2 countries FinCard does not support for issuance (per
+     * their card-holders docs). We fail fast on these before calling FinCard.
+     */
+    public const RESTRICTED_COUNTRIES = [
+        'CU', 'KP', 'EG', 'IR', 'MM', 'NG', 'RU', 'BY', 'ZA', 'SY', 'UA',
+        'VE', 'SD', 'SS', 'LY', 'BI', 'CF', 'SO', 'ZW', 'AF',
+    ];
+
+    public static function isRestrictedCountry(string $iso2): bool
+    {
+        return in_array(strtoupper($iso2), self::RESTRICTED_COUNTRIES, true);
+    }
+
+    /** The subset of KYC fields persisted (encrypted) locally for support/audit. */
+    public const PERSISTED_KEYS = [
+        'gender', 'birthday', 'nationality', 'occupation', 'account_purpose',
+        'id_type', 'issue_date', 'id_expiry_date',
+    ];
+
+    /**
+     * @param  array<string, mixed>  $data  validated request data (snake_case)
+     * @return array<string, mixed>  FinCard createCardholder payload (camelCase)
+     */
+    public static function toPayload(array $data, string $ipAddress): array
+    {
+        return array_filter([
+            'firstName'             => $data['first_name'] ?? null,
+            'lastName'              => $data['last_name'] ?? null,
+            'gender'                => $data['gender'] ?? null,
+            'birthday'              => $data['birthday'] ?? null,
+            'nationality'           => $data['nationality'] ?? null,
+            'occupation'            => $data['occupation'] ?? null,
+            'annualSalary'          => $data['annual_salary'] ?? null,
+            'expectedMonthlyVolume' => $data['expected_monthly_volume'] ?? null,
+            'accountPurpose'        => $data['account_purpose'] ?? null,
+            'phone'                 => $data['phone'] ?? null,
+            'phoneCountryCode'      => $data['phone_country_code'] ?? null,
+            'email'                 => $data['email'] ?? null,
+            'country'               => $data['country'] ?? null,
+            'state'                 => $data['state'] ?? null,
+            'city'                  => $data['city'] ?? null,
+            'address'               => $data['address'] ?? null,
+            'zipCode'               => $data['zip_code'] ?? null,
+            'idType'                => $data['id_type'] ?? null,
+            'idNumber'              => $data['id_number'] ?? null,
+            'issueDate'             => $data['issue_date'] ?? null,
+            'idNoExpiryDate'        => $data['id_expiry_date'] ?? null,
+            'idFrontId'             => $data['id_front_file_id'] ?? null,
+            'idBackId'              => $data['id_back_file_id'] ?? null,
+            'idHoldId'              => $data['id_selfie_file_id'] ?? null,
+            'ipAddress'             => $ipAddress,
+        ], static fn ($v): bool => $v !== null && $v !== '');
+    }
+
+    /**
+     * The non-sensitive subset kept in the cardholder's encrypted
+     * verification_data blob (never ID numbers or file ids).
+     *
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    public static function persistedAttributes(array $data): array
+    {
+        return array_intersect_key($data, array_flip(self::PERSISTED_KEYS));
+    }
+}

--- a/app/Http/Controllers/Api/CardIssuance/FinCardOnboardingController.php
+++ b/app/Http/Controllers/Api/CardIssuance/FinCardOnboardingController.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\CardIssuance;
+
+use App\Domain\CardIssuance\Http\Requests\CreateFinCardCardholderRequest;
+use App\Domain\CardIssuance\Http\Requests\UploadKycDocumentRequest;
+use App\Domain\CardIssuance\Models\Cardholder;
+use App\Domain\CardIssuance\Services\FinCardCardholderService;
+use App\Domain\CardIssuance\Support\FinCardCardholderMapper;
+use App\Http\Controllers\Controller;
+use App\Infrastructure\FinCard\FinCardApiException;
+use App\Infrastructure\FinCard\FinCardClient;
+use App\Models\User;
+use App\Support\ErrorResponse;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * FinCard cardholder onboarding + KYC (Phase 2).
+ *
+ * Mobile-facing surface for the dedicated FinCard KYC flow: prefill + field
+ * schema, ID document upload, cardholder creation, and status polling. Cards
+ * can only be created once the cardholder reaches `verified` (pass_audit).
+ *
+ * @see docs/FINCARD_MOBILE_INTEGRATION.md §4.1
+ */
+class FinCardOnboardingController extends Controller
+{
+    /** Fields the mobile app must collect (beyond the three ID photos). */
+    private const REQUIRED_FIELDS = [
+        'first_name', 'last_name', 'gender', 'birthday', 'nationality',
+        'occupation', 'annual_salary', 'expected_monthly_volume', 'account_purpose',
+        'phone', 'phone_country_code', 'email', 'country', 'city', 'address',
+        'zip_code', 'id_type', 'id_number',
+    ];
+
+    public function __construct(
+        private readonly FinCardClient $client,
+        private readonly FinCardCardholderService $cardholders,
+    ) {
+    }
+
+    /**
+     * Prefilled draft + the field schema the app renders the KYC form from.
+     */
+    public function onboarding(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        if (! $user instanceof User) {
+            return ErrorResponse::make('ERR_CARDS_007');
+        }
+
+        if ($this->cardholders->existingFor($user) !== null) {
+            return ErrorResponse::make('ERR_CARDS_009');
+        }
+
+        // Reference data is best-effort — a FinCard outage must not block the
+        // form from rendering (occupations degrade to empty).
+        $occupations = [];
+        try {
+            $response = $this->client->getOccupations($this->context($request));
+            $occupations = is_array($response['data'] ?? null) ? $response['data'] : [];
+        } catch (FinCardApiException $e) {
+            Log::warning('FinCard occupations fetch failed', ['msg' => $e->getMessage()]);
+        }
+
+        return response()->json([
+            'success' => true,
+            'data'    => [
+                'prefill' => array_filter([
+                    'email'   => $user->email,
+                    'country' => $user->country_code ?? null,
+                ], static fn ($v): bool => $v !== null && $v !== ''),
+                'schema' => [
+                    'required_fields'    => self::REQUIRED_FIELDS,
+                    'id_types'           => FinCardCardholderMapper::ID_TYPES,
+                    'occupations'        => $occupations,
+                    'required_documents' => ['id_front', 'selfie'],
+                    'optional_documents' => ['id_back'],
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * Upload one KYC photo → returns the fileId to reference on create.
+     */
+    public function uploadDocument(UploadKycDocumentRequest $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $file = $request->file('file');
+        if (! $file instanceof UploadedFile) {
+            return ErrorResponse::make('ERR_CARDS_011');
+        }
+
+        $contents = file_get_contents($file->getRealPath());
+        if ($contents === false) {
+            return ErrorResponse::make('ERR_CARDS_011');
+        }
+
+        try {
+            $fileId = $this->cardholders->uploadDocument(
+                $contents,
+                $file->getClientOriginalName(),
+                $file->getMimeType() ?? 'application/octet-stream',
+                $this->context($request),
+            );
+        } catch (FinCardApiException $e) {
+            Log::warning('FinCard document upload failed', ['user_id' => $user->id, 'msg' => $e->getMessage()]);
+
+            return ErrorResponse::make('ERR_CARDS_011');
+        }
+
+        if ($fileId === '') {
+            return ErrorResponse::make('ERR_CARDS_011');
+        }
+
+        return response()->json([
+            'success' => true,
+            'data'    => ['file_id' => $fileId, 'type' => (string) $request->validated('type')],
+        ], 201);
+    }
+
+    /**
+     * Create the FinCard cardholder and start the KYC review.
+     */
+    public function createCardholder(CreateFinCardCardholderRequest $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        if ($this->cardholders->existingFor($user) !== null) {
+            return ErrorResponse::make('ERR_CARDS_009');
+        }
+
+        /** @var array<string, mixed> $validated */
+        $validated = $request->validated();
+
+        if (FinCardCardholderMapper::isRestrictedCountry((string) $validated['country'])) {
+            return ErrorResponse::make('ERR_CARDS_010');
+        }
+
+        try {
+            $cardholder = $this->cardholders->createCardholder($user, $validated, $this->context($request));
+        } catch (FinCardApiException $e) {
+            Log::warning('FinCard cardholder create rejected', ['user_id' => $user->id, 'msg' => $e->getMessage()]);
+
+            return ErrorResponse::make('ERR_CARDS_012');
+        }
+
+        return response()->json([
+            'success' => true,
+            'data'    => $this->present($cardholder),
+        ], 201);
+    }
+
+    /**
+     * The user's cardholder KYC status (one cardholder per user).
+     */
+    public function status(Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $cardholder = $this->cardholders->existingFor($user);
+
+        if (! $cardholder instanceof Cardholder) {
+            return response()->json([
+                'success' => true,
+                'data'    => ['cardholder_id' => null, 'kyc_status' => 'not_started', 'kyc_stage' => null],
+            ]);
+        }
+
+        return response()->json(['success' => true, 'data' => $this->present($cardholder)]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function present(Cardholder $cardholder): array
+    {
+        return [
+            'cardholder_id'    => $cardholder->id,
+            'kyc_status'       => $cardholder->kyc_status,
+            'kyc_stage'        => $cardholder->kyc_stage,
+            'rejection_reason' => $cardholder->kyc_rejection_reason,
+        ];
+    }
+
+    /**
+     * FinCard context headers from the mobile request (real end-user IP/device).
+     *
+     * @return array<string, mixed>
+     */
+    private function context(Request $request): array
+    {
+        return [
+            'forwarded_for' => $request->ip() ?? '127.0.0.1',
+            'platform'      => (string) ($request->header('platform') ?? 'ios'),
+            'device_id'     => (string) ($request->header('deviceId') ?? ''),
+        ];
+    }
+}

--- a/app/Infrastructure/FinCard/FinCardClient.php
+++ b/app/Infrastructure/FinCard/FinCardClient.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\FinCard;
 
+use Closure;
 use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Cache;
@@ -189,38 +191,95 @@ final class FinCardClient
         return $this->rpc('/wallet/v2/coins', [], $context);
     }
 
+    // ── Cardholder / KYC (Phase 2) ───────────────────────────────────────
+
+    /**
+     * Upload a KYC document (multipart). Returns the envelope whose `data`
+     * carries the `fileId` referenced by createCardholder.
+     *
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function uploadKycDocument(string $contents, string $filename, string $mimeType, array $context = []): array
+    {
+        return $this->dispatch(
+            '/common/file/upload',
+            fn (PendingRequest $request): PendingRequest => $request->attach('file', $contents, $filename, ['Content-Type' => $mimeType]),
+            $context,
+        );
+    }
+
+    /**
+     * Create a FinCard cardholder (Cardholder-V2). `$payload` must already be in
+     * FinCard's field shape (see FinCardCardholderPayload). Returns the envelope
+     * whose `data` carries the `holderId`.
+     *
+     * @param  array<string, mixed>  $payload
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function createCardholder(array $payload, array $context = []): array
+    {
+        return $this->rpc('/card/holder/v2/create', $payload, $context);
+    }
+
+    /**
+     * List cardholders (used to reconcile KYC state for a known holder).
+     *
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function listCardholders(int $pageNum = 1, int $pageSize = 20, array $context = []): array
+    {
+        return $this->rpc('/card/holder/list', ['pageNum' => $pageNum, 'pageSize' => $pageSize], $context);
+    }
+
     // ── Core RPC ─────────────────────────────────────────────────────────
 
     /**
-     * POST an RPC call and return the decoded envelope.
-     *
-     * Re-authenticates once on a 401 (expired/invalidated token) before giving
-     * up, so a stale cached JWT self-heals without failing the caller.
+     * POST a JSON-RPC call and return the decoded envelope.
      *
      * @param  array<string, mixed>  $params
      * @param  array<string, mixed>  $context  platform / device_id / forwarded_for overrides
      * @return array<string, mixed>
      */
-    public function rpc(string $path, array $params = [], array $context = [], bool $isRetry = false): array
+    public function rpc(string $path, array $params = [], array $context = []): array
     {
-        $response = Http::asJson()
-            ->timeout(self::REQUEST_TIMEOUT_SECONDS)
+        return $this->dispatch(
+            $path,
+            fn (PendingRequest $request): PendingRequest => $request->asJson()->withBody($this->encodeBody($params), 'application/json'),
+            $context,
+        );
+    }
+
+    // ── Internals ────────────────────────────────────────────────────────
+
+    /**
+     * Send an authenticated POST and return the decoded envelope. `$applyBody`
+     * shapes the request (JSON body vs multipart). Re-authenticates once on a
+     * 401 (expired/invalidated token) so a stale cached JWT self-heals.
+     *
+     * @param  Closure(PendingRequest): PendingRequest  $applyBody
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    private function dispatch(string $path, Closure $applyBody, array $context, bool $isRetry = false): array
+    {
+        $request = Http::timeout(self::REQUEST_TIMEOUT_SECONDS)
             ->retry(2, 500, $this->shouldRetry(...), throw: false)
             ->withToken($this->getAccessToken())
-            ->withHeaders($this->contextHeaders($context))
-            ->withBody($this->encodeBody($params), 'application/json')
-            ->post($this->baseUrl . $path);
+            ->withHeaders($this->contextHeaders($context));
+
+        $response = $applyBody($request)->post($this->baseUrl . $path);
 
         if ($response->status() === 401 && ! $isRetry) {
             Cache::forget(self::CACHE_TOKEN_KEY);
 
-            return $this->rpc($path, $params, $context, isRetry: true);
+            return $this->dispatch($path, $applyBody, $context, isRetry: true);
         }
 
         return $this->decode($response, $path);
     }
-
-    // ── Internals ────────────────────────────────────────────────────────
 
     /**
      * Retry transient failures only — connection errors and 5xx. A 4xx (incl.

--- a/config/error_codes.php
+++ b/config/error_codes.php
@@ -73,4 +73,12 @@ return [
     'ERR_CARDS_004' => ['http' => 409, 'description' => 'Deposit state conflict — already shipped or cancellation already in progress.'],
     'ERR_CARDS_005' => ['http' => 422, 'description' => 'Invalid return URL — not in the configured allow-list.'],
     'ERR_CARDS_006' => ['http' => 409, 'description' => 'Quote kind is not card_waitlist_deposit.'],
+
+    // ─── FinCard cardholder / KYC (Phase 2) ────────────────────────────────
+    'ERR_CARDS_007' => ['http' => 403, 'description' => 'No verified FinCard cardholder — identity verification required before this action.'],
+    'ERR_CARDS_008' => ['http' => 409, 'description' => 'FinCard cardholder KYC is still under review.'],
+    'ERR_CARDS_009' => ['http' => 409, 'description' => 'A FinCard cardholder already exists for this user.'],
+    'ERR_CARDS_010' => ['http' => 422, 'description' => 'Cardholder country is not supported for card issuance.'],
+    'ERR_CARDS_011' => ['http' => 422, 'description' => 'KYC document upload failed or the document type is invalid.'],
+    'ERR_CARDS_012' => ['http' => 502, 'description' => 'The card issuer rejected the cardholder request.'],
 ];

--- a/config/error_codes.php
+++ b/config/error_codes.php
@@ -75,10 +75,12 @@ return [
     'ERR_CARDS_006' => ['http' => 409, 'description' => 'Quote kind is not card_waitlist_deposit.'],
 
     // ─── FinCard cardholder / KYC (Phase 2) ────────────────────────────────
-    'ERR_CARDS_007' => ['http' => 403, 'description' => 'No verified FinCard cardholder — identity verification required before this action.'],
-    'ERR_CARDS_008' => ['http' => 409, 'description' => 'FinCard cardholder KYC is still under review.'],
-    'ERR_CARDS_009' => ['http' => 409, 'description' => 'A FinCard cardholder already exists for this user.'],
-    'ERR_CARDS_010' => ['http' => 422, 'description' => 'Cardholder country is not supported for card issuance.'],
-    'ERR_CARDS_011' => ['http' => 422, 'description' => 'KYC document upload failed or the document type is invalid.'],
-    'ERR_CARDS_012' => ['http' => 502, 'description' => 'The card issuer rejected the cardholder request.'],
+    // User-facing descriptions stay brand-neutral (no partner name) — the app
+    // branches on the code and can override the copy.
+    'ERR_CARDS_007' => ['http' => 403, 'description' => 'Identity verification is required before you can create a card.'],
+    'ERR_CARDS_008' => ['http' => 409, 'description' => 'Your identity verification is still under review.'],
+    'ERR_CARDS_009' => ['http' => 409, 'description' => 'A card profile already exists for your account.'],
+    'ERR_CARDS_010' => ['http' => 422, 'description' => 'Your country is not supported for card issuance.'],
+    'ERR_CARDS_011' => ['http' => 422, 'description' => 'Document upload failed or the document type is not accepted.'],
+    'ERR_CARDS_012' => ['http' => 502, 'description' => 'We could not verify your details right now. Please try again later.'],
 ];

--- a/database/migrations/2026_07_06_100001_add_fincard_kyc_columns_to_cardholders_table.php
+++ b/database/migrations/2026_07_06_100001_add_fincard_kyc_columns_to_cardholders_table.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * FinCard KYC — cardholder approval tracking.
+ *
+ * FinCard's cardholder KYC is a two-stage review (admin → channel) reported via
+ * webhooks. `kyc_status` (existing: pending/in_review/verified/rejected) records
+ * the outcome; `kyc_stage` records which review stage is in flight, and
+ * `kyc_rejection_reason` captures the reason on a reject. Richer KYC attributes
+ * (occupation, financial fields, ID metadata) live in the existing encrypted
+ * `verification_data` blob — no new plaintext PII columns.
+ *
+ * @see docs/superpowers/specs/2026-07-06-fincard-card-issuing-design.md §4, §7
+ */
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('cardholders', function (Blueprint $table): void {
+            $table->string('kyc_stage')->nullable()->after('kyc_status'); // admin, channel
+            $table->text('kyc_rejection_reason')->nullable()->after('kyc_stage');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('cardholders', function (Blueprint $table): void {
+            $table->dropColumn(['kyc_stage', 'kyc_rejection_reason']);
+        });
+    }
+};

--- a/docs/FINCARD_MOBILE_INTEGRATION.md
+++ b/docs/FINCARD_MOBILE_INTEGRATION.md
@@ -38,7 +38,7 @@ Identical to the rest of the Zelta mobile API:
 - **Bodies are snake_case** (e.g. `card_id`, `coin_key`, `amount_cents`).
 - **Idempotency:** POST/PATCH/DELETE require an `Idempotency-Key` HTTP header (UUID or 16–255 `[A-Za-z0-9_-]`). Reusing a key replays the first response; same key + different body → `409`.
 - **Lists** return `data: [...]` plus `pagination: { next_cursor, has_more, total }`. Query with `?cursor=…&limit=…` (limit ≤ 100, default 20).
-- **KYC gate:** issuance/spend endpoints require completed Zelta KYC (`require.kyc`) *and* a `pass_audit` FinCard cardholder; a missing FinCard cardholder returns `ERR_CARDS_403_KYC` (see §7).
+- **KYC gate:** issuance/spend endpoints require completed Zelta KYC (`require.kyc`) *and* a `pass_audit` FinCard cardholder; a missing verified cardholder returns `ERR_CARDS_007` (see §7).
 
 ---
 
@@ -59,7 +59,7 @@ FinCard requires its own KYC — richer than the app's existing profile. Prefill
 3. `POST /v1/cardholders` with the full field set + the three `file_id`s → creates the cardholder; response `kyc_status: "in_review"`, `kyc_stage: "admin"`.
 4. Poll `GET /v1/cardholders/{id}` **or** listen for the WebSocket events in §6. Approval is two-stage (`admin` → `channel`). Only `kyc_status: "verified"` (`pass_audit`) unlocks card creation. `rejected` carries `kyc_rejection_reason`.
 
-> Restricted countries are rejected up front with `ERR_CARDS_422_COUNTRY`. The full FinCard field list and photo requirements are *(pending FinCard)* final confirmation; `GET /v1/cards/onboarding` is the source of truth at runtime — render from it, don't hard-code the field set.
+> Restricted countries are rejected up front with `ERR_CARDS_010`. The full FinCard field list and photo requirements are *(pending FinCard)* final confirmation; `GET /v1/cards/onboarding` is the source of truth at runtime — render from it, don't hard-code the field set.
 
 ### 4.2 Funding ⚪ (phase 3 crypto, phase 5 fiat)
 
@@ -138,20 +138,21 @@ Push notifications (FCM/APNs) fire on the **terminal KYC states** (`verified`, `
 
 ## 7. Error codes
 
-Card endpoints use the `ERR_CARDS_*` family (registered in `config/error_codes.php`). Handle at minimum:
+Card endpoints use the `ERR_CARDS_*` family (registered in `config/error_codes.php`). Codes match `^ERR_[A-Z]+_\d{3}$` (numbered, not semantic) — branch on the exact code. Cardholder/KYC codes (Phase 2) shipped are:
 
 | Code | HTTP | Meaning / UX |
 |---|---|---|
-| `ERR_CARDS_403_KYC` | 403 | No verified FinCard cardholder yet → route to onboarding |
-| `ERR_CARDS_409_KYC_PENDING` | 409 | KYC still under review → show pending state |
-| `ERR_CARDS_422_COUNTRY` | 422 | User's country is restricted by FinCard |
-| `ERR_CARDS_422_INSUFFICIENT_FUNDS` | 422 | Account/card balance too low → prompt to fund |
-| `ERR_CARDS_404` | 404 | Card / resource not found |
+| `ERR_CARDS_007` | 403 | No verified cardholder yet → route to onboarding |
+| `ERR_CARDS_008` | 409 | Identity verification still under review → show pending state |
+| `ERR_CARDS_009` | 409 | A cardholder already exists for the user |
+| `ERR_CARDS_010` | 422 | User's country is restricted for issuance |
+| `ERR_CARDS_011` | 422 | KYC document upload failed / unsupported type |
+| `ERR_CARDS_012` | 502 | Card issuer rejected the cardholder request → retry later |
 | `ERR_VALIDATION_001/003` | 422 | Missing/invalid `Idempotency-Key` or body |
 | `ERR_IDEMPOTENCY_409` | 409 | Same key, different body |
 | (rate limit) | 429 | Too many card operations → back off |
 
-Exact final code list is confirmed as endpoints land per phase; the shape (`{success:false, error:{code,message}}`) is stable.
+Funding/card-lifecycle codes (`ERR_CARDS_013+`) are added as phases 3–4 land. The envelope shape (`{success:false, error:{code,message}}`) is stable; the app branches on `code` and may override the message copy.
 
 ---
 

--- a/tests/Feature/Api/FinCard/FinCardWebhookEndpointTest.php
+++ b/tests/Feature/Api/FinCard/FinCardWebhookEndpointTest.php
@@ -10,8 +10,10 @@
 
 declare(strict_types=1);
 
+use App\Domain\CardIssuance\Models\Cardholder;
 use App\Domain\Subscription\Models\ProcessedWebhookEvent;
 use App\Infrastructure\FinCard\FinCardWebhookVerifier;
+use App\Models\User;
 
 /**
  * @return array{0: string, 1: string} [privatePem, publicPem]
@@ -101,4 +103,23 @@ it('rejects a validly signed but identifier-less payload with 400', function () 
 
     $this->call('POST', '/api/v1/webhooks/fincard', [], [], [], fincardWebhookServer('X-FC-SIGNATURE', $sig), $body)
         ->assertStatus(400);
+});
+
+it('applies a cardholder pass_audit event to the local KYC state', function () {
+    $user = User::factory()->create();
+    Cardholder::create([
+        'user_id'    => $user->id, 'first_name' => 'Jane', 'last_name' => 'Smith',
+        'kyc_status' => 'in_review', 'kyc_stage' => 'admin', 'issuer_cardholder_id' => 'h-web',
+    ]);
+
+    $body = (string) json_encode(['eventType' => 'pass_audit', 'data' => ['holderId' => 'h-web', 'orderNo' => 'ord-kyc']]);
+    $sig = fincardEndpointSign($body, $this->finCardPriv);
+
+    $this->call('POST', '/api/v1/webhooks/fincard', [], [], [], fincardWebhookServer('X-FC-SIGNATURE', $sig), $body)
+        ->assertOk()
+        ->assertExactJson(['success' => true]);
+
+    $fresh = Cardholder::query()->where('issuer_cardholder_id', 'h-web')->firstOrFail();
+    expect($fresh->kyc_status)->toBe('verified')
+        ->and($fresh->verified_at)->not->toBeNull();
 });

--- a/tests/Feature/CardIssuance/FinCardCardholderServiceTest.php
+++ b/tests/Feature/CardIssuance/FinCardCardholderServiceTest.php
@@ -48,19 +48,20 @@ class FinCardCardholderServiceTest extends TestCase
         ];
     }
 
-    /**
-     * @param  array<string, mixed>  $overrides
-     */
-    private function cardholder(User $user, array $overrides = []): Cardholder
+    private function cardholder(User $user): Cardholder
     {
-        return Cardholder::create(array_merge([
-            'user_id'              => $user->id,
-            'first_name'           => 'Jane',
-            'last_name'            => 'Smith',
-            'kyc_status'           => 'in_review',
-            'kyc_stage'            => 'admin',
-            'issuer_cardholder_id' => 'h-9',
-        ], $overrides));
+        // Assign explicitly (not Model::create(array<string,mixed>)) — Larastan
+        // rejects a non-shaped array to create().
+        $cardholder = new Cardholder();
+        $cardholder->user_id = (string) $user->id;
+        $cardholder->first_name = 'Jane';
+        $cardholder->last_name = 'Smith';
+        $cardholder->kyc_status = 'in_review';
+        $cardholder->kyc_stage = 'admin';
+        $cardholder->issuer_cardholder_id = 'h-9';
+        $cardholder->save();
+
+        return $cardholder;
     }
 
     public function test_create_cardholder_calls_fincard_and_persists_local_row(): void

--- a/tests/Feature/CardIssuance/FinCardCardholderServiceTest.php
+++ b/tests/Feature/CardIssuance/FinCardCardholderServiceTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\CardIssuance;
+
+use App\Domain\CardIssuance\Events\Broadcast\FinCardKycStatusChanged;
+use App\Domain\CardIssuance\Models\Cardholder;
+use App\Domain\CardIssuance\Services\FinCardCardholderService;
+use App\Infrastructure\FinCard\FinCardClient;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class FinCardCardholderServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['cache.default' => 'array']);
+        Cache::flush();
+    }
+
+    private function client(): FinCardClient
+    {
+        return new FinCardClient(
+            baseUrl: 'https://sandbox.finhub.cloud/api/v2.1/fincard/virtual',
+            tenantId: 't',
+            orgId: 'o',
+            userId: 'u',
+            username: 'x',
+            password: 'y',
+        );
+    }
+
+    /**
+     * @return array<string, \GuzzleHttp\Promise\PromiseInterface>
+     */
+    private function loginFake(): array
+    {
+        return [
+            'sandbox.finhub.cloud/api/v2.1/admin/*' => Http::response([
+                'success' => true, 'code' => 0, 'msg' => 'ok',
+                'data'    => ['accessToken' => 'jwt', 'expiresIn' => 3600],
+            ]),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function cardholder(User $user, array $overrides = []): Cardholder
+    {
+        return Cardholder::create(array_merge([
+            'user_id'              => $user->id,
+            'first_name'           => 'Jane',
+            'last_name'            => 'Smith',
+            'kyc_status'           => 'in_review',
+            'kyc_stage'            => 'admin',
+            'issuer_cardholder_id' => 'h-9',
+        ], $overrides));
+    }
+
+    public function test_create_cardholder_calls_fincard_and_persists_local_row(): void
+    {
+        Http::fake(array_merge($this->loginFake(), [
+            'sandbox.finhub.cloud/api/v2.1/fincard/virtual/card/holder/v2/create' => Http::response([
+                'success' => true, 'code' => 0, 'msg' => 'ok', 'data' => ['holderId' => 'h-123'],
+            ]),
+        ]));
+
+        $user = User::factory()->create();
+        $service = new FinCardCardholderService($this->client());
+
+        $cardholder = $service->createCardholder($user, [
+            'first_name' => 'Jane', 'last_name' => 'Smith', 'email' => 'jane@example.com',
+            'phone'      => '5551234', 'country' => 'US', 'city' => 'NYC', 'gender' => 'female',
+            'birthday'   => '1990-01-01', 'address' => '1 Main St', 'zip_code' => '10001',
+        ], ['forwarded_for' => '203.0.113.4', 'platform' => 'ios', 'device_id' => 'd1']);
+
+        $this->assertSame('h-123', $cardholder->issuer_cardholder_id);
+        $this->assertSame('in_review', $cardholder->kyc_status);
+        $this->assertSame('admin', $cardholder->kyc_stage);
+        $this->assertSame((int) $user->id, (int) $cardholder->user_id);
+        $this->assertDatabaseHas('cardholders', ['issuer_cardholder_id' => 'h-123', 'user_id' => $user->id]);
+
+        // The FinCard payload used camelCase + carried the end-user IP.
+        Http::assertSent(function ($request): bool {
+            if (! str_contains($request->url(), '/card/holder/v2/create')) {
+                return false;
+            }
+            $body = json_decode($request->body(), true);
+
+            return ($body['firstName'] ?? null) === 'Jane' && ($body['ipAddress'] ?? null) === '203.0.113.4';
+        });
+    }
+
+    public function test_apply_kyc_webhook_pass_audit_verifies_and_broadcasts(): void
+    {
+        Event::fake([FinCardKycStatusChanged::class]);
+        $user = User::factory()->create();
+        $this->cardholder($user);
+
+        (new FinCardCardholderService($this->client()))->applyKycWebhook('pass_audit', ['data' => ['holderId' => 'h-9']]);
+
+        $fresh = Cardholder::query()->where('issuer_cardholder_id', 'h-9')->firstOrFail();
+        $this->assertSame('verified', $fresh->kyc_status);
+        $this->assertNotNull($fresh->verified_at);
+        Event::assertDispatched(FinCardKycStatusChanged::class, fn ($e): bool => $e->kycStatus === 'verified' && $e->cardholderId === $fresh->id);
+    }
+
+    public function test_apply_kyc_webhook_reject_records_reason(): void
+    {
+        Event::fake([FinCardKycStatusChanged::class]);
+        $user = User::factory()->create();
+        $this->cardholder($user);
+
+        (new FinCardCardholderService($this->client()))->applyKycWebhook('reject', ['data' => ['holderId' => 'h-9', 'reason' => 'document blurry']]);
+
+        $fresh = Cardholder::query()->where('issuer_cardholder_id', 'h-9')->firstOrFail();
+        $this->assertSame('rejected', $fresh->kyc_status);
+        $this->assertSame('document blurry', $fresh->kyc_rejection_reason);
+    }
+
+    public function test_apply_kyc_webhook_for_unknown_holder_is_a_noop(): void
+    {
+        Event::fake([FinCardKycStatusChanged::class]);
+
+        (new FinCardCardholderService($this->client()))->applyKycWebhook('pass_audit', ['data' => ['holderId' => 'nope']]);
+
+        Event::assertNotDispatched(FinCardKycStatusChanged::class);
+    }
+
+    public function test_existing_for_finds_the_users_cardholder(): void
+    {
+        $user = User::factory()->create();
+        $this->cardholder($user);
+        $service = new FinCardCardholderService($this->client());
+
+        $this->assertNotNull($service->existingFor($user));
+        $this->assertNull($service->existingFor(User::factory()->create()));
+    }
+}

--- a/tests/Feature/CardIssuance/FinCardOnboardingControllerTest.php
+++ b/tests/Feature/CardIssuance/FinCardOnboardingControllerTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\CardIssuance\Models\Cardholder;
+use App\Infrastructure\FinCard\FinCardClient;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Laravel\Sanctum\Sanctum;
+
+/**
+ * @param  array<string, mixed>  $overrides
+ * @return array<string, mixed>
+ */
+function validFinCardCardholderBody(array $overrides = []): array
+{
+    return array_merge([
+        'first_name'              => 'Jane',
+        'last_name'               => 'Smith',
+        'gender'                  => 'female',
+        'birthday'                => '1992-03-20',
+        'nationality'             => 'US',
+        'occupation'              => 'Engineer',
+        'annual_salary'           => '50k-100k',
+        'expected_monthly_volume' => '1k-5k',
+        'account_purpose'         => 'personal spending',
+        'phone'                   => '5559876543',
+        'phone_country_code'      => '+1',
+        'email'                   => 'jane@example.com',
+        'country'                 => 'US',
+        'city'                    => 'Los Angeles',
+        'address'                 => '456 Oak Avenue',
+        'zip_code'                => '90001',
+        'id_type'                 => 'PASSPORT',
+        'id_number'               => 'A1234567',
+        'id_front_file_id'        => 'file-front',
+        'id_selfie_file_id'       => 'file-selfie',
+    ], $overrides);
+}
+
+beforeEach(function () {
+    config(['cache.default' => 'array']);
+    Cache::flush();
+
+    // Real client, faked HTTP — exercises the client + service + controller.
+    $this->app->instance(FinCardClient::class, new FinCardClient(
+        baseUrl: 'https://sandbox.finhub.cloud/api/v2.1/fincard/virtual',
+        tenantId: 't',
+        orgId: 'o',
+        userId: 'u',
+        username: 'x',
+        password: 'y',
+    ));
+
+    Http::fake([
+        'sandbox.finhub.cloud/api/v2.1/admin/*' => Http::response([
+            'success' => true, 'data' => ['accessToken' => 'jwt', 'expiresIn' => 3600],
+        ]),
+        'sandbox.finhub.cloud/api/v2.1/fincard/virtual/card/holder/occupations' => Http::response([
+            'success' => true, 'data' => [['code' => 'ENG', 'name' => 'Engineer']],
+        ]),
+        'sandbox.finhub.cloud/api/v2.1/fincard/virtual/card/holder/v2/create' => Http::response([
+            'success' => true, 'data' => ['holderId' => 'h-777'],
+        ]),
+        'sandbox.finhub.cloud/api/v2.1/fincard/virtual/common/file/upload' => Http::response([
+            'success' => true, 'data' => ['fileId' => 'f-1'],
+        ]),
+    ]);
+
+    $this->user = User::factory()->create();
+    Sanctum::actingAs($this->user, ['read', 'write', 'delete']);
+});
+
+it('returns a prefilled draft and field schema for onboarding', function () {
+    $this->getJson('/api/v1/cards/onboarding')
+        ->assertOk()
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.schema.id_types', ['PASSPORT', 'DLN', 'GOVERNMENT_ISSUED_ID_CARD'])
+        ->assertJsonPath('data.schema.occupations.0.code', 'ENG')
+        ->assertJsonPath('data.prefill.email', $this->user->email);
+});
+
+it('creates a FinCard cardholder and persists the local row', function () {
+    $this->withHeader('Idempotency-Key', (string) Illuminate\Support\Str::uuid())
+        ->postJson('/api/v1/cards/cardholder', validFinCardCardholderBody())
+        ->assertCreated()
+        ->assertJsonPath('data.kyc_status', 'in_review')
+        ->assertJsonPath('data.kyc_stage', 'admin');
+
+    expect(Cardholder::where('user_id', $this->user->id)->where('issuer_cardholder_id', 'h-777')->exists())->toBeTrue();
+});
+
+it('rejects a second cardholder for the same user with ERR_CARDS_009', function () {
+    Cardholder::create([
+        'user_id'    => $this->user->id, 'first_name' => 'J', 'last_name' => 'S',
+        'kyc_status' => 'in_review', 'issuer_cardholder_id' => 'h-existing',
+    ]);
+
+    $this->withHeader('Idempotency-Key', (string) Illuminate\Support\Str::uuid())
+        ->postJson('/api/v1/cards/cardholder', validFinCardCardholderBody())
+        ->assertStatus(409)
+        ->assertJsonPath('error.code', 'ERR_CARDS_009');
+});
+
+it('rejects a restricted country with ERR_CARDS_010', function () {
+    $this->withHeader('Idempotency-Key', (string) Illuminate\Support\Str::uuid())
+        ->postJson('/api/v1/cards/cardholder', validFinCardCardholderBody(['country' => 'RU', 'nationality' => 'RU']))
+        ->assertStatus(422)
+        ->assertJsonPath('error.code', 'ERR_CARDS_010');
+});
+
+it('validates the cardholder body', function () {
+    $this->withHeader('Idempotency-Key', (string) Illuminate\Support\Str::uuid())
+        ->postJson('/api/v1/cards/cardholder', validFinCardCardholderBody(['id_type' => 'NATIONAL_ID']))
+        ->assertStatus(422);
+});
+
+it('reports not_started status when no cardholder exists', function () {
+    $this->getJson('/api/v1/cards/cardholder')
+        ->assertOk()
+        ->assertJsonPath('data.kyc_status', 'not_started');
+});
+
+it('uploads a KYC document and returns a file id', function () {
+    $this->postJson('/api/v1/cards/kyc/documents', [
+        'type' => 'id_front',
+        'file' => UploadedFile::fake()->image('front.jpg'),
+    ])
+        ->assertCreated()
+        ->assertJsonPath('data.file_id', 'f-1')
+        ->assertJsonPath('data.type', 'id_front');
+});

--- a/tests/Unit/Domain/CardIssuance/FinCardCardholderMapperTest.php
+++ b/tests/Unit/Domain/CardIssuance/FinCardCardholderMapperTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\CardIssuance\Support\FinCardCardholderMapper;
+
+it('maps snake_case onboarding fields to FinCard camelCase payload', function () {
+    $payload = FinCardCardholderMapper::toPayload([
+        'first_name'              => 'Jane',
+        'last_name'               => 'Smith',
+        'birthday'                => '1992-03-20',
+        'nationality'             => 'US',
+        'annual_salary'           => '50k-100k',
+        'expected_monthly_volume' => '1k-5k',
+        'zip_code'                => '90001',
+        'id_type'                 => 'PASSPORT',
+        'id_front_file_id'        => 'file-1',
+        'id_selfie_file_id'       => 'file-3',
+    ], '203.0.113.7');
+
+    expect($payload['firstName'])->toBe('Jane')
+        ->and($payload['lastName'])->toBe('Smith')
+        ->and($payload['annualSalary'])->toBe('50k-100k')
+        ->and($payload['expectedMonthlyVolume'])->toBe('1k-5k')
+        ->and($payload['zipCode'])->toBe('90001')
+        ->and($payload['idFrontId'])->toBe('file-1')
+        ->and($payload['idHoldId'])->toBe('file-3')
+        ->and($payload['ipAddress'])->toBe('203.0.113.7');
+});
+
+it('drops empty/null fields from the payload', function () {
+    $payload = FinCardCardholderMapper::toPayload([
+        'first_name' => 'Jane',
+        'last_name'  => '',
+        'state'      => null,
+    ], '127.0.0.1');
+
+    expect($payload)->toHaveKey('firstName')
+        ->and($payload)->not->toHaveKey('lastName')
+        ->and($payload)->not->toHaveKey('state');
+});
+
+it('persists only the non-sensitive attribute subset', function () {
+    $persisted = FinCardCardholderMapper::persistedAttributes([
+        'gender'           => 'female',
+        'birthday'         => '1992-03-20',
+        'id_number'        => 'SECRET123',
+        'id_front_file_id' => 'file-1',
+    ]);
+
+    expect($persisted)->toHaveKeys(['gender', 'birthday'])
+        ->and($persisted)->not->toHaveKey('id_number')
+        ->and($persisted)->not->toHaveKey('id_front_file_id');
+});
+
+it('flags restricted countries case-insensitively', function () {
+    expect(FinCardCardholderMapper::isRestrictedCountry('RU'))->toBeTrue()
+        ->and(FinCardCardholderMapper::isRestrictedCountry('ir'))->toBeTrue()
+        ->and(FinCardCardholderMapper::isRestrictedCountry('US'))->toBeFalse();
+});


### PR DESCRIPTION
## FinCard card-issuing — Phase 2 (Cardholder KYC onboarding)

Builds on Phase 1 (#1174). Adds the dedicated FinCard cardholder KYC flow, prefilled from the Zelta profile. A card can only be created once the cardholder reaches `verified` (FinCard's `pass_audit`).

Design spec §2.3/§4/§7: `docs/superpowers/specs/2026-07-06-fincard-card-issuing-design.md` · Mobile contract §4.1: `docs/FINCARD_MOBILE_INTEGRATION.md`

### What's in this PR

**Data model**
- Migration adds `kyc_stage` + `kyc_rejection_reason` to `cardholders`; `Cardholder` fillable/`@property` updated. Richer KYC attributes stay in the existing **encrypted** `verification_data` blob — no new plaintext PII columns.
- 6 new error codes `ERR_CARDS_007..012` (numbered per the enforced `^ERR_[A-Z]+_\d{3}$` contract), with brand-neutral user-facing copy.

**Client (`app/Infrastructure/FinCard`)**
- `uploadKycDocument` (multipart), `createCardholder` (V2), `listCardholders`. The auth + 401-retry logic is refactored into a shared `dispatch()` helper so multipart reuses it; JSON `rpc()` delegates to the same path (Phase 1 behavior preserved, tests still green).

**Domain**
- `FinCardCardholderMapper` — isolates FinCard's camelCase field names + the restricted-country list. The **one place** to adjust when the sandbox confirms the exact contract.
- `FinCardCardholderService` — creates the remote cardholder, persists the local row (the user ↔ `holderId` bridge the adapter path doesn't provide), and applies the **two-stage approval webhook state machine** (`wait_audit`/`under_review`/`pass_audit`/`reject` → `kyc_status`/`kyc_stage`), broadcasting `FinCardKycStatusChanged` on the terminal transitions.
- Webhook controller now routes cardholder events to the service (Phase 1's marked extension point).

**Mobile endpoints** (`/api/v1/cards`, `auth:sanctum`, snake_case, `{success,data}` / `ErrorResponse`)
- `GET /onboarding` — prefill + the field schema the app renders the KYC form from (occupations fetched live, degrade gracefully on issuer outage).
- `POST /kyc/documents` — upload one of the three ID photos → `file_id`.
- `POST /cardholder` — create (idempotency-key required) → 201 + `in_review`.
- `GET /cardholder` — KYC status (one cardholder per user).

Registered **before** the greedy `/v1/cards/{cardId}` route so these specific paths aren't swallowed. No `require.kyc` — these endpoints *start* the KYC flow (mirrors the Bridge KYC-setup routes); card creation gates on a verified cardholder in a later phase.

### Tests (all green; PHPStan L8 + phpcs clean)
- **Mapper** (unit): field mapping, empty-drop, persisted subset, restricted-country.
- **Service**: create + persist + camelCase/IP payload assertion; KYC state machine (`pass_audit` verifies + broadcasts, `reject` records reason, unknown holder = no-op); `existingFor`.
- **Controller**: onboarding schema/prefill, create (201 + persisted), `ERR_CARDS_009` conflict, `ERR_CARDS_010` restricted country, body validation, status not-started, document upload.
- **Webhook → service**: a signed `pass_audit` event flips local KYC state end-to-end.

> Fillable bug caught in testing: the two new columns weren't mass-assignable, so `kyc_stage` came back null on create — fixed in the model.

### Notes / open items (unchanged from the design)
- The FinCard cardholder **request field names + response/webhook envelope** are docs-based, pending confirmation against a live sandbox (no credentials yet). All of it is faked in tests; when the sandbox is exercised, `FinCardCardholderMapper` + the service's payload extraction are the only spots to adjust.
- Next: Phase 3 (per-user account + crypto USDT funding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
