### PR TITLE
feat(cards): fincard:inspect-user operator command (support visibility)

### DIFF
--- a/app/Domain/CardIssuance/Console/Commands/FinCardInspectUserCommand.php
+++ b/app/Domain/CardIssuance/Console/Commands/FinCardInspectUserCommand.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\CardIssuance\Console\Commands;
+
+use App\Domain\CardIssuance\Models\Card;
+use App\Domain\CardIssuance\Models\Cardholder;
+use App\Domain\CardIssuance\Models\FinCardAccount;
+use App\Domain\CardIssuance\Models\FinCardDepositAddress;
+use App\Models\User;
+use Illuminate\Console\Command;
+
+/**
+ * Operator query: print everything FinCard-related for a single user. Reads only
+ * — never writes. Mirror of bridge:inspect-user / wallet:inspect-user.
+ *
+ * Use when support needs to see a user's card state end to end:
+ *
+ *   php artisan fincard:inspect-user user@example.com
+ *
+ * @see docs/superpowers/specs/2026-07-06-fincard-card-issuing-design.md
+ */
+final class FinCardInspectUserCommand extends Command
+{
+    protected $signature = 'fincard:inspect-user {email : User email to look up}';
+
+    protected $description = 'Print FinCard cardholder KYC, funding account, deposit addresses and cards for a user';
+
+    public function handle(): int
+    {
+        $email = (string) $this->argument('email');
+        $user = User::query()->where('email', $email)->first();
+
+        if (! $user instanceof User) {
+            $this->error(sprintf('No user with email "%s".', $email));
+
+            return self::FAILURE;
+        }
+
+        $this->info("User #{$user->id} — {$user->email}");
+        $this->newLine();
+
+        $this->printCardholder($user);
+        $this->newLine();
+        $this->printAccount($user);
+        $this->newLine();
+        $this->printCards($user);
+
+        return self::SUCCESS;
+    }
+
+    private function printCardholder(User $user): void
+    {
+        $this->line('<comment>Cardholder (KYC)</comment>');
+        $cardholder = Cardholder::query()
+            ->where('user_id', $user->id)
+            ->whereNotNull('issuer_cardholder_id')
+            ->first();
+
+        if (! $cardholder instanceof Cardholder) {
+            $this->line('  (none — KYC not started)');
+
+            return;
+        }
+
+        $this->table(['holderId', 'kyc_status', 'kyc_stage', 'rejection', 'verified_at'], [[
+            $cardholder->issuer_cardholder_id,
+            $cardholder->kyc_status,
+            $cardholder->kyc_stage ?? '—',
+            $cardholder->kyc_rejection_reason ?? '—',
+            $cardholder->verified_at?->toDateTimeString() ?? '—',
+        ]]);
+    }
+
+    private function printAccount(User $user): void
+    {
+        $this->line('<comment>Funding account + deposit addresses</comment>');
+        $account = FinCardAccount::query()->where('user_id', $user->id)->first();
+
+        if (! $account instanceof FinCardAccount) {
+            $this->line('  (no FinCard account provisioned)');
+
+            return;
+        }
+
+        $this->table(['accountId', 'balance', 'currency', 'status'], [[
+            $account->fincard_account_id,
+            $this->money((int) $account->balance_cents),
+            $account->currency,
+            $account->status,
+        ]]);
+
+        $addresses = FinCardDepositAddress::query()->where('user_id', $user->id)->get();
+        if ($addresses->isNotEmpty()) {
+            $this->table(
+                ['coin', 'chain', 'address'],
+                $addresses->map(fn (FinCardDepositAddress $a): array => [$a->coin_key, $a->chain ?? '—', $a->address])->all(),
+            );
+        }
+    }
+
+    private function printCards(User $user): void
+    {
+        $this->line('<comment>Cards</comment>');
+        $cards = Card::query()->where('user_id', $user->id)->where('issuer', 'fincard')->get();
+
+        if ($cards->isEmpty()) {
+            $this->line('  (no cards)');
+
+            return;
+        }
+
+        $this->table(
+            ['cardId', 'last4', 'network', 'status', 'balance'],
+            $cards->map(fn (Card $c): array => [
+                $c->issuer_card_token,
+                $c->last4,
+                $c->network,
+                $c->status,
+                $this->money((int) $c->balance_cents),
+            ])->all(),
+        );
+    }
+
+    private function money(int $cents): string
+    {
+        return '$' . bcdiv((string) $cents, '100', 2);
+    }
+}

--- a/tests/Feature/CardIssuance/FinCardInspectUserCommandTest.php
+++ b/tests/Feature/CardIssuance/FinCardInspectUserCommandTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\CardIssuance\Models\Card;
+use App\Domain\CardIssuance\Models\Cardholder;
+use App\Domain\CardIssuance\Models\FinCardAccount;
+use App\Models\User;
+
+it('prints a users FinCard cardholder, account and cards', function () {
+    $user = User::factory()->create(['email' => 'jane@example.com']);
+
+    $ch = new Cardholder();
+    $ch->user_id = (string) $user->id;
+    $ch->first_name = 'Jane';
+    $ch->last_name = 'Smith';
+    $ch->kyc_status = 'verified';
+    $ch->kyc_stage = 'channel';
+    $ch->issuer_cardholder_id = 'h-42';
+    $ch->save();
+
+    $account = new FinCardAccount();
+    $account->user_id = (string) $user->id;
+    $account->fincard_account_id = 'acc-42';
+    $account->currency = 'USD';
+    $account->balance_cents = 12345;
+    $account->status = 'active';
+    $account->save();
+
+    $card = new Card();
+    $card->user_id = (string) $user->id;
+    $card->cardholder_id = $ch->id;
+    $card->issuer_card_token = 'card-42';
+    $card->issuer = 'fincard';
+    $card->last4 = '4242';
+    $card->network = 'visa';
+    $card->status = 'active';
+    $card->currency = 'USD';
+    $card->balance_cents = 5000;
+    $card->save();
+
+    $this->artisan('fincard:inspect-user', ['email' => 'jane@example.com'])
+        ->expectsOutputToContain('h-42')
+        ->expectsOutputToContain('acc-42')
+        ->expectsOutputToContain('card-42')
+        ->assertExitCode(0);
+});
+
+it('errors for an unknown email', function () {
+    $this->artisan('fincard:inspect-user', ['email' => 'nobody@example.com'])
+        ->assertExitCode(1);
+});


### PR DESCRIPTION
Builds on the merged FinCard phases. Adds support/ops visibility into a user's FinCard state.

`php artisan fincard:inspect-user user@example.com` prints, read-only: the cardholder KYC (status/stage/rejection/verified-at), the funding account balance, crypto deposit addresses, and cards (status/balance) — mirroring the existing `bridge:inspect-user` / `wallet:inspect-user` operator commands.

### Why a command, not a Filament panel view
The FinCard models (`fincard_accounts`, `fincard_deposit_addresses`, `cards`) use `UsesTenantConnection`, while `User` is on the default connection. A Filament relation-manager would be a cross-connection Eloquent relationship query — fragile in the admin context. The operator command reads each tenant-connection model directly, which is the codebase's established, robust visibility pattern for this. A full Filament panel view for FinCard is deferred pending a clean cross-connection approach.

Tests (Pest): populated user prints holder/account/card ids; unknown email exits 1. PHPStan L8 (larastan v3) + phpcs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)