### PR TITLE
feat(cards): FinCard integration Phase 3 — account + crypto funding

### DIFF
--- a/app/Domain/CardIssuance/Events/Broadcast/FinCardAccountFunded.php
+++ b/app/Domain/CardIssuance/Events/Broadcast/FinCardAccountFunded.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\CardIssuance\Events\Broadcast;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Broadcast when a FinCard funding account's balance changes (a crypto deposit
+ * credits, or a withdrawal debits). Delivered on the user's private channel as
+ * `fincard.account.funded`. All amounts are integer minor units (USD cents).
+ *
+ * @see docs/FINCARD_MOBILE_INTEGRATION.md §6
+ */
+final class FinCardAccountFunded implements ShouldBroadcast
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly int $userId,
+        public readonly string $accountId,
+        public readonly int $balanceCents,
+        public readonly ?int $creditedCents = null,
+        public readonly ?string $coinKey = null,
+    ) {
+    }
+
+    /**
+     * @return array<int, PrivateChannel>
+     */
+    public function broadcastOn(): array
+    {
+        return [new PrivateChannel("user.{$this->userId}")];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'fincard.account.funded';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        return array_filter([
+            'account_id'     => $this->accountId,
+            'balance_cents'  => $this->balanceCents,
+            'credited_cents' => $this->creditedCents,
+            'coin_key'       => $this->coinKey,
+        ], static fn ($v): bool => $v !== null);
+    }
+
+    public function broadcastWhen(): bool
+    {
+        return (bool) config('websocket.enabled', true);
+    }
+}

--- a/app/Domain/CardIssuance/Http/Controllers/FinCardWebhookController.php
+++ b/app/Domain/CardIssuance/Http/Controllers/FinCardWebhookController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Domain\CardIssuance\Http\Controllers;
 
+use App\Domain\CardIssuance\Services\FinCardAccountService;
 use App\Domain\CardIssuance\Services\FinCardCardholderService;
 use App\Domain\Subscription\Models\ProcessedWebhookEvent;
 use App\Http\Controllers\Controller;
@@ -40,9 +41,13 @@ class FinCardWebhookController extends Controller
     /** FinCard cardholder-event types (KYC approval workflow). */
     private const CARDHOLDER_EVENTS = ['wait_audit', 'under_review', 'pass_audit', 'reject'];
 
+    /** Wallet v2 (crypto) funding event types. */
+    private const WALLET_EVENTS = ['DEPOSIT', 'WITHDRAW'];
+
     public function __construct(
         private readonly FinCardWebhookVerifier $verifier,
         private readonly FinCardCardholderService $cardholderService,
+        private readonly FinCardAccountService $accountService,
     ) {
     }
 
@@ -128,6 +133,12 @@ class FinCardWebhookController extends Controller
     {
         if (in_array($eventType, self::CARDHOLDER_EVENTS, true)) {
             $this->cardholderService->applyKycWebhook($eventType, $payload);
+
+            return;
+        }
+
+        if (in_array($eventType, self::WALLET_EVENTS, true)) {
+            $this->accountService->applyFundingWebhook($eventType, $payload);
 
             return;
         }

--- a/app/Domain/CardIssuance/Http/Requests/CreateDepositAddressRequest.php
+++ b/app/Domain/CardIssuance/Http/Requests/CreateDepositAddressRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\CardIssuance\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validates a crypto deposit-address request. The coin set is dynamic (FinCard's
+ * /wallet/v2/coins is the runtime authority), so we only shape-check here and
+ * let FinCard reject an unsupported coin.
+ */
+final class CreateDepositAddressRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'coin_key' => ['required', 'string', 'max:32', 'regex:/^[A-Z0-9_]+$/'],
+        ];
+    }
+}

--- a/app/Domain/CardIssuance/Models/FinCardAccount.php
+++ b/app/Domain/CardIssuance/Models/FinCardAccount.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\CardIssuance\Models;
+
+use App\Domain\Shared\Traits\UsesTenantConnection;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * A user's FinCard funding account (USD ledger mirror).
+ *
+ * @property string $id
+ * @property string $user_id
+ * @property string $fincard_account_id
+ * @property string $currency
+ * @property int $balance_cents
+ * @property string $status
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ */
+class FinCardAccount extends Model
+{
+    use HasUuids;
+    use UsesTenantConnection;
+
+    protected $table = 'fincard_accounts';
+
+    protected $fillable = [
+        'user_id',
+        'fincard_account_id',
+        'currency',
+        'balance_cents',
+        'status',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'balance_cents' => 'integer',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<\App\Models\User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(\App\Models\User::class);
+    }
+}

--- a/app/Domain/CardIssuance/Models/FinCardDepositAddress.php
+++ b/app/Domain/CardIssuance/Models/FinCardDepositAddress.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\CardIssuance\Models;
+
+use App\Domain\Shared\Traits\UsesTenantConnection;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * A user's FinCard crypto deposit address for a given coin.
+ *
+ * @property string $id
+ * @property string $user_id
+ * @property string $fincard_account_id
+ * @property string $coin_key
+ * @property string|null $chain
+ * @property string $address
+ * @property int|null $min_deposit_cents
+ * @property int|null $confirmations
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ */
+class FinCardDepositAddress extends Model
+{
+    use HasUuids;
+    use UsesTenantConnection;
+
+    protected $table = 'fincard_deposit_addresses';
+
+    protected $fillable = [
+        'user_id',
+        'fincard_account_id',
+        'coin_key',
+        'chain',
+        'address',
+        'min_deposit_cents',
+        'confirmations',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'min_deposit_cents' => 'integer',
+            'confirmations'     => 'integer',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<\App\Models\User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(\App\Models\User::class);
+    }
+}

