### PR TITLE
fix(cards): reconcile FinCard mobile contract with registered routes

### DIFF
--- a/app/Domain/CardIssuance/Http/Requests/OpenFinCardCardRequest.php
+++ b/app/Domain/CardIssuance/Http/Requests/OpenFinCardCardRequest.php
@@ -8,8 +8,12 @@ use Illuminate\Foundation\Http\FormRequest;
 
 /**
  * Validates a FinCard card-open request. `amount_cents` is the initial load in
- * integer minor units; `card_type_id` selects the BIN/product (from
- * /v1/cards/reference/card-types).
+ * integer minor units; `card_type_id` selects the BIN/product (enumerated via
+ * GET /v1/cards/reference/card-types).
+ *
+ * `card_type_id` is OPTIONAL: when omitted the controller falls back to the
+ * tenant default (`FINCARD_DEFAULT_CARD_TYPE_ID`). A v1 single-product tenant
+ * therefore never has to send it; multi-product tenants pass the chosen id.
  */
 final class OpenFinCardCardRequest extends FormRequest
 {
@@ -24,7 +28,7 @@ final class OpenFinCardCardRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'card_type_id' => ['required', 'integer', 'min:1'],
+            'card_type_id' => ['nullable', 'integer', 'min:1'],
             'amount_cents' => ['required', 'integer', 'min:1', 'max:100000000'],
             'label'        => ['nullable', 'string', 'max:64'],
         ];

