### PR TITLE
feat(cards): dev-only FinCard simulate-deposit affordance

### DIFF
--- a/app/Domain/CardIssuance/Routes/api.php
+++ b/app/Domain/CardIssuance/Routes/api.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Api\CardIssuance\CardholderController;
 use App\Http\Controllers\Api\CardIssuance\CardTransactionWebhookController;
 use App\Http\Controllers\Api\CardIssuance\FinCardAccountController;
 use App\Http\Controllers\Api\CardIssuance\FinCardCardController;
+use App\Http\Controllers\Api\CardIssuance\FinCardDevController;
 use App\Http\Controllers\Api\CardIssuance\FinCardOnboardingController;
 use App\Http\Controllers\Api\CardIssuance\JitFundingWebhookController;
 use Illuminate\Support\Facades\Route;
@@ -56,6 +57,17 @@ Route::prefix('v1/cards')->name('api.cards.fincard.')
         Route::post('/account/deposit-address', [FinCardAccountController::class, 'depositAddress'])
             ->middleware(['idempotency.required', 'api.rate_limit:mutation'])
             ->name('account.deposit-address');
+
+        // DEV/QA ONLY — simulate an inbound deposit to exercise the funding UI
+        // without a chain deposit or FinCard creds. Registered in non-production
+        // ONLY; additionally gated behind FINCARD_DEV_SIMULATE_ENABLED in the
+        // controller. Credits the LOCAL balance mirror + fires the same
+        // fincard.account.funded broadcast a real webhook would.
+        if (! app()->environment('production')) {
+            Route::post('/dev/simulate-deposit', [FinCardDevController::class, 'simulateDeposit'])
+                ->middleware(['idempotency.required', 'api.rate_limit:mutation'])
+                ->name('dev.simulate-deposit');
+        }
 
         // Card lifecycle (Phase 4) — namespaced under /fincard/* to avoid the
         // generic card routes. Sensitive PAN/CVV is fetched on demand, never stored.

--- a/app/Domain/CardIssuance/Services/FinCardAccountService.php
+++ b/app/Domain/CardIssuance/Services/FinCardAccountService.php
@@ -175,6 +175,40 @@ final class FinCardAccountService
     }
 
     /**
+     * DEV ONLY — simulate an inbound crypto deposit crediting the caller's
+     * account. Drives the exact balance-credit + FinCardAccountFunded broadcast
+     * a real FinCard wallet DEPOSIT webhook would, so the mobile funding UI can be
+     * exercised with no chain deposit and no FinCard connectivity. Credits the
+     * LOCAL mirror only; on a backend wired to real FinCard, syncBalance() / the
+     * reconcile cron will overwrite it. The HTTP surface is registered in
+     * non-production only and additionally gated behind FINCARD_DEV_SIMULATE_ENABLED.
+     */
+    public function simulateDeposit(User $user, int $amountCents, ?string $coinKey = null): FinCardAccount
+    {
+        $account = $this->existingAccount($user);
+        if (! $account instanceof FinCardAccount) {
+            $account = new FinCardAccount();
+            $account->user_id = (string) $user->id;
+            $account->fincard_account_id = 'sim-' . $user->id;
+            $account->currency = 'USD';
+            $account->balance_cents = 0;
+            $account->status = 'active';
+            $account->save();
+        }
+
+        // Reuse the real webhook credit path — amount is a major-unit string there.
+        $this->applyFundingWebhook('DEPOSIT', [
+            'data' => [
+                'accountId' => $account->fincard_account_id,
+                'amount'    => bcdiv((string) $amountCents, '100', 2),
+                'coinKey'   => $coinKey,
+            ],
+        ]);
+
+        return $account->refresh();
+    }
+
+    /**
      * Convert a decimal amount string to integer minor units via bcmath.
      */
     private function toCents(string $amount): int