--- a/app/Domain/CardIssuance/Routes/api.php
+++ b/app/Domain/CardIssuance/Routes/api.php
@@ -8,6 +8,7 @@ use App\Domain\CardIssuance\Webhooks\CardWaitlistWebhookController;
 use App\Http\Controllers\Api\CardIssuance\CardController;
 use App\Http\Controllers\Api\CardIssuance\CardholderController;
 use App\Http\Controllers\Api\CardIssuance\CardTransactionWebhookController;
+use App\Http\Controllers\Api\CardIssuance\FinCardAccountController;
 use App\Http\Controllers\Api\CardIssuance\FinCardOnboardingController;
 use App\Http\Controllers\Api\CardIssuance\JitFundingWebhookController;
 use Illuminate\Support\Facades\Route;
@@ -46,6 +47,13 @@ Route::prefix('v1/cards')->name('api.cards.fincard.')
         Route::post('/cardholder', [FinCardOnboardingController::class, 'createCardholder'])
             ->middleware(['idempotency.required', 'api.rate_limit:mutation'])
             ->name('cardholder.create');
+
+        // Funding (Phase 3) — account balance, deposit coins, crypto address.
+        Route::get('/account', [FinCardAccountController::class, 'account'])->name('account');
+        Route::get('/account/coins', [FinCardAccountController::class, 'coins'])->name('account.coins');
+        Route::post('/account/deposit-address', [FinCardAccountController::class, 'depositAddress'])
+            ->middleware(['idempotency.required', 'api.rate_limit:mutation'])
+            ->name('account.deposit-address');
     });
 
 Route::prefix('v1/cards')->name('api.cards.')->group(function () {

--- a/app/Domain/CardIssuance/Services/FinCardAccountService.php
+++ b/app/Domain/CardIssuance/Services/FinCardAccountService.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\CardIssuance\Services;
+
+use App\Domain\CardIssuance\Events\Broadcast\FinCardAccountFunded;
+use App\Domain\CardIssuance\Models\FinCardAccount;
+use App\Domain\CardIssuance\Models\FinCardDepositAddress;
+use App\Infrastructure\FinCard\FinCardClient;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * FinCard funding: per-user account provisioning, crypto deposit addresses, and
+ * applying wallet funding webhooks to the mirrored balance.
+ *
+ * The local `fincard_accounts.balance_cents` is a CACHE — FinCard holds the
+ * authoritative USD funds. It is updated from wallet webhooks (deduped once at
+ * the controller via processed_webhook_events) and can be reconciled from
+ * FinCard via syncBalance(). All amounts are integer minor units; conversions
+ * use bcmath (never float). Balance mutations lock the row inside a
+ * tenant-connection transaction and run OUTSIDE the webhook controller's
+ * default-connection dedupe (cross-connection transactions self-deadlock).
+ *
+ * @see docs/superpowers/specs/2026-07-06-fincard-card-issuing-design.md §6
+ */
+final class FinCardAccountService
+{
+    public function __construct(
+        private readonly FinCardClient $client,
+    ) {
+    }
+
+    public function existingAccount(User $user): ?FinCardAccount
+    {
+        return FinCardAccount::query()->where('user_id', $user->id)->first();
+    }
+
+    /**
+     * The user's FinCard account, creating it on FinCard on first use.
+     *
+     * @param  array<string, mixed>  $context
+     */
+    public function getOrCreateAccount(User $user, array $context = []): FinCardAccount
+    {
+        $existing = $this->existingAccount($user);
+        if ($existing instanceof FinCardAccount) {
+            return $existing;
+        }
+
+        $response = $this->client->createAccount("Zelta user {$user->id}", 'USD', $context);
+        $data = is_array($response['data'] ?? null) ? $response['data'] : [];
+
+        $account = new FinCardAccount();
+        $account->user_id = (string) $user->id;
+        $account->fincard_account_id = (string) ($data['accountId'] ?? $data['id'] ?? '');
+        $account->currency = 'USD';
+        $account->balance_cents = 0;
+        $account->status = 'active';
+        $account->save();
+
+        return $account;
+    }
+
+    /**
+     * The user's deposit address for a coin, creating it on FinCard on first use.
+     *
+     * @param  array<string, mixed>  $context
+     */
+    public function getOrCreateDepositAddress(User $user, string $coinKey, array $context = []): FinCardDepositAddress
+    {
+        $existing = FinCardDepositAddress::query()
+            ->where('user_id', $user->id)
+            ->where('coin_key', $coinKey)
+            ->first();
+        if ($existing instanceof FinCardDepositAddress) {
+            return $existing;
+        }
+
+        $account = $this->getOrCreateAccount($user, $context);
+        $response = $this->client->createDepositAddress($coinKey, $account->fincard_account_id, $context);
+        $data = is_array($response['data'] ?? null) ? $response['data'] : [];
+
+        $address = new FinCardDepositAddress();
+        $address->user_id = (string) $user->id;
+        $address->fincard_account_id = $account->fincard_account_id;
+        $address->coin_key = $coinKey;
+        $address->chain = $this->stringOrNull($data['chain'] ?? null);
+        $address->address = (string) ($data['address'] ?? '');
+        $address->min_deposit_cents = isset($data['minDepositAmount']) ? $this->toCents((string) $data['minDepositAmount']) : null;
+        $address->confirmations = isset($data['confirmations']) ? (int) $data['confirmations'] : null;
+        $address->save();
+
+        return $address;
+    }
+
+    /**
+     * Reconcile the mirrored balance from FinCard's authoritative account query.
+     *
+     * @param  array<string, mixed>  $context
+     */
+    public function syncBalance(FinCardAccount $account, array $context = []): FinCardAccount
+    {
+        $response = $this->client->queryAccount($account->fincard_account_id, $context);
+        $data = is_array($response['data'] ?? null) ? $response['data'] : [];
+
+        if (isset($data['balance']) && is_numeric((string) $data['balance'])) {
+            $account->balance_cents = $this->toCents((string) $data['balance']);
+            $account->save();
+        }
+
+        return $account;
+    }
+
+    /**
+     * Apply a wallet funding webhook (DEPOSIT credit / WITHDRAW debit) to the
+     * mirrored balance. Idempotency is guaranteed by the controller's
+     * processed_webhook_events dedupe, so a delta is applied at most once.
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    public function applyFundingWebhook(string $eventType, array $payload): void
+    {
+        $data = is_array($payload['data'] ?? null) ? $payload['data'] : [];
+        $accountId = (string) ($data['accountId'] ?? $data['account_id'] ?? '');
+        if ($accountId === '') {
+            Log::warning('FinCard funding webhook without accountId', ['event' => $eventType]);
+
+            return;
+        }
+
+        $isDeposit = strtoupper($eventType) === 'DEPOSIT';
+        $amountCents = $this->toCents((string) ($data['amount'] ?? '0'));
+        // Prefer an authoritative balance if FinCard includes it; else apply the delta.
+        $authoritativeBalance = isset($data['balance']) && is_numeric((string) $data['balance'])
+            ? $this->toCents((string) $data['balance'])
+            : null;
+
+        $connection = (new FinCardAccount())->getConnectionName();
+
+        $account = DB::connection($connection)->transaction(function () use ($accountId, $isDeposit, $amountCents, $authoritativeBalance): ?FinCardAccount {
+            $account = FinCardAccount::query()->where('fincard_account_id', $accountId)->lockForUpdate()->first();
+            if (! $account instanceof FinCardAccount) {
+                return null;
+            }
+
+            if ($authoritativeBalance !== null) {
+                $account->balance_cents = $authoritativeBalance;
+            } elseif ($isDeposit) {
+                $account->balance_cents += $amountCents;
+            } else {
+                $account->balance_cents = max(0, $account->balance_cents - $amountCents);
+            }
+
+            $account->save();
+
+            return $account;
+        });
+
+        if (! $account instanceof FinCardAccount) {
+            Log::warning('FinCard funding webhook for unknown account', ['account_id' => $accountId, 'event' => $eventType]);
+
+            return;
+        }
+
+        FinCardAccountFunded::dispatch(
+            (int) $account->user_id,
+            $account->fincard_account_id,
+            $account->balance_cents,
+            $isDeposit ? $amountCents : null,
+            $this->stringOrNull($data['coinKey'] ?? null),
+        );
+    }
+
+    /**
+     * Convert a decimal amount string to integer minor units via bcmath.
+     */
+    private function toCents(string $amount): int
+    {
+        if (! is_numeric($amount)) {
+            return 0;
+        }
+
+        return (int) bcmul(bcadd($amount, '0', 2), '100', 0);
+    }
+
+    private function stringOrNull(mixed $value): ?string
+    {
+        return $value === null || $value === '' ? null : (string) $value;
+    }
+}

--- a/app/Domain/Compliance/Services/GdprService.php
+++ b/app/Domain/Compliance/Services/GdprService.php
@@ -157,6 +157,8 @@ class GdprService
         'delegated_proof_jobs'         => self::EXCL_LEGACY,
         'device_fingerprints'          => self::EXCL_SECURITY,
         'exports'                      => self::EXCL_EPHEMERAL,
+        'fincard_accounts'             => self::EXCL_FINANCIAL,
+        'fincard_deposit_addresses'    => 'FinCard-issued crypto deposit addresses tied to the funding account; financial-account artifacts retained with the account under Art. 17(3)(b). FinCard (the regulated card issuer) is the controller of record; no direct identifiers beyond the user FK and the provider-issued address.',
         'gcu_votes'                    => self::EXCL_LEGACY,
         'hardware_wallet_associations' => self::EXCL_LEGACY,
         'idempotency_keys'             => self::EXCL_EPHEMERAL,

--- a/app/Http/Controllers/Api/CardIssuance/FinCardAccountController.php
+++ b/app/Http/Controllers/Api/CardIssuance/FinCardAccountController.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\CardIssuance;
+
+use App\Domain\CardIssuance\Http\Requests\CreateDepositAddressRequest;
+use App\Domain\CardIssuance\Models\FinCardAccount;
+use App\Domain\CardIssuance\Models\FinCardDepositAddress;
+use App\Domain\CardIssuance\Services\FinCardAccountService;
+use App\Http\Controllers\Controller;
+use App\Infrastructure\FinCard\FinCardApiException;
+use App\Infrastructure\FinCard\FinCardClient;
+use App\Models\User;
+use App\Support\ErrorResponse;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * FinCard funding — account balance, supported deposit coins, and crypto
+ * deposit-address provisioning (Phase 3).
+ *
+ * @see docs/FINCARD_MOBILE_INTEGRATION.md §4.2
+ */
+class FinCardAccountController extends Controller
+{
+    public function __construct(
+        private readonly FinCardClient $client,
+        private readonly FinCardAccountService $accounts,
+    ) {
+    }
+
+    /**
+     * The user's funding account + balance (mirror, reconciled best-effort).
+     */
+    public function account(Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $account = $this->accounts->existingAccount($user);
+
+        if (! $account instanceof FinCardAccount) {
+            return response()->json([
+                'success' => true,
+                'data'    => ['provisioned' => false, 'currency' => 'USD', 'balance_cents' => 0],
+            ]);
+        }
+
+        // Reconcile from FinCard's authoritative balance, but never fail the read
+        // if FinCard is momentarily unavailable — fall back to the mirror.
+        try {
+            $account = $this->accounts->syncBalance($account, $this->context($request));
+        } catch (FinCardApiException $e) {
+            Log::warning('FinCard balance sync failed; serving mirror', ['user_id' => $user->id, 'msg' => $e->getMessage()]);
+        }
+
+        return response()->json([
+            'success' => true,
+            'data'    => [
+                'provisioned'   => true,
+                'account_id'    => $account->fincard_account_id,
+                'currency'      => $account->currency,
+                'balance_cents' => $account->balance_cents,
+                'status'        => $account->status,
+            ],
+        ]);
+    }
+
+    /**
+     * Supported crypto deposit coins (live from FinCard — the runtime authority).
+     */
+    public function coins(Request $request): JsonResponse
+    {
+        try {
+            $response = $this->client->getCoins($this->context($request));
+        } catch (FinCardApiException $e) {
+            Log::warning('FinCard coins fetch failed', ['msg' => $e->getMessage()]);
+
+            return ErrorResponse::make('ERR_CARDS_013');
+        }
+
+        $coins = is_array($response['data'] ?? null) ? $response['data'] : [];
+
+        return response()->json(['success' => true, 'data' => ['coins' => $coins]]);
+    }
+
+    /**
+     * Get or create the user's deposit address for a coin.
+     */
+    public function depositAddress(CreateDepositAddressRequest $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $coinKey = (string) $request->validated('coin_key');
+
+        try {
+            $address = $this->accounts->getOrCreateDepositAddress($user, $coinKey, $this->context($request));
+        } catch (FinCardApiException $e) {
+            Log::warning('FinCard deposit address failed', ['user_id' => $user->id, 'coin' => $coinKey, 'msg' => $e->getMessage()]);
+
+            return ErrorResponse::make('ERR_CARDS_013');
+        }
+
+        if ($address->address === '') {
+            return ErrorResponse::make('ERR_CARDS_013');
+        }
+
+        return response()->json(['success' => true, 'data' => $this->presentAddress($address)], 201);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function presentAddress(FinCardDepositAddress $address): array
+    {
+        return [
+            'coin_key'          => $address->coin_key,
+            'chain'             => $address->chain,
+            'address'           => $address->address,
+            'min_deposit_cents' => $address->min_deposit_cents,
+            'confirmations'     => $address->confirmations,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function context(Request $request): array
+    {
+        return [
+            'forwarded_for' => $request->ip() ?? '127.0.0.1',
+            'platform'      => (string) ($request->header('platform') ?? 'ios'),
+            'device_id'     => (string) ($request->header('deviceId') ?? ''),
+        ];
+    }
+}

--- a/app/Infrastructure/FinCard/FinCardClient.php
+++ b/app/Infrastructure/FinCard/FinCardClient.php
@@ -234,6 +234,63 @@ final class FinCardClient
         return $this->rpc('/card/holder/list', ['pageNum' => $pageNum, 'pageSize' => $pageSize], $context);
     }
 
+    // ── Account / Wallet funding (Phase 3) ───────────────────────────────
+
+    /**
+     * Create a FinCard account (USD ledger) for the tenant.
+     *
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function createAccount(string $accountName, string $currency, array $context = []): array
+    {
+        return $this->rpc('/account/create', ['accountName' => $accountName, 'currency' => $currency], $context);
+    }
+
+    /**
+     * Query a single account (balance + status).
+     *
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function queryAccount(string $accountId, array $context = []): array
+    {
+        return $this->rpc('/account/single/query', ['accountId' => $accountId], $context);
+    }
+
+    /**
+     * Account ledger transactions.
+     *
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function getAccountTransactions(string $accountId, int $pageNum = 1, int $pageSize = 20, array $context = []): array
+    {
+        return $this->rpc('/account/transaction', ['accountId' => $accountId, 'pageNum' => $pageNum, 'pageSize' => $pageSize], $context);
+    }
+
+    /**
+     * Create a crypto deposit address for a coin, tied to an account.
+     *
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function createDepositAddress(string $coinKey, string $accountId, array $context = []): array
+    {
+        return $this->rpc('/wallet/v2/create', ['coinKey' => $coinKey, 'accountId' => $accountId], $context);
+    }
+
+    /**
+     * List existing wallet deposit addresses.
+     *
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function listDepositAddresses(int $pageNum = 1, int $pageSize = 20, array $context = []): array
+    {
+        return $this->rpc('/wallet/v2/addressList', ['pageNum' => $pageNum, 'pageSize' => $pageSize], $context);
+    }
+
     // ── Core RPC ─────────────────────────────────────────────────────────
 
     /**

--- a/config/error_codes.php
+++ b/config/error_codes.php
@@ -83,4 +83,8 @@ return [
     'ERR_CARDS_010' => ['http' => 422, 'description' => 'Your country is not supported for card issuance.'],
     'ERR_CARDS_011' => ['http' => 422, 'description' => 'Document upload failed or the document type is not accepted.'],
     'ERR_CARDS_012' => ['http' => 502, 'description' => 'We could not verify your details right now. Please try again later.'],
+
+    // ─── FinCard funding (Phase 3) ─────────────────────────────────────────
+    'ERR_CARDS_013' => ['http' => 502, 'description' => 'Funding is temporarily unavailable. Please try again later.'],
+    'ERR_CARDS_014' => ['http' => 422, 'description' => 'That deposit coin is not supported.'],
 ];

--- a/database/migrations/2026_07_06_110001_create_fincard_accounts_table.php
+++ b/database/migrations/2026_07_06_110001_create_fincard_accounts_table.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * FinCard funding accounts — one per Zelta user.
+ *
+ * FinCard is a prefunded card program: each user gets a FinCard "account" (a USD
+ * ledger) that cards spend from. We mirror its balance here (`balance_cents`,
+ * integer minor units) from wallet-deposit + account webhooks and periodic sync;
+ * `fincard_account_id` is FinCard's identifier for the account. Runs on the
+ * default connection (the model reads/writes via the tenant connection at
+ * runtime, matching cardholders/cards).
+ *
+ * @see docs/superpowers/specs/2026-07-06-fincard-card-issuing-design.md §4, §6
+ */
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('fincard_accounts', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('fincard_account_id')->unique();
+            $table->string('currency', 3)->default('USD');
+            $table->bigInteger('balance_cents')->default(0);
+            $table->string('status')->default('active'); // active, frozen, closed
+            $table->timestamps();
+
+            $table->index(['user_id', 'status']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('fincard_accounts');
+    }
+};

--- a/database/migrations/2026_07_06_110002_create_fincard_deposit_addresses_table.php
+++ b/database/migrations/2026_07_06_110002_create_fincard_deposit_addresses_table.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * FinCard crypto deposit addresses — one per user per coin.
+ *
+ * A user funds their FinCard account by sending stablecoin (e.g. USDT_TRC20)
+ * from their own Zelta wallet to a FinCard-provided deposit address; FinCard
+ * converts to USD and credits the account. Addresses are stable per (user,
+ * coin), so we persist them. Amounts are integer minor units.
+ *
+ * @see docs/superpowers/specs/2026-07-06-fincard-card-issuing-design.md §6.1
+ */
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('fincard_deposit_addresses', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('fincard_account_id');
+            $table->string('coin_key');            // e.g. USDT_TRC20, USDT_BEP20
+            $table->string('chain')->nullable();   // e.g. TRON, BSC
+            $table->string('address')->index();
+            $table->bigInteger('min_deposit_cents')->nullable();
+            $table->unsignedInteger('confirmations')->nullable();
+            $table->timestamps();
+
+            $table->unique(['user_id', 'coin_key']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('fincard_deposit_addresses');
+    }
+};

--- a/docs/FINCARD_MOBILE_INTEGRATION.md
+++ b/docs/FINCARD_MOBILE_INTEGRATION.md
@@ -148,11 +148,13 @@ Card endpoints use the `ERR_CARDS_*` family (registered in `config/error_codes.p
 | `ERR_CARDS_010` | 422 | User's country is restricted for issuance |
 | `ERR_CARDS_011` | 422 | KYC document upload failed / unsupported type |
 | `ERR_CARDS_012` | 502 | Card issuer rejected the cardholder request → retry later |
+| `ERR_CARDS_013` | 502 | Funding temporarily unavailable (deposit-address/coins failure) → retry |
+| `ERR_CARDS_014` | 422 | Deposit coin not supported |
 | `ERR_VALIDATION_001/003` | 422 | Missing/invalid `Idempotency-Key` or body |
 | `ERR_IDEMPOTENCY_409` | 409 | Same key, different body |
 | (rate limit) | 429 | Too many card operations → back off |
 
-Funding/card-lifecycle codes (`ERR_CARDS_013+`) are added as phases 3–4 land. The envelope shape (`{success:false, error:{code,message}}`) is stable; the app branches on `code` and may override the message copy.
+Card-lifecycle codes (`ERR_CARDS_015+`) are added as phase 4 lands. The envelope shape (`{success:false, error:{code,message}}`) is stable; the app branches on `code` and may override the message copy.
 
 ---
 

--- a/tests/Feature/Api/FinCard/FinCardWebhookEndpointTest.php
+++ b/tests/Feature/Api/FinCard/FinCardWebhookEndpointTest.php
@@ -11,6 +11,7 @@
 declare(strict_types=1);
 
 use App\Domain\CardIssuance\Models\Cardholder;
+use App\Domain\CardIssuance\Models\FinCardAccount;
 use App\Domain\Subscription\Models\ProcessedWebhookEvent;
 use App\Infrastructure\FinCard\FinCardWebhookVerifier;
 use App\Models\User;
@@ -122,4 +123,25 @@ it('applies a cardholder pass_audit event to the local KYC state', function () {
     $fresh = Cardholder::query()->where('issuer_cardholder_id', 'h-web')->firstOrFail();
     expect($fresh->kyc_status)->toBe('verified')
         ->and($fresh->verified_at)->not->toBeNull();
+});
+
+it('credits the funding account on a wallet DEPOSIT event', function () {
+    $user = User::factory()->create();
+    $account = new FinCardAccount();
+    $account->user_id = (string) $user->id;
+    $account->fincard_account_id = 'acc-web';
+    $account->currency = 'USD';
+    $account->balance_cents = 1000;
+    $account->status = 'active';
+    $account->save();
+
+    $body = (string) json_encode(['eventType' => 'DEPOSIT', 'data' => ['accountId' => 'acc-web', 'amount' => '8.86', 'orderNo' => 'ord-dep']]);
+    $sig = fincardEndpointSign($body, $this->finCardPriv);
+
+    $this->call('POST', '/api/v1/webhooks/fincard', [], [], [], fincardWebhookServer('X-FC-SIGNATURE', $sig), $body)
+        ->assertOk()
+        ->assertExactJson(['success' => true]);
+
+    $fresh = FinCardAccount::query()->where('fincard_account_id', 'acc-web')->firstOrFail();
+    expect($fresh->balance_cents)->toBe(1886);
 });

--- a/tests/Feature/CardIssuance/FinCardAccountControllerTest.php
+++ b/tests/Feature/CardIssuance/FinCardAccountControllerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\CardIssuance\Models\FinCardAccount;
+use App\Infrastructure\FinCard\FinCardClient;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\Sanctum;
+
+beforeEach(function () {
+    config(['cache.default' => 'array']);
+    Cache::flush();
+
+    $this->app->instance(FinCardClient::class, new FinCardClient(
+        baseUrl: 'https://sandbox.finhub.cloud/api/v2.1/fincard/virtual',
+        tenantId: 't',
+        orgId: 'o',
+        userId: 'u',
+        username: 'x',
+        password: 'y',
+    ));
+
+    Http::fake([
+        'sandbox.finhub.cloud/api/v2.1/admin/*' => Http::response([
+            'success' => true, 'data' => ['accessToken' => 'jwt', 'expiresIn' => 3600],
+        ]),
+        'sandbox.finhub.cloud/api/v2.1/fincard/virtual/wallet/v2/coins' => Http::response([
+            'success' => true, 'data' => [['coinKey' => 'USDT_TRC20', 'chain' => 'TRON']],
+        ]),
+        'sandbox.finhub.cloud/api/v2.1/fincard/virtual/account/create' => Http::response([
+            'success' => true, 'data' => ['accountId' => 'acc-new'],
+        ]),
+        'sandbox.finhub.cloud/api/v2.1/fincard/virtual/wallet/v2/create' => Http::response([
+            'success' => true, 'data' => ['address' => 'TXyz', 'chain' => 'TRON', 'confirmations' => 38],
+        ]),
+        'sandbox.finhub.cloud/api/v2.1/fincard/virtual/account/single/query' => Http::response([
+            'success' => true, 'data' => ['balance' => '12.34'],
+        ]),
+    ]);
+
+    $this->user = User::factory()->create();
+    Sanctum::actingAs($this->user, ['read', 'write', 'delete']);
+});
+
+it('reports not-provisioned when the user has no FinCard account', function () {
+    $this->getJson('/api/v1/cards/account')
+        ->assertOk()
+        ->assertJsonPath('data.provisioned', false)
+        ->assertJsonPath('data.balance_cents', 0);
+});
+
+it('returns the account with a reconciled balance', function () {
+    $account = new FinCardAccount();
+    $account->user_id = (string) $this->user->id;
+    $account->fincard_account_id = 'acc-1';
+    $account->currency = 'USD';
+    $account->balance_cents = 100;
+    $account->status = 'active';
+    $account->save();
+
+    $this->getJson('/api/v1/cards/account')
+        ->assertOk()
+        ->assertJsonPath('data.provisioned', true)
+        ->assertJsonPath('data.account_id', 'acc-1')
+        ->assertJsonPath('data.balance_cents', 1234); // reconciled from FinCard
+});
+
+it('lists supported deposit coins', function () {
+    $this->getJson('/api/v1/cards/account/coins')
+        ->assertOk()
+        ->assertJsonPath('data.coins.0.coinKey', 'USDT_TRC20');
+});
+
+it('creates a deposit address', function () {
+    $this->withHeader('Idempotency-Key', (string) Str::uuid())
+        ->postJson('/api/v1/cards/account/deposit-address', ['coin_key' => 'USDT_TRC20'])
+        ->assertCreated()
+        ->assertJsonPath('data.coin_key', 'USDT_TRC20')
+        ->assertJsonPath('data.address', 'TXyz')
+        ->assertJsonPath('data.chain', 'TRON');
+
+    expect(App\Domain\CardIssuance\Models\FinCardDepositAddress::where('user_id', $this->user->id)->where('coin_key', 'USDT_TRC20')->exists())->toBeTrue();
+});
+
+it('validates the coin_key format', function () {
+    $this->withHeader('Idempotency-Key', (string) Str::uuid())
+        ->postJson('/api/v1/cards/account/deposit-address', ['coin_key' => 'not a coin!'])
+        ->assertStatus(422);
+});

--- a/tests/Feature/CardIssuance/FinCardAccountServiceTest.php
+++ b/tests/Feature/CardIssuance/FinCardAccountServiceTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\CardIssuance;
+
+use App\Domain\CardIssuance\Events\Broadcast\FinCardAccountFunded;
+use App\Domain\CardIssuance\Models\FinCardAccount;
+use App\Domain\CardIssuance\Services\FinCardAccountService;
+use App\Infrastructure\FinCard\FinCardClient;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class FinCardAccountServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['cache.default' => 'array']);
+        Cache::flush();
+    }
+
+    private function client(): FinCardClient
+    {
+        return new FinCardClient(
+            baseUrl: 'https://sandbox.finhub.cloud/api/v2.1/fincard/virtual',
+            tenantId: 't',
+            orgId: 'o',
+            userId: 'u',
+            username: 'x',
+            password: 'y',
+        );
+    }
+
+    /**
+     * @return array<string, \GuzzleHttp\Promise\PromiseInterface>
+     */
+    private function loginFake(): array
+    {
+        return [
+            'sandbox.finhub.cloud/api/v2.1/admin/*' => Http::response([
+                'success' => true, 'data' => ['accessToken' => 'jwt', 'expiresIn' => 3600],
+            ]),
+        ];
+    }
+
+    private function account(User $user, int $balanceCents = 0, string $accountId = 'acc-1'): FinCardAccount
+    {
+        $account = new FinCardAccount();
+        $account->user_id = (string) $user->id;
+        $account->fincard_account_id = $accountId;
+        $account->currency = 'USD';
+        $account->balance_cents = $balanceCents;
+        $account->status = 'active';
+        $account->save();
+
+        return $account;
+    }
+
+    public function test_get_or_create_account_creates_and_persists(): void
+    {
+        Http::fake(array_merge($this->loginFake(), [
+            'sandbox.finhub.cloud/api/v2.1/fincard/virtual/account/create' => Http::response([
+                'success' => true, 'data' => ['accountId' => 'acc-new'],
+            ]),
+        ]));
+
+        $user = User::factory()->create();
+        $account = (new FinCardAccountService($this->client()))->getOrCreateAccount($user);
+
+        $this->assertSame('acc-new', $account->fincard_account_id);
+        $this->assertSame(0, $account->balance_cents);
+        $this->assertDatabaseHas('fincard_accounts', ['fincard_account_id' => 'acc-new', 'user_id' => $user->id]);
+    }
+
+    public function test_get_or_create_account_reuses_existing_without_calling_fincard(): void
+    {
+        Http::fake($this->loginFake());
+        $user = User::factory()->create();
+        $this->account($user, accountId: 'acc-existing');
+
+        $account = (new FinCardAccountService($this->client()))->getOrCreateAccount($user);
+
+        $this->assertSame('acc-existing', $account->fincard_account_id);
+        Http::assertNothingSent();
+    }
+
+    public function test_get_or_create_deposit_address_persists_with_chain_and_min(): void
+    {
+        Http::fake(array_merge($this->loginFake(), [
+            'sandbox.finhub.cloud/api/v2.1/fincard/virtual/wallet/v2/create' => Http::response([
+                'success' => true,
+                'data'    => ['address' => 'TXyz...abc', 'chain' => 'TRON', 'minDepositAmount' => '5.00', 'confirmations' => 38],
+            ]),
+        ]));
+
+        $user = User::factory()->create();
+        $this->account($user, accountId: 'acc-1');
+
+        $address = (new FinCardAccountService($this->client()))->getOrCreateDepositAddress($user, 'USDT_TRC20');
+
+        $this->assertSame('TXyz...abc', $address->address);
+        $this->assertSame('TRON', $address->chain);
+        $this->assertSame(500, $address->min_deposit_cents);
+        $this->assertSame(38, $address->confirmations);
+        $this->assertDatabaseHas('fincard_deposit_addresses', ['user_id' => $user->id, 'coin_key' => 'USDT_TRC20']);
+    }
+
+    public function test_deposit_webhook_credits_balance_via_bcmath_and_broadcasts(): void
+    {
+        Event::fake([FinCardAccountFunded::class]);
+        $user = User::factory()->create();
+        $this->account($user, balanceCents: 1000, accountId: 'acc-1');
+
+        (new FinCardAccountService($this->client()))->applyFundingWebhook('DEPOSIT', [
+            'data' => ['accountId' => 'acc-1', 'amount' => '8.86', 'coinKey' => 'USDT_TRC20'],
+        ]);
+
+        $fresh = FinCardAccount::query()->where('fincard_account_id', 'acc-1')->firstOrFail();
+        $this->assertSame(1886, $fresh->balance_cents); // 1000 + 886
+        Event::assertDispatched(FinCardAccountFunded::class, fn ($e): bool => $e->balanceCents === 1886 && $e->creditedCents === 886);
+    }
+
+    public function test_deposit_webhook_prefers_authoritative_balance_when_present(): void
+    {
+        $user = User::factory()->create();
+        $this->account($user, balanceCents: 1000, accountId: 'acc-1');
+
+        (new FinCardAccountService($this->client()))->applyFundingWebhook('DEPOSIT', [
+            'data' => ['accountId' => 'acc-1', 'amount' => '8.86', 'balance' => '50.00'],
+        ]);
+
+        $fresh = FinCardAccount::query()->where('fincard_account_id', 'acc-1')->firstOrFail();
+        $this->assertSame(5000, $fresh->balance_cents); // set to authoritative 50.00
+    }
+
+    public function test_withdraw_webhook_debits_and_floors_at_zero(): void
+    {
+        $user = User::factory()->create();
+        $this->account($user, balanceCents: 500, accountId: 'acc-1');
+
+        (new FinCardAccountService($this->client()))->applyFundingWebhook('WITHDRAW', [
+            'data' => ['accountId' => 'acc-1', 'amount' => '9.00'],
+        ]);
+
+        $fresh = FinCardAccount::query()->where('fincard_account_id', 'acc-1')->firstOrFail();
+        $this->assertSame(0, $fresh->balance_cents); // max(0, 500 - 900)
+    }
+
+    public function test_funding_webhook_for_unknown_account_is_a_noop(): void
+    {
+        Event::fake([FinCardAccountFunded::class]);
+
+        (new FinCardAccountService($this->client()))->applyFundingWebhook('DEPOSIT', [
+            'data' => ['accountId' => 'nope', 'amount' => '5.00'],
+        ]);
+
+        Event::assertNotDispatched(FinCardAccountFunded::class);
+    }
+
+    public function test_sync_balance_reconciles_from_fincard(): void
+    {
+        Http::fake(array_merge($this->loginFake(), [
+            'sandbox.finhub.cloud/api/v2.1/fincard/virtual/account/single/query' => Http::response([
+                'success' => true, 'data' => ['balance' => '12.34'],
+            ]),
+        ]));
+
+        $user = User::factory()->create();
+        $account = $this->account($user, balanceCents: 100, accountId: 'acc-1');
+
+        $synced = (new FinCardAccountService($this->client()))->syncBalance($account);
+
+        $this->assertSame(1234, $synced->balance_cents);
+    }
+}


### PR DESCRIPTION
## FinCard card-issuing — Phase 3 (Account + crypto funding)

Builds on Phase 2 (#1175). Adds per-user FinCard funding **accounts** and crypto (USDT) deposit funding. The local balance is a **cache** — FinCard holds the authoritative USD; balance mutations use bcmath, lock the row inside a tenant-connection transaction, and rely on the webhook dedupe for once-only application.

Design §6 · Mobile §4.2: `docs/superpowers/specs/2026-07-06-fincard-card-issuing-design.md`, `docs/FINCARD_MOBILE_INTEGRATION.md`

### What's in this PR
- **Migrations:** `fincard_accounts` (USD balance mirror, one per user) + `fincard_deposit_addresses` (one per user per coin). Models use `UsesTenantConnection`.
- **Client:** `createAccount`, `queryAccount`, `getAccountTransactions`, `createDepositAddress`, `listDepositAddresses`.
- **`FinCardAccountService`:** `getOrCreateAccount`, `getOrCreateDepositAddress`, `syncBalance` (reconcile from FinCard's authoritative balance), and `applyFundingWebhook` — DEPOSIT credits / WITHDRAW debits (prefers an authoritative balance if the webhook carries one, else applies the delta; floors at zero), broadcasting `FinCardAccountFunded`.
- **Webhook controller** routes wallet `DEPOSIT`/`WITHDRAW` to the account service.
- **Mobile endpoints (`/v1/cards`):** `GET /account` (balance, reconciled best-effort), `GET /account/coins` (live coin list), `POST /account/deposit-address` (idempotent). Registered before the greedy `{cardId}` route.
- **`ERR_CARDS_013/014`** (funding); mobile spec error table updated.

### Money-handling discipline
Integer minor units throughout; `bcmath` for amount→cents (no float). Balance writes `lockForUpdate` inside a **tenant-connection** transaction, kept out of the webhook controller's default-connection dedupe (cross-connection transactions self-deadlock). Idempotency from `processed_webhook_events` (once-only). Withdraw floors at zero.

### Tests (120 FinCard tests green incl. Phase 1+2; PHPStan L8 + phpcs clean)
Account create/reuse; deposit-address persistence (chain/min/confirmations); **bcmath credit (1000+886=1886), authoritative-balance override, zero-floored withdraw, unknown-account no-op**; balance sync; controller endpoints; and a signed `DEPOSIT` webhook crediting end-to-end.

> Verified with the correct larastan v3.10.0 toolchain (composer.lock version), after discovering the earlier hardlinked vendor had a stale larastan.

Next: Phase 4 (card lifecycle — open/sensitive/freeze/topup/withdraw + transaction sync). FinCard's exact request/response + webhook envelope remain docs-based pending a live sandbox; `FinCardAccountService` payload extraction + `FinCardCardholderMapper` are the spots to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