--- a/app/Domain/CardIssuance/Routes/api.php
+++ b/app/Domain/CardIssuance/Routes/api.php
@@ -41,6 +41,7 @@ Route::prefix('v1/cards')->name('api.cards.fincard.')
     ->middleware(['auth:sanctum'])
     ->group(function (): void {
         Route::get('/onboarding', [FinCardOnboardingController::class, 'onboarding'])->name('onboarding');
+        Route::get('/reference/card-types', [FinCardOnboardingController::class, 'cardTypes'])->name('reference.card-types');
         Route::get('/cardholder', [FinCardOnboardingController::class, 'status'])->name('cardholder.status');
         Route::post('/kyc/documents', [FinCardOnboardingController::class, 'uploadDocument'])
             ->middleware('api.rate_limit:mutation')

--- a/app/Http/Controllers/Api/CardIssuance/FinCardCardController.php
+++ b/app/Http/Controllers/Api/CardIssuance/FinCardCardController.php
@@ -54,11 +54,21 @@ class FinCardCardController extends Controller
         /** @var array<string, mixed> $validated */
         $validated = $request->validated();
 
+        // card_type_id is optional: fall back to the tenant default so a
+        // single-product v1 client never has to send one. No id + no default
+        // configured is a clean 422 rather than a downstream issuer 502.
+        $cardTypeId = isset($validated['card_type_id'])
+            ? (int) $validated['card_type_id']
+            : (int) config('cardissuance.issuers.fincard.default_card_type_id');
+        if ($cardTypeId < 1) {
+            return ErrorResponse::make('ERR_CARDS_018');
+        }
+
         try {
             $card = $this->cards->openCard(
                 $user,
                 $cardholder,
-                (int) $validated['card_type_id'],
+                $cardTypeId,
                 (int) $validated['amount_cents'],
                 $this->orderNo($request),
                 $this->context($request),

--- a/app/Http/Controllers/Api/CardIssuance/FinCardOnboardingController.php
+++ b/app/Http/Controllers/Api/CardIssuance/FinCardOnboardingController.php
@@ -87,6 +87,39 @@ class FinCardOnboardingController extends Controller
     }
 
     /**
+     * Available card products for the tenant (id, network, currency, product
+     * name). Optional for the app: a single-product v1 tenant can skip this and
+     * omit `card_type_id` on open — the backend applies the configured default.
+     * `default_card_type_id` echoes that fallback so the UI can pre-select it.
+     * Item shape passes through FinCard *(pending FinCard schema confirmation)*.
+     */
+    public function cardTypes(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        if (! $user instanceof User) {
+            return ErrorResponse::make('ERR_CARDS_007');
+        }
+
+        try {
+            $response = $this->client->getCardTypes($this->context($request));
+        } catch (FinCardApiException $e) {
+            Log::warning('FinCard card-types fetch failed', ['msg' => $e->getMessage()]);
+
+            return ErrorResponse::make('ERR_CARDS_016');
+        }
+
+        $default = config('cardissuance.issuers.fincard.default_card_type_id');
+
+        return response()->json([
+            'success' => true,
+            'data'    => [
+                'card_types'           => is_array($response['data'] ?? null) ? $response['data'] : [],
+                'default_card_type_id' => $default !== null ? (int) $default : null,
+            ],
+        ]);
+    }
+
+    /**
      * Upload one KYC photo → returns the fileId to reference on create.
      */
     public function uploadDocument(UploadKycDocumentRequest $request): JsonResponse

--- a/config/error_codes.php
+++ b/config/error_codes.php
@@ -92,4 +92,5 @@ return [
     'ERR_CARDS_015' => ['http' => 404, 'description' => 'Card not found.'],
     'ERR_CARDS_016' => ['http' => 502, 'description' => 'The card operation could not be completed right now. Please try again later.'],
     'ERR_CARDS_017' => ['http' => 422, 'description' => 'Insufficient balance for this operation.'],
+    'ERR_CARDS_018' => ['http' => 422, 'description' => 'No card product was specified and no default is configured.'],
 ];

--- a/docs/FINCARD_MOBILE_INTEGRATION.md
+++ b/docs/FINCARD_MOBILE_INTEGRATION.md
@@ -37,8 +37,39 @@ Identical to the rest of the Zelta mobile API:
 - **Error:** `{ "success": false, "error": { "code": "ERR_CARDS_00x", "message": "…" } }`. HTTP status carries the class (401/403/404/409/422/429). Branch on `error.code`, not the message.
 - **Bodies are snake_case** (e.g. `card_id`, `coin_key`, `amount_cents`).
 - **Idempotency:** POST/PATCH/DELETE require an `Idempotency-Key` HTTP header (UUID or 16–255 `[A-Za-z0-9_-]`). Reusing a key replays the first response; same key + different body → `409`.
-- **Lists** return `data: [...]` plus `pagination: { next_cursor, has_more, total }`. Query with `?cursor=…&limit=…` (limit ≤ 100, default 20).
+- **Lists** return `data: [...]`. The cursor envelope (`pagination: { next_cursor, has_more, total }`, `?cursor=…&limit=…`) applies where noted; the FinCard **card list and transactions return a bare `data: [...]`**, and transactions paginate via `?page=&limit=` (limit ≤ 100, default 20).
 - **KYC gate:** issuance/spend endpoints require completed Zelta KYC (`require.kyc`) *and* a `pass_audit` FinCard cardholder; a missing verified cardholder returns `ERR_CARDS_007` (see §7).
+
+---
+
+## 2.1 Canonical endpoints — read this first
+
+**This document is the single source of truth for the mobile FinCard surface.** The registered Laravel routes below are authoritative. `/api/documentation` (OpenAPI) does **not** yet describe these endpoints — the FinCard mobile controllers carry no `@OA` annotations — so do not diff against OpenAPI for FinCard. And do **not** use the generic `/v1/cardholders` group or the generic `/v1/cards` (index / store / provision / `{id}` / PATCH / DELETE) group: those are the legacy Marqeta-era surface, not part of the FinCard flow.
+
+All paths are under `/api`. "Idem" = an `Idempotency-Key` header is required.
+
+| Flow | Method + path | Idem | Notes |
+|---|---|:--:|---|
+| Onboarding schema + prefill | `GET /v1/cards/onboarding` | — | render the KYC form from this |
+| Card products | `GET /v1/cards/reference/card-types` | — | optional (see §4.3) |
+| Create cardholder | `POST /v1/cards/cardholder` | ✓ | one per user |
+| Cardholder status | `GET /v1/cards/cardholder` | — | **no `{id}`** — one per user |
+| Upload KYC document | `POST /v1/cards/kyc/documents` | — | multipart |
+| Account | `GET /v1/cards/account` | — | account `balance_cents` is here |
+| Deposit coins | `GET /v1/cards/account/coins` | — | dynamic set |
+| Deposit address | `POST /v1/cards/account/deposit-address` | ✓ | `{ coin_key }` |
+| List cards | `GET /v1/cards/fincard` | — | bare `data: [...]` |
+| Open card | `POST /v1/cards/fincard/open` | ✓ | `card_type_id` optional |
+| Card detail | `GET /v1/cards/fincard/{cardId}` | — | card `balance_cents` is here |
+| Sensitive PAN/CVV | `GET /v1/cards/fincard/{cardId}/sensitive` | — | ephemeral, never persist |
+| Transactions | `GET /v1/cards/fincard/{cardId}/transactions` | — | `?page=&limit=` |
+| Freeze | `POST /v1/cards/fincard/{cardId}/freeze` | ✓ | |
+| Unfreeze | `POST /v1/cards/fincard/{cardId}/unfreeze` | ✓ | **POST, not DELETE** |
+| Cancel | `POST /v1/cards/fincard/{cardId}/cancel` | ✓ | **POST, not DELETE** |
+| Top up | `POST /v1/cards/fincard/{cardId}/topup` | ✓ | `{ amount_cents }` |
+| Withdraw | `POST /v1/cards/fincard/{cardId}/withdraw` | ✓ | `{ amount_cents }` |
+
+There is **no separate card-balance endpoint** — read `balance_cents` off the card object (§5.2); the account balance is on `GET /v1/cards/account` (§5.1).
 
 ---
 
@@ -56,8 +87,8 @@ FinCard requires its own KYC — richer than the app's existing profile. Prefill
 
 1. `GET /v1/cards/onboarding` → returns a prefilled draft (name, DOB, nationality, address from the Zelta profile) **plus the field schema** the user must complete: `occupations` list, allowed `id_types` (`PASSPORT`, `DLN`, `GOVERNMENT_ISSUED_ID_CARD`), and the required financial fields (`annual_salary`, `expected_monthly_volume`, `account_purpose`, `gender`).
 2. Capture **three photos** and upload each: `POST /v1/cards/kyc/documents` (multipart, `type` = `id_front` | `id_back` | `selfie`) → returns `{ file_id }`. A selfie is mandatory.
-3. `POST /v1/cardholders` with the full field set + the three `file_id`s → creates the cardholder; response `kyc_status: "in_review"`, `kyc_stage: "admin"`.
-4. Poll `GET /v1/cardholders/{id}` **or** listen for the WebSocket events in §6. Approval is two-stage (`admin` → `channel`). Only `kyc_status: "verified"` (`pass_audit`) unlocks card creation. `rejected` carries `kyc_rejection_reason`.
+3. `POST /v1/cards/cardholder` (+ `Idempotency-Key`) with the full field set + the three `file_id`s → creates the cardholder (one per user); response `kyc_status: "in_review"`, `kyc_stage: "admin"`.
+4. Poll `GET /v1/cards/cardholder` (no `{id}` — one cardholder per user; before creation it returns `kyc_status: "not_started"`) **or** listen for the WebSocket events in §6. Approval is two-stage (`admin` → `channel`). Only `kyc_status: "verified"` (`pass_audit`) unlocks card creation. `rejected` carries `kyc_rejection_reason`.
 
 > Restricted countries are rejected up front with `ERR_CARDS_010`. The full FinCard field list and photo requirements are *(pending FinCard)* final confirmation; `GET /v1/cards/onboarding` is the source of truth at runtime — render from it, don't hard-code the field set.
 
@@ -73,11 +104,11 @@ FinCard requires its own KYC — richer than the app's existing profile. Prefill
 
 ### 4.3 Open & use a card ⚪ (phase 4)
 
-1. `GET /v1/cards/reference/card-types` → available products (`card_type_id`, network, currency).
-2. `POST /v1/cards` `{ card_type_id, amount_cents, cardholder_id }` (+ `Idempotency-Key`) → opens a card, moving `amount_cents` from the account onto the card. Response is the card object (§5.2), `status: "active"`.
-3. `GET /v1/cards/{card_id}/sensitive` → **ephemeral** PAN/CVV/expiry for display or manual entry. Never cache or persist these; fetch on demand behind a biometric re-auth and clear from memory after display.
-4. Manage: `POST /v1/cards/{card_id}/topup`, `/withdraw`, `/freeze`, `DELETE /{card_id}/freeze` (unfreeze), `DELETE /{card_id}` (cancel, biometric-gated).
-5. `GET /v1/cards/{card_id}/transactions?type=purchase` for history (types: `purchase`, `auth`, `fee`, `3ds`, `refund`).
+1. `GET /v1/cards/reference/card-types` → `{ card_types: [...], default_card_type_id }`. **Optional:** v1 is a single product, so you can skip this call and omit `card_type_id` on open — the backend applies the tenant default. Call it only to let the user choose among multiple products. The `card_types` item shape passes through FinCard *(pending FinCard schema confirmation)*.
+2. `POST /v1/cards/fincard/open` `{ amount_cents, card_type_id?, label? }` (+ `Idempotency-Key`) → opens a card, moving `amount_cents` from the account onto the card. `card_type_id` is **optional** (falls back to the tenant default server-side); do **not** send `cardholder_id` — the backend resolves the caller's single cardholder. Response is the card object (§5.2), `status: "active"`. If no `card_type_id` is sent and no default is configured → `ERR_CARDS_018`.
+3. `GET /v1/cards/fincard/{card_id}/sensitive` → **ephemeral** PAN/CVV/expiry for display or manual entry. Never cache or persist these; fetch on demand behind a biometric re-auth and clear from memory after display.
+4. Manage (all **POST** + `Idempotency-Key`): `/v1/cards/fincard/{card_id}/topup`, `/withdraw`, `/freeze`, `/unfreeze`, `/cancel` (cancel is biometric-gated). Unfreeze and cancel are **POST, not DELETE**.
+5. `GET /v1/cards/fincard/{card_id}/transactions?page=1&limit=20` for history → bare `data: [ … ]` (page-based, not cursor). FinCard transaction item fields are *(pending FinCard schema confirmation)*.
 
 ---
 
@@ -150,11 +181,15 @@ Card endpoints use the `ERR_CARDS_*` family (registered in `config/error_codes.p
 | `ERR_CARDS_012` | 502 | Card issuer rejected the cardholder request → retry later |
 | `ERR_CARDS_013` | 502 | Funding temporarily unavailable (deposit-address/coins failure) → retry |
 | `ERR_CARDS_014` | 422 | Deposit coin not supported |
+| `ERR_CARDS_015` | 404 | Card not found (not the caller's, or unknown id) |
+| `ERR_CARDS_016` | 502 | Card operation (open / refresh / sensitive / mutate / card-types) failed at the issuer → retry |
+| `ERR_CARDS_017` | 422 | Insufficient card balance for the withdraw |
+| `ERR_CARDS_018` | 422 | No `card_type_id` sent and no tenant default configured |
 | `ERR_VALIDATION_001/003` | 422 | Missing/invalid `Idempotency-Key` or body |
 | `ERR_IDEMPOTENCY_409` | 409 | Same key, different body |
 | (rate limit) | 429 | Too many card operations → back off |
 
-Card-lifecycle codes (`ERR_CARDS_015+`) are added as phase 4 lands. The envelope shape (`{success:false, error:{code,message}}`) is stable; the app branches on `code` and may override the message copy.
+The envelope shape (`{success:false, error:{code,message}}`) is stable; the app branches on `code` and may override the message copy.
 
 ---
 
@@ -176,9 +211,9 @@ KYC: `in_review (admin)` → `in_review (channel)` → `verified` | `rejected`. 
 
 | Screen | Blocked on backend phase |
 |---|---|
-| Card onboarding / KYC | Phase 2 (`/onboarding`, `/kyc/documents`, `/cardholders`) |
-| Fund with crypto | Phase 3 (`/account`, `/account/coins`, `/account/deposit-address`) |
-| Card list / open / manage / sensitive | Phase 4 (`/cards*`, `/sensitive`, `/topup`, `/withdraw`) |
+| Card onboarding / KYC | Phase 2 (`/cards/onboarding`, `/cards/kyc/documents`, `/cards/cardholder`) |
+| Fund with crypto | Phase 3 (`/cards/account`, `/cards/account/coins`, `/cards/account/deposit-address`) |
+| Card list / open / manage / sensitive | Phase 4 (`/cards/fincard*`, `/cards/reference/card-types`) |
 | Fund with fiat | Phase 5 (Bridge path) |
 
-Each phase ships with its OpenAPI (`/api/documentation`) regenerated, so request/response schemas are always live there. When a phase merges, diff this doc against the generated spec for the authoritative field list.
+> **OpenAPI note:** the FinCard mobile controllers are **not** yet annotated, so `/api/documentation` does not describe these endpoints. **This document is authoritative** for the FinCard surface until they are annotated (tracked as a follow-up). Other Zelta domains remain live in OpenAPI as usual.

--- a/tests/Feature/CardIssuance/FinCardCardControllerTest.php
+++ b/tests/Feature/CardIssuance/FinCardCardControllerTest.php
@@ -77,6 +77,7 @@ beforeEach(function () {
         'sandbox.finhub.cloud/api/v2.1/fincard/virtual/card/v2/freeze'      => Http::response(['success' => true, 'data' => []]),
         'sandbox.finhub.cloud/api/v2.1/fincard/virtual/card/deposit'        => Http::response(['success' => true, 'data' => []]),
         'sandbox.finhub.cloud/api/v2.1/fincard/virtual/card/withdraw'       => Http::response(['success' => true, 'data' => []]),
+        'sandbox.finhub.cloud/api/v2.1/fincard/virtual/card/v2/cardTypes'   => Http::response(['success' => true, 'data' => [['cardTypeId' => 111001, 'network' => 'visa', 'currency' => 'USD']]]),
     ]);
 
     $this->user = User::factory()->create();
@@ -154,4 +155,33 @@ it('404s an unknown card', function () {
     makeVerifiedCardholder($this->user);
 
     $this->getJson('/api/v1/cards/fincard/nope')->assertStatus(404)->assertJsonPath('error.code', 'ERR_CARDS_015');
+});
+
+it('opens a card without card_type_id using the configured default', function () {
+    config(['cardissuance.issuers.fincard.default_card_type_id' => 111001]);
+    makeVerifiedCardholder($this->user);
+
+    $this->withHeader('Idempotency-Key', idemKey())
+        ->postJson('/api/v1/cards/fincard/open', ['amount_cents' => 20000])
+        ->assertCreated()
+        ->assertJsonPath('data.card_id', 'card-new');
+});
+
+it('rejects open with no card_type_id and no default configured (ERR_CARDS_018)', function () {
+    config(['cardissuance.issuers.fincard.default_card_type_id' => null]);
+    makeVerifiedCardholder($this->user);
+
+    $this->withHeader('Idempotency-Key', idemKey())
+        ->postJson('/api/v1/cards/fincard/open', ['amount_cents' => 20000])
+        ->assertStatus(422)
+        ->assertJsonPath('error.code', 'ERR_CARDS_018');
+});
+
+it('lists tenant card types with the configured default', function () {
+    config(['cardissuance.issuers.fincard.default_card_type_id' => 111001]);
+
+    $this->getJson('/api/v1/cards/reference/card-types')
+        ->assertOk()
+        ->assertJsonPath('data.card_types.0.cardTypeId', 111001)
+        ->assertJsonPath('data.default_card_type_id', 111001);
 });


### PR DESCRIPTION
## Why

A mobile backend dev cross-checked `docs/FINCARD_MOBILE_INTEGRATION.md` against the merged code and found the doc's endpoint paths never matched the registered routes, there was no runtime way to obtain a `card_type_id`, and `/api/documentation` doesn't describe the FinCard surface. This makes the doc the single authoritative source and closes the `card_type_id` gap. No behavior change to the already-shipped happy paths.

## What

**Canonical paths (doc was wrong).** The registered routes in `app/Domain/CardIssuance/Routes/api.php` are authoritative. The doc had documented `POST /v1/cardholders`, `GET /v1/cardholders/{id}`, `POST /v1/cards`, `GET /v1/cards/{id}/sensitive`, `DELETE /{id}/freeze` (unfreeze), `DELETE /{id}` (cancel) — none of which exist. Real surface:
- Cardholder: `POST` / `GET /v1/cards/cardholder` (one per user, no `{id}`)
- Card lifecycle: `/v1/cards/fincard/*`; **unfreeze/cancel are POST, not DELETE**
- **No separate balance endpoint** — `balance_cents` is on the card (and account) object

**`card_type_id` (was required, no way to get one).**
- New `GET /v1/cards/reference/card-types` → `{ card_types: [...], default_card_type_id }` (thin best-effort passthrough over `FinCardClient::getCardTypes()`).
- `card_type_id` is now **optional** on `POST /v1/cards/fincard/open`; when omitted it falls back to `FINCARD_DEFAULT_CARD_TYPE_ID` (config key already existed, now wired in). A single-product v1 client never sends it. No id + no default → **`ERR_CARDS_018`** (clean 422, not a downstream issuer 502).

**Doc rewrite.** Canonical route table with per-endpoint idempotency flags; corrected §4.1/§4.3/§9; page-based (not cursor) transactions; shipped `ERR_CARDS_015–018`; explicit "this doc is authoritative; OpenAPI does not cover FinCard (controllers unannotated)" note; "ignore the generic `/v1/cardholders` + `/v1/cards` groups" warning.

## Tests

`tests/Feature/CardIssuance/FinCardCardControllerTest.php` — open without `card_type_id` uses the configured default; no-id + no-default → `ERR_CARDS_018`; `reference/card-types` lists products + default. Full CardIssuance feature suite green (77 passed); PHPStan L8 + phpcs clean.

## Follow-up (not in this PR)

Add `#[OA\*]` annotations to the FinCard mobile controllers so `/api/documentation` reflects them; until then the doc is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)