### PR TITLE
feat(cards): FinCard CardIssuerInterface adapter + CARD_ISSUER=fincard wiring

### DIFF
--- a/app/Domain/CardIssuance/Adapters/FinCardCardIssuerAdapter.php
+++ b/app/Domain/CardIssuance/Adapters/FinCardCardIssuerAdapter.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\CardIssuance\Adapters;
+
+use App\Domain\CardIssuance\Contracts\CardIssuerInterface;
+use App\Domain\CardIssuance\Enums\CardNetwork;
+use App\Domain\CardIssuance\Enums\CardStatus;
+use App\Domain\CardIssuance\Enums\WalletType;
+use App\Domain\CardIssuance\Exceptions\UnsupportedCardOperationException;
+use App\Domain\CardIssuance\Models\Card;
+use App\Domain\CardIssuance\Services\FinCardCardService;
+use App\Domain\CardIssuance\ValueObjects\CardTransaction;
+use App\Domain\CardIssuance\ValueObjects\ProvisioningData;
+use App\Domain\CardIssuance\ValueObjects\VirtualCard;
+use App\Infrastructure\FinCard\FinCardClient;
+use DateTimeImmutable;
+use Exception;
+use Illuminate\Support\Str;
+
+/**
+ * FinCard adapter for the generic CardIssuerInterface (GraphQL + any
+ * CardIssuerInterface consumer). It covers the lifecycle overlap FinCard's
+ * prefunded model maps to; the rich open/fund/sensitive operations that need a
+ * card-type + amount + account are the FinCard-specific /v1/cards/fincard/*
+ * endpoints, so `createCard` and `getProvisioningData` (no wallet provisioning
+ * in v1) throw {@see UnsupportedCardOperationException}. Reads come from the
+ * local Card mirror; state changes delegate to {@see FinCardCardService}.
+ *
+ * @see docs/superpowers/specs/2026-07-06-fincard-card-issuing-design.md §3.2
+ */
+final class FinCardCardIssuerAdapter implements CardIssuerInterface
+{
+    public function __construct(
+        private readonly FinCardCardService $cardService,
+        private readonly FinCardClient $client,
+    ) {
+    }
+
+    /**
+     * @param  array<string, mixed>  $metadata
+     */
+    public function createCard(
+        string $userId,
+        string $cardholderName,
+        array $metadata = [],
+        ?CardNetwork $network = null,
+        ?string $label = null,
+    ): VirtualCard {
+        throw new UnsupportedCardOperationException(
+            'FinCard cards are opened with a card-type + amount against a funded account — use POST /v1/cards/fincard/open.',
+        );
+    }
+
+    /**
+     * @param  array<string>  $certificates
+     */
+    public function getProvisioningData(
+        string $cardToken,
+        WalletType $walletType,
+        string $deviceId,
+        array $certificates = [],
+    ): ProvisioningData {
+        throw new UnsupportedCardOperationException('FinCard v1 has no Apple/Google Pay push provisioning.');
+    }
+
+    public function freezeCard(string $cardToken): bool
+    {
+        $card = $this->findCard($cardToken);
+        if (! $card instanceof Card) {
+            return false;
+        }
+        $this->cardService->freeze($card, $this->orderNo());
+
+        return true;
+    }
+
+    public function unfreezeCard(string $cardToken): bool
+    {
+        $card = $this->findCard($cardToken);
+        if (! $card instanceof Card) {
+            return false;
+        }
+        $this->cardService->unfreeze($card, $this->orderNo());
+
+        return true;
+    }
+
+    public function cancelCard(string $cardToken, string $reason): bool
+    {
+        $card = $this->findCard($cardToken);
+        if (! $card instanceof Card) {
+            return false;
+        }
+        $this->cardService->cancel($card, $this->orderNo());
+
+        return true;
+    }
+
+    public function getCard(string $cardToken): ?VirtualCard
+    {
+        $card = $this->findCard($cardToken);
+
+        return $card instanceof Card ? $this->toVirtualCard($card) : null;
+    }
+
+    /**
+     * @return array<VirtualCard>
+     */
+    public function listUserCards(string $userId): array
+    {
+        return Card::query()
+            ->where('user_id', $userId)
+            ->where('issuer', 'fincard')
+            ->orderByDesc('created_at')
+            ->get()
+            ->map(fn (Card $card): VirtualCard => $this->toVirtualCard($card))
+            ->all();
+    }
+
+    /**
+     * @return array{transactions: array<CardTransaction>, next_cursor: string|null}
+     */
+    public function getTransactions(string $cardToken, int $limit = 20, ?string $cursor = null): array
+    {
+        $page = $cursor !== null && ctype_digit($cursor) ? max((int) $cursor, 1) : 1;
+        $response = $this->client->getCardPurchaseTransactions($cardToken, $page, $limit);
+        $data = is_array($response['data'] ?? null) ? $response['data'] : [];
+        $records = is_array($data['records'] ?? null) ? $data['records'] : (array_is_list($data) ? $data : []);
+
+        $transactions = [];
+        foreach ($records as $record) {
+            if (is_array($record)) {
+                $transactions[] = $this->toCardTransaction($cardToken, $record);
+            }
+        }
+
+        $hasMore = count($records) >= $limit;
+
+        return ['transactions' => $transactions, 'next_cursor' => $hasMore ? (string) ($page + 1) : null];
+    }
+
+    public function getName(): string
+    {
+        return 'fincard';
+    }
+
+    private function findCard(string $cardToken): ?Card
+    {
+        return Card::query()
+            ->where('issuer_card_token', $cardToken)
+            ->where('issuer', 'fincard')
+            ->first();
+    }
+
+    private function toVirtualCard(Card $card): VirtualCard
+    {
+        return new VirtualCard(
+            cardToken: $card->issuer_card_token,
+            last4: $card->last4,
+            network: CardNetwork::tryFrom($card->network) ?? CardNetwork::VISA,
+            status: CardStatus::tryFrom($card->status) ?? CardStatus::PENDING,
+            cardholderName: $card->cardholder?->getFullName() ?? '',
+            expiresAt: $card->expires_at !== null
+                ? DateTimeImmutable::createFromInterface($card->expires_at)
+                : new DateTimeImmutable('+3 years'),
+            metadata: [],
+            label: $card->label,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $record
+     */
+    private function toCardTransaction(string $cardToken, array $record): CardTransaction
+    {
+        $amount = (string) ($record['amount'] ?? $record['tradeAmount'] ?? '0');
+        $amountCents = is_numeric($amount) ? (int) bcmul(bcadd($amount, '0', 2), '100', 0) : 0;
+        $ts = (string) ($record['tradeTime'] ?? $record['createTime'] ?? '');
+
+        return new CardTransaction(
+            transactionId: (string) ($record['orderNo'] ?? $record['tradeNo'] ?? $record['id'] ?? ''),
+            cardToken: $cardToken,
+            merchantName: (string) ($record['merchantName'] ?? $record['merchant'] ?? ''),
+            merchantCategory: (string) ($record['merchantCategory'] ?? $record['mcc'] ?? ''),
+            amountCents: $amountCents,
+            currency: (string) ($record['currency'] ?? 'USD'),
+            status: (string) ($record['status'] ?? 'settled'),
+            timestamp: $this->parseTimestamp($ts),
+        );
+    }
+
+    private function parseTimestamp(string $ts): DateTimeImmutable
+    {
+        if ($ts !== '' && ctype_digit($ts)) {
+            // Epoch seconds or milliseconds.
+            $seconds = strlen($ts) > 11 ? (int) substr($ts, 0, 10) : (int) $ts;
+
+            return (new DateTimeImmutable())->setTimestamp($seconds);
+        }
+
+        try {
+            return $ts !== '' ? new DateTimeImmutable($ts) : new DateTimeImmutable();
+        } catch (Exception) {
+            return new DateTimeImmutable();
+        }
+    }
+
+    private function orderNo(): string
+    {
+        return 'ADP' . str_replace('-', '', (string) Str::uuid());
+    }
+}

--- a/app/Domain/CardIssuance/Exceptions/UnsupportedCardOperationException.php
+++ b/app/Domain/CardIssuance/Exceptions/UnsupportedCardOperationException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\CardIssuance\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Thrown when a CardIssuerInterface operation isn't supported by the active
+ * issuer. FinCard's prefunded model can't express createCard through the generic
+ * interface (it needs a card-type + amount + funded account) — use the
+ * FinCard-specific POST /v1/cards/fincard/open — and it has no Apple/Google Pay
+ * push provisioning in v1.
+ */
+final class UnsupportedCardOperationException extends RuntimeException
+{
+}

--- a/app/Providers/CardIssuanceServiceProvider.php
+++ b/app/Providers/CardIssuanceServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Providers;
 
 use App\Domain\CardIssuance\Adapters\DemoCardIssuerAdapter;
+use App\Domain\CardIssuance\Adapters\FinCardCardIssuerAdapter;
 use App\Domain\CardIssuance\Adapters\MarqetaCardIssuerAdapter;
 use App\Domain\CardIssuance\Contracts\CardIssuerInterface;
 use App\Infrastructure\FinCard\FinCardClient;
@@ -32,7 +33,8 @@ class CardIssuanceServiceProvider extends ServiceProvider
                 'marqeta' => new MarqetaCardIssuerAdapter(
                     config: (array) config('cardissuance.issuers.marqeta', []),
                 ),
-                default => new DemoCardIssuerAdapter(),
+                'fincard' => $app->make(FinCardCardIssuerAdapter::class),
+                default   => new DemoCardIssuerAdapter(),
             };
         });
 

