### PR TITLE
feat(cards): FinCard balance reconciliation cron (Phase 5a)

### DIFF
--- a/app/Domain/CardIssuance/Console/Commands/ReconcileFinCardBalancesCommand.php
+++ b/app/Domain/CardIssuance/Console/Commands/ReconcileFinCardBalancesCommand.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\CardIssuance\Console\Commands;
+
+use App\Domain\CardIssuance\Models\FinCardAccount;
+use App\Domain\CardIssuance\Services\FinCardAccountService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * Reconcile cached FinCard account balances against FinCard's authoritative
+ * figure. The mirror (`fincard_accounts.balance_cents`) is normally kept current
+ * by wallet webhooks; this catches drift from a missed/failed webhook. Runs only
+ * when FinCard is the active issuer.
+ *
+ * @see docs/superpowers/specs/2026-07-06-fincard-card-issuing-design.md §6.3
+ */
+final class ReconcileFinCardBalancesCommand extends Command
+{
+    protected $signature = 'fincard:reconcile-balances {--limit=500 : Max accounts to reconcile per run}';
+
+    protected $description = 'Reconcile cached FinCard account balances against FinCard (drift from missed webhooks).';
+
+    public function __construct(private readonly FinCardAccountService $accounts)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        if (config('cardissuance.default_issuer') !== 'fincard') {
+            $this->info('CARD_ISSUER is not fincard — nothing to reconcile.');
+
+            return self::SUCCESS;
+        }
+
+        $limit = max((int) $this->option('limit'), 1);
+        $drift = 0;
+        $errors = 0;
+        $checked = 0;
+
+        FinCardAccount::query()
+            ->where('status', 'active')
+            ->limit($limit)
+            ->get()
+            ->each(function (FinCardAccount $account) use (&$drift, &$errors, &$checked): void {
+                $checked++;
+                $before = (int) $account->balance_cents;
+
+                try {
+                    $this->accounts->syncBalance($account);
+                } catch (Throwable $e) {
+                    $errors++;
+                    Log::error('FinCard balance reconcile failed', [
+                        'account_id' => $account->fincard_account_id,
+                        'msg'        => $e->getMessage(),
+                    ]);
+
+                    return;
+                }
+
+                if ((int) $account->balance_cents !== $before) {
+                    $drift++;
+                    Log::warning('FinCard account balance drift reconciled', [
+                        'account_id' => $account->fincard_account_id,
+                        'from_cents' => $before,
+                        'to_cents'   => (int) $account->balance_cents,
+                    ]);
+                }
+            });
+
+        $this->info(sprintf('Reconciled %d account(s): %d drift-corrected, %d error(s).', $checked, $drift, $errors));
+
+        return $errors > 0 ? self::FAILURE : self::SUCCESS;
+    }
+}

--- a/routes/console.php
+++ b/routes/console.php
@@ -383,6 +383,14 @@ Schedule::command('cards:purge-expired-deposits')
     ->appendOutputTo(storage_path('logs/cards-deposits-purge.log'))
     ->withoutOverlapping();
 
+// Reconcile cached FinCard account balances against FinCard (catches drift from
+// a missed wallet webhook). No-op unless CARD_ISSUER=fincard.
+Schedule::command('fincard:reconcile-balances')
+    ->hourly()
+    ->description('Reconcile FinCard account balance mirror against FinCard')
+    ->appendOutputTo(storage_path('logs/fincard-reconcile.log'))
+    ->withoutOverlapping();
+
 // Nightly database backup (spatie/laravel-backup, DB-only — for an
 // event-sourced platform the event store IS the ledger). Destination disk is
 // BACKUP_DISK (default `local`; production must point it at s3 — see

--- a/tests/Feature/CardIssuance/ReconcileFinCardBalancesCommandTest.php
+++ b/tests/Feature/CardIssuance/ReconcileFinCardBalancesCommandTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\CardIssuance\Models\FinCardAccount;
+use App\Infrastructure\FinCard\FinCardClient;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function (): void {
+    config(['cache.default' => 'array']);
+    Cache::flush();
+
+    $this->app->instance(FinCardClient::class, new FinCardClient(
+        baseUrl: 'https://sandbox.finhub.cloud/api/v2.1/fincard/virtual',
+        tenantId: 't',
+        orgId: 'o',
+        userId: 'u',
+        username: 'x',
+        password: 'y',
+    ));
+});
+
+function reconcileTestAccount(int $balanceCents): FinCardAccount
+{
+    $account = new FinCardAccount();
+    $account->user_id = (string) User::factory()->create()->id;
+    $account->fincard_account_id = 'acc-1';
+    $account->currency = 'USD';
+    $account->balance_cents = $balanceCents;
+    $account->status = 'active';
+    $account->save();
+
+    return $account;
+}
+
+it('reconciles a drifted balance when fincard is the issuer', function () {
+    config(['cardissuance.default_issuer' => 'fincard']);
+    Http::fake([
+        'sandbox.finhub.cloud/api/v2.1/admin/*'                              => Http::response(['success' => true, 'data' => ['accessToken' => 'jwt', 'expiresIn' => 3600]]),
+        'sandbox.finhub.cloud/api/v2.1/fincard/virtual/account/single/query' => Http::response(['success' => true, 'data' => ['balance' => '12.34']]),
+    ]);
+
+    reconcileTestAccount(100); // stale mirror
+
+    $this->artisan('fincard:reconcile-balances')
+        ->expectsOutputToContain('drift-corrected')
+        ->assertExitCode(0);
+
+    expect(FinCardAccount::query()->where('fincard_account_id', 'acc-1')->firstOrFail()->balance_cents)->toBe(1234);
+});
+
+it('skips when fincard is not the active issuer', function () {
+    config(['cardissuance.default_issuer' => 'marqeta']);
+    Http::fake();
+
+    reconcileTestAccount(100);
+
+    $this->artisan('fincard:reconcile-balances')
+        ->expectsOutputToContain('not fincard')
+        ->assertExitCode(0);
+
+    Http::assertNothingSent();
+    expect(FinCardAccount::query()->where('fincard_account_id', 'acc-1')->firstOrFail()->balance_cents)->toBe(100);
+});


### PR DESCRIPTION
Builds on Phase 4 (#1177). The unblocked, money-accuracy piece of Phase 5.

Adds an hourly `fincard:reconcile-balances` command that syncs the cached FinCard account balance mirror (`fincard_accounts.balance_cents`) against FinCard's authoritative balance — a safety net for drift when a wallet `DEPOSIT`/`WITHDRAW` webhook is missed or fails. No-op unless `CARD_ISSUER=fincard`; logs each drift correction; exits non-zero on any per-account error so the scheduler surfaces it. Auto-discovered domain command; scheduled hourly `withoutOverlapping`.

Tests: drift is reconciled (stale 100¢ → FinCard's $12.34 → 1234¢); when FinCard isn't the active issuer it skips with no HTTP. PHPStan L8 (larastan v3) + phpcs clean.

### Remaining Phase 5 (not in this PR)
- **Fiat funding via Bridge** — BLOCKED on FinCard confirming whether a merchant account can be funded with fiat directly, or whether fiat must route Bridge → stablecoin → FinCard deposit (a treasury operation). Deferred until confirmed.
- **Filament admin visibility** for FinCard accounts/cards — ops nice-to-have.
- Optional `CardIssuerInterface` adapter wiring `CARD_ISSUER=fincard` through the generic/GraphQL seam (mobile already has full card functionality via the FinCard-specific endpoints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)