--- a/app/Http/Controllers/Api/CardIssuance/FinCardDevController.php
+++ b/app/Http/Controllers/Api/CardIssuance/FinCardDevController.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\CardIssuance;
+
+use App\Domain\CardIssuance\Services\FinCardAccountService;
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * DEV/QA-ONLY FinCard test affordances. The route is registered in
+ * non-production ONLY (see Routes/api.php) and every action additionally
+ * requires FINCARD_DEV_SIMULATE_ENABLED — a money-crediting surface must never
+ * be reachable in production.
+ *
+ * @see docs/FINCARD_MOBILE_INTEGRATION.md §4.2
+ */
+class FinCardDevController extends Controller
+{
+    public function __construct(
+        private readonly FinCardAccountService $accounts,
+    ) {
+    }
+
+    /**
+     * Simulate an inbound crypto deposit crediting the caller's account, firing
+     * the same `fincard.account.funded` broadcast a real webhook would — so the
+     * funding UI can be exercised without a chain deposit or FinCard creds.
+     */
+    public function simulateDeposit(Request $request): JsonResponse
+    {
+        $this->assertEnabled();
+
+        /** @var User $user */
+        $user = $request->user();
+
+        /** @var array<string, mixed> $validated */
+        $validated = $request->validate([
+            'amount_cents' => ['required', 'integer', 'min:1', 'max:100000000'],
+            'coin_key'     => ['nullable', 'string', 'max:32'],
+        ]);
+
+        $account = $this->accounts->simulateDeposit(
+            $user,
+            (int) $validated['amount_cents'],
+            isset($validated['coin_key']) ? (string) $validated['coin_key'] : null,
+        );
+
+        return response()->json([
+            'success' => true,
+            'data'    => [
+                'provisioned'   => true,
+                'account_id'    => $account->fincard_account_id,
+                'currency'      => $account->currency,
+                'balance_cents' => $account->balance_cents,
+                'status'        => $account->status,
+            ],
+        ]);
+    }
+
+    /**
+     * Hard gate: never in production, and only when explicitly enabled.
+     */
+    private function assertEnabled(): void
+    {
+        $enabled = ! app()->environment('production')
+            && (bool) config('cardissuance.issuers.fincard.dev_simulate_enabled', false);
+
+        if (! $enabled) {
+            throw new NotFoundHttpException();
+        }
+    }
+}

--- a/config/cardissuance.php
+++ b/config/cardissuance.php
@@ -77,6 +77,12 @@ return [
             'webhook_public_key'   => env('FINCARD_WEBHOOK_PUBLIC_KEY', ''),
             'default_card_type_id' => env('FINCARD_DEFAULT_CARD_TYPE_ID'),
             'default_coin_key'     => env('FINCARD_DEFAULT_COIN_KEY', 'USDT_TRC20'),
+
+            // DEV/QA ONLY — enables POST /v1/cards/dev/simulate-deposit, a
+            // money-crediting test affordance for the funding UI. The route is
+            // registered in non-production ONLY; this flag is a second gate.
+            // Never set in production.
+            'dev_simulate_enabled' => (bool) env('FINCARD_DEV_SIMULATE_ENABLED', false),
         ],
     ],
 

--- a/docs/FINCARD_MOBILE_INTEGRATION.md
+++ b/docs/FINCARD_MOBILE_INTEGRATION.md
@@ -102,6 +102,8 @@ FinCard requires its own KYC — richer than the app's existing profile. Prefill
 
 **Fiat (phase 5):** routes through the existing Bridge ramp; exact UX TBD pending the fiat-funding rail (*open item*). Treat as a later addition.
 
+> **Dev/QA only — simulate a deposit.** On a non-production backend with `FINCARD_DEV_SIMULATE_ENABLED=true`, `POST /v1/cards/dev/simulate-deposit` `{ amount_cents, coin_key? }` (+ `Idempotency-Key`) credits the caller's account and fires the same `fincard.account.funded` WebSocket event (§6) a real deposit would — so you can exercise the funding UI end-to-end without sending crypto. It returns the account object (§5.1) and credits the local balance mirror only (no real FinCard call). The route **does not exist in production**. Use it on a backend with **no** FinCard creds; on one wired to real FinCard, balance reconciliation will later overwrite the simulated credit.
+
 ### 4.3 Open & use a card ⚪ (phase 4)
 
 1. `GET /v1/cards/reference/card-types` → `{ card_types: [...], default_card_type_id }`. **Optional:** v1 is a single product, so you can skip this call and omit `card_type_id` on open — the backend applies the tenant default. Call it only to let the user choose among multiple products. The `card_types` item shape passes through FinCard *(pending FinCard schema confirmation)*.

