### PR TITLE
feat(cards): FinCard integration Phase 4 — card lifecycle

### DIFF
--- a/app/Domain/CardIssuance/Events/Broadcast/CardStateChanged.php
+++ b/app/Domain/CardIssuance/Events/Broadcast/CardStateChanged.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\CardIssuance\Events\Broadcast;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Broadcast when a FinCard card's state changes (created, frozen, cancelled, or
+ * balance moved). Delivered on the user's private channel as `card.state_changed`.
+ * `balanceCents` is integer minor units (USD cents).
+ *
+ * @see docs/FINCARD_MOBILE_INTEGRATION.md §6
+ */
+final class CardStateChanged implements ShouldBroadcast
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly int $userId,
+        public readonly string $cardId,
+        public readonly string $status,
+        public readonly int $balanceCents,
+    ) {
+    }
+
+    /**
+     * @return array<int, PrivateChannel>
+     */
+    public function broadcastOn(): array
+    {
+        return [new PrivateChannel("user.{$this->userId}")];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'card.state_changed';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        return [
+            'card_id'       => $this->cardId,
+            'status'        => $this->status,
+            'balance_cents' => $this->balanceCents,
+        ];
+    }
+
+    public function broadcastWhen(): bool
+    {
+        return (bool) config('websocket.enabled', true);
+    }
+}

--- a/app/Domain/CardIssuance/Http/Controllers/FinCardWebhookController.php
+++ b/app/Domain/CardIssuance/Http/Controllers/FinCardWebhookController.php
@@ -6,6 +6,7 @@ namespace App\Domain\CardIssuance\Http\Controllers;
 
 use App\Domain\CardIssuance\Services\FinCardAccountService;
 use App\Domain\CardIssuance\Services\FinCardCardholderService;
+use App\Domain\CardIssuance\Services\FinCardCardService;
 use App\Domain\Subscription\Models\ProcessedWebhookEvent;
 use App\Http\Controllers\Controller;
 use App\Infrastructure\FinCard\FinCardWebhookVerifier;
@@ -41,13 +42,17 @@ class FinCardWebhookController extends Controller
     /** FinCard cardholder-event types (KYC approval workflow). */
     private const CARDHOLDER_EVENTS = ['wait_audit', 'under_review', 'pass_audit', 'reject'];
 
-    /** Wallet v2 (crypto) funding event types. */
+    /** Wallet v2 (crypto) funding event types (uppercase — distinct from card-op). */
     private const WALLET_EVENTS = ['DEPOSIT', 'WITHDRAW'];
+
+    /** Card-operation event types (lowercase deposit/withdraw affect the card, not the account). */
+    private const CARD_OP_EVENTS = ['create', 'deposit', 'withdraw', 'Freeze', 'UnFreeze', 'cancel', 'blocked', 'overdraft_statement'];
 
     public function __construct(
         private readonly FinCardWebhookVerifier $verifier,
         private readonly FinCardCardholderService $cardholderService,
         private readonly FinCardAccountService $accountService,
+        private readonly FinCardCardService $cardService,
     ) {
     }
 
@@ -139,6 +144,12 @@ class FinCardWebhookController extends Controller
 
         if (in_array($eventType, self::WALLET_EVENTS, true)) {
             $this->accountService->applyFundingWebhook($eventType, $payload);
+
+            return;
+        }
+
+        if (in_array($eventType, self::CARD_OP_EVENTS, true)) {
+            $this->cardService->applyCardWebhook($eventType, $payload);
 
             return;
         }

--- a/app/Domain/CardIssuance/Http/Requests/FinCardAmountRequest.php
+++ b/app/Domain/CardIssuance/Http/Requests/FinCardAmountRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\CardIssuance\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validates a card top-up / withdraw amount in integer minor units.
+ */
+final class FinCardAmountRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'amount_cents' => ['required', 'integer', 'min:1', 'max:100000000'],
+        ];
+    }
+}

--- a/app/Domain/CardIssuance/Http/Requests/OpenFinCardCardRequest.php
+++ b/app/Domain/CardIssuance/Http/Requests/OpenFinCardCardRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\CardIssuance\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validates a FinCard card-open request. `amount_cents` is the initial load in
+ * integer minor units; `card_type_id` selects the BIN/product (from
+ * /v1/cards/reference/card-types).
+ */
+final class OpenFinCardCardRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'card_type_id' => ['required', 'integer', 'min:1'],
+            'amount_cents' => ['required', 'integer', 'min:1', 'max:100000000'],
+            'label'        => ['nullable', 'string', 'max:64'],
+        ];
+    }
+}

--- a/app/Domain/CardIssuance/Models/Card.php
+++ b/app/Domain/CardIssuance/Models/Card.php
@@ -21,6 +21,9 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string $network
  * @property string $status
  * @property string $currency
+ * @property int|null $balance_cents
+ * @property string|null $fincard_account_id
+ * @property string|null $merchant_order_no
  * @property string|null $label
  * @property string|null $funding_source
  * @property int|null $spend_limit_cents
@@ -48,6 +51,9 @@ class Card extends Model
         'network',
         'status',
         'currency',
+        'balance_cents',
+        'fincard_account_id',
+        'merchant_order_no',
         'label',
         'funding_source',
         'spend_limit_cents',