--- a/tests/Feature/CardIssuance/FinCardCardIssuerAdapterTest.php
+++ b/tests/Feature/CardIssuance/FinCardCardIssuerAdapterTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\CardIssuance;
+
+use App\Domain\CardIssuance\Adapters\FinCardCardIssuerAdapter;
+use App\Domain\CardIssuance\Contracts\CardIssuerInterface;
+use App\Domain\CardIssuance\Enums\CardNetwork;
+use App\Domain\CardIssuance\Enums\CardStatus;
+use App\Domain\CardIssuance\Exceptions\UnsupportedCardOperationException;
+use App\Domain\CardIssuance\Models\Card;
+use App\Domain\CardIssuance\Models\Cardholder;
+use App\Infrastructure\FinCard\FinCardClient;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class FinCardCardIssuerAdapterTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['cache.default' => 'array']);
+        Cache::flush();
+
+        $this->app->instance(FinCardClient::class, new FinCardClient(
+            baseUrl: 'https://sandbox.finhub.cloud/api/v2.1/fincard/virtual',
+            tenantId: 't',
+            orgId: 'o',
+            userId: 'u',
+            username: 'x',
+            password: 'y',
+        ));
+
+        Http::fake([
+            'sandbox.finhub.cloud/api/v2.1/admin/*'                                   => Http::response(['success' => true, 'data' => ['accessToken' => 'jwt', 'expiresIn' => 3600]]),
+            'sandbox.finhub.cloud/api/v2.1/fincard/virtual/card/v2/freeze'            => Http::response(['success' => true, 'data' => []]),
+            'sandbox.finhub.cloud/api/v2.1/fincard/virtual/card/purchase/transaction' => Http::response([
+                'success' => true,
+                'data'    => ['records' => [['orderNo' => 'tx-1', 'merchantName' => 'ACME', 'amount' => '19.99', 'currency' => 'USD', 'status' => 'settled']]],
+            ]),
+        ]);
+    }
+
+    private function adapter(): FinCardCardIssuerAdapter
+    {
+        return $this->app->make(FinCardCardIssuerAdapter::class);
+    }
+
+    private function card(User $user, string $network = 'discover', string $status = 'active'): Card
+    {
+        $ch = new Cardholder();
+        $ch->user_id = (string) $user->id;
+        $ch->first_name = 'Jane';
+        $ch->last_name = 'Smith';
+        $ch->kyc_status = 'verified';
+        $ch->issuer_cardholder_id = 'h-1';
+        $ch->save();
+
+        $card = new Card();
+        $card->user_id = (string) $user->id;
+        $card->cardholder_id = $ch->id;
+        $card->issuer_card_token = 'card-1';
+        $card->issuer = 'fincard';
+        $card->last4 = '4242';
+        $card->network = $network;
+        $card->status = $status;
+        $card->currency = 'USD';
+        $card->save();
+
+        return $card;
+    }
+
+    public function test_get_name(): void
+    {
+        $this->assertSame('fincard', $this->adapter()->getName());
+    }
+
+    public function test_create_card_and_provisioning_are_unsupported(): void
+    {
+        $this->expectException(UnsupportedCardOperationException::class);
+        $this->adapter()->createCard('1', 'Jane Smith');
+    }
+
+    public function test_get_card_maps_db_card_to_virtual_card_with_network_fallback(): void
+    {
+        $user = User::factory()->create();
+        $this->card($user, network: 'discover', status: 'active');
+
+        $vc = $this->adapter()->getCard('card-1');
+
+        $this->assertNotNull($vc);
+        $this->assertSame('card-1', $vc->cardToken);
+        $this->assertSame('4242', $vc->last4);
+        $this->assertSame(CardNetwork::VISA, $vc->network); // discover -> visa (not in enum)
+        $this->assertSame(CardStatus::ACTIVE, $vc->status);
+        $this->assertSame('Jane Smith', $vc->cardholderName);
+    }
+
+    public function test_get_card_returns_null_for_unknown_token(): void
+    {
+        $this->assertNull($this->adapter()->getCard('nope'));
+    }
+
+    public function test_freeze_delegates_and_returns_bool(): void
+    {
+        $user = User::factory()->create();
+        $this->card($user);
+
+        $this->assertTrue($this->adapter()->freezeCard('card-1'));
+        $this->assertSame('frozen', Card::query()->where('issuer_card_token', 'card-1')->firstOrFail()->status);
+        $this->assertFalse($this->adapter()->freezeCard('unknown'));
+    }
+
+    public function test_list_user_cards(): void
+    {
+        $user = User::factory()->create();
+        $this->card($user);
+
+        $cards = $this->adapter()->listUserCards((string) $user->id);
+
+        $this->assertCount(1, $cards);
+        $this->assertSame('card-1', $cards[0]->cardToken);
+    }
+
+    public function test_get_transactions_maps_records(): void
+    {
+        $result = $this->adapter()->getTransactions('card-1', 20);
+
+        $this->assertCount(1, $result['transactions']);
+        $this->assertSame('tx-1', $result['transactions'][0]->transactionId);
+        $this->assertSame('ACME', $result['transactions'][0]->merchantName);
+        $this->assertSame(1999, $result['transactions'][0]->amountCents); // bcmath 19.99 -> 1999
+    }
+
+    public function test_provider_resolves_fincard_adapter_when_selected(): void
+    {
+        config(['cardissuance.default_issuer' => 'fincard']);
+        $this->app->forgetInstance(CardIssuerInterface::class);
+
+        $this->assertInstanceOf(FinCardCardIssuerAdapter::class, $this->app->make(CardIssuerInterface::class));
+    }
+}


### PR DESCRIPTION
Builds on the merged FinCard phases (#1174–#1178). Completes the design's issuer-adapter seam (§3.2): wires `CARD_ISSUER=fincard` through the generic `CardIssuerInterface` so GraphQL and any interface consumer get FinCard.

- **Maps cleanly:** freeze/unfreeze/cancel delegate to `FinCardCardService`; `getCard`/`listUserCards` read the local Card mirror → `VirtualCard` (discover→visa, since `CardNetwork` has no discover case); `getTransactions` maps FinCard records → `CardTransaction` (bcmath, defensive field extraction).
- **Honestly unsupported:** `createCard` (FinCard needs card-type + amount + funded account → use `POST /v1/cards/fincard/open`) and `getProvisioningData` (no Apple/Google Pay in v1) throw `UnsupportedCardOperationException`.
- Provider gains the `fincard` match arm (container-resolved).

The mobile app already has full card functionality via the FinCard-specific endpoints; this adapter is for the generic/GraphQL seam. 8 tests green, PHPStan L8 (larastan v3) + phpcs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)