--- a/tests/Feature/CardIssuance/FinCardDevSimulateTest.php
+++ b/tests/Feature/CardIssuance/FinCardDevSimulateTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\CardIssuance\Events\Broadcast\FinCardAccountFunded;
+use App\Domain\CardIssuance\Models\FinCardAccount;
+use App\Infrastructure\FinCard\FinCardClient;
+use App\Models\User;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\Sanctum;
+
+beforeEach(function () {
+    // The simulate path never calls FinCard, but the service constructor needs a
+    // client — bind a dummy so the container resolves it without live creds.
+    $this->app->instance(FinCardClient::class, new FinCardClient(
+        baseUrl: 'https://sandbox.finhub.cloud/api/v2.1/fincard/virtual',
+        tenantId: 't',
+        orgId: 'o',
+        userId: 'u',
+        username: 'x',
+        password: 'y',
+    ));
+
+    $this->user = User::factory()->create();
+    Sanctum::actingAs($this->user, ['read', 'write', 'delete']);
+});
+
+it('simulates a deposit and credits a fresh account when enabled', function () {
+    config(['cardissuance.issuers.fincard.dev_simulate_enabled' => true]);
+    Event::fake([FinCardAccountFunded::class]);
+
+    $this->withHeader('Idempotency-Key', (string) Str::uuid())
+        ->postJson('/api/v1/cards/dev/simulate-deposit', ['amount_cents' => 25000, 'coin_key' => 'USDT_TRC20'])
+        ->assertOk()
+        ->assertJsonPath('data.provisioned', true)
+        ->assertJsonPath('data.balance_cents', 25000);
+
+    expect((int) FinCardAccount::query()->where('user_id', $this->user->id)->value('balance_cents'))->toBe(25000);
+    Event::assertDispatched(FinCardAccountFunded::class);
+});
+
+it('accumulates onto an existing account balance', function () {
+    config(['cardissuance.issuers.fincard.dev_simulate_enabled' => true]);
+
+    $account = new FinCardAccount();
+    $account->user_id = (string) $this->user->id;
+    $account->fincard_account_id = 'acc-x';
+    $account->currency = 'USD';
+    $account->balance_cents = 10000;
+    $account->status = 'active';
+    $account->save();
+
+    $this->withHeader('Idempotency-Key', (string) Str::uuid())
+        ->postJson('/api/v1/cards/dev/simulate-deposit', ['amount_cents' => 5000])
+        ->assertOk()
+        ->assertJsonPath('data.account_id', 'acc-x')
+        ->assertJsonPath('data.balance_cents', 15000);
+});
+
+it('404s when the dev flag is disabled', function () {
+    config(['cardissuance.issuers.fincard.dev_simulate_enabled' => false]);
+
+    $this->withHeader('Idempotency-Key', (string) Str::uuid())
+        ->postJson('/api/v1/cards/dev/simulate-deposit', ['amount_cents' => 5000])
+        ->assertNotFound();
+});
+
+it('validates the amount', function () {
+    config(['cardissuance.issuers.fincard.dev_simulate_enabled' => true]);
+
+    $this->withHeader('Idempotency-Key', (string) Str::uuid())
+        ->postJson('/api/v1/cards/dev/simulate-deposit', ['amount_cents' => 0])
+        ->assertStatus(422);
+});


### PR DESCRIPTION
## Why

Mobile is building the FinCard funding UI mock-first against `FINCARD_MOBILE_INTEGRATION.md`. To let them exercise the **real** funding loop (fund → account credited → live UI update) without sending crypto or standing up FinCard creds, this adds a dev-only "simulate deposit" affordance. Follow-up to #1183.

## What

`POST /v1/cards/dev/simulate-deposit` `{ amount_cents, coin_key? }` (+ `Idempotency-Key`) credits the caller's FinCard account by driving the **exact same** path a real FinCard wallet `DEPOSIT` webhook uses — `FinCardAccountService::applyFundingWebhook` → locked bcmath credit → `fincard.account.funded` broadcast. So the app sees identical realtime behaviour (WebSocket event on `private-user.{userId}`, §6) to production. Returns the account object (§5.1).

## Safety — a money-crediting surface, gated two ways

1. **Route registered in non-production only** — wrapped in `if (! app()->environment('production'))` in `Routes/api.php`, so it literally does not exist in prod (and `route:cache` bakes it out).
2. **`FINCARD_DEV_SIMULATE_ENABLED` flag** (default `false`) — the controller `assertEnabled()` 404s unless explicitly enabled, so even a staging box is opt-in.

Credits the **local balance mirror only** (no FinCard call). On a backend wired to real FinCard, `syncBalance`/the reconcile cron will overwrite the simulated credit — so it's for a **no-creds** backend doing pure UI testing. Documented as such in the mobile spec (§4.2 callout).

## Tests

`tests/Feature/CardIssuance/FinCardDevSimulateTest.php` — credits a fresh account + asserts the `FinCardAccountFunded` broadcast; accumulates onto an existing balance; **404 when the flag is off**; 422 on a bad amount. Full CardIssuance feature suite green (81 passed); PHPStan L8 + phpcs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)