@@ -65,6 +71,7 @@ class Card extends Model
     {
         return [
             'metadata'          => 'encrypted:array',
+            'balance_cents'     => 'integer',
             'spend_limit_cents' => 'integer',
             'expires_at'        => 'datetime',
             'frozen_at'         => 'datetime',

--- a/app/Domain/CardIssuance/Routes/api.php
+++ b/app/Domain/CardIssuance/Routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Api\CardIssuance\CardController;
 use App\Http\Controllers\Api\CardIssuance\CardholderController;
 use App\Http\Controllers\Api\CardIssuance\CardTransactionWebhookController;
 use App\Http\Controllers\Api\CardIssuance\FinCardAccountController;
+use App\Http\Controllers\Api\CardIssuance\FinCardCardController;
 use App\Http\Controllers\Api\CardIssuance\FinCardOnboardingController;
 use App\Http\Controllers\Api\CardIssuance\JitFundingWebhookController;
 use Illuminate\Support\Facades\Route;
@@ -54,6 +55,24 @@ Route::prefix('v1/cards')->name('api.cards.fincard.')
         Route::post('/account/deposit-address', [FinCardAccountController::class, 'depositAddress'])
             ->middleware(['idempotency.required', 'api.rate_limit:mutation'])
             ->name('account.deposit-address');
+
+        // Card lifecycle (Phase 4) — namespaced under /fincard/* to avoid the
+        // generic card routes. Sensitive PAN/CVV is fetched on demand, never stored.
+        Route::prefix('/fincard')->name('cards.')->group(function (): void {
+            Route::get('/', [FinCardCardController::class, 'index'])->name('index');
+            Route::post('/open', [FinCardCardController::class, 'open'])
+                ->middleware(['idempotency.required', 'api.rate_limit:mutation'])->name('open');
+            Route::get('/{cardId}', [FinCardCardController::class, 'show'])->name('show');
+            Route::get('/{cardId}/sensitive', [FinCardCardController::class, 'sensitive'])->name('sensitive');
+            Route::get('/{cardId}/transactions', [FinCardCardController::class, 'transactions'])->name('transactions');
+            Route::middleware(['idempotency.required', 'api.rate_limit:mutation'])->group(function (): void {
+                Route::post('/{cardId}/freeze', [FinCardCardController::class, 'freeze'])->name('freeze');
+                Route::post('/{cardId}/unfreeze', [FinCardCardController::class, 'unfreeze'])->name('unfreeze');
+                Route::post('/{cardId}/cancel', [FinCardCardController::class, 'cancel'])->name('cancel');
+                Route::post('/{cardId}/topup', [FinCardCardController::class, 'topUp'])->name('topup');
+                Route::post('/{cardId}/withdraw', [FinCardCardController::class, 'withdraw'])->name('withdraw');
+            });
+        });
     });
 
 Route::prefix('v1/cards')->name('api.cards.')->group(function () {

--- a/app/Domain/CardIssuance/Services/FinCardCardService.php
+++ b/app/Domain/CardIssuance/Services/FinCardCardService.php
@@ -1,0 +1,314 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\CardIssuance\Services;
+
+use App\Domain\CardIssuance\Events\Broadcast\CardStateChanged;
+use App\Domain\CardIssuance\Models\Card;
+use App\Domain\CardIssuance\Models\Cardholder;
+use App\Domain\CardIssuance\Models\FinCardAccount;
+use App\Infrastructure\FinCard\FinCardClient;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * FinCard card lifecycle: open a prefunded card, refresh its details, view
+ * sensitive PAN/CVV (ephemeral — never persisted), freeze/unfreeze/cancel, move
+ * funds between the account and the card, and apply card webhooks.
+ *
+ * The persistent Card row (issuer='fincard') maps the Zelta user ↔ FinCard
+ * cardId and caches the card's spendable balance (FinCard is authoritative).
+ * All amounts are integer minor units; FinCard expects/returns major-unit
+ * decimal strings — converted here via bcmath (never float).
+ *
+ * @see docs/superpowers/specs/2026-07-06-fincard-card-issuing-design.md §8
+ */
+final class FinCardCardService
+{
+    public function __construct(
+        private readonly FinCardClient $client,
+        private readonly FinCardAccountService $accounts,
+    ) {
+    }
+
+    /**
+     * @return Collection<int, Card>
+     */
+    public function listCards(User $user): Collection
+    {
+        return Card::query()
+            ->where('user_id', $user->id)
+            ->where('issuer', 'fincard')
+            ->orderByDesc('created_at')
+            ->get();
+    }
+
+    public function findForUser(User $user, string $cardId): ?Card
+    {
+        return Card::query()
+            ->where('user_id', $user->id)
+            ->where('issuer', 'fincard')
+            ->where('issuer_card_token', $cardId)
+            ->first();
+    }
+
+    /**
+     * Open a virtual card against the user's account + a verified cardholder,
+     * loading `$amountCents` onto it. Persists the local mapping; the card's
+     * final details (last4/network/expiry) settle via refresh/webhook.
+     *
+     * @param  array<string, mixed>  $context
+     */
+    public function openCard(User $user, Cardholder $cardholder, int $cardTypeId, int $amountCents, string $merchantOrderNo, array $context): Card
+    {
+        $account = $this->accounts->existingAccount($user);
+        $accountId = $account instanceof FinCardAccount ? $account->fincard_account_id : '';
+
+        $response = $this->client->openCard(
+            $cardTypeId,
+            $this->toMajor($amountCents),
+            $accountId,
+            (string) $cardholder->issuer_cardholder_id,
+            $merchantOrderNo,
+            $context,
+        );
+        $data = is_array($response['data'] ?? null) ? $response['data'] : [];
+
+        $card = new Card();
+        $card->user_id = (string) $user->id;
+        $card->cardholder_id = (string) $cardholder->id;
+        $card->issuer_card_token = (string) ($data['cardId'] ?? $data['id'] ?? '');
+        $card->issuer = 'fincard';
+        $card->last4 = $this->extractLast4($data);
+        $card->network = $this->mapNetwork((string) ($data['network'] ?? $data['cardBrand'] ?? 'visa'));
+        $card->status = 'pending';
+        $card->currency = 'USD';
+        $card->balance_cents = $amountCents;
+        $card->fincard_account_id = $accountId;
+        $card->merchant_order_no = $merchantOrderNo;
+        $card->save();
+
+        return $card;
+    }
+
+    /**
+     * Refresh a card's details + balance from FinCard.
+     *
+     * @param  array<string, mixed>  $context
+     */
+    public function refresh(Card $card, array $context = []): Card
+    {
+        $response = $this->client->getCardInfo($card->issuer_card_token, $context);
+        $data = is_array($response['data'] ?? null) ? $response['data'] : [];
+
+        if (($last4 = $this->extractLast4($data)) !== '0000') {
+            $card->last4 = $last4;
+        }
+        if (isset($data['status'])) {
+            $card->status = $this->mapStatus((string) $data['status']);
+        }
+        if (isset($data['balance']) && is_numeric((string) $data['balance'])) {
+            $card->balance_cents = $this->toCents((string) $data['balance']);
+        }
+        $card->save();
+
+        return $card;
+    }
+
+    /**
+     * Ephemeral PAN/CVV/expiry — returned to the caller, never persisted.
+     *
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function sensitiveDetails(Card $card, array $context = []): array
+    {
+        $response = $this->client->getCardSensitive($card->issuer_card_token, $context);
+
+        return is_array($response['data'] ?? null) ? $response['data'] : [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    public function freeze(Card $card, string $merchantOrderNo, array $context = []): Card
+    {
+        $this->client->freezeCard($card->issuer_card_token, $merchantOrderNo, $context);
+        $card->status = 'frozen';
+        $card->frozen_at = now();
+        $card->save();
+        $this->broadcast($card);
+
+        return $card;
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    public function unfreeze(Card $card, string $merchantOrderNo, array $context = []): Card
+    {
+        $this->client->unfreezeCard($card->issuer_card_token, $merchantOrderNo, $context);
+        $card->status = 'active';
+        $card->frozen_at = null;
+        $card->save();
+        $this->broadcast($card);
+
+        return $card;
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    public function cancel(Card $card, string $merchantOrderNo, array $context = []): Card
+    {
+        $this->client->cancelCard($card->issuer_card_token, $merchantOrderNo, $context);
+        $card->status = 'cancelled';
+        $card->cancelled_at = now();
+        $card->save();
+        $this->broadcast($card);
+
+        return $card;
+    }
+
+    /**
+     * Move funds account → card (top up) and reflect the new balance.
+     *
+     * @param  array<string, mixed>  $context
+     */
+    public function topUp(Card $card, int $amountCents, string $merchantOrderNo, array $context = []): Card
+    {
+        $this->client->depositToCard($card->issuer_card_token, $this->toMajor($amountCents), $merchantOrderNo, $context);
+        $card->balance_cents = (int) $card->balance_cents + $amountCents;
+        $card->save();
+        $this->broadcast($card);
+
+        return $card;
+    }
+
+    /**
+     * Move funds card → account (withdraw).
+     *
+     * @param  array<string, mixed>  $context
+     */
+    public function withdraw(Card $card, int $amountCents, string $merchantOrderNo, array $context = []): Card
+    {
+        $this->client->withdrawFromCard($card->issuer_card_token, $this->toMajor($amountCents), $merchantOrderNo, $context);
+        $card->balance_cents = max(0, (int) $card->balance_cents - $amountCents);
+        $card->save();
+        $this->broadcast($card);
+
+        return $card;
+    }
+
+    /**
+     * Apply a FinCard card-operation webhook (create/freeze/unfreeze/cancel/
+     * deposit/withdraw/blocked) to the local card state.
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    public function applyCardWebhook(string $eventType, array $payload): void
+    {
+        $data = is_array($payload['data'] ?? null) ? $payload['data'] : [];
+        $cardId = (string) ($data['cardId'] ?? $data['id'] ?? '');
+        if ($cardId === '') {
+            Log::warning('FinCard card webhook without cardId', ['event' => $eventType]);
+
+            return;
+        }
+
+        $card = Card::query()->where('issuer_card_token', $cardId)->where('issuer', 'fincard')->first();
+        if (! $card instanceof Card) {
+            Log::warning('FinCard card webhook for unknown card', ['card_id' => $cardId, 'event' => $eventType]);
+
+            return;
+        }
+
+        $status = $this->mapCardEvent($eventType);
+        if ($status !== null) {
+            $card->status = $status;
+            if ($status === 'frozen') {
+                $card->frozen_at = now();
+            } elseif ($status === 'cancelled') {
+                $card->cancelled_at = now();
+            }
+        }
+        if (isset($data['balance']) && is_numeric((string) $data['balance'])) {
+            $card->balance_cents = $this->toCents((string) $data['balance']);
+        }
+        if (($last4 = $this->extractLast4($data)) !== '0000') {
+            $card->last4 = $last4;
+        }
+        $card->save();
+
+        $this->broadcast($card);
+    }
+
+    private function broadcast(Card $card): void
+    {
+        CardStateChanged::dispatch((int) $card->user_id, $card->issuer_card_token, $card->status, (int) $card->balance_cents);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function extractLast4(array $data): string
+    {
+        foreach (['last4', 'lastFour', 'cardLast4'] as $key) {
+            $v = (string) ($data[$key] ?? '');
+            if ($v !== '') {
+                return substr($v, -4);
+            }
+        }
+        $pan = (string) ($data['cardNo'] ?? $data['maskedPan'] ?? '');
+
+        return $pan !== '' ? substr($pan, -4) : '0000';
+    }
+
+    private function mapNetwork(string $network): string
+    {
+        return match (strtolower($network)) {
+            'mastercard', 'master' => 'mastercard',
+            'discover'             => 'discover',
+            default                => 'visa',
+        };
+    }
+
+    private function mapStatus(string $status): string
+    {
+        return match (strtolower($status)) {
+            'normal', 'active'              => 'active',
+            'freeze', 'frozen'              => 'frozen',
+            'blocked'                       => 'frozen',
+            'cancel', 'cancelled', 'closed' => 'cancelled',
+            'expired'                       => 'expired',
+            default                         => 'pending',
+        };
+    }
+
+    private function mapCardEvent(string $eventType): ?string
+    {
+        return match ($eventType) {
+            'create'            => 'active',
+            'Freeze', 'blocked' => 'frozen',
+            'UnFreeze'          => 'active',
+            'cancel'            => 'cancelled',
+            default             => null, // deposit/withdraw/overdraft_statement: balance only
+        };
+    }
+
+    private function toMajor(int $cents): string
+    {
+        return bcdiv((string) $cents, '100', 2);
+    }
+
+    private function toCents(string $amount): int
+    {
+        if (! is_numeric($amount)) {
+            return 0;
+        }
+
+        return (int) bcmul(bcadd($amount, '0', 2), '100', 0);
+    }
+}

--- a/app/Http/Controllers/Api/CardIssuance/FinCardCardController.php
+++ b/app/Http/Controllers/Api/CardIssuance/FinCardCardController.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\CardIssuance;
+
+use App\Domain\CardIssuance\Http\Requests\FinCardAmountRequest;
+use App\Domain\CardIssuance\Http\Requests\OpenFinCardCardRequest;
+use App\Domain\CardIssuance\Models\Card;
+use App\Domain\CardIssuance\Models\Cardholder;
+use App\Domain\CardIssuance\Services\FinCardCardholderService;
+use App\Domain\CardIssuance\Services\FinCardCardService;
+use App\Http\Controllers\Controller;
+use App\Infrastructure\FinCard\FinCardApiException;
+use App\Models\User;
+use App\Support\ErrorResponse;
+use Closure;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+/**
+ * FinCard card lifecycle (Phase 4) — open, view, sensitive details, freeze/
+ * unfreeze/cancel, top-up/withdraw, and transactions. Namespaced under
+ * /v1/cards/fincard/* to avoid colliding with the generic card routes.
+ *
+ * @see docs/FINCARD_MOBILE_INTEGRATION.md §4.3
+ */
+class FinCardCardController extends Controller
+{
+    public function __construct(
+        private readonly FinCardCardService $cards,
+        private readonly FinCardCardholderService $cardholders,
+    ) {
+    }
+
+    /**
+     * Open a virtual card (requires a verified cardholder + funded account).
+     */
+    public function open(OpenFinCardCardRequest $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        $cardholder = $this->cardholders->existingFor($user);
+        if (! $cardholder instanceof Cardholder) {
+            return ErrorResponse::make('ERR_CARDS_007');
+        }
+        if ($cardholder->kyc_status !== 'verified') {
+            return ErrorResponse::make('ERR_CARDS_008');
+        }
+
+        /** @var array<string, mixed> $validated */
+        $validated = $request->validated();
+
+        try {
+            $card = $this->cards->openCard(
+                $user,
+                $cardholder,
+                (int) $validated['card_type_id'],
+                (int) $validated['amount_cents'],
+                $this->orderNo($request),
+                $this->context($request),
+            );
+        } catch (FinCardApiException $e) {
+            Log::warning('FinCard open card failed', ['user_id' => $user->id, 'msg' => $e->getMessage()]);
+
+            return ErrorResponse::make('ERR_CARDS_016');
+        }
+
+        return response()->json(['success' => true, 'data' => $this->present($card)], 201);
+    }
+
+    public function index(Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        $data = $this->cards->listCards($user)->map(fn (Card $c): array => $this->present($c))->all();
+
+        return response()->json(['success' => true, 'data' => $data]);
+    }
+
+    public function show(Request $request, string $cardId): JsonResponse
+    {
+        return $this->withCard($request, $cardId, function (Card $card) use ($request): JsonResponse {
+            try {
+                $card = $this->cards->refresh($card, $this->context($request));
+            } catch (FinCardApiException $e) {
+                Log::warning('FinCard card refresh failed; serving cache', ['msg' => $e->getMessage()]);
+            }
+
+            return response()->json(['success' => true, 'data' => $this->present($card)]);
+        });
+    }
+
+    public function sensitive(Request $request, string $cardId): JsonResponse
+    {
+        return $this->withCard($request, $cardId, function (Card $card) use ($request): JsonResponse {
+            try {
+                $details = $this->cards->sensitiveDetails($card, $this->context($request));
+            } catch (FinCardApiException $e) {
+                Log::warning('FinCard sensitive fetch failed', ['msg' => $e->getMessage()]);
+
+                return ErrorResponse::make('ERR_CARDS_016');
+            }
+
+            return response()->json(['success' => true, 'data' => $details]);
+        });
+    }
+
+    public function freeze(Request $request, string $cardId): JsonResponse
+    {
+        return $this->mutate($request, $cardId, fn (Card $card): Card => $this->cards->freeze($card, $this->orderNo($request), $this->context($request)));
+    }
+
+    public function unfreeze(Request $request, string $cardId): JsonResponse
+    {
+        return $this->mutate($request, $cardId, fn (Card $card): Card => $this->cards->unfreeze($card, $this->orderNo($request), $this->context($request)));
+    }
+
+    public function cancel(Request $request, string $cardId): JsonResponse
+    {
+        return $this->mutate($request, $cardId, fn (Card $card): Card => $this->cards->cancel($card, $this->orderNo($request), $this->context($request)));
+    }
+
+    public function topUp(FinCardAmountRequest $request, string $cardId): JsonResponse
+    {
+        $amount = (int) $request->validated('amount_cents');
+
+        return $this->mutate($request, $cardId, fn (Card $card): Card => $this->cards->topUp($card, $amount, $this->orderNo($request), $this->context($request)));
+    }
+
+    public function withdraw(FinCardAmountRequest $request, string $cardId): JsonResponse
+    {
+        $amount = (int) $request->validated('amount_cents');
+
+        return $this->mutate($request, $cardId, function (Card $card) use ($amount, $request): Card {
+            if ((int) $card->balance_cents < $amount) {
+                throw new FinCardApiException('insufficient card balance');
+            }
+
+            return $this->cards->withdraw($card, $amount, $this->orderNo($request), $this->context($request));
+        }, insufficientCode: 'ERR_CARDS_017');
+    }
+
+    public function transactions(Request $request, string $cardId): JsonResponse
+    {
+        return $this->withCard($request, $cardId, function (Card $card) use ($request): JsonResponse {
+            try {
+                $limit = min((int) $request->query('limit', '20'), 100);
+                $page = max((int) $request->query('page', '1'), 1);
+                $response = app(\App\Infrastructure\FinCard\FinCardClient::class)
+                    ->getCardPurchaseTransactions($card->issuer_card_token, $page, $limit, $this->context($request));
+                $data = is_array($response['data'] ?? null) ? $response['data'] : [];
+            } catch (FinCardApiException $e) {
+                Log::warning('FinCard tx fetch failed', ['msg' => $e->getMessage()]);
+
+                return ErrorResponse::make('ERR_CARDS_016');
+            }
+
+            return response()->json(['success' => true, 'data' => $data]);
+        });
+    }
+
+    /**
+     * Resolve the user's card and run the callback, or 404.
+     *
+     * @param  Closure(Card): JsonResponse  $callback
+     */
+    private function withCard(Request $request, string $cardId, Closure $callback): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $card = $this->cards->findForUser($user, $cardId);
+        if (! $card instanceof Card) {
+            return ErrorResponse::make('ERR_CARDS_015');
+        }
+
+        return $callback($card);
+    }
+
+    /**
+     * Resolve the card, run a mutating action, and return the presented card.
+     *
+     * @param  Closure(Card): Card  $action
+     */
+    private function mutate(Request $request, string $cardId, Closure $action, string $insufficientCode = 'ERR_CARDS_016'): JsonResponse
+    {
+        return $this->withCard($request, $cardId, function (Card $card) use ($action, $insufficientCode): JsonResponse {
+            try {
+                $card = $action($card);
+            } catch (FinCardApiException $e) {
+                $code = str_contains($e->getMessage(), 'insufficient') ? $insufficientCode : 'ERR_CARDS_016';
+                Log::warning('FinCard card mutation failed', ['msg' => $e->getMessage()]);
+
+                return ErrorResponse::make($code);
+            }
+
+            return response()->json(['success' => true, 'data' => $this->present($card)]);
+        });
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function present(Card $card): array
+    {
+        return [
+            'card_id'       => $card->issuer_card_token,
+            'last4'         => $card->last4,
+            'network'       => $card->network,
+            'status'        => $card->status,
+            'currency'      => $card->currency,
+            'balance_cents' => (int) $card->balance_cents,
+            'label'         => $card->label,
+            'expires_at'    => $card->expires_at?->toDateString(),
+        ];
+    }
+
+    /**
+     * FinCard merchantOrderNo derived from the Idempotency-Key so a client retry
+     * reuses the same order number (aligning our idempotency with FinCard's).
+     */
+    private function orderNo(Request $request): string
+    {
+        $key = (string) $request->header('Idempotency-Key', '');
+
+        return $key !== '' ? substr(preg_replace('/[^A-Za-z0-9]/', '', $key) ?? '', 0, 32) : (string) Str::uuid();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function context(Request $request): array
+    {
+        return [
+            'forwarded_for' => $request->ip() ?? '127.0.0.1',
+            'platform'      => (string) ($request->header('platform') ?? 'ios'),
+            'device_id'     => (string) ($request->header('deviceId') ?? ''),
+        ];
+    }
+}

--- a/app/Infrastructure/FinCard/FinCardClient.php
+++ b/app/Infrastructure/FinCard/FinCardClient.php
@@ -291,6 +291,145 @@ final class FinCardClient
         return $this->rpc('/wallet/v2/addressList', ['pageNum' => $pageNum, 'pageSize' => $pageSize], $context);
     }
 
+    // ── Card lifecycle (Phase 4) ─────────────────────────────────────────
+
+    /**
+     * Open a virtual card against an account + cardholder. `$amountMinor` is the
+     * initial load in the card's major-unit string (FinCard expects e.g. "200").
+     *
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function openCard(int $cardTypeId, string $amount, string $accountId, string $holderId, string $merchantOrderNo, array $context = []): array
+    {
+        return $this->rpc('/card/v2/openCard', [
+            'cardTypeId'      => $cardTypeId,
+            'amount'          => $amount,
+            'accountId'       => $accountId,
+            'holderId'        => $holderId,
+            'merchantOrderNo' => $merchantOrderNo,
+        ], $context);
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function getCardInfo(string $cardId, array $context = []): array
+    {
+        return $this->rpc('/card/info', ['cardId' => $cardId], $context);
+    }
+
+    /**
+     * PAN/CVV/expiry — relay ephemerally to the client, never persist.
+     *
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function getCardSensitive(string $cardId, array $context = []): array
+    {
+        return $this->rpc('/card/info/sensitive', ['cardId' => $cardId], $context);
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function getCardBalance(string $cardId, array $context = []): array
+    {
+        return $this->rpc('/card/balance', ['cardId' => $cardId], $context);
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function listCards(int $pageNum = 1, int $pageSize = 20, ?string $status = null, array $context = []): array
+    {
+        $params = ['pageNum' => $pageNum, 'pageSize' => $pageSize];
+        if ($status !== null) {
+            $params['status'] = $status;
+        }
+
+        return $this->rpc('/card/list', $params, $context);
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function freezeCard(string $cardId, string $merchantOrderNo, array $context = []): array
+    {
+        return $this->rpc('/card/v2/freeze', ['cardId' => $cardId, 'merchantOrderNo' => $merchantOrderNo], $context);
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function unfreezeCard(string $cardId, string $merchantOrderNo, array $context = []): array
+    {
+        return $this->rpc('/card/v2/unfreeze', ['cardId' => $cardId, 'merchantOrderNo' => $merchantOrderNo], $context);
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function cancelCard(string $cardId, string $merchantOrderNo, array $context = []): array
+    {
+        return $this->rpc('/card/cancel', ['cardId' => $cardId, 'merchantOrderNo' => $merchantOrderNo], $context);
+    }
+
+    /**
+     * Move funds account → card.
+     *
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function depositToCard(string $cardId, string $amount, string $merchantOrderNo, array $context = []): array
+    {
+        return $this->rpc('/card/deposit', ['cardId' => $cardId, 'amount' => $amount, 'merchantOrderNo' => $merchantOrderNo], $context);
+    }
+
+    /**
+     * Move funds card → account.
+     *
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function withdrawFromCard(string $cardId, string $amount, string $merchantOrderNo, array $context = []): array
+    {
+        return $this->rpc('/card/withdraw', ['cardId' => $cardId, 'amount' => $amount, 'merchantOrderNo' => $merchantOrderNo], $context);
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function getCardPurchaseTransactions(string $cardId, int $pageNum = 1, int $pageSize = 20, array $context = []): array
+    {
+        return $this->rpc('/card/purchase/transaction', ['cardId' => $cardId, 'pageNum' => $pageNum, 'pageSize' => $pageSize], $context);
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function getCardAuthTransactions(string $cardId, int $pageNum = 1, int $pageSize = 20, array $context = []): array
+    {
+        return $this->rpc('/card/authorize/transaction', ['cardId' => $cardId, 'pageNum' => $pageNum, 'pageSize' => $pageSize], $context);
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function getCard3dsTransactions(string $cardId, int $pageNum = 1, int $pageSize = 20, array $context = []): array
+    {
+        return $this->rpc('/card/3ds/transaction', ['cardId' => $cardId, 'pageNum' => $pageNum, 'pageSize' => $pageSize], $context);
+    }
+
     // ── Core RPC ─────────────────────────────────────────────────────────
 
     /**

--- a/config/error_codes.php
+++ b/config/error_codes.php
@@ -87,4 +87,9 @@ return [
     // ─── FinCard funding (Phase 3) ─────────────────────────────────────────
     'ERR_CARDS_013' => ['http' => 502, 'description' => 'Funding is temporarily unavailable. Please try again later.'],
     'ERR_CARDS_014' => ['http' => 422, 'description' => 'That deposit coin is not supported.'],
+
+    // ─── FinCard card lifecycle (Phase 4) ──────────────────────────────────
+    'ERR_CARDS_015' => ['http' => 404, 'description' => 'Card not found.'],
+    'ERR_CARDS_016' => ['http' => 502, 'description' => 'The card operation could not be completed right now. Please try again later.'],
+    'ERR_CARDS_017' => ['http' => 422, 'description' => 'Insufficient balance for this operation.'],
 ];

--- a/database/migrations/2026_07_06_120001_add_fincard_columns_to_cards_table.php
+++ b/database/migrations/2026_07_06_120001_add_fincard_columns_to_cards_table.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * FinCard card lifecycle — prefunded stored-value columns.
+ *
+ * FinCard cards carry their own spendable balance (funds moved from the user's
+ * FinCard account on open / top-up), tracked here as an integer-minor-unit
+ * cache (`balance_cents`; FinCard holds the authoritative figure).
+ * `fincard_account_id` links the card to the account it draws from;
+ * `merchant_order_no` is the client idempotency key used on open/reconcile.
+ *
+ * @see docs/superpowers/specs/2026-07-06-fincard-card-issuing-design.md §8
+ */
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('cards', function (Blueprint $table): void {
+            $table->bigInteger('balance_cents')->nullable()->after('currency');
+            $table->string('fincard_account_id')->nullable()->after('balance_cents');
+            $table->string('merchant_order_no')->nullable()->after('fincard_account_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('cards', function (Blueprint $table): void {
+            $table->dropColumn(['balance_cents', 'fincard_account_id', 'merchant_order_no']);
+        });
+    }
+};

--- a/tests/Feature/Api/FinCard/FinCardWebhookEndpointTest.php
+++ b/tests/Feature/Api/FinCard/FinCardWebhookEndpointTest.php
@@ -10,6 +10,7 @@
 
 declare(strict_types=1);
 
+use App\Domain\CardIssuance\Models\Card;
 use App\Domain\CardIssuance\Models\Cardholder;
 use App\Domain\CardIssuance\Models\FinCardAccount;
 use App\Domain\Subscription\Models\ProcessedWebhookEvent;
@@ -144,4 +145,35 @@ it('credits the funding account on a wallet DEPOSIT event', function () {
 
     $fresh = FinCardAccount::query()->where('fincard_account_id', 'acc-web')->firstOrFail();
     expect($fresh->balance_cents)->toBe(1886);
+});
+
+it('activates a card on a card-op create event', function () {
+    $user = User::factory()->create();
+    $ch = new Cardholder();
+    $ch->user_id = (string) $user->id;
+    $ch->first_name = 'Jane';
+    $ch->last_name = 'Smith';
+    $ch->kyc_status = 'verified';
+    $ch->issuer_cardholder_id = 'h-c';
+    $ch->save();
+
+    $card = new Card();
+    $card->user_id = (string) $user->id;
+    $card->cardholder_id = $ch->id;
+    $card->issuer_card_token = 'card-web';
+    $card->issuer = 'fincard';
+    $card->last4 = '0000';
+    $card->network = 'visa';
+    $card->status = 'pending';
+    $card->currency = 'USD';
+    $card->save();
+
+    $body = (string) json_encode(['eventType' => 'create', 'data' => ['cardId' => 'card-web', 'status' => 'Normal', 'orderNo' => 'ord-cardcreate']]);
+    $sig = fincardEndpointSign($body, $this->finCardPriv);
+
+    $this->call('POST', '/api/v1/webhooks/fincard', [], [], [], fincardWebhookServer('X-FC-SIGNATURE', $sig), $body)
+        ->assertOk()
+        ->assertExactJson(['success' => true]);
+
+    expect(Card::query()->where('issuer_card_token', 'card-web')->firstOrFail()->status)->toBe('active');
 });

--- a/tests/Feature/CardIssuance/FinCardCardControllerTest.php
+++ b/tests/Feature/CardIssuance/FinCardCardControllerTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\CardIssuance\Models\Card;
+use App\Domain\CardIssuance\Models\Cardholder;
+use App\Domain\CardIssuance\Models\FinCardAccount;
+use App\Infrastructure\FinCard\FinCardClient;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\Sanctum;
+
+function idemKey(): string
+{
+    return (string) Str::uuid();
+}
+
+function makeVerifiedCardholder(User $user): void
+{
+    $c = new Cardholder();
+    $c->user_id = (string) $user->id;
+    $c->first_name = 'Jane';
+    $c->last_name = 'Smith';
+    $c->kyc_status = 'verified';
+    $c->issuer_cardholder_id = 'h-1';
+    $c->save();
+
+    $a = new FinCardAccount();
+    $a->user_id = (string) $user->id;
+    $a->fincard_account_id = 'acc-1';
+    $a->currency = 'USD';
+    $a->balance_cents = 50000;
+    $a->status = 'active';
+    $a->save();
+}
+
+function makeFinCardCard(User $user, int $balanceCents = 20000): Card
+{
+    /** @var Cardholder $ch */
+    $ch = Cardholder::query()->where('user_id', $user->id)->first();
+    $card = new Card();
+    $card->user_id = (string) $user->id;
+    $card->cardholder_id = $ch->id;
+    $card->issuer_card_token = 'card-1';
+    $card->issuer = 'fincard';
+    $card->last4 = '4242';
+    $card->network = 'visa';
+    $card->status = 'active';
+    $card->currency = 'USD';
+    $card->balance_cents = $balanceCents;
+    $card->fincard_account_id = 'acc-1';
+    $card->save();
+
+    return $card;
+}
+
+beforeEach(function () {
+    config(['cache.default' => 'array']);
+    Cache::flush();
+
+    $this->app->instance(FinCardClient::class, new FinCardClient(
+        baseUrl: 'https://sandbox.finhub.cloud/api/v2.1/fincard/virtual',
+        tenantId: 't',
+        orgId: 'o',
+        userId: 'u',
+        username: 'x',
+        password: 'y',
+    ));
+
+    Http::fake([
+        'sandbox.finhub.cloud/api/v2.1/admin/*'                             => Http::response(['success' => true, 'data' => ['accessToken' => 'jwt', 'expiresIn' => 3600]]),
+        'sandbox.finhub.cloud/api/v2.1/fincard/virtual/card/v2/openCard'    => Http::response(['success' => true, 'data' => ['cardId' => 'card-new', 'last4' => '1234']]),
+        'sandbox.finhub.cloud/api/v2.1/fincard/virtual/card/info'           => Http::response(['success' => true, 'data' => ['status' => 'Normal', 'last4' => '4242', 'balance' => '200.00']]),
+        'sandbox.finhub.cloud/api/v2.1/fincard/virtual/card/info/sensitive' => Http::response(['success' => true, 'data' => ['pan' => '4242424242424242', 'cvv' => '123', 'expiry' => '05/29']]),
+        'sandbox.finhub.cloud/api/v2.1/fincard/virtual/card/v2/freeze'      => Http::response(['success' => true, 'data' => []]),
+        'sandbox.finhub.cloud/api/v2.1/fincard/virtual/card/deposit'        => Http::response(['success' => true, 'data' => []]),
+        'sandbox.finhub.cloud/api/v2.1/fincard/virtual/card/withdraw'       => Http::response(['success' => true, 'data' => []]),
+    ]);
+
+    $this->user = User::factory()->create();
+    Sanctum::actingAs($this->user, ['read', 'write', 'delete']);
+});
+
+it('refuses to open a card without a verified cardholder (ERR_CARDS_007)', function () {
+    $this->withHeader('Idempotency-Key', idemKey())
+        ->postJson('/api/v1/cards/fincard/open', ['card_type_id' => 111001, 'amount_cents' => 20000])
+        ->assertStatus(403)
+        ->assertJsonPath('error.code', 'ERR_CARDS_007');
+});
+
+it('opens a card for a verified cardholder', function () {
+    makeVerifiedCardholder($this->user);
+
+    $this->withHeader('Idempotency-Key', idemKey())
+        ->postJson('/api/v1/cards/fincard/open', ['card_type_id' => 111001, 'amount_cents' => 20000])
+        ->assertCreated()
+        ->assertJsonPath('data.card_id', 'card-new')
+        ->assertJsonPath('data.balance_cents', 20000);
+
+    expect(Card::where('issuer_card_token', 'card-new')->where('user_id', $this->user->id)->exists())->toBeTrue();
+});
+
+it('lists and shows the users FinCard cards', function () {
+    makeVerifiedCardholder($this->user);
+    makeFinCardCard($this->user);
+
+    $this->getJson('/api/v1/cards/fincard')->assertOk()->assertJsonPath('data.0.card_id', 'card-1');
+    $this->getJson('/api/v1/cards/fincard/card-1')->assertOk()->assertJsonPath('data.card_id', 'card-1');
+});
+
+it('returns ephemeral sensitive details', function () {
+    makeVerifiedCardholder($this->user);
+    makeFinCardCard($this->user);
+
+    $this->getJson('/api/v1/cards/fincard/card-1/sensitive')
+        ->assertOk()
+        ->assertJsonPath('data.pan', '4242424242424242')
+        ->assertJsonPath('data.cvv', '123');
+});
+
+it('freezes a card', function () {
+    makeVerifiedCardholder($this->user);
+    makeFinCardCard($this->user);
+
+    $this->withHeader('Idempotency-Key', idemKey())
+        ->postJson('/api/v1/cards/fincard/card-1/freeze')
+        ->assertOk()
+        ->assertJsonPath('data.status', 'frozen');
+});
+
+it('tops up a card', function () {
+    makeVerifiedCardholder($this->user);
+    makeFinCardCard($this->user, 20000);
+
+    $this->withHeader('Idempotency-Key', idemKey())
+        ->postJson('/api/v1/cards/fincard/card-1/topup', ['amount_cents' => 5000])
+        ->assertOk()
+        ->assertJsonPath('data.balance_cents', 25000);
+});
+
+it('rejects a withdraw exceeding the card balance (ERR_CARDS_017)', function () {
+    makeVerifiedCardholder($this->user);
+    makeFinCardCard($this->user, 3000);
+
+    $this->withHeader('Idempotency-Key', idemKey())
+        ->postJson('/api/v1/cards/fincard/card-1/withdraw', ['amount_cents' => 9000])
+        ->assertStatus(422)
+        ->assertJsonPath('error.code', 'ERR_CARDS_017');
+});
+
+it('404s an unknown card', function () {
+    makeVerifiedCardholder($this->user);
+
+    $this->getJson('/api/v1/cards/fincard/nope')->assertStatus(404)->assertJsonPath('error.code', 'ERR_CARDS_015');
+});

--- a/tests/Feature/CardIssuance/FinCardCardServiceTest.php
+++ b/tests/Feature/CardIssuance/FinCardCardServiceTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\CardIssuance;
+
+use App\Domain\CardIssuance\Events\Broadcast\CardStateChanged;
+use App\Domain\CardIssuance\Models\Card;
+use App\Domain\CardIssuance\Models\Cardholder;
+use App\Domain\CardIssuance\Models\FinCardAccount;
+use App\Domain\CardIssuance\Services\FinCardAccountService;
+use App\Domain\CardIssuance\Services\FinCardCardService;
+use App\Infrastructure\FinCard\FinCardClient;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class FinCardCardServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['cache.default' => 'array']);
+        Cache::flush();
+    }
+
+    private function service(): FinCardCardService
+    {
+        $client = new FinCardClient(
+            baseUrl: 'https://sandbox.finhub.cloud/api/v2.1/fincard/virtual',
+            tenantId: 't',
+            orgId: 'o',
+            userId: 'u',
+            username: 'x',
+            password: 'y',
+        );
+
+        return new FinCardCardService($client, new FinCardAccountService($client));
+    }
+
+    /**
+     * @return array<string, \GuzzleHttp\Promise\PromiseInterface>
+     */
+    private function loginFake(): array
+    {
+        return [
+            'sandbox.finhub.cloud/api/v2.1/admin/*' => Http::response([
+                'success' => true, 'data' => ['accessToken' => 'jwt', 'expiresIn' => 3600],
+            ]),
+        ];
+    }
+
+    private function cardholder(User $user): Cardholder
+    {
+        $c = new Cardholder();
+        $c->user_id = (string) $user->id;
+        $c->first_name = 'Jane';
+        $c->last_name = 'Smith';
+        $c->kyc_status = 'verified';
+        $c->issuer_cardholder_id = 'h-1';
+        $c->save();
+
+        return $c;
+    }
+
+    private function account(User $user): FinCardAccount
+    {
+        $a = new FinCardAccount();
+        $a->user_id = (string) $user->id;
+        $a->fincard_account_id = 'acc-1';
+        $a->currency = 'USD';
+        $a->balance_cents = 50000;
+        $a->status = 'active';
+        $a->save();
+
+        return $a;
+    }
+
+    private function card(User $user, int $balanceCents = 20000): Card
+    {
+        $card = new Card();
+        $card->user_id = (string) $user->id;
+        $card->cardholder_id = $this->cardholder($user)->id;
+        $card->issuer_card_token = 'card-1';
+        $card->issuer = 'fincard';
+        $card->last4 = '4242';
+        $card->network = 'visa';
+        $card->status = 'active';
+        $card->currency = 'USD';
+        $card->balance_cents = $balanceCents;
+        $card->fincard_account_id = 'acc-1';
+        $card->save();
+
+        return $card;
+    }
+
+    public function test_open_card_sends_major_amount_and_persists_mapping(): void
+    {
+        Http::fake(array_merge($this->loginFake(), [
+            'sandbox.finhub.cloud/api/v2.1/fincard/virtual/card/v2/openCard' => Http::response([
+                'success' => true, 'data' => ['cardId' => 'card-new', 'last4' => '1234', 'network' => 'visa'],
+            ]),
+        ]));
+
+        $user = User::factory()->create();
+        $cardholder = $this->cardholder($user);
+        $this->account($user);
+
+        $card = $this->service()->openCard($user, $cardholder, 111001, 20000, 'ord-open', ['forwarded_for' => '1.2.3.4']);
+
+        $this->assertSame('card-new', $card->issuer_card_token);
+        $this->assertSame('fincard', $card->issuer);
+        $this->assertSame(20000, $card->balance_cents);
+        $this->assertSame('acc-1', $card->fincard_account_id);
+        $this->assertDatabaseHas('cards', ['issuer_card_token' => 'card-new', 'user_id' => $user->id]);
+
+        Http::assertSent(function ($request): bool {
+            if (! str_contains($request->url(), '/card/v2/openCard')) {
+                return false;
+            }
+            $body = json_decode($request->body(), true);
+
+            return ($body['amount'] ?? null) === '200.00' && ($body['accountId'] ?? null) === 'acc-1' && ($body['holderId'] ?? null) === 'h-1';
+        });
+    }
+
+    public function test_topup_credits_card_balance_via_bcmath_and_broadcasts(): void
+    {
+        Event::fake([CardStateChanged::class]);
+        Http::fake(array_merge($this->loginFake(), [
+            'sandbox.finhub.cloud/api/v2.1/fincard/virtual/card/deposit' => Http::response(['success' => true, 'data' => []]),
+        ]));
+
+        $user = User::factory()->create();
+        $card = $this->card($user, 20000);
+
+        $updated = $this->service()->topUp($card, 5000, 'ord-topup');
+
+        $this->assertSame(25000, $updated->balance_cents);
+        Event::assertDispatched(CardStateChanged::class, fn ($e): bool => $e->balanceCents === 25000);
+
+        Http::assertSent(fn ($request): bool => str_contains($request->url(), '/card/deposit')
+            && (json_decode($request->body(), true)['amount'] ?? null) === '50.00');
+    }
+
+    public function test_withdraw_debits_and_floors_at_zero(): void
+    {
+        Http::fake(array_merge($this->loginFake(), [
+            'sandbox.finhub.cloud/api/v2.1/fincard/virtual/card/withdraw' => Http::response(['success' => true, 'data' => []]),
+        ]));
+
+        $user = User::factory()->create();
+        $card = $this->card($user, 3000);
+
+        $updated = $this->service()->withdraw($card, 9000, 'ord-wd');
+
+        $this->assertSame(0, $updated->balance_cents);
+    }
+
+    public function test_freeze_and_cancel_update_status(): void
+    {
+        Http::fake(array_merge($this->loginFake(), [
+            'sandbox.finhub.cloud/api/v2.1/fincard/virtual/card/v2/freeze' => Http::response(['success' => true, 'data' => []]),
+            'sandbox.finhub.cloud/api/v2.1/fincard/virtual/card/cancel'    => Http::response(['success' => true, 'data' => []]),
+        ]));
+
+        $user = User::factory()->create();
+        $card = $this->card($user);
+
+        $this->assertSame('frozen', $this->service()->freeze($card, 'ord-fz')->status);
+        $this->assertSame('cancelled', $this->service()->cancel($card, 'ord-cx')->status);
+    }
+
+    public function test_apply_card_webhook_create_activates(): void
+    {
+        $user = User::factory()->create();
+        $card = $this->card($user);
+        $card->status = 'pending';
+        $card->save();
+
+        $this->service()->applyCardWebhook('create', ['data' => ['cardId' => 'card-1', 'status' => 'Normal']]);
+
+        $this->assertSame('active', Card::query()->where('issuer_card_token', 'card-1')->firstOrFail()->status);
+    }
+
+    public function test_apply_card_webhook_freeze_freezes(): void
+    {
+        $user = User::factory()->create();
+        $this->card($user);
+
+        $this->service()->applyCardWebhook('Freeze', ['data' => ['cardId' => 'card-1']]);
+
+        $this->assertSame('frozen', Card::query()->where('issuer_card_token', 'card-1')->firstOrFail()->status);
+    }
+}


### PR DESCRIPTION
## FinCard card-issuing — Phase 4 (Card lifecycle)

Builds on Phase 3 (#1176). Adds the actual card product: open a prefunded virtual card, view it and its sensitive PAN/CVV, freeze/unfreeze/cancel, move funds on/off the card, and sync card webhooks. Gated on a verified cardholder + funded account.

Design §8 · Mobile §4.3: `docs/superpowers/specs/2026-07-06-fincard-card-issuing-design.md`, `docs/FINCARD_MOBILE_INTEGRATION.md`

### What's in this PR
- **Migration:** `cards` gains `balance_cents` (card's spendable balance cache), `fincard_account_id`, `merchant_order_no`. Model fillable/@property/cast updated. (`cards` is already GDPR-excluded — no guard change.)
- **Client:** openCard, getCardInfo, getCardSensitive, getCardBalance, listCards, freezeCard, unfreezeCard, cancelCard, depositToCard, withdrawFromCard, and the purchase/auth/3DS transaction reads.
- **`FinCardCardService`:** openCard (persists the user↔cardId mapping + initial balance; details settle via refresh/webhook), refresh, ephemeral sensitiveDetails (never persisted), freeze/unfreeze/cancel, topUp/withdraw (bcmath, floored), and applyCardWebhook (create/Freeze/UnFreeze/cancel/blocked → status; deposit/withdraw → balance), broadcasting `CardStateChanged`.
- **Webhook controller** routes card-op events (case-sensitively distinct from the wallet DEPOSIT/WITHDRAW) to the card service.
- **Mobile endpoints** under `/v1/cards/fincard/*` (namespaced to avoid the generic card routes): `POST /open`, `GET /` (list), `GET /{id}`, `GET /{id}/sensitive`, `POST /{id}/{freeze,unfreeze,cancel,topup,withdraw}` (idempotent), `GET /{id}/transactions`. FinCard's `merchantOrderNo` is derived from the `Idempotency-Key` so a client retry reuses the same order number.
- **ERR_CARDS_015/016/017** (not-found / issuer-error / insufficient-balance).

### Money-handling
Integer minor units; bcmath cents↔major-unit strings (FinCard uses e.g. "200.00"). Balance is a cache (FinCard authoritative); withdraw floors at zero and pre-checks card balance (`ERR_CARDS_017`).

### Tests (green; PHPStan L8 correct-larastan + phpcs clean)
Service: open sends "200.00" + persists mapping, topup bcmath (20000+5000=25000) + broadcast, withdraw floored, freeze/cancel status, card webhook create→active / Freeze→frozen. Controller: open gated on verified cardholder (403 ERR_CARDS_007), open success, list/show, ephemeral sensitive, freeze, topup, withdraw-insufficient (422 ERR_CARDS_017), unknown card (404). Webhook endpoint: signed card `create` activates end-to-end.

### Remaining
- Phase 5: fiat funding via Bridge; Filament admin visibility; reconciliation cron. Plus the `CardIssuerInterface` adapter wiring `CARD_ISSUER=fincard` through the generic seam/GraphQL (the mobile app uses the FinCard-specific endpoints here).
- FinCard's exact request/response + webhook envelope remain docs-based pending a live sandbox; the services' payload extraction + `FinCardCardholderMapper` are the adjustment